### PR TITLE
Reenable Beanstalk tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -227,13 +227,13 @@
   branch = "master"
   name = "github.com/pulumi/pulumi-fabric"
   packages = ["pkg/compiler/ast","pkg/compiler/binder","pkg/compiler/core","pkg/compiler/errors","pkg/compiler/metadata","pkg/compiler/symbols","pkg/compiler/types","pkg/compiler/types/predef","pkg/diag","pkg/diag/colors","pkg/encoding","pkg/eval","pkg/eval/rt","pkg/integrationtesting","pkg/pack","pkg/resource","pkg/resource/plugin","pkg/resource/provider","pkg/tokens","pkg/tools","pkg/util/cmdutil","pkg/util/contract","pkg/util/mapper","pkg/util/rpcutil","pkg/workspace","sdk/go/pkg/lumirpc"]
-  revision = "a9939c8e6a446755c65014fc8669a73903e2ad56"
+  revision = "c0e4bdb03b4bda51135cbafe083b7ff19a3942d6"
 
 [[projects]]
   branch = "master"
   name = "github.com/pulumi/pulumi-terraform"
   packages = ["pkg/tfbridge","pkg/tfgen"]
-  revision = "a58c0a73121c6d1c0f3206a4fe1c1859fe8c7efd"
+  revision = "7d52bd66e6eefc881e086caf956ff734251fd20e"
 
 [[projects]]
   branch = "master"

--- a/examples/beanstalk/index.ts
+++ b/examples/beanstalk/index.ts
@@ -7,9 +7,8 @@ import { File } from "@lumi/lumi/asset";
 import { jsonStringify } from "@lumi/lumirt";
 
 let sourceBucket = new Bucket("sourceBucket", {});
-let source = new Object({
+let source = new Object("testSource/app.zip", {
     bucket: sourceBucket,
-    key: "testSource/app.zip",
     source: new File("app.zip"),
 });
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -31,8 +31,7 @@ func TestExamples(t *testing.T) {
 			path.Join(cwd, "minimal"),
 			path.Join(cwd, "webserver"),
 			path.Join(cwd, "webserver-comp"),
-			// TODO[pulumi/pulumi-aws#5]: Reenable this test once unblocked.
-			// path.Join(cwd, "beanstalk"),
+			path.Join(cwd, "beanstalk"),
 			path.Join(cwd, "cpuwatch"),
 		}
 	}

--- a/pack/s3/object.ts
+++ b/pack/s3/object.ts
@@ -6,7 +6,7 @@ import * as lumirt from "@lumi/lumirt";
 
 import {Bucket} from "./bucket";
 
-export class Object extends lumi.Resource implements ObjectArgs {
+export class Object extends lumi.NamedResource implements ObjectArgs {
     public readonly acl?: string;
     public readonly bucket: Bucket;
     public readonly cacheControl?: string;
@@ -33,8 +33,8 @@ export class Object extends lumi.Resource implements ObjectArgs {
         return <any>undefined; // functionality provided by the runtime
     }
 
-    constructor(args: ObjectArgs) {
-        super();
+    constructor(name: string, args: ObjectArgs) {
+        super(name);
         this.acl = <any>args.acl;
         if (lumirt.defaultIfComputed(args.bucket, "") === undefined) {
             throw new Error("Property argument 'bucket' is required, but was missing");
@@ -47,9 +47,6 @@ export class Object extends lumi.Resource implements ObjectArgs {
         this.contentLanguage = <any>args.contentLanguage;
         this.contentType = <any>args.contentType;
         this.etag = <any>args.etag;
-        if (lumirt.defaultIfComputed(args.key, "") === undefined) {
-            throw new Error("Property argument 'key' is required, but was missing");
-        }
         this.key = <any>args.key;
         this.kmsKeyId = <any>args.kmsKeyId;
         this.serverSideEncryption = <any>args.serverSideEncryption;
@@ -70,7 +67,7 @@ export interface ObjectArgs {
     readonly contentLanguage?: string;
     readonly contentType?: string;
     readonly etag?: string;
-    readonly key: string;
+    readonly key?: string;
     readonly kmsKeyId?: string;
     readonly serverSideEncryption?: string;
     readonly source?: lumi.asset.Asset;

--- a/resources.go
+++ b/resources.go
@@ -736,12 +736,16 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"aws_s3_bucket_policy": {Tok: awsrestok(s3Mod, "BucketPolicy")},
 			"aws_s3_bucket_object": {
-				Tok:                 awsrestok(s3Mod, "Object"),
-				IDFields:            []string{"bucket", "key"},
-				NameFields:          []string{"bucket", "key"},
-				NameFieldsDelimiter: ":",
+				Tok:      awsrestok(s3Mod, "Object"),
+				IDFields: []string{"bucket", "key"},
 				Fields: map[string]tfbridge.SchemaInfo{
 					"bucket": {Type: awsrestok(s3Mod, "Bucket")},
+					"key": {
+						// By default, use the name as the key.  It may of course be overridden.
+						Default: tfbridge.DefaultInfo{
+							From: tfbridge.NameProperty,
+						},
+					},
 					"source": {
 						Asset: &tfbridge.AssetTranslation{
 							Kind: tfbridge.FileAsset,


### PR DESCRIPTION
This change fixes some issues that were previously blocking the
Elastic Beanstalk tests, and reenables our tests for the sample.

In summary:

* Ingest two relevant fixes from the fabric and repos:
    - https://github.com/pulumi/pulumi-fabric/commit/a160741931374bb9cbfc453ae8fe5c9518a8ae09
    - https://github.com/pulumi/pulumi-terraform/commit/7d52bd66e6eefc881e086caf956ff734251fd20e

* Subtly, our projection of S3 objects is plain wrong.  It attempts
  to create a name automatically by combining the bucket namd with the
  object key name.  This suffers from an obvious issue: almost always,
  the bucket is going to be another resource, whose ID is computed.
  And therefore we attempt to generate a URN using a computed property,
  which cannot work (URNs are required before actually deploying things).

  This is a little unfortunate.  A bucket's name itself is easy to
  "guess" based on the inputs, so there's no real reason it needs to
  be computed.  Eventually, we can explore doing something smarter here,
  although there are a number of challenges with that.  This is being
  tracked by https://github.com/pulumi/pulumi-aws/issues/10.

  Instead, we'll give S3 objects a traditional name, and use said name
  as the key by default unless a separate key is also given.  This is
  simple and intuitive for most cases, although the fact that two objects
  in the same module that share a key but are in totally different
  buckets is going to pop up and annoy/confuse people.