### PR TITLE
Add "*" as a valid IAM principal

### DIFF
--- a/overlays/iam/documents.ts
+++ b/overlays/iam/documents.ts
@@ -35,7 +35,7 @@ export interface ConditionArguments {
     [value: string]: string;
 }
 
-export type Principal = AWSPrincipal | ServicePrincipal | FederatedPrincipal;
+export type Principal = "*" | AWSPrincipal | ServicePrincipal | FederatedPrincipal;
 
 export interface AWSPrincipal {
     AWS: string | string[];


### PR DESCRIPTION
This is necessary e.g. to allow anonymous access to Elasticsearch.