### PR TITLE
Pick up the latest Terraform AWS provider.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -328,7 +328,7 @@
   branch = "pulumi-master"
   name = "github.com/terraform-providers/terraform-provider-aws"
   packages = ["aws"]
-  revision = "3cf80a831663297d431d2e73db9eb32da496fe71"
+  revision = "24f1055fad149ba7924e6d537656b0213739a2f2"
   source = "github.com/pulumi/terraform-provider-aws"
 
 [[projects]]

--- a/examples/beanstalk/index.ts
+++ b/examples/beanstalk/index.ts
@@ -39,7 +39,7 @@ let instanceWebTierPolicyAttach = new iam.RolePolicyAttachment("myapp-instanceRo
     policyArn: iam.AWSElasticBeanstalkWebTier,
 });
 let instanceProfile = new iam.InstanceProfile("myapp-instanceProfile", {
-    roles: [ instanceRole ],
+    role: instanceRole,
 });
 let serviceRolePolicyDocument = {
     "Version": "2012-10-17",


### PR DESCRIPTION
This has the `role` fix for IAM instance profiles. The only example that
was using `roles` has been updated accordingly.