### PR TITLE
Fix publishing scripts to include package.json

### DIFF
--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -30,6 +30,7 @@ copy_package() {
 
     mkdir -p "${module_root}"
     cp -R "$1" "${module_root}/"
+    cp "$1/../package.json" "${module_root}/"
     if [ -e "${module_root}/node_modules" ]; then
         rm -rf "${module_root}/node_modules"
     fi


### PR DESCRIPTION
This is needed because install.sh will run yarn install at install
time, so we need the dependency information this provides.