### PR TITLE
Enable Terraform logging in the AWS provider.

### DIFF
--- a/cmd/pulumi-provider-aws/main.go
+++ b/cmd/pulumi-provider-aws/main.go
@@ -3,11 +3,15 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
+	"github.com/hashicorp/terraform/helper/logging"
 
 	"github.com/pulumi/pulumi-aws"
+	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
 )
 
 func main() {
+	// Enable Terraform logging.
+	logging.SetOutput()
+
 	tfbridge.Main("aws", aws.Provider())
 }


### PR DESCRIPTION
Terraform logs can be enabled with the `TF_LOG` envvar. Logs can be
redirected to a file using the `TF_LOG_PATH` envvar. Note that because
Terraform uses the `log` package for logging, enabling Terraform logs
will also redirect any other logging performed using the `log` package
to the same destination as the Terraform logs.