### PR TITLE
Permit bucket names, alongside strongly typed Buckets

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -267,7 +267,7 @@
   branch = "master"
   name = "github.com/pulumi/pulumi-terraform"
   packages = ["pkg/tfbridge","pkg/tfgen"]
-  revision = "642fb0ad182df5b479d8d6a7b45336be238d3746"
+  revision = "53ee06dad0189ad7725b8ef4b943b8567ab7f1c3"
 
 [[projects]]
   branch = "master"

--- a/resources.go
+++ b/resources.go
@@ -371,7 +371,12 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(elasticbeanstalkMod, "ApplicationVersion"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"application": {Type: awsResource(elasticbeanstalkMod, "Application")},
-					"bucket":      {Type: awsResource(s3Mod, "Bucket")},
+					"bucket": {
+						// Prefer a strongly typed Bucket reference.
+						Type: awsResource(s3Mod, "Bucket"),
+						// But also permit a string in cases where all we have is a name.
+						AltTypes: []tokens.Type{"string"},
+					},
 				},
 			},
 			"aws_elastic_beanstalk_configuration_template": {Tok: awsResource(elasticbeanstalkMod, "ConfigurationTemplate")},
@@ -907,7 +912,12 @@ func Provider() tfbridge.ProviderInfo {
 				Tok:      awsResource(s3Mod, "BucketObject"),
 				IDFields: []string{"bucket", "key"},
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"bucket": {Type: awsResource(s3Mod, "Bucket")},
+					"bucket": {
+						// Prefer a strongly typed Bucket reference.
+						Type: awsResource(s3Mod, "Bucket"),
+						// But also permit a string in cases where all we have is a name.
+						AltTypes: []tokens.Type{"string"},
+					},
 					"key": {
 						// By default, use the name as the key.  It may of course be overridden.
 						Default: &tfbridge.DefaultInfo{


### PR DESCRIPTION
In cross-stack linking, often you just have a name from a configuration
variable.  Not having a Bucket in hand meant there was no way to populate
such a bucket with objects.  This change adopts a new feature in the TF
bridge where we can use union types to accept both.