### PR TITLE
Update to latest terraform-provider-aws

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -310,10 +310,10 @@
   version = "v1.1.4"
 
 [[projects]]
-  branch = "pulumi-adopt16plus"
+  branch = "pulumi-master"
   name = "github.com/terraform-providers/terraform-provider-aws"
   packages = ["aws"]
-  revision = "5bf533b1e3479be2f24282aa76edf69236b17eb9"
+  revision = "d1cc7be0433c0b002cc80d90266302756990ca9f"
   source = "github.com/pulumi/terraform-provider-aws"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,4 +14,4 @@
 [[override]]
   name = "github.com/terraform-providers/terraform-provider-aws"
   source = "github.com/pulumi/terraform-provider-aws"
-  branch = "pulumi-adopt16plus"
+  branch = "pulumi-master"

--- a/resources.go
+++ b/resources.go
@@ -119,11 +119,6 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{
-
-			// warning: Resource aws_media_store_container not found in provider map; skipping
-			// warning: Resource aws_service_discovery_private_dns_namespace not found in provider map; skipping
-			// warning: Resource aws_service_discovery_public_dns_namespace not found in provider map; skipping
-
 			// API Gateway
 			"aws_api_gateway_account": {Tok: awsResource(apigatewayMod, "Account")},
 			"aws_api_gateway_api_key": {


### PR DESCRIPTION
This includes several new features we want to use:
* API Gateway VPC support so that we can remove our custom `proxy` from the PPC
* Initial Fargate support
* ECR Lifecycle piolicy as needed for https://github.com/pulumi/pulumi-service/issues/215