### PR TITLE
Consume NPM packages in our examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,3 @@ after_failure:
     - aws --region us-west-2 s3 cp --recursive "${PULUMI_FAILED_TESTS_DIR}" "s3://eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failures"
 notifications:
     webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis
-
-

--- a/README.md
+++ b/README.md
@@ -3,4 +3,3 @@
 # aws
 
 An Amazon Web Services (AWS) Pulumi resource package.
-

--- a/examples/beanstalk/package.json
+++ b/examples/beanstalk/package.json
@@ -1,19 +1,19 @@
 {
     "name": "beanstalk",
-    "version": "0.1",
+    "version": "0.1.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+         "@pulumi/aws": "latest"
+    },
     "devDependencies": {
-        "typescript": "^2.5.3"
+        "typescript": "^2.5.3",
+        "@types/node": "^8.0.27"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
-    },
-    "dependencies": {
-        "@types/node": "^8.0.27"
+        "pulumi": "latest"
     }
 }

--- a/examples/beanstalk/yarn.lock
+++ b/examples/beanstalk/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 "@types/node@^8.0.27":
   version "8.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.27.tgz#13fbe7e92afeecebb843d7cea6c15b521e0000e1"

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,16 +1,18 @@
 {
     "name": "minimal",
-    "version": "0.1",
+    "version": "0.1.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/minimal/yarn.lock
+++ b/examples/minimal/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"

--- a/examples/serverless-raw/package.json
+++ b/examples/serverless-raw/package.json
@@ -1,16 +1,18 @@
 {
     "name": "serverless-raw",
-    "version": "0.1",
+    "version": "0.1.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/serverless-raw/yarn.lock
+++ b/examples/serverless-raw/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -1,16 +1,18 @@
 {
     "name": "serverless",
-    "version": "0.1",
+    "version": "0.1.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/serverless/yarn.lock
+++ b/examples/serverless/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"

--- a/examples/webserver-comp/package.json
+++ b/examples/webserver-comp/package.json
@@ -1,16 +1,18 @@
 {
     "name": "webserver",
-    "version": "0.1",
+    "version": "0.1.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/webserver-comp/yarn.lock
+++ b/examples/webserver-comp/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"

--- a/examples/webserver/package.json
+++ b/examples/webserver/package.json
@@ -1,19 +1,19 @@
 {
     "name": "webserver",
-    "version": "0.1",
+    "version": "0.1.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
+        "@types/node": "^8.0.26",
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
-    },
-    "dependencies": {
-        "@types/node": "^8.0.26"
+        "pulumi": "latest"
     }
 }

--- a/examples/webserver/variants/ssh/package.json
+++ b/examples/webserver/variants/ssh/package.json
@@ -6,11 +6,13 @@
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/webserver/variants/ssh/yarn.lock
+++ b/examples/webserver/variants/ssh/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"

--- a/examples/webserver/variants/ssh_description/package.json
+++ b/examples/webserver/variants/ssh_description/package.json
@@ -6,11 +6,13 @@
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/webserver/variants/ssh_description/yarn.lock
+++ b/examples/webserver/variants/ssh_description/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"

--- a/examples/webserver/variants/zones/package.json
+++ b/examples/webserver/variants/zones/package.json
@@ -6,11 +6,13 @@
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/aws": "latest"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },
     "peerDependencies": {
-        "@pulumi/aws": "*",
-        "pulumi": "*"
+        "pulumi": "latest"
     }
 }

--- a/examples/webserver/variants/zones/yarn.lock
+++ b/examples/webserver/variants/zones/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"

--- a/examples/webserver/yarn.lock
+++ b/examples/webserver/yarn.lock
@@ -2,10 +2,14 @@
 # yarn lockfile v1
 
 
+"@pulumi/aws@latest":
+  version "0.9.11-10-gcb20031"
+  resolved "https://npmjs-dot-testing.moolumi.io/@pulumi%2faws/-/aws-0.9.11-10-gcb20031.tgz#0a3058256ab72a41dfde4353552b72f0c85d6c73"
+
 "@types/node@^8.0.26":
-  version "8.0.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.26.tgz#4d58be925306fd22b1141085535a0268b8beb189"
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.9.tgz#7155cfb4ae405bca4dd8df1a214c339e939109bf"
 
 typescript@^2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"


### PR DESCRIPTION
This change switches our examples over to using real NPM packages.
It uses the `"latest"` tag so that we always download the latest
package.  There is currently a known issue which is that we won't
actually land on the latest due to the Yarn lock files, however,
we will be addressing that shortly with updates to our test framework.