### PR TITLE
Publish with real @pulumi/pulumi dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -473,8 +473,8 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "2bd9d8af8da4305027acba8874656b95c204e746"
-  version = "v0.10.0-rc2"
+  revision = "ab1eb4632c762f8ddd956fde7dc740efaaf70fc9"
+  version = "v0.10.0-rc3"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-terraform"
@@ -482,8 +482,8 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "31031e915530228a61244a5ec014204aff9f550a"
-  version = "v0.10.0-rc2"
+  revision = "c163de69734d246f98959c6911d4955251becdc3"
+  version = "v0.10.0-rc3"
 
 [[projects]]
   branch = "master"

--- a/examples/beanstalk/package.json
+++ b/examples/beanstalk/package.json
@@ -12,6 +12,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/serverless-raw/package.json
+++ b/examples/serverless-raw/package.json
@@ -11,6 +11,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -11,6 +11,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/webserver-comp/package.json
+++ b/examples/webserver-comp/package.json
@@ -11,6 +11,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/webserver/package.json
+++ b/examples/webserver/package.json
@@ -12,6 +12,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/webserver/variants/ssh/package.json
+++ b/examples/webserver/variants/ssh/package.json
@@ -11,6 +11,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/webserver/variants/ssh/yarn.lock
+++ b/examples/webserver/variants/ssh/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@pulumi/aws@latest":
-  version "0.9.11-11-g977c466"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.9.11-11-g977c466.tgz#dca94aac3e3de913cc17b2e8422dcbb94f222118"
-
 typescript@^2.5.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"

--- a/examples/webserver/variants/ssh_description/package.json
+++ b/examples/webserver/variants/ssh_description/package.json
@@ -11,6 +11,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/webserver/variants/ssh_description/yarn.lock
+++ b/examples/webserver/variants/ssh_description/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@pulumi/aws@latest":
-  version "0.9.11-11-g977c466"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.9.11-11-g977c466.tgz#dca94aac3e3de913cc17b2e8422dcbb94f222118"
-
 typescript@^2.5.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"

--- a/examples/webserver/variants/zones/package.json
+++ b/examples/webserver/variants/zones/package.json
@@ -11,6 +11,6 @@
     },
     "peerDependencies": {
         "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.10.0-rc3"
     }
 }

--- a/examples/webserver/variants/zones/yarn.lock
+++ b/examples/webserver/variants/zones/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@pulumi/aws@latest":
-  version "0.9.11-11-g977c466"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.9.11-11-g977c466.tgz#dca94aac3e3de913cc17b2e8422dcbb94f222118"
-
 typescript@^2.5.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"

--- a/resources.go
+++ b/resources.go
@@ -1205,6 +1205,9 @@ func Provider() tfbridge.ProviderInfo {
 			DevDependencies: map[string]string{
 				"@types/node": "^8.0.25", // so we can access strongly typed node definitions.
 			},
+			PeerDependencies: map[string]string{
+				"@pulumi/pulumi": "^0.10.0-rc3",
+			},
 		},
 	}
 

--- a/scripts/promote.js
+++ b/scripts/promote.js
@@ -1,0 +1,40 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+// This program simply reads a package.json from stdin, takes a set of arguments representing
+// package names, and for each one, promotes that package from a peerDependency to a real dependency.
+
+// Read the package.json from stdin.
+let packageJSONText = "";
+const readline = require("readline");
+const stdin = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+});
+stdin.on("line", function(line) {
+    packageJSONText += `${line}\n`;
+});
+stdin.on("close", function() {
+    // All stdin is available.  Parse the JSON and move dependencies around.
+    const packageJSON = JSON.parse(packageJSONText);
+    for (const arg of process.argv.slice(2)) {
+        if (!packageJSON.peerDependencies || !packageJSON.peerDependencies[arg]) {
+            throw new Error(`No peerDependency for "${arg}" found`);
+        }
+
+        // Add this dependency.
+        if (!packageJSON.dependencies) {
+            packageJSON.dependencies = {};
+        }
+        packageJSON.dependencies[arg] = packageJSON.peerDependencies[arg];
+
+        // And now delete the peer dependency.
+        delete packageJSON.peerDependencies[arg];
+        if (Object.keys(packageJSON.peerDependencies).length === 0) {
+            delete packageJSON.peerDependencies;
+        }
+    }
+
+    // Now print out the result to stdout.
+    console.log(JSON.stringify(packageJSON, null, 4));
+});

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,7 +27,20 @@ do
 done
 
 echo "Publishing NPM package to NPMjs.com:"
-pushd ${ROOT}/pack/bin && \
-    npm publish && \
-    npm info 2>/dev/null || true && \
-    popd
+
+# First create the package.json to publish.  This must be different than the one we use for development
+# and testing the SDK, since we use symlinking for those workflows.  Namely, we must promote the SDK
+# dependencies from peerDependencies that are resolved via those links, to real installable dependencies.
+pushd ${ROOT}/pack/bin
+node $(dirname $0)/promote.js @pulumi/pulumi < package.json > package.json.publish
+mv package.json package.json.dev
+mv package.json.publish package.json
+
+# Now, perform the publish.
+npm publish
+npm info 2>/dev/null
+
+# And finally restore the original package.json.
+mv package.json package.json.publish
+mv package.json.dev package.json
+popd


### PR DESCRIPTION
This change adopts our new workflow for publishing a @pulumi/aws
package to NPM that can be used entirely with npm install, and notably
no symlinking.  Because all of our tests still use symlinking *within*
the SDK, we still use peerDependencies in most places.  Upon publishing,
we will promote the peerDependency of @pulumi/pulumi to a real one.