### PR TITLE
Publish plugin package for provider

### DIFF
--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# publish-plugin.sh builds and publishes a package containing the resource provider to
+# s3://rel.pulumi.com/releases/plugins.
+set -o nounset -o errexit -o pipefail
+
+ROOT=$(dirname $0)/..
+WORK_PATH=$(mktemp -d)
+VERSION=$(git describe --tags --dirty 2>/dev/null)
+PLUGIN_PACKAGE_NAME="pulumi-provider-aws-${VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz"
+PLUGIN_PACKAGE_DIR="$(mktemp -d)"
+PLUGIN_PACKAGE_PATH="${PLUGIN_PACKAGE_DIR}/${PLUGIN_PACKAGE_NAME}"
+
+# When crossbuilding, we want to ensure we have .exe for the windows binaries.
+BIN_SUFFIX=
+if [ "$(go env GOOS)" = "windows" ]; then
+    BIN_SUFFIX=".exe"
+fi
+
+go build \
+   -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" \
+   -o "${WORK_PATH}/pulumi-provider-aws${BIN_SUFFIX}" \
+   "${ROOT}/cmd/pulumi-provider-aws"
+
+# Tar up the plugin
+tar -czf ${PLUGIN_PACKAGE_PATH} -C ${WORK_PATH} .
+
+# rel.pulumi.com is in our production account, so assume that role first
+CREDS_JSON=$(aws sts assume-role \
+                 --role-arn "arn:aws:iam::058607598222:role/UploadPulumiReleases" \
+                 --role-session-name "upload-plugin-pulumi-provider-aws" \
+                 --external-id "upload-pulumi-release")
+
+# Use the credentials we just assumed
+export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
+export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
+export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
+
+aws s3 cp --only-show-errors "${PLUGIN_PACKAGE_PATH}" "s3://rel.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
+
+rm -rf "${PLUGIN_PACKAGE_DIR}"
+rm -rf "${WORK_PATH}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -26,6 +26,18 @@ do
     done
 done
 
+echo "Publishing Plugin archive to s3://rel.pulumi.com/:"
+for OS in "${PUBLISH_GOOS[@]}"
+do
+    for ARCH in "${PUBLISH_GOARCH[@]}"
+    do
+        export GOOS=${OS}
+        export GOARCH=${ARCH}
+
+        ${ROOT}/scripts/publish-plugin.sh
+    done
+done
+
 echo "Publishing NPM package to NPMjs.com:"
 
 # First create the package.json to publish.  This must be different than the one we use for development


### PR DESCRIPTION
As part of publishing, produce a plugin archive of the provider, which
`pulumi` will use to obtain the resource provider at runtime. Plugins
are published to s3://rel.pulumi.com/releases/plugins and are named
${provider-name}-${version}-${GOOS}-${GOARCH}.tar.gz.