### PR TITLE
Project nested structs of ElasticSearch Domain as scalars

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -696,6 +696,11 @@ func Provider() tfbridge.ProviderInfo {
 					"domain_name": tfbridge.AutoNameTransform("domainName", 28, func(name string) string {
 						return strings.ToLower(name)
 					}),
+					// These only accept a single value in the AWS API, but are not marked as MaxItems==1 in the TF
+					// provider.
+					"cluster_config":   {Name: "clusterConfig", MaxItemsOne: boolRef(true)},
+					"ebs_options":      {Name: "ebsOptions", MaxItemsOne: boolRef(true)},
+					"snapshot_options": {Name: "snapshotOptions", MaxItemsOne: boolRef(true)},
 				},
 			},
 			"aws_elasticsearch_domain_policy": {Tok: awsResource(elasticsearchMod, "DomainPolicy")},


### PR DESCRIPTION
These three properties are not marked as MaxItems==1 in the TF provider,
but can only accept a single value in the underlying AWS API.