### PR TITLE
Add ECS container definition JSON schemas

### DIFF
--- a/examples/webserver-comp/linuxAmi.ts
+++ b/examples/webserver-comp/linuxAmi.ts
@@ -5,12 +5,12 @@
 // Ultimately, this lets us choose a recommended Amazon Linux AMI; see:
 //     https://aws.amazon.com/amazon-linux-ami/instance-type-matrix/
 
-import * as config from "../config";
+import * as aws from "@pulumi/aws";
 
 /**
  * instanceTypeArch is a map of instance type to its architecture.
  */
-export let instanceTypeArch: {
+const instanceTypeArch: {
     [instanceType: string]: string,
 } = {
     "t1.micro"   : "PV64" ,
@@ -155,7 +155,7 @@ export let regionArchLinuxAMI: {
  * getLinuxAMI gets the recommended Linux AMI for the given instance in the current AWS region.
  */
 export function getLinuxAMI(instanceType: string): string {
-    let region = config.requireRegion();
+    let region = aws.config.requireRegion();
     let arch = instanceTypeArch[instanceType];
     return regionArchLinuxAMI[region][arch];
 }

--- a/examples/webserver-comp/webserver.ts
+++ b/examples/webserver-comp/webserver.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import { getLinuxAMI } from "./linuxAmi";
 
 let group = new aws.ec2.SecurityGroup("web-secgrp", {
     description: "Enable HTTP access",
@@ -16,7 +17,7 @@ export class Server {
         this.instance = new aws.ec2.Instance("web-server-" + name, {
             instanceType: size,
             securityGroups: [ group.name ],
-            ami: aws.ec2.getLinuxAMI(size),
+            ami: getLinuxAMI(size),
         });
     }
 }

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -2,6 +2,7 @@
 
 import * as aws from "@pulumi/aws";
 import { Output } from "@pulumi/pulumi";
+import { getLinuxAMI } from "./linuxAmi";
 
 let size: aws.ec2.InstanceType = "t2.micro";
 
@@ -15,7 +16,7 @@ let group = new aws.ec2.SecurityGroup("web-secgrp-2", {
 let server = new aws.ec2.Instance("web-server-www", {
     instanceType: size,
     securityGroups: [ group.name ],
-    ami: aws.ec2.getLinuxAMI(size),
+    ami: getLinuxAMI(size),
 });
 
 export let publicIp = server.publicIp;

--- a/examples/webserver/linuxAmi.ts
+++ b/examples/webserver/linuxAmi.ts
@@ -1,0 +1,162 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+// This file defines some maps that correspond to the recommended AWS Marketplace values:
+//     http://docs.aws.amazon.com/servicecatalog/latest/adminguide/catalogs_marketplace-products.html
+// Ultimately, this lets us choose a recommended Amazon Linux AMI; see:
+//     https://aws.amazon.com/amazon-linux-ami/instance-type-matrix/
+
+import * as aws from "@pulumi/aws";
+
+/**
+ * instanceTypeArch is a map of instance type to its architecture.
+ */
+const instanceTypeArch: {
+    [instanceType: string]: string,
+} = {
+    "t1.micro"   : "PV64" ,
+    "t2.nano"    : "HVM64",
+    "t2.micro"   : "HVM64",
+    "t2.small"   : "HVM64",
+    "t2.medium"  : "HVM64",
+    "t2.large"   : "HVM64",
+    "m1.small"   : "PV64" ,
+    "m1.medium"  : "PV64" ,
+    "m1.large"   : "PV64" ,
+    "m1.xlarge"  : "PV64" ,
+    "m2.xlarge"  : "PV64" ,
+    "m2.2xlarge" : "PV64" ,
+    "m2.4xlarge" : "PV64" ,
+    "m3.medium"  : "HVM64",
+    "m3.large"   : "HVM64",
+    "m3.xlarge"  : "HVM64",
+    "m3.2xlarge" : "HVM64",
+    "m4.large"   : "HVM64",
+    "m4.xlarge"  : "HVM64",
+    "m4.2xlarge" : "HVM64",
+    "m4.4xlarge" : "HVM64",
+    "m4.10xlarge": "HVM64",
+    "c1.medium"  : "PV64" ,
+    "c1.xlarge"  : "PV64" ,
+    "c3.large"   : "HVM64",
+    "c3.xlarge"  : "HVM64",
+    "c3.2xlarge" : "HVM64",
+    "c3.4xlarge" : "HVM64",
+    "c3.8xlarge" : "HVM64",
+    "c4.large"   : "HVM64",
+    "c4.xlarge"  : "HVM64",
+    "c4.2xlarge" : "HVM64",
+    "c4.4xlarge" : "HVM64",
+    "c4.8xlarge" : "HVM64",
+    "g2.2xlarge" : "HVMG2",
+    "g2.8xlarge" : "HVMG2",
+    "r3.large"   : "HVM64",
+    "r3.xlarge"  : "HVM64",
+    "r3.2xlarge" : "HVM64",
+    "r3.4xlarge" : "HVM64",
+    "r3.8xlarge" : "HVM64",
+    "i2.xlarge"  : "HVM64",
+    "i2.2xlarge" : "HVM64",
+    "i2.4xlarge" : "HVM64",
+    "i2.8xlarge" : "HVM64",
+    "d2.xlarge"  : "HVM64",
+    "d2.2xlarge" : "HVM64",
+    "d2.4xlarge" : "HVM64",
+    "d2.8xlarge" : "HVM64",
+    "hi1.4xlarge": "HVM64",
+    "hs1.8xlarge": "HVM64",
+    "cr1.8xlarge": "HVM64",
+    "cc2.8xlarge": "HVM64",
+};
+
+/**
+ * regionArchLinuxAMI is a map from region to inner maps from architecture to the recommended Linux AMI.
+ */
+export let regionArchLinuxAMI: {
+    [region: string]: { [arch: string]: string; },
+} = {
+    "us-east-1": {
+        "PV64" : "ami-2a69aa47",
+        "HVM64": "ami-6869aa05",
+        "HVMG2": "ami-648d9973",
+    },
+    "us-west-2": {
+        "PV64" : "ami-7f77b31f",
+        "HVM64": "ami-7172b611",
+        "HVMG2": "ami-09cd7a69",
+    },
+    "us-west-1": {
+        "PV64" : "ami-a2490dc2",
+        "HVM64": "ami-31490d51",
+        "HVMG2": "ami-1e5f0e7e",
+    },
+    "eu-west-1": {
+        "PV64" : "ami-4cdd453f",
+        "HVM64": "ami-f9dd458a",
+        "HVMG2": "ami-b4694ac7",
+    },
+    "eu-west-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-886369ec",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "eu-central-1": {
+        "PV64" : "ami-6527cf0a",
+        "HVM64": "ami-ea26ce85",
+        "HVMG2": "ami-de5191b1",
+    },
+    "ap-northeast-1": {
+        "PV64" : "ami-3e42b65f",
+        "HVM64": "ami-374db956",
+        "HVMG2": "ami-df9ff4b8",
+    },
+    "ap-northeast-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-2b408b45",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ap-southeast-1": {
+        "PV64" : "ami-df9e4cbc",
+        "HVM64": "ami-a59b49c6",
+        "HVMG2": "ami-8d8d23ee",
+    },
+    "ap-southeast-2": {
+        "PV64" : "ami-63351d00",
+        "HVM64": "ami-dc361ebf",
+        "HVMG2": "ami-cbaf94a8",
+    },
+    "ap-south-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-ffbdd790",
+        "HVMG2": "ami-decdbab1",
+    },
+    "us-east-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-f6035893",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ca-central-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-730ebd17",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "sa-east-1": {
+        "PV64" : "ami-1ad34676",
+        "HVM64": "ami-6dd04501",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "cn-north-1": {
+        "PV64" : "ami-77559f1a",
+        "HVM64": "ami-8e6aa0e3",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+};
+
+/**
+ * getLinuxAMI gets the recommended Linux AMI for the given instance in the current AWS region.
+ */
+export function getLinuxAMI(instanceType: string): string {
+    let region = aws.config.requireRegion();
+    let arch = instanceTypeArch[instanceType];
+    return regionArchLinuxAMI[region][arch];
+}
+

--- a/examples/webserver/variants/ssh/index.ts
+++ b/examples/webserver/variants/ssh/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import { getLinuxAMI } from "./linuxAmi";
 
 export let size: aws.ec2.InstanceType = "t2.micro";
 
@@ -15,5 +16,5 @@ let group = new aws.ec2.SecurityGroup("web-secgrp", {
 let server = new aws.ec2.Instance("web-server-www", {
     instanceType: size,
     securityGroups: [ group.name ],
-    ami: aws.ec2.getLinuxAMI(size),
+    ami: getLinuxAMI(size),
 });

--- a/examples/webserver/variants/ssh/linuxAmi.ts
+++ b/examples/webserver/variants/ssh/linuxAmi.ts
@@ -1,0 +1,162 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+// This file defines some maps that correspond to the recommended AWS Marketplace values:
+//     http://docs.aws.amazon.com/servicecatalog/latest/adminguide/catalogs_marketplace-products.html
+// Ultimately, this lets us choose a recommended Amazon Linux AMI; see:
+//     https://aws.amazon.com/amazon-linux-ami/instance-type-matrix/
+
+import * as aws from "@pulumi/aws";
+
+/**
+ * instanceTypeArch is a map of instance type to its architecture.
+ */
+const instanceTypeArch: {
+    [instanceType: string]: string,
+} = {
+    "t1.micro"   : "PV64" ,
+    "t2.nano"    : "HVM64",
+    "t2.micro"   : "HVM64",
+    "t2.small"   : "HVM64",
+    "t2.medium"  : "HVM64",
+    "t2.large"   : "HVM64",
+    "m1.small"   : "PV64" ,
+    "m1.medium"  : "PV64" ,
+    "m1.large"   : "PV64" ,
+    "m1.xlarge"  : "PV64" ,
+    "m2.xlarge"  : "PV64" ,
+    "m2.2xlarge" : "PV64" ,
+    "m2.4xlarge" : "PV64" ,
+    "m3.medium"  : "HVM64",
+    "m3.large"   : "HVM64",
+    "m3.xlarge"  : "HVM64",
+    "m3.2xlarge" : "HVM64",
+    "m4.large"   : "HVM64",
+    "m4.xlarge"  : "HVM64",
+    "m4.2xlarge" : "HVM64",
+    "m4.4xlarge" : "HVM64",
+    "m4.10xlarge": "HVM64",
+    "c1.medium"  : "PV64" ,
+    "c1.xlarge"  : "PV64" ,
+    "c3.large"   : "HVM64",
+    "c3.xlarge"  : "HVM64",
+    "c3.2xlarge" : "HVM64",
+    "c3.4xlarge" : "HVM64",
+    "c3.8xlarge" : "HVM64",
+    "c4.large"   : "HVM64",
+    "c4.xlarge"  : "HVM64",
+    "c4.2xlarge" : "HVM64",
+    "c4.4xlarge" : "HVM64",
+    "c4.8xlarge" : "HVM64",
+    "g2.2xlarge" : "HVMG2",
+    "g2.8xlarge" : "HVMG2",
+    "r3.large"   : "HVM64",
+    "r3.xlarge"  : "HVM64",
+    "r3.2xlarge" : "HVM64",
+    "r3.4xlarge" : "HVM64",
+    "r3.8xlarge" : "HVM64",
+    "i2.xlarge"  : "HVM64",
+    "i2.2xlarge" : "HVM64",
+    "i2.4xlarge" : "HVM64",
+    "i2.8xlarge" : "HVM64",
+    "d2.xlarge"  : "HVM64",
+    "d2.2xlarge" : "HVM64",
+    "d2.4xlarge" : "HVM64",
+    "d2.8xlarge" : "HVM64",
+    "hi1.4xlarge": "HVM64",
+    "hs1.8xlarge": "HVM64",
+    "cr1.8xlarge": "HVM64",
+    "cc2.8xlarge": "HVM64",
+};
+
+/**
+ * regionArchLinuxAMI is a map from region to inner maps from architecture to the recommended Linux AMI.
+ */
+export let regionArchLinuxAMI: {
+    [region: string]: { [arch: string]: string; },
+} = {
+    "us-east-1": {
+        "PV64" : "ami-2a69aa47",
+        "HVM64": "ami-6869aa05",
+        "HVMG2": "ami-648d9973",
+    },
+    "us-west-2": {
+        "PV64" : "ami-7f77b31f",
+        "HVM64": "ami-7172b611",
+        "HVMG2": "ami-09cd7a69",
+    },
+    "us-west-1": {
+        "PV64" : "ami-a2490dc2",
+        "HVM64": "ami-31490d51",
+        "HVMG2": "ami-1e5f0e7e",
+    },
+    "eu-west-1": {
+        "PV64" : "ami-4cdd453f",
+        "HVM64": "ami-f9dd458a",
+        "HVMG2": "ami-b4694ac7",
+    },
+    "eu-west-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-886369ec",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "eu-central-1": {
+        "PV64" : "ami-6527cf0a",
+        "HVM64": "ami-ea26ce85",
+        "HVMG2": "ami-de5191b1",
+    },
+    "ap-northeast-1": {
+        "PV64" : "ami-3e42b65f",
+        "HVM64": "ami-374db956",
+        "HVMG2": "ami-df9ff4b8",
+    },
+    "ap-northeast-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-2b408b45",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ap-southeast-1": {
+        "PV64" : "ami-df9e4cbc",
+        "HVM64": "ami-a59b49c6",
+        "HVMG2": "ami-8d8d23ee",
+    },
+    "ap-southeast-2": {
+        "PV64" : "ami-63351d00",
+        "HVM64": "ami-dc361ebf",
+        "HVMG2": "ami-cbaf94a8",
+    },
+    "ap-south-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-ffbdd790",
+        "HVMG2": "ami-decdbab1",
+    },
+    "us-east-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-f6035893",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ca-central-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-730ebd17",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "sa-east-1": {
+        "PV64" : "ami-1ad34676",
+        "HVM64": "ami-6dd04501",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "cn-north-1": {
+        "PV64" : "ami-77559f1a",
+        "HVM64": "ami-8e6aa0e3",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+};
+
+/**
+ * getLinuxAMI gets the recommended Linux AMI for the given instance in the current AWS region.
+ */
+export function getLinuxAMI(instanceType: string): string {
+    let region = aws.config.requireRegion();
+    let arch = instanceTypeArch[instanceType];
+    return regionArchLinuxAMI[region][arch];
+}
+

--- a/examples/webserver/variants/ssh_description/index.ts
+++ b/examples/webserver/variants/ssh_description/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import { getLinuxAMI } from "./linuxAmi";
 
 export let size: aws.ec2.InstanceType = "t2.micro";
 
@@ -15,5 +16,5 @@ let group = new aws.ec2.SecurityGroup("web-secgrp", {
 let server = new aws.ec2.Instance("web-server-www", {
     instanceType: size,
     securityGroups: [ group.name ],
-    ami: aws.ec2.getLinuxAMI(size),
+    ami: getLinuxAMI(size),
 });

--- a/examples/webserver/variants/ssh_description/linuxAmi.ts
+++ b/examples/webserver/variants/ssh_description/linuxAmi.ts
@@ -1,0 +1,162 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+// This file defines some maps that correspond to the recommended AWS Marketplace values:
+//     http://docs.aws.amazon.com/servicecatalog/latest/adminguide/catalogs_marketplace-products.html
+// Ultimately, this lets us choose a recommended Amazon Linux AMI; see:
+//     https://aws.amazon.com/amazon-linux-ami/instance-type-matrix/
+
+import * as aws from "@pulumi/aws";
+
+/**
+ * instanceTypeArch is a map of instance type to its architecture.
+ */
+const instanceTypeArch: {
+    [instanceType: string]: string,
+} = {
+    "t1.micro"   : "PV64" ,
+    "t2.nano"    : "HVM64",
+    "t2.micro"   : "HVM64",
+    "t2.small"   : "HVM64",
+    "t2.medium"  : "HVM64",
+    "t2.large"   : "HVM64",
+    "m1.small"   : "PV64" ,
+    "m1.medium"  : "PV64" ,
+    "m1.large"   : "PV64" ,
+    "m1.xlarge"  : "PV64" ,
+    "m2.xlarge"  : "PV64" ,
+    "m2.2xlarge" : "PV64" ,
+    "m2.4xlarge" : "PV64" ,
+    "m3.medium"  : "HVM64",
+    "m3.large"   : "HVM64",
+    "m3.xlarge"  : "HVM64",
+    "m3.2xlarge" : "HVM64",
+    "m4.large"   : "HVM64",
+    "m4.xlarge"  : "HVM64",
+    "m4.2xlarge" : "HVM64",
+    "m4.4xlarge" : "HVM64",
+    "m4.10xlarge": "HVM64",
+    "c1.medium"  : "PV64" ,
+    "c1.xlarge"  : "PV64" ,
+    "c3.large"   : "HVM64",
+    "c3.xlarge"  : "HVM64",
+    "c3.2xlarge" : "HVM64",
+    "c3.4xlarge" : "HVM64",
+    "c3.8xlarge" : "HVM64",
+    "c4.large"   : "HVM64",
+    "c4.xlarge"  : "HVM64",
+    "c4.2xlarge" : "HVM64",
+    "c4.4xlarge" : "HVM64",
+    "c4.8xlarge" : "HVM64",
+    "g2.2xlarge" : "HVMG2",
+    "g2.8xlarge" : "HVMG2",
+    "r3.large"   : "HVM64",
+    "r3.xlarge"  : "HVM64",
+    "r3.2xlarge" : "HVM64",
+    "r3.4xlarge" : "HVM64",
+    "r3.8xlarge" : "HVM64",
+    "i2.xlarge"  : "HVM64",
+    "i2.2xlarge" : "HVM64",
+    "i2.4xlarge" : "HVM64",
+    "i2.8xlarge" : "HVM64",
+    "d2.xlarge"  : "HVM64",
+    "d2.2xlarge" : "HVM64",
+    "d2.4xlarge" : "HVM64",
+    "d2.8xlarge" : "HVM64",
+    "hi1.4xlarge": "HVM64",
+    "hs1.8xlarge": "HVM64",
+    "cr1.8xlarge": "HVM64",
+    "cc2.8xlarge": "HVM64",
+};
+
+/**
+ * regionArchLinuxAMI is a map from region to inner maps from architecture to the recommended Linux AMI.
+ */
+export let regionArchLinuxAMI: {
+    [region: string]: { [arch: string]: string; },
+} = {
+    "us-east-1": {
+        "PV64" : "ami-2a69aa47",
+        "HVM64": "ami-6869aa05",
+        "HVMG2": "ami-648d9973",
+    },
+    "us-west-2": {
+        "PV64" : "ami-7f77b31f",
+        "HVM64": "ami-7172b611",
+        "HVMG2": "ami-09cd7a69",
+    },
+    "us-west-1": {
+        "PV64" : "ami-a2490dc2",
+        "HVM64": "ami-31490d51",
+        "HVMG2": "ami-1e5f0e7e",
+    },
+    "eu-west-1": {
+        "PV64" : "ami-4cdd453f",
+        "HVM64": "ami-f9dd458a",
+        "HVMG2": "ami-b4694ac7",
+    },
+    "eu-west-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-886369ec",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "eu-central-1": {
+        "PV64" : "ami-6527cf0a",
+        "HVM64": "ami-ea26ce85",
+        "HVMG2": "ami-de5191b1",
+    },
+    "ap-northeast-1": {
+        "PV64" : "ami-3e42b65f",
+        "HVM64": "ami-374db956",
+        "HVMG2": "ami-df9ff4b8",
+    },
+    "ap-northeast-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-2b408b45",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ap-southeast-1": {
+        "PV64" : "ami-df9e4cbc",
+        "HVM64": "ami-a59b49c6",
+        "HVMG2": "ami-8d8d23ee",
+    },
+    "ap-southeast-2": {
+        "PV64" : "ami-63351d00",
+        "HVM64": "ami-dc361ebf",
+        "HVMG2": "ami-cbaf94a8",
+    },
+    "ap-south-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-ffbdd790",
+        "HVMG2": "ami-decdbab1",
+    },
+    "us-east-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-f6035893",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ca-central-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-730ebd17",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "sa-east-1": {
+        "PV64" : "ami-1ad34676",
+        "HVM64": "ami-6dd04501",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "cn-north-1": {
+        "PV64" : "ami-77559f1a",
+        "HVM64": "ami-8e6aa0e3",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+};
+
+/**
+ * getLinuxAMI gets the recommended Linux AMI for the given instance in the current AWS region.
+ */
+export function getLinuxAMI(instanceType: string): string {
+    let region = aws.config.requireRegion();
+    let arch = instanceTypeArch[instanceType];
+    return regionArchLinuxAMI[region][arch];
+}
+

--- a/examples/webserver/variants/zones/index.ts
+++ b/examples/webserver/variants/zones/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import { getLinuxAMI } from "./linuxAmi";
 
 export let size: aws.ec2.InstanceType = "t2.micro";
 
@@ -19,7 +20,7 @@ let group = new aws.ec2.SecurityGroup("web-secgrp", {
             availabilityZone: zones[i],
             instanceType: size,
             securityGroups: [ group.name ],
-            ami: aws.ec2.getLinuxAMI(size),
+            ami: getLinuxAMI(size),
         });
     }
 })();

--- a/examples/webserver/variants/zones/linuxAmi.ts
+++ b/examples/webserver/variants/zones/linuxAmi.ts
@@ -1,0 +1,162 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+// This file defines some maps that correspond to the recommended AWS Marketplace values:
+//     http://docs.aws.amazon.com/servicecatalog/latest/adminguide/catalogs_marketplace-products.html
+// Ultimately, this lets us choose a recommended Amazon Linux AMI; see:
+//     https://aws.amazon.com/amazon-linux-ami/instance-type-matrix/
+
+import * as aws from "@pulumi/aws";
+
+/**
+ * instanceTypeArch is a map of instance type to its architecture.
+ */
+const instanceTypeArch: {
+    [instanceType: string]: string,
+} = {
+    "t1.micro"   : "PV64" ,
+    "t2.nano"    : "HVM64",
+    "t2.micro"   : "HVM64",
+    "t2.small"   : "HVM64",
+    "t2.medium"  : "HVM64",
+    "t2.large"   : "HVM64",
+    "m1.small"   : "PV64" ,
+    "m1.medium"  : "PV64" ,
+    "m1.large"   : "PV64" ,
+    "m1.xlarge"  : "PV64" ,
+    "m2.xlarge"  : "PV64" ,
+    "m2.2xlarge" : "PV64" ,
+    "m2.4xlarge" : "PV64" ,
+    "m3.medium"  : "HVM64",
+    "m3.large"   : "HVM64",
+    "m3.xlarge"  : "HVM64",
+    "m3.2xlarge" : "HVM64",
+    "m4.large"   : "HVM64",
+    "m4.xlarge"  : "HVM64",
+    "m4.2xlarge" : "HVM64",
+    "m4.4xlarge" : "HVM64",
+    "m4.10xlarge": "HVM64",
+    "c1.medium"  : "PV64" ,
+    "c1.xlarge"  : "PV64" ,
+    "c3.large"   : "HVM64",
+    "c3.xlarge"  : "HVM64",
+    "c3.2xlarge" : "HVM64",
+    "c3.4xlarge" : "HVM64",
+    "c3.8xlarge" : "HVM64",
+    "c4.large"   : "HVM64",
+    "c4.xlarge"  : "HVM64",
+    "c4.2xlarge" : "HVM64",
+    "c4.4xlarge" : "HVM64",
+    "c4.8xlarge" : "HVM64",
+    "g2.2xlarge" : "HVMG2",
+    "g2.8xlarge" : "HVMG2",
+    "r3.large"   : "HVM64",
+    "r3.xlarge"  : "HVM64",
+    "r3.2xlarge" : "HVM64",
+    "r3.4xlarge" : "HVM64",
+    "r3.8xlarge" : "HVM64",
+    "i2.xlarge"  : "HVM64",
+    "i2.2xlarge" : "HVM64",
+    "i2.4xlarge" : "HVM64",
+    "i2.8xlarge" : "HVM64",
+    "d2.xlarge"  : "HVM64",
+    "d2.2xlarge" : "HVM64",
+    "d2.4xlarge" : "HVM64",
+    "d2.8xlarge" : "HVM64",
+    "hi1.4xlarge": "HVM64",
+    "hs1.8xlarge": "HVM64",
+    "cr1.8xlarge": "HVM64",
+    "cc2.8xlarge": "HVM64",
+};
+
+/**
+ * regionArchLinuxAMI is a map from region to inner maps from architecture to the recommended Linux AMI.
+ */
+export let regionArchLinuxAMI: {
+    [region: string]: { [arch: string]: string; },
+} = {
+    "us-east-1": {
+        "PV64" : "ami-2a69aa47",
+        "HVM64": "ami-6869aa05",
+        "HVMG2": "ami-648d9973",
+    },
+    "us-west-2": {
+        "PV64" : "ami-7f77b31f",
+        "HVM64": "ami-7172b611",
+        "HVMG2": "ami-09cd7a69",
+    },
+    "us-west-1": {
+        "PV64" : "ami-a2490dc2",
+        "HVM64": "ami-31490d51",
+        "HVMG2": "ami-1e5f0e7e",
+    },
+    "eu-west-1": {
+        "PV64" : "ami-4cdd453f",
+        "HVM64": "ami-f9dd458a",
+        "HVMG2": "ami-b4694ac7",
+    },
+    "eu-west-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-886369ec",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "eu-central-1": {
+        "PV64" : "ami-6527cf0a",
+        "HVM64": "ami-ea26ce85",
+        "HVMG2": "ami-de5191b1",
+    },
+    "ap-northeast-1": {
+        "PV64" : "ami-3e42b65f",
+        "HVM64": "ami-374db956",
+        "HVMG2": "ami-df9ff4b8",
+    },
+    "ap-northeast-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-2b408b45",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ap-southeast-1": {
+        "PV64" : "ami-df9e4cbc",
+        "HVM64": "ami-a59b49c6",
+        "HVMG2": "ami-8d8d23ee",
+    },
+    "ap-southeast-2": {
+        "PV64" : "ami-63351d00",
+        "HVM64": "ami-dc361ebf",
+        "HVMG2": "ami-cbaf94a8",
+    },
+    "ap-south-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-ffbdd790",
+        "HVMG2": "ami-decdbab1",
+    },
+    "us-east-2": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-f6035893",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "ca-central-1": {
+        "PV64" : "NOT_SUPPORTED",
+        "HVM64": "ami-730ebd17",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "sa-east-1": {
+        "PV64" : "ami-1ad34676",
+        "HVM64": "ami-6dd04501",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+    "cn-north-1": {
+        "PV64" : "ami-77559f1a",
+        "HVM64": "ami-8e6aa0e3",
+        "HVMG2": "NOT_SUPPORTED",
+    },
+};
+
+/**
+ * getLinuxAMI gets the recommended Linux AMI for the given instance in the current AWS region.
+ */
+export function getLinuxAMI(instanceType: string): string {
+    let region = aws.config.requireRegion();
+    let arch = instanceTypeArch[instanceType];
+    return regionArchLinuxAMI[region][arch];
+}
+

--- a/overlays/ecs/container.ts
+++ b/overlays/ecs/container.ts
@@ -1,0 +1,118 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+// This file defines interfaces that match the structure of ECS Container definitions used in task definitions to
+// describe the different containers that are launched as part of a task.
+
+// See http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html
+export interface ContainerDefinition {
+    command?: string[];
+    cpu?: number;
+    disableNetworking?: boolean;
+    dnsSearchDomains?: string[];
+    dnsServers?: string[];
+    dockerLabels?: { [label: string]: string };
+    dockerSecurityOptions?: string[];
+    entryPoint?: string[];
+    environment?: KeyValuePair[];
+    essential?: boolean;
+    extraHosts?: HostEntry[];
+    hostname?: string;
+    image?: string;
+    links?: string[];
+    linuxParameters?: LinuxParameters;
+    logConfiguration?: LogConfiguration;
+    memory?: number;
+    memoryReservation?: number;
+    mountPoints?: MountPoint[];
+    name: string;
+    portMappings?: PortMapping[];
+    privileged?: boolean;
+    readonlyRootFilesystem?: boolean;
+    ulimits?: Ulimit[];
+    user?: string;
+    volumesFrom?: VolumeFrom[];
+    workingDirectory?: string;
+}
+
+// https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KeyValuePair.html
+export interface KeyValuePair {
+    name: string;
+    value: string;
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HostEntry.html
+export interface HostEntry {
+    hostname: string;
+    ipAddress: string;
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html
+export interface LinuxParameters {
+    capabilities?: KernelCapabilities;
+    devices?: Device[];
+    initProcessEnabled?: boolean;
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html
+export interface KernelCapabilities {
+    add?: KernelCapability[];
+    drop?: KernelCapability[];
+}
+
+// See http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html
+export type KernelCapability = "ALL" | "AUDIT_CONTROL" | "AUDIT_WRITE" | "BLOCK_SUSPEND" | "CHOWN" | "DAC_OVERRIDE" |
+    "DAC_READ_SEARCH" | "FOWNER" | "FSETID" | "IPC_LOCK" | "IPC_OWNER" | "KILL" | "LEASE" | "LINUX_IMMUTABLE" |
+    "MAC_ADMIN" | "MAC_OVERRIDE" | "MKNOD" | "NET_ADMIN" | "NET_BIND_SERVICE" | "NET_BROADCAST" | "NET_RAW" |
+    "SETFCAP" | "SETGID" | "SETPCAP" | "SETUID" | "SYS_ADMIN" | "SYS_BOOT" | "SYS_CHROOT" | "SYS_MODULE" |
+    "SYS_NICE" | "SYS_PACCT" | "SYS_PTRACE" | "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME" | "SYS_TTY_CONFIG" |
+    "SYSLOG" | "WAKE_ALARM";
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Device.html
+export interface Device {
+    containerPath?: string;
+    hostPath: string;
+    permissions?: string[];
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
+export interface LogConfiguration {
+    logDriver:  LogDriver;
+    options?: { [key: string]: string };
+}
+
+// See `logdriver` at http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
+export type LogDriver = "json-file" | "syslog" | "journald" | "gelf" | "fluentd" | "awslogs" | "splunk";
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_MountPoint.html
+export interface MountPoint {
+    containerPath?: string;
+    readOnly?: boolean;
+    sourceVolume?: string
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html
+export interface PortMapping {
+    containerPort?: number;
+    hostPort?: number;
+    protocol?: Protocol;
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html
+export type Protocol = "tcp" | "udp";
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html
+export interface Ulimit {
+    name: UlimitName;
+    hardLimit: number;
+    softLimit: number;
+}
+
+// See http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html
+export type UlimitName = "core" | "cpu" | "data" | "fsize" | "locks" | "memlock" | "msgqueue" | "nice" |
+    "nofile" | "nproc" | "rss" | "rtprio" | "rttime" | "sigpending" | "stack";
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_VolumeFrom.html
+export interface VolumeFrom {
+    sourceContainer?: string;
+    readOnly?: boolean
+}

--- a/overlays/lambda/runtimes.ts
+++ b/overlays/lambda/runtimes.ts
@@ -5,18 +5,23 @@
  */
 export type Runtime =
     "dotnetcore1.0"  |
+    "dotnetcore2.0"  |
+    "go1.x"          |
     "java8"          |
     "nodejs4.3-edge" |
     "nodejs4.3"      |
     "nodejs6.10"     |
     "nodejs"         |
-    "python2.7"      ;
+    "python2.7"      |
+    "python3.6"      ;
 
 export let DotnetCore1d0Runtime: Runtime = "dotnetcore1.0";
+export let DotnetCore2d0Runtime: Runtime = "dotnetcore2.0";
+export let Go1dxRuntime: Runtime = "go1.x";
 export let Java8Runtime: Runtime = "java8";
 export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";
 export let NodeJS4d3Runtime: Runtime = "nodejs4.3";
 export let NodeJS6d10Runtime: Runtime = "nodejs6.10";
 export let NodeJSRuntime: Runtime = "nodejs";
 export let Python2d7Runtime: Runtime = "python2.7";
-
+export let Python3d6Runtime: Runtime = "python3.6";

--- a/resources.go
+++ b/resources.go
@@ -1253,8 +1253,12 @@ func Provider() tfbridge.ProviderInfo {
 				},
 				"ec2": {
 					Files: []string{
-						"instanceMaps.ts", // getLinuxAMI helper for looking up AMIs
 						"instanceType.ts", // InstanceType union type and constants
+					},
+				},
+				"ecs": {
+					Files: []string{
+						"container.ts", // Container definition JSON schema
 					},
 				},
 				"iam": {


### PR DESCRIPTION
Also update Lambda runtime enum, and remove `getLinuxAMI` from API surface and move into examples.