### PR TITLE
Upgrade the version of tfgen we use

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -492,7 +492,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "96d4cca4c8e93fb95a549f006505519388128eda"
+  revision = "890673131553214bdfd38373437cfaa1427b4958"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-terraform"
@@ -500,7 +500,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "6c3ee3e2a025764c50871b17d6bc622665902361"
+  revision = "a55696036de63ad74fed271ee7fcfa1a4adc00cb"
 
 [[projects]]
   branch = "master"
@@ -693,6 +693,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9347292bcc61f41afc220f7f685db28ac822eae37b2996004852eb7c3211a133"
+  inputs-digest = "9970dd56a3f248ca5e17bf1e334ea7c1dcb00e17c4312cc5f1d84d228f7f5abe"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,10 +1,10 @@
 [[override]]
   name = "github.com/pulumi/pulumi"
-  revision = "96d4cca4c8e93fb95a549f006505519388128eda"
+  revision = "890673131553214bdfd38373437cfaa1427b4958"
 
 [[override]]
   name = "github.com/pulumi/pulumi-terraform"
-  revision = "6c3ee3e2a025764c50871b17d6bc622665902361"
+  revision = "a55696036de63ad74fed271ee7fcfa1a4adc00cb"
 
 [[override]]
   name = "github.com/hashicorp/terraform"

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -25,7 +25,7 @@ func TestExamples(t *testing.T) {
 	// base options shared amongst all tests.
 	base := integration.ProgramTestOptions{
 		Config: map[string]string{
-			"aws:config:region": region,
+			"aws:region": region,
 		},
 		Dependencies: []string{
 			"@pulumi/pulumi",

--- a/examples/webserver-py/Pulumi.yaml
+++ b/examples/webserver-py/Pulumi.yaml
@@ -4,4 +4,4 @@ description: Basic example of an AWS web server accessible over HTTP (in Python!
 stacks:
   test-stack:
     config:
-      aws:config:region: us-west-2
+      aws:region: us-west-2

--- a/resources.go
+++ b/resources.go
@@ -1287,7 +1287,7 @@ func Provider() tfbridge.ProviderInfo {
 				"@types/node": "^8.0.25", // so we can access strongly typed node definitions.
 			},
 			PeerDependencies: map[string]string{
-				"@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+				"@pulumi/pulumi": "^0.11.0-dev-163-g89067313",
 			},
 		},
 	}


### PR DESCRIPTION
Pick up pulumi/pulumi-terraform@a556960 to get the codegen changes for
the configuration bag.  Our files now do `new Config("aws")` instead
of `new Config("aws:config")` with this change.

Also pull in a newer version of pulumi that understands the new shape
of the world.