### PR TITLE
Add Pulumi.*.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /pack/
 /vendor/
 .pulumi
+Pulumi.*.yaml

--- a/examples/webserver/Pulumi.yaml
+++ b/examples/webserver/Pulumi.yaml
@@ -1,4 +1,3 @@
 name: webserver
-description: Basic example of an AWS web server accessible over HTTP.
 runtime: nodejs
-
+description: Basic example of an AWS web server accessible over HTTP.


### PR DESCRIPTION
In this repo, these files are always development stacks (we have no long-lived stacks for the examples here).