### PR TITLE
Publishing Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,19 @@ install::
 test_all::
 	PATH=$(PULUMI_BIN):$(PATH) go test -v -cover -timeout 1h -parallel ${TESTPARALLELISM} ./examples
 
-.PHONY: publish
-publish:
+.PHONY: publish_tgz
+publish_tgz:
 	$(call STEP_MESSAGE)
-	./scripts/publish.sh
+	./scripts/publish_tgz.sh
+
+.PHONY: publish_packages
+publish_packages:
+	$(call STEP_MESSAGE)
+	./scripts/publish_packages.sh
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
-travis_push: only_build publish only_test
+travis_push: only_build publish_tgz only_test publish_packages
 travis_pull_request: all
 travis_api: all

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -1,43 +1,7 @@
 #!/bin/bash
-# publish.sh builds and publishes a release.
+# publish_packages.sh uploads our packages to package repositories like npm
 set -o nounset -o errexit -o pipefail
-
 ROOT=$(dirname $0)/..
-PUBLISH=$GOPATH/src/github.com/pulumi/home/scripts/publish.sh
-PUBLISH_GOOS=("linux" "windows" "darwin")
-PUBLISH_GOARCH=("amd64")
-PUBLISH_PROJECT="pulumi-aws"
-
-if [ ! -f $PUBLISH ]; then
-    >&2 echo "error: Missing publish script at $PUBLISH"
-    exit 1
-fi
-
-echo "Publishing SDK build to s3://eng.pulumi.com/:"
-for OS in "${PUBLISH_GOOS[@]}"
-do
-    for ARCH in "${PUBLISH_GOARCH[@]}"
-    do
-        export GOOS=${OS}
-        export GOARCH=${ARCH}
-
-        RELEASE_INFO=($($(dirname $0)/make_release.sh))
-        ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
-    done
-done
-
-echo "Publishing Plugin archive to s3://rel.pulumi.com/:"
-for OS in "${PUBLISH_GOOS[@]}"
-do
-    for ARCH in "${PUBLISH_GOARCH[@]}"
-    do
-        export GOOS=${OS}
-        export GOARCH=${ARCH}
-
-        ${ROOT}/scripts/publish-plugin.sh
-    done
-done
-
 if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     # Publish the NPM package.
     echo "Publishing NPM package to NPMjs.com:"
@@ -52,8 +16,17 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     mv package.json package.json.dev
     mv package.json.publish package.json
 
+    NPM_TAG="dev"
+
+    # If the package doesn't have a pre-release tag, use the tag of latest instead of
+    # dev. NPM uses this tag as the default version to add, so we want it to mean
+    # the newest released version.
+    if [[ $(jq -r .version < package.json) != *-* ]]; then
+        NPM_TAG="latest"
+    fi
+
     # Now, perform the publish.
-    npm publish
+    npm publish -tag ${NPM_TAG}
     npm info 2>/dev/null
 
     # And finally restore the original package.json.

--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# publish_tgz.sh builds and publishes the tarballs that our other repositories consume.
+set -o nounset -o errexit -o pipefail
+
+ROOT=$(dirname $0)/..
+PUBLISH=$GOPATH/src/github.com/pulumi/home/scripts/publish.sh
+PUBLISH_GOOS=("linux" "windows" "darwin")
+PUBLISH_GOARCH=("amd64")
+PUBLISH_PROJECT="pulumi-aws"
+
+if [ ! -f $PUBLISH ]; then
+    >&2 echo "error: Missing publish script at $PUBLISH"
+    exit 1
+fi
+
+echo "Publishing SDK build to s3://eng.pulumi.com/:"
+for OS in "${PUBLISH_GOOS[@]}"
+do
+    for ARCH in "${PUBLISH_GOARCH[@]}"
+    do
+        export GOOS=${OS}
+        export GOARCH=${ARCH}
+
+        RELEASE_INFO=($($(dirname $0)/make_release.sh))
+        ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
+    done
+done
+
+echo "Publishing Plugin archive to s3://rel.pulumi.com/:"
+for OS in "${PUBLISH_GOOS[@]}"
+do
+    for ARCH in "${PUBLISH_GOARCH[@]}"
+    do
+        export GOOS=${OS}
+        export GOARCH=${ARCH}
+
+        ${ROOT}/scripts/publish-plugin.sh
+    done
+done


### PR DESCRIPTION
1. Don't publish NPM and PyPI packages until after the tests have
passed. This means we won't publish untested packages and when tests
fail we can re-try the Travis job if we'd like, without NPM erroring
out because a package has already been published.

2. Adopt the changes in pulumi/pulumi to not tag pre-release builds
with the "latest" tag on NPM.