### PR TITLE
Ensure install script is added before publishing

### DIFF
--- a/scripts/promote.js
+++ b/scripts/promote.js
@@ -1,0 +1,44 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program simply reads a package.json from stdin, takes a set of arguments representing
+// package names, and for each one, promotes that package from a peerDependency to a real dependency.
+
+// Read the package.json from stdin.
+let packageJSONText = "";
+const readline = require("readline");
+const stdin = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+});
+stdin.on("line", function(line) {
+    packageJSONText += `${line}\n`;
+});
+stdin.on("close", function() {
+    // All stdin is available. Add our install script.
+    const packageJSON = JSON.parse(packageJSONText);
+
+    if (!packageJSON.scripts) {
+        packageJSON.scripts = {};
+    }
+    var name = packageJSON.name;
+    if (name.lastIndexOf("/") !== -1) {
+        name = name.substring(name.lastIndexOf("/")+1);
+    }
+    packageJSON.scripts["install"] = `pulumi plugin install resource ${name} ${packageJSON.version}`;
+
+    // Now print out the result to stdout.
+    console.log(JSON.stringify(packageJSON, null, 4));
+});

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -5,7 +5,14 @@ ROOT=$(dirname $0)/..
 if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     # Publish the NPM package.
     echo "Publishing NPM package to NPMjs.com:"
+
+    # First, add an install script to our package.json
+    node $(dirname $0)/promote.js < \
+        ${ROOT}/pack/nodejs/bin/package.json > \
+        ${ROOT}/pack/nodejs/bin/package.json.publish
     pushd ${ROOT}/pack/nodejs/bin
+    mv package.json package.json.dev
+    mv package.json.publish package.json
 
     NPM_TAG="dev"
 
@@ -19,6 +26,10 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     # Now, perform the publish.
     npm publish -tag ${NPM_TAG}
     npm info 2>/dev/null
+
+    # And finally restore the original package.json.
+    mv package.json package.json.publish
+    mv package.json.dev package.json
     popd
 
     # Next, publish the PyPI package.


### PR DESCRIPTION
In #226 we removed calling promote.js when publishing, as we no longer
used peerDependencies for `@pulumi/pulumi`. However, that script was
also responsible for adding an install script to the package.json so
when installed, we would call `pulumi plugin install`. We need to
retain this behavior until we stop using tfgen to generate the
package.json and can add it by hand (or if we decide we want to
continue to use tfgen to write the package.json file, fix tfgen to do
add the install script).

Fixes #229