### PR TITLE
Expose the `publish` property on aws.serverless.Function

### DIFF
--- a/examples/serverless/index.ts
+++ b/examples/serverless/index.ts
@@ -56,6 +56,7 @@ function getContentType() {
 }
 const testFunc = new aws.serverless.Function("f", {
   policies: [aws.iam.AWSLambdaFullAccess],
+  publish: true,
   includePaths: ['./Pulumi.yaml'],
   includePackages: ['body-parser'],
 }, async (ev, ctx, cb) => {
@@ -70,3 +71,4 @@ const testFunc = new aws.serverless.Function("f", {
 });
 
 exports.functionARN = testFunc.lambda.arn;
+exports.qualifiedFunctionARN = testFunc.lambda.qualifiedArn;

--- a/overlays/nodejs/serverless/function.ts
+++ b/overlays/nodejs/serverless/function.ts
@@ -73,6 +73,10 @@ export interface FunctionOptions {
      */
     runtime?: lambda.Runtime;
     /**
+     * Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
+     */
+    publish?: pulumi.Input<boolean>;
+    /**
      * A dead letter target ARN to send function invocation failures to.
      */
     deadLetterConfig?: { targetArn: pulumi.Input<string>; };
@@ -166,6 +170,7 @@ export class Function extends pulumi.ComponentResource {
             memorySize: options.memorySize,
             deadLetterConfig: options.deadLetterConfig,
             vpcConfig: options.vpcConfig,
+            publish: options.publish,
         }, { parent: this });
     }
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/aws",
-    "version": "v0.14.0-dev-1528665069-gb49752a-dirty",
+    "version": "v0.14.0-dev-1528729003-gc537668-dirty",
     "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
     "keywords": [
         "pulumi",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/aws",
-    "version": "v0.14.0-dev-1528729003-gc537668-dirty",
+    "version": "v0.14.0-dev-1528749571-g41810f6-dirty",
     "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
     "keywords": [
         "pulumi",

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -73,6 +73,10 @@ export interface FunctionOptions {
      */
     runtime?: lambda.Runtime;
     /**
+     * Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
+     */
+    publish?: pulumi.Input<boolean>;
+    /**
      * A dead letter target ARN to send function invocation failures to.
      */
     deadLetterConfig?: { targetArn: pulumi.Input<string>; };
@@ -166,6 +170,7 @@ export class Function extends pulumi.ComponentResource {
             memorySize: options.memorySize,
             deadLetterConfig: options.deadLetterConfig,
             vpcConfig: options.vpcConfig,
+            publish: options.publish,
         }, { parent: this });
     }
 }

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -8,10 +8,10 @@ from subprocess import check_call
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
-        check_call(['pulumi', 'plugin', 'install', 'resource', 'aws', 'v0.14.0-dev-1528729003-gc537668-dirty'])
+        check_call(['pulumi', 'plugin', 'install', 'resource', 'aws', 'v0.14.0-dev-1528749571-g41810f6-dirty'])
 
 setup(name='pulumi_aws',
-      version='0.14.0.dev1528729003+gc537668.dirty',
+      version='0.14.0.dev1528749571+g41810f6.dirty',
       description='A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.',
       cmdclass={
           'install': InstallPluginCommand,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -8,10 +8,10 @@ from subprocess import check_call
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
-        check_call(['pulumi', 'plugin', 'install', 'resource', 'aws', 'v0.14.0-dev-1528665069-gb49752a-dirty'])
+        check_call(['pulumi', 'plugin', 'install', 'resource', 'aws', 'v0.14.0-dev-1528729003-gc537668-dirty'])
 
 setup(name='pulumi_aws',
-      version='0.14.0.dev1528665069+gb49752a.dirty',
+      version='0.14.0.dev1528729003+gc537668.dirty',
       description='A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.',
       cmdclass={
           'install': InstallPluginCommand,


### PR DESCRIPTION
Workaround for the issue in https://github.com/pulumi/pulumi-aws-serverless/issues/9.  Longer term we should just support all `aws.lambda.FunctionArgs` inputs here.