### PR TITLE
Don't generate fixed versions in files we check in

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -585,7 +585,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "afd57da2ae436bc8b3c9a5827d96c9e2126b7e9b"
+  revision = "c02e0d03adf5055d6eaa1e5d05e50ae3b58c7946"
 
 [[projects]]
   branch = "master"
@@ -867,6 +867,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5b2e2da817476fcd5b80c2b61d10ea81bf54df010e23a258148577916213b982"
+  inputs-digest = "4e3e18b71a110219b0c9415e3b3a1cee00ee1768dcd85ab122d296050b3b25f3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[override]]
   name = "github.com/pulumi/pulumi-terraform"
-  revision = "afd57da2ae436bc8b3c9a5827d96c9e2126b7e9b"
+  revision = "c02e0d03adf5055d6eaa1e5d05e50ae3b58c7946"
 
 [[override]]
   name = "github.com/terraform-providers/terraform-provider-aws"

--- a/scripts/get-py-version
+++ b/scripts/get-py-version
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NPM_VERSION="$($SCRIPT_ROOT/get-version "$@")"
+
+go run "${SCRIPT_ROOT}/get-py-version.go" "${NPM_VERSION}"

--- a/scripts/get-py-version.go
+++ b/scripts/get-py-version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/util/buildutil"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "error: need exactly one argument\n")
+		os.Exit(-1)
+	}
+
+	p, err := buildutil.PyPiVersionFromNpmVersion(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(-1)
+	}
+
+	fmt.Println(p)
+}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/aws",
-    "version": "v0.14.0-dev-1528757330-gfa4bee3-dirty",
+    "version": "${VERSION}",
     "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
     "keywords": [
         "pulumi",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -8,10 +8,10 @@ from subprocess import check_call
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
-        check_call(['pulumi', 'plugin', 'install', 'resource', 'aws', 'v0.14.0-dev-1528757330-gfa4bee3-dirty'])
+        check_call(['pulumi', 'plugin', 'install', 'resource', 'aws', '${PLUGIN_VERSION}'])
 
 setup(name='pulumi_aws',
-      version='0.14.0.dev1528757330+dirty',
+      version='${VERSION}',
       description='A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.',
       cmdclass={
           'install': InstallPluginCommand,


### PR DESCRIPTION
Adopt a newer version of pulumi-terraform that does include version
information in the generated `package.json` and `setup.py` files and
deal with the fallout (i.e. start doing the template replacement at
build time when generating the directories we are going to publish).