### PR TITLE
Add autoscaling NotificationType union and overlay

### DIFF
--- a/overlays/nodejs/autoscaling/notificationType.ts
+++ b/overlays/nodejs/autoscaling/notificationType.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains two categories of exports:
+//
+//     1) A union type, NotificationType, that accepts any valid AutoScaling Notification type
+//     2) Individual constants for each such AutoScaling Notification type
+//
+// These give a better developer experience and are just sugared strings.
+
+export let InstanceLaunchNotification:         NotificationType = "autoscaling:EC2_INSTANCE_LAUNCH";
+export let InstanceTerminateNotification:      NotificationType = "autoscaling:EC2_INSTANCE_TERMINATE";
+export let InstanceLaunchErrorNotification:    NotificationType = "autoscaling:EC2_INSTANCE_LAUNCH_ERROR";
+export let InstanceTerminateErrorNotification: NotificationType = "autoscaling:EC2_INSTANCE_TERMINATE_ERROR";
+export let TestNotification:                   NotificationType = "autoscaling:TEST_NOTIFICATION";
+
+// See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_NotificationConfiguration.html
+export type NotificationType =
+    "autoscaling:EC2_INSTANCE_LAUNCH" |
+    "autoscaling:EC2_INSTANCE_TERMINATE" |
+    "autoscaling:EC2_INSTANCE_LAUNCH_ERROR" |
+    "autoscaling:EC2_INSTANCE_TERMINATE_ERROR" |
+    "autoscaling:TEST_NOTIFICATION"

--- a/resources.go
+++ b/resources.go
@@ -383,9 +383,16 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "autoscaling_lifecycle_hooks.html.markdown",
 				},
 			},
-			"aws_autoscaling_notification": {Tok: awsResource(autoscalingMod, "Notification")},
-			"aws_autoscaling_policy":       {Tok: awsResource(autoscalingMod, "Policy")},
-			"aws_autoscaling_schedule":     {Tok: awsResource(autoscalingMod, "Schedule")},
+			"aws_autoscaling_notification": {
+				Tok: awsResource(autoscalingMod, "Notification"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"notifications": {
+						Elem: &tfbridge.SchemaInfo{Type: awsType(autoscalingMod+"/notificationType", "NotificationType")},
+					},
+				},
+			},
+			"aws_autoscaling_policy":   {Tok: awsResource(autoscalingMod, "Policy")},
+			"aws_autoscaling_schedule": {Tok: awsResource(autoscalingMod, "Schedule")},
 			// Batch
 			"aws_batch_compute_environment": {Tok: awsResource(batchMod, "ComputeEnvironment")},
 			"aws_batch_job_definition":      {Tok: awsResource(batchMod, "JobDefinition")},
@@ -1446,6 +1453,11 @@ func Provider() tfbridge.ProviderInfo {
 					"region.ts", // Region union type and constants
 				},
 				Modules: map[string]*tfbridge.OverlayInfo{
+					"autoscaling": {
+						Files: []string{
+							"notificationType.ts", // NotificationType union type and constants
+						},
+					},
 					"config": {
 						Files: []string{
 							"require.ts", // requireRegion helpers for validating proper config

--- a/sdk/nodejs/autoscaling/index.ts
+++ b/sdk/nodejs/autoscaling/index.ts
@@ -6,5 +6,6 @@ export * from "./attachment";
 export * from "./group";
 export * from "./lifecycleHook";
 export * from "./notification";
+export * from "./notificationType";
 export * from "./policy";
 export * from "./schedule";

--- a/sdk/nodejs/autoscaling/notification.ts
+++ b/sdk/nodejs/autoscaling/notification.ts
@@ -3,6 +3,8 @@
 
 import * as pulumi from "@pulumi/pulumi";
 
+import {NotificationType} from "./notificationType";
+
 /**
  * Provides an AutoScaling Group with Notification support, via SNS Topics. Each of
  * the `notifications` map to a [Notification Configuration][2] inside Amazon Web
@@ -29,7 +31,7 @@ export class Notification extends pulumi.CustomResource {
      * A list of Notification Types that trigger
      * notifications. Acceptable values are documented [in the AWS documentation here][1]
      */
-    public readonly notifications: pulumi.Output<string[]>;
+    public readonly notifications: pulumi.Output<NotificationType[]>;
     /**
      * The Topic ARN for notifications to be sent through
      */
@@ -81,7 +83,7 @@ export interface NotificationState {
      * A list of Notification Types that trigger
      * notifications. Acceptable values are documented [in the AWS documentation here][1]
      */
-    readonly notifications?: pulumi.Input<pulumi.Input<string>[]>;
+    readonly notifications?: pulumi.Input<pulumi.Input<NotificationType>[]>;
     /**
      * The Topic ARN for notifications to be sent through
      */
@@ -100,7 +102,7 @@ export interface NotificationArgs {
      * A list of Notification Types that trigger
      * notifications. Acceptable values are documented [in the AWS documentation here][1]
      */
-    readonly notifications: pulumi.Input<pulumi.Input<string>[]>;
+    readonly notifications: pulumi.Input<pulumi.Input<NotificationType>[]>;
     /**
      * The Topic ARN for notifications to be sent through
      */

--- a/sdk/nodejs/autoscaling/notificationType.ts
+++ b/sdk/nodejs/autoscaling/notificationType.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains two categories of exports:
+//
+//     1) A union type, NotificationType, that accepts any valid AutoScaling Notification type
+//     2) Individual constants for each such AutoScaling Notification type
+//
+// These give a better developer experience and are just sugared strings.
+
+export let InstanceLaunchNotification:         NotificationType = "autoscaling:EC2_INSTANCE_LAUNCH";
+export let InstanceTerminateNotification:      NotificationType = "autoscaling:EC2_INSTANCE_TERMINATE";
+export let InstanceLaunchErrorNotification:    NotificationType = "autoscaling:EC2_INSTANCE_LAUNCH_ERROR";
+export let InstanceTerminateErrorNotification: NotificationType = "autoscaling:EC2_INSTANCE_TERMINATE_ERROR";
+export let TestNotification:                   NotificationType = "autoscaling:TEST_NOTIFICATION";
+
+// See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_NotificationConfiguration.html
+export type NotificationType =
+    "autoscaling:EC2_INSTANCE_LAUNCH" |
+    "autoscaling:EC2_INSTANCE_TERMINATE" |
+    "autoscaling:EC2_INSTANCE_LAUNCH_ERROR" |
+    "autoscaling:EC2_INSTANCE_TERMINATE_ERROR" |
+    "autoscaling:TEST_NOTIFICATION"

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -66,6 +66,7 @@
         "autoscaling/index.ts",
         "autoscaling/lifecycleHook.ts",
         "autoscaling/notification.ts",
+        "autoscaling/notificationType.ts",
         "autoscaling/policy.ts",
         "autoscaling/schedule.ts",
         "batch/computeEnvironment.ts",


### PR DESCRIPTION
This pull request adds a new overlay for nodejs, defining a union type of valid Autoscaling Notification Types, and overrides the `notifications` property of the aws.autoscaling.Notification type to accept an array of these instead of raw strings.

Some outstanding questions:

- [x] What copyright should go on the new file
- [x] Is there work here to be done for other SDKs? Currently only Node appears to have overlays

I've opened the pull request early in order to take advantage of the properly configured Travis CI building for PRs, and don't anticipate this will be ready to merge without further work.