### PR TITLE
Add `environment` to `aws.serverless.Function`

### DIFF
--- a/overlays/nodejs/serverless/function.ts
+++ b/overlays/nodejs/serverless/function.ts
@@ -84,6 +84,10 @@ export interface FunctionOptions {
         subnetIds: pulumi.Input<string[]>,
     };
     /**
+     * The Lambda environment's configuration settings.
+     */
+    environment?: pulumi.Input<{ variables?: pulumi.Input<{[key: string]: pulumi.Input<string>}> }>;
+    /**
      * The paths relative to the program folder to include in the Lambda upload.  Default is `[]`.
      */
     includePaths?: string[];
@@ -169,6 +173,7 @@ export class Function extends pulumi.ComponentResource {
             code: new pulumi.asset.AssetArchive(codePaths),
             handler: serializedFileName + "." + handlerName,
             runtime: options.runtime || lambda.NodeJS8d10Runtime,
+            environment: options.environment,
             role: this.role.arn,
             timeout: options.timeout === undefined ? 180 : options.timeout,
             memorySize: options.memorySize,

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -84,6 +84,10 @@ export interface FunctionOptions {
         subnetIds: pulumi.Input<string[]>,
     };
     /**
+     * The Lambda environment's configuration settings.
+     */
+    environment?: pulumi.Input<{ variables?: pulumi.Input<{[key: string]: pulumi.Input<string>}> }>;
+    /**
      * The paths relative to the program folder to include in the Lambda upload.  Default is `[]`.
      */
     includePaths?: string[];
@@ -169,6 +173,7 @@ export class Function extends pulumi.ComponentResource {
             code: new pulumi.asset.AssetArchive(codePaths),
             handler: serializedFileName + "." + handlerName,
             runtime: options.runtime || lambda.NodeJS8d10Runtime,
+            environment: options.environment,
             role: this.role.arn,
             timeout: options.timeout === undefined ? 180 : options.timeout,
             memorySize: options.memorySize,


### PR DESCRIPTION
This is targeted fix to add an environment variable map to the `aws.serverless.Function` type, as an interim step to allowing it to configure all facets of a Lambda function.