### PR TITLE
Fix detection of org-scoped packages

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -3,6 +3,7 @@
 package examples
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -88,7 +89,10 @@ func TestExamples(t *testing.T) {
 					if !assert.NoError(t, err) {
 						return
 					}
-					assert.Nil(t, out.FunctionError)
+
+					if !assert.Nil(t, out.FunctionError) {
+						fmt.Printf("Function error: %s\n", *out.FunctionError)
+					}
 				},
 			}),
 			// Python tests:

--- a/examples/serverless/index.ts
+++ b/examples/serverless/index.ts
@@ -62,6 +62,7 @@ const testFunc = new aws.serverless.Function("f", {
   var aws = await import('aws-sdk');
   var express = await import('express');
   var os = require('os');
+  var slack = require('@slack/client');
   // TODO[pulumi/pulumi#463] Its reasonable to expect that `./other` would work here, but it currently does not.  For
   // now, validate that the approach that does currently work will serialize the dependencies correctly.
   var answer = require('./bin/other').answer;

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^0.14.0-rc1",
+        "@slack/client": "^4.3.1",
         "aws-sdk": "^2.252.1"
     },
     "devDependencies": {

--- a/examples/serverless/yarn.lock
+++ b/examples/serverless/yarn.lock
@@ -57,6 +57,43 @@
     source-map-support "^0.4.16"
     typescript "^2.5.2"
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
+"@slack/client@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@slack/client/-/client-4.3.1.tgz#5caa1eaf753e4fcd23d8c04bcdc215336867a233"
+  dependencies:
+    "@types/delay" "^2.0.1"
+    "@types/form-data" "^2.2.1"
+    "@types/got" "^7.1.7"
+    "@types/is-stream" "^1.1.0"
+    "@types/loglevel" "^1.5.3"
+    "@types/node" "^9.4.7"
+    "@types/p-cancelable" "^0.3.0"
+    "@types/p-queue" "^2.3.1"
+    "@types/p-retry" "^1.0.1"
+    "@types/retry" "^0.10.2"
+    "@types/url-join" "^0.8.2"
+    "@types/ws" "^5.1.1"
+    delay "^2.0.0"
+    eventemitter3 "^3.0.0"
+    finity "^0.5.4"
+    form-data "^2.3.1"
+    got "^8.0.3"
+    is-stream "^1.1.0"
+    loglevel "^1.6.1"
+    object.entries "^1.0.4"
+    object.getownpropertydescriptors "^2.0.3"
+    object.values "^1.0.4"
+    p-cancelable "^0.3.0"
+    p-queue "^2.3.0"
+    p-retry "^1.0.0"
+    retry "^0.10.1"
+    url-join "^4.0.0"
+    ws "^5.2.0"
+
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
@@ -69,6 +106,10 @@
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
   dependencies:
     "@types/node" "*"
+
+"@types/delay@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/delay/-/delay-2.0.1.tgz#61bcf318a74b61e79d1658fbf054f984c90ef901"
 
 "@types/events@*":
   version "1.2.0"
@@ -90,6 +131,28 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/form-data@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
+  dependencies:
+    "@types/node" "*"
+
+"@types/got@^7.1.7":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@types/got/-/got-7.1.8.tgz#c5f421b25770689bf8948b1241f710d71a00d7dd"
+  dependencies:
+    "@types/node" "*"
+
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  dependencies:
+    "@types/node" "*"
+
+"@types/loglevel@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@types/loglevel/-/loglevel-1.5.3.tgz#adfce55383edc5998a2170ad581b3e23d6adb5b8"
+
 "@types/long@^3.0.32":
   version "3.0.32"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
@@ -110,9 +173,31 @@
   version "8.10.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.18.tgz#eb9ad8b0723d13fa9bc8b42543e3661ed805f2bb"
 
+"@types/node@^9.4.7":
+  version "9.6.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.22.tgz#05b55093faaadedea7a4b3f76e9a61346a6dd209"
+
+"@types/p-cancelable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/p-cancelable/-/p-cancelable-0.3.0.tgz#3e4fcc54a3dfd81d0f5b93546bb68d0df50553bb"
+
+"@types/p-queue@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.1.tgz#2fb251e46e884e31c4bd1bf58f0e188972353ff4"
+
+"@types/p-retry@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/p-retry/-/p-retry-1.0.1.tgz#2302bc3da425014208c8a9b68293d37325124785"
+  dependencies:
+    "@types/retry" "*"
+
 "@types/range-parser@*":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
+
+"@types/retry@*", "@types/retry@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.10.2.tgz#bd1740c4ad51966609b058803ee6874577848b37"
 
 "@types/serve-static@*":
   version "1.13.2"
@@ -120,6 +205,17 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/url-join@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-0.8.2.tgz#1181ecbe1d97b7034e0ea1e35e62e86cc26b422d"
+
+"@types/ws@^5.1.1":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-5.1.2.tgz#f02d3b1cd46db7686734f3ce83bdf46c49decd64"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
 
 abbrev@1:
   version "1.1.1"
@@ -161,6 +257,14 @@ ascli@~1:
   dependencies:
     colour "~0.7.1"
     optjs "~3.2.2"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
 aws-sdk@^2.252.1:
   version "2.252.1"
@@ -224,6 +328,18 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 camelcase@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
@@ -240,6 +356,12 @@ cliui@^3.0.3:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+clone-response@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  dependencies:
+    mimic-response "^1.0.0"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -247,6 +369,12 @@ code-point-at@^1.0.0:
 colour@~0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
+
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -286,9 +414,36 @@ decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+delay@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-2.0.0.tgz#9112eadc03e4ec7e00297337896f273bbd91fae5"
+  dependencies:
+    p-defer "^1.0.0"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -310,6 +465,10 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -318,6 +477,24 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
+es-abstract@^1.5.1, es-abstract@^1.6.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -325,6 +502,10 @@ escape-html@~1.0.3:
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
+eventemitter3@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
 events@1.1.1:
   version "1.1.1"
@@ -377,6 +558,22 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
+finity@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/finity/-/finity-0.5.4.tgz#f2a8a9198e8286467328ec32c8bfcc19a2229c11"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
+form-data@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -384,6 +581,13 @@ forwarded@~0.1.2:
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -394,6 +598,10 @@ fs-minipass@^1.2.5:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+function-bind@^1.1.0, function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -407,6 +615,10 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+get-stream@3.0.0, get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 glob@^7.0.5:
   version "7.1.2"
@@ -423,6 +635,28 @@ google-protobuf@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.5.0.tgz#b8cc63c74d83457bd8a9a904503c8efb26bca339"
 
+got@^8.0.3:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.2.tgz#1d23f64390e97f776cac52e5b936e5f514d2e937"
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.4.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
+    url-to-options "^1.0.1"
+
 grpc@^1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.12.2.tgz#b9f853540825c6c716c30d06794d7d52d081d968"
@@ -432,9 +666,29 @@ grpc@^1.12.2:
     node-pre-gyp "^0.10.0"
     protobufjs "^5.0.3"
 
+has-symbol-support-x@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
+
+has-to-string-tag-x@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
+  dependencies:
+    has-symbol-support-x "^1.4.1"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
+
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
 
 http-errors@1.6.2:
   version "1.6.2"
@@ -485,13 +739,20 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -500,6 +761,14 @@ invert-kv@^1.0.0:
 ipaddr.js@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
+
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -511,13 +780,56 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
+is-retry-allowed@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isurl@^1.0.0-alpha5:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
+  dependencies:
+    has-to-string-tag-x "^1.2.0"
+    is-object "^1.0.1"
+
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  dependencies:
+    json-buffer "3.0.0"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -529,6 +841,10 @@ lodash@^4.0.0, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+loglevel@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -536,6 +852,14 @@ long@^4.0.0:
 long@~3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+
+lowercase-keys@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lowercase-keys@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -553,7 +877,7 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@~2.1.18:
+mime-types@^2.1.12, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
@@ -562,6 +886,10 @@ mime-types@~2.1.18:
 mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -638,6 +966,14 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 npm-bundled@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
@@ -665,6 +1001,35 @@ number-is-nan@^1.0.0:
 object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-keys@^1.0.8:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -703,6 +1068,42 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-cancelable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
+
+p-cancelable@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+
+p-queue@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.4.2.tgz#03609826682b743be9a22dba25051bd46724fc34"
+
+p-retry@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-1.0.0.tgz#3927332a4b7d70269b535515117fc547da1a6968"
+  dependencies:
+    retry "^0.10.0"
+
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  dependencies:
+    p-finally "^1.0.0"
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
@@ -714,6 +1115,14 @@ path-is-absolute@^1.0.0:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
 
 process-nextick-args@~2.0.0:
   version "2.0.0"
@@ -761,6 +1170,14 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+query-string@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -787,7 +1204,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-readable-stream@^2.0.6:
+readable-stream@^2.0.0, readable-stream@^2.0.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -803,6 +1220,16 @@ require-from-string@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
+responselike@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  dependencies:
+    lowercase-keys "^1.0.0"
+
+retry@^0.10.0, retry@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+
 rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -813,7 +1240,7 @@ safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -876,6 +1303,12 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-map-support@^0.4.16:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -893,6 +1326,10 @@ source-map@^0.5.6:
 statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -943,6 +1380,10 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+timed-out@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
 type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
@@ -961,6 +1402,20 @@ typescript@^2.5.3:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+url-join@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
+
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  dependencies:
+    prepend-http "^2.0.0"
+
+url-to-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
 
 url@0.10.3:
   version "0.10.3"
@@ -1005,6 +1460,12 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+ws@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.1.tgz#37827a0ba772d072a843c3615b0ad38bcdb354eb"
+  dependencies:
+    async-limiter "~1.0.0"
 
 xml2js@0.4.17:
   version "0.4.17"

--- a/overlays/nodejs/serverless/function.ts
+++ b/overlays/nodejs/serverless/function.ts
@@ -315,11 +315,13 @@ function findDependency(root: Package, name: string) {
         for (var child of root.children) {
             let childName = child.name;
             // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
-            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
-            // Match any name that ends with something that looks like `@foo/bar`.
-            const match = /\@[^\/]*\/[^\/]*$/.exec(child.path);
-            if (match) {
-                childName = match[0];
+            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead. Match
+            // any name that ends with something that looks like `@foo/bar`, such as `node_modules/@foo/bar` or
+            // `node_modules/baz/node_modules/@foo/bar.
+            const childFolderName = filepath.basename(child.path);
+            const parentFolderName = filepath.basename(filepath.dirname(child.path));
+            if (parentFolderName[0] == "@") {
+                childName = filepath.join(parentFolderName, childFolderName);
             }
             if (childName === name) {
                 return child;

--- a/overlays/nodejs/serverless/function.ts
+++ b/overlays/nodejs/serverless/function.ts
@@ -104,10 +104,10 @@ export class Function extends pulumi.ComponentResource {
     public readonly role: Role;
 
     constructor(name: string,
-                options: FunctionOptions,
-                func: Handler,
-                opts?: pulumi.ResourceOptions,
-                serialize?: (obj: any) => boolean) {
+        options: FunctionOptions,
+        func: Handler,
+        opts?: pulumi.ResourceOptions,
+        serialize?: (obj: any) => boolean) {
         if (!name) {
             throw new Error("Missing required resource name");
         }
@@ -172,10 +172,10 @@ export class Function extends pulumi.ComponentResource {
 
 // computeCodePaths calculates an AssetMap of files to include in the Lambda package.
 async function computeCodePaths(
-        closure: Promise<pulumi.runtime.SerializedFunction>, 
-        serializedFileName: string,
-        extraIncludePaths?: string[], 
-        extraPackages?: string[]): Promise<pulumi.asset.AssetMap> {
+    closure: Promise<pulumi.runtime.SerializedFunction>,
+    serializedFileName: string,
+    extraIncludePaths?: string[],
+    extraPackages?: string[]): Promise<pulumi.asset.AssetMap> {
 
     const serializedFunction = await closure;
 
@@ -299,11 +299,9 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
         console.warn(`Could not include required dependency '${pkg}' in '${filepath.resolve(root.path)}'.`)
         return;
     }
-
     s.add(child.path);
-
     if (child.package.dependencies) {
-        for (let dep of Object.keys(child.package.dependencies) ) {
+        for (let dep of Object.keys(child.package.dependencies)) {
             addPackageAndDependenciesToSet(s, child, dep);
         }
     }
@@ -313,20 +311,18 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
 // It is assumed that the tree was correctly construted such that dependencies are resolved to compatible versions in
 // the closest available match starting at the provided root and walking up to the head of the tree.
 function findDependency(root: Package, name: string) {
-    for(; root; root = root.parent) {
+    for (; root; root = root.parent) {
         for (var child of root.children) {
-            if (name.indexOf("@") === -1) {
-                if (name === child.name) {
-                    return child;
-                }
-            } else {
-                // `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization, like
-                // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
-                // We split the path name using the filesystem delimiter and look at the last two components.
-                const parts = child.path.split(filepath.sep);
-                if (parts.length >= 2 && (parts[parts.length-2]+"/"+parts[parts.length-1]) === name) {
-                    return child;
-                }
+            let childName = child.name;
+            // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
+            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
+            // Match any name that ends with something that looks like `@foo/bar`.
+            const match = /\@[^\/]*\/[^\/]*$/.exec(child.path);
+            if (match) {
+                childName = match[0];
+            }
+            if (childName === name) {
+                return child;
             }
         }
     }
@@ -339,7 +335,7 @@ function findDependency(root: Package, name: string) {
 function removeBuiltins(packages: Set<string>): Set<string> {
     const ret = new Set<string>();
     const builtIns = new Set(builtinModules);
-    for(const p of packages) {
+    for (const p of packages) {
         if (!builtIns.has(p)) {
             ret.add(p);
         }

--- a/overlays/nodejs/serverless/function.ts
+++ b/overlays/nodejs/serverless/function.ts
@@ -155,7 +155,7 @@ export class Function extends pulumi.ComponentResource {
         });
 
         let codePaths = computeCodePaths(closure, serializedFileName, options.includePaths, options.includePackages);
-        
+
         // Create the Lambda Function.
         this.lambda = new lambda.Function(name, {
             code: new pulumi.asset.AssetArchive(codePaths),
@@ -187,11 +187,11 @@ async function computeCodePaths(
 
     // Compute the set of required packages
     const packages = removeBuiltins(serializedFunction.requiredPackages);
-    
+
     // AWS Lambda always provides `aws-sdk`, so skip this.  Do this before processing user-provided extraPackages so
     // that users can force aws-sdk to be incldued (if they need a specific version).
     packages.delete("aws-sdk")
-    
+
     // Add user-defined extraPackages
     for (const p of (extraPackages || [])) {
         packages.add(p);
@@ -199,7 +199,7 @@ async function computeCodePaths(
 
     // Find folders for all packages requested by the user
     const pathSet = await allFoldersForPackages(".", [...packages]);
-    
+
     // Add all paths explciitly requested by the user
     for (const path of (extraIncludePaths || [])) {
         pathSet.add(path);
@@ -216,7 +216,7 @@ async function computeCodePaths(
             codePaths[path] = new pulumi.asset.FileAsset(path);
         }
     }
-    
+
     return codePaths;
 }
 
@@ -246,9 +246,9 @@ interface Package {
     name: string;
     path: string;
     package: {
-        dependencies: { [key: string]: string;};
+        dependencies: { [key: string]: string; };
     };
-    parent?: Package
+    parent?: Package;
     children: Package[];
 }
 
@@ -272,11 +272,13 @@ function allFoldersForPackages(path: string, packages: string[]): Promise<Set<st
                         const relativePath = filepath.relative(path, resolvedPath);
                         s.add(relativePath);
                     } catch (err) {
-                        console.warn(`Could not find module for relative path '${pkg}' in '${filepath.resolve(root.path)}'.`)    
+                        console.warn(
+                            `Could not find module for relative path '${pkg}' in '${filepath.resolve(root.path)}'.`);
                     }
                 } else if (pkg[0] == '/') {
                     // Absolute path, this won't work, so warn and move on.
-                    console.warn(`Could not include module for absolute path '${pkg}' in '${filepath.resolve(root.path)}'.`)
+                    console.warn(
+                        `Could not include module for absolute path '${pkg}' in '${filepath.resolve(root.path)}'.`);
                 } else {
                     // Neither relative nor aboslute path, so expected to be a name that resovles to `node_modules` (or
                     // to a builtin, but those were removed).  We can add the package and all its transitive
@@ -297,7 +299,9 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
         console.warn(`Could not include required dependency '${pkg}' in '${filepath.resolve(root.path)}'.`)
         return;
     }
+
     s.add(child.path);
+
     if (child.package.dependencies) {
         for (let dep of Object.keys(child.package.dependencies) ) {
             addPackageAndDependenciesToSet(s, child, dep);
@@ -309,18 +313,20 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
 // It is assumed that the tree was correctly construted such that dependencies are resolved to compatible versions in
 // the closest available match starting at the provided root and walking up to the head of the tree.
 function findDependency(root: Package, name: string) {
-    for(;root;root = root.parent) {
+    for(; root; root = root.parent) {
         for (var child of root.children) {
-            let childName = child.name;
-            // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
-            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
-            // Match any name that ends with something that looks like `@foo/bar`.
-            const match = /\/\@[^\/]*\/[^\/]*$/.exec(child.path);
-            if (match) {
-                childName = match[0];
-            }
-            if(childName === name) {
-                return child;
+            if (name.indexOf("@") === -1) {
+                if (name === child.name) {
+                    return child;
+                }
+            } else {
+                // `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization, like
+                // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
+                // We split the path name using the filesystem delimiter and look at the last two components.
+                const parts = child.path.split(filepath.sep);
+                if (parts.length >= 2 && (parts[parts.length-2]+"/"+parts[parts.length-1]) === name) {
+                    return child;
+                }
             }
         }
     }

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -315,11 +315,13 @@ function findDependency(root: Package, name: string) {
         for (var child of root.children) {
             let childName = child.name;
             // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
-            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
-            // Match any name that ends with something that looks like `@foo/bar`.
-            const match = /\@[^\/]*\/[^\/]*$/.exec(child.path);
-            if (match) {
-                childName = match[0];
+            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead. Match
+            // any name that ends with something that looks like `@foo/bar`, such as `node_modules/@foo/bar` or
+            // `node_modules/baz/node_modules/@foo/bar.
+            const childFolderName = filepath.basename(child.path);
+            const parentFolderName = filepath.basename(filepath.dirname(child.path));
+            if (parentFolderName[0] == "@") {
+                childName = filepath.join(parentFolderName, childFolderName);
             }
             if (childName === name) {
                 return child;

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -104,10 +104,10 @@ export class Function extends pulumi.ComponentResource {
     public readonly role: Role;
 
     constructor(name: string,
-                options: FunctionOptions,
-                func: Handler,
-                opts?: pulumi.ResourceOptions,
-                serialize?: (obj: any) => boolean) {
+        options: FunctionOptions,
+        func: Handler,
+        opts?: pulumi.ResourceOptions,
+        serialize?: (obj: any) => boolean) {
         if (!name) {
             throw new Error("Missing required resource name");
         }
@@ -172,10 +172,10 @@ export class Function extends pulumi.ComponentResource {
 
 // computeCodePaths calculates an AssetMap of files to include in the Lambda package.
 async function computeCodePaths(
-        closure: Promise<pulumi.runtime.SerializedFunction>, 
-        serializedFileName: string,
-        extraIncludePaths?: string[], 
-        extraPackages?: string[]): Promise<pulumi.asset.AssetMap> {
+    closure: Promise<pulumi.runtime.SerializedFunction>,
+    serializedFileName: string,
+    extraIncludePaths?: string[],
+    extraPackages?: string[]): Promise<pulumi.asset.AssetMap> {
 
     const serializedFunction = await closure;
 
@@ -299,11 +299,9 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
         console.warn(`Could not include required dependency '${pkg}' in '${filepath.resolve(root.path)}'.`)
         return;
     }
-
     s.add(child.path);
-
     if (child.package.dependencies) {
-        for (let dep of Object.keys(child.package.dependencies) ) {
+        for (let dep of Object.keys(child.package.dependencies)) {
             addPackageAndDependenciesToSet(s, child, dep);
         }
     }
@@ -313,20 +311,18 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
 // It is assumed that the tree was correctly construted such that dependencies are resolved to compatible versions in
 // the closest available match starting at the provided root and walking up to the head of the tree.
 function findDependency(root: Package, name: string) {
-    for(; root; root = root.parent) {
+    for (; root; root = root.parent) {
         for (var child of root.children) {
-            if (name.indexOf("@") === -1) {
-                if (name === child.name) {
-                    return child;
-                }
-            } else {
-                // `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization, like
-                // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
-                // We split the path name using the filesystem delimiter and look at the last two components.
-                const parts = child.path.split(filepath.sep);
-                if (parts.length >= 2 && (parts[parts.length-2]+"/"+parts[parts.length-1]) === name) {
-                    return child;
-                }
+            let childName = child.name;
+            // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
+            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
+            // Match any name that ends with something that looks like `@foo/bar`.
+            const match = /\@[^\/]*\/[^\/]*$/.exec(child.path);
+            if (match) {
+                childName = match[0];
+            }
+            if (childName === name) {
+                return child;
             }
         }
     }
@@ -339,7 +335,7 @@ function findDependency(root: Package, name: string) {
 function removeBuiltins(packages: Set<string>): Set<string> {
     const ret = new Set<string>();
     const builtIns = new Set(builtinModules);
-    for(const p of packages) {
+    for (const p of packages) {
         if (!builtIns.has(p)) {
             ret.add(p);
         }

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -155,7 +155,7 @@ export class Function extends pulumi.ComponentResource {
         });
 
         let codePaths = computeCodePaths(closure, serializedFileName, options.includePaths, options.includePackages);
-        
+
         // Create the Lambda Function.
         this.lambda = new lambda.Function(name, {
             code: new pulumi.asset.AssetArchive(codePaths),
@@ -187,11 +187,11 @@ async function computeCodePaths(
 
     // Compute the set of required packages
     const packages = removeBuiltins(serializedFunction.requiredPackages);
-    
+
     // AWS Lambda always provides `aws-sdk`, so skip this.  Do this before processing user-provided extraPackages so
     // that users can force aws-sdk to be incldued (if they need a specific version).
     packages.delete("aws-sdk")
-    
+
     // Add user-defined extraPackages
     for (const p of (extraPackages || [])) {
         packages.add(p);
@@ -199,7 +199,7 @@ async function computeCodePaths(
 
     // Find folders for all packages requested by the user
     const pathSet = await allFoldersForPackages(".", [...packages]);
-    
+
     // Add all paths explciitly requested by the user
     for (const path of (extraIncludePaths || [])) {
         pathSet.add(path);
@@ -216,7 +216,7 @@ async function computeCodePaths(
             codePaths[path] = new pulumi.asset.FileAsset(path);
         }
     }
-    
+
     return codePaths;
 }
 
@@ -246,9 +246,9 @@ interface Package {
     name: string;
     path: string;
     package: {
-        dependencies: { [key: string]: string;};
+        dependencies: { [key: string]: string; };
     };
-    parent?: Package
+    parent?: Package;
     children: Package[];
 }
 
@@ -272,11 +272,13 @@ function allFoldersForPackages(path: string, packages: string[]): Promise<Set<st
                         const relativePath = filepath.relative(path, resolvedPath);
                         s.add(relativePath);
                     } catch (err) {
-                        console.warn(`Could not find module for relative path '${pkg}' in '${filepath.resolve(root.path)}'.`)    
+                        console.warn(
+                            `Could not find module for relative path '${pkg}' in '${filepath.resolve(root.path)}'.`);
                     }
                 } else if (pkg[0] == '/') {
                     // Absolute path, this won't work, so warn and move on.
-                    console.warn(`Could not include module for absolute path '${pkg}' in '${filepath.resolve(root.path)}'.`)
+                    console.warn(
+                        `Could not include module for absolute path '${pkg}' in '${filepath.resolve(root.path)}'.`);
                 } else {
                     // Neither relative nor aboslute path, so expected to be a name that resovles to `node_modules` (or
                     // to a builtin, but those were removed).  We can add the package and all its transitive
@@ -297,7 +299,9 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
         console.warn(`Could not include required dependency '${pkg}' in '${filepath.resolve(root.path)}'.`)
         return;
     }
+
     s.add(child.path);
+
     if (child.package.dependencies) {
         for (let dep of Object.keys(child.package.dependencies) ) {
             addPackageAndDependenciesToSet(s, child, dep);
@@ -309,18 +313,20 @@ function addPackageAndDependenciesToSet(s: Set<string>, root: Package, pkg: stri
 // It is assumed that the tree was correctly construted such that dependencies are resolved to compatible versions in
 // the closest available match starting at the provided root and walking up to the head of the tree.
 function findDependency(root: Package, name: string) {
-    for(;root;root = root.parent) {
+    for(; root; root = root.parent) {
         for (var child of root.children) {
-            let childName = child.name;
-            // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
-            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
-            // Match any name that ends with something that looks like `@foo/bar`.
-            const match = /\/\@[^\/]*\/[^\/]*$/.exec(child.path);
-            if (match) {
-                childName = match[0];
-            }
-            if(childName === name) {
-                return child;
+            if (name.indexOf("@") === -1) {
+                if (name === child.name) {
+                    return child;
+                }
+            } else {
+                // `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization, like
+                // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead.
+                // We split the path name using the filesystem delimiter and look at the last two components.
+                const parts = child.path.split(filepath.sep);
+                if (parts.length >= 2 && (parts[parts.length-2]+"/"+parts[parts.length-1]) === name) {
+                    return child;
+                }
             }
         }
     }


### PR DESCRIPTION
Alternative fix for #260, adds tests and makes a more targeted fix than #261 which appears to introduce other issues.

Use path APIs instead of regexp in workaround for incorrect package names coming from `read-package-tree` dependency when seeing organization-scoped packages.

Add tests for additional cases of organization-scoped packages (at the root as well as nested).