### PR TITLE
iam: Add iam.assumeRolePolicyForPrincipal function

### DIFF
--- a/overlays/nodejs/iam/documents.ts
+++ b/overlays/nodejs/iam/documents.ts
@@ -61,3 +61,24 @@ export interface FederatedPrincipal {
     Federated: string | string[];
 }
 
+/**
+ * assumeRolePolicyForPrincipal returns a well-formed policy document which can be
+ * used to control which principals may assume an IAM Role, by granting the `sts:AssumeRole`
+ * action to those principals.
+ *
+ * @param {Principal} principal The principals for whom assuming the role is allowed
+ * @returns {PolicyDocument} A policy document allowing principals to invoke `sts:AssumeRole`
+ */
+export function assumeRolePolicyForPrincipal(principal: Principal): PolicyDocument {
+    return {
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Sid: "AllowAssumeRole",
+                Effect: "Allow",
+                Principal: principal,
+                Action: "sts:AssumeRole"
+            }
+        ]
+    };
+}

--- a/sdk/nodejs/iam/documents.ts
+++ b/sdk/nodejs/iam/documents.ts
@@ -61,3 +61,24 @@ export interface FederatedPrincipal {
     Federated: string | string[];
 }
 
+/**
+ * assumeRolePolicyForPrincipal returns a well-formed policy document which can be
+ * used to control which principals may assume an IAM Role, by granting the `sts:AssumeRole`
+ * action to those principals.
+ *
+ * @param {Principal} principal The principals for whom assuming the role is allowed
+ * @returns {PolicyDocument} A policy document allowing principals to invoke `sts:AssumeRole`
+ */
+export function assumeRolePolicyForPrincipal(principal: Principal): PolicyDocument {
+    return {
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Sid: "AllowAssumeRole",
+                Effect: "Allow",
+                Principal: principal,
+                Action: "sts:AssumeRole"
+            }
+        ]
+    };
+}


### PR DESCRIPTION
This commit adds a new function, `assumeRolePolicyForPrincipal`, which constructs a well-formed role assumption policy for a given Principal. This is useful when constructing IAM roles using Pulumi.