### PR TITLE
Use "Apache-2.0" for NPM licenses as per SPDX

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -191,7 +191,7 @@ func Provider() tfbridge.ProviderInfo {
 		Name:        "aws",
 		Description: "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
 		Keywords:    []string{"pulumi", "aws"},
-		License:     "Apache 2.0",
+		License:     "Apache-2.0",
 		Homepage:    "https://pulumi.io",
 		Repository:  "https://github.com/pulumi/pulumi-aws",
 		Config: map[string]*tfbridge.SchemaInfo{

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -8,7 +8,7 @@
     ],
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-aws",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "scripts": {
         "build": "tsc"
     },

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -26,7 +26,7 @@ setup(name='pulumi_aws',
       project_urls={
           'Repository': 'https://github.com/pulumi/pulumi-aws'
       },
-      license='Apache 2.0',
+      license='Apache-2.0',
       packages=find_packages(),
       install_requires=[
           'pulumi>=0.14.2,<0.15.0'


### PR DESCRIPTION
This fixes the following warning from yarn when building:

```
warning package.json: License should be a valid SPDX license expression
```

I'm not 100% sure that this has no negative impact on Python, however.