### PR TITLE
iam: Override role on RolePolicy to accept a Role

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -921,7 +921,15 @@ func Provider() tfbridge.ProviderInfo {
 				// deletes the same attachment we just created, since it is structurally equivalent!
 				DeleteBeforeReplace: true,
 			},
-			"aws_iam_role_policy": {Tok: awsResource(iamMod, "RolePolicy")},
+			"aws_iam_role_policy": {
+				Tok: awsResource(iamMod, "RolePolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"role": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(iamMod+"/role", "Role")},
+					},
+				},
+			},
 			"aws_iam_role": {
 				Tok: awsResource(iamMod, "Role"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/nodejs/iam/rolePolicy.ts
+++ b/sdk/nodejs/iam/rolePolicy.ts
@@ -3,6 +3,8 @@
 
 import * as pulumi from "@pulumi/pulumi";
 
+import {Role} from "./role";
+
 /**
  * Provides an IAM role policy.
  */
@@ -37,7 +39,7 @@ export class RolePolicy extends pulumi.CustomResource {
     /**
      * The IAM role to attach to the policy.
      */
-    public readonly role: pulumi.Output<string>;
+    public readonly role: pulumi.Output<string | Role>;
 
     /**
      * Create a RolePolicy resource with the given unique name, arguments, and options.
@@ -94,7 +96,7 @@ export interface RolePolicyState {
     /**
      * The IAM role to attach to the policy.
      */
-    readonly role?: pulumi.Input<string>;
+    readonly role?: pulumi.Input<string | Role>;
 }
 
 /**
@@ -119,5 +121,5 @@ export interface RolePolicyArgs {
     /**
      * The IAM role to attach to the policy.
      */
-    readonly role: pulumi.Input<string>;
+    readonly role: pulumi.Input<string | Role>;
 }


### PR DESCRIPTION
This brings `RolePolicy` in line with `RolePolicyAttachment` in accepting a `Role` rather than requiring the ID as a `string`.