### PR TITLE
Add the .js extension to our generate closure code file.

### DIFF
--- a/overlays/nodejs/serverless/function.ts
+++ b/overlays/nodejs/serverless/function.ts
@@ -158,7 +158,7 @@ export class Function extends pulumi.ComponentResource {
         }
 
         const handlerName = "handler";
-        const serializedFileName = "__index";
+        const serializedFileNameNoExtension = "__index";
 
         let closure = pulumi.runtime.serializeFunction(func, {
             serialize: finalSerialize,
@@ -166,12 +166,12 @@ export class Function extends pulumi.ComponentResource {
         });
 
         let codePaths = computeCodePaths(
-            closure, serializedFileName, options.includePaths, options.excludePackages);
+            closure, serializedFileNameNoExtension, options.includePaths, options.excludePackages);
 
         // Create the Lambda Function.
         this.lambda = new lambda.Function(name, {
             code: new pulumi.asset.AssetArchive(codePaths),
-            handler: serializedFileName + "." + handlerName,
+            handler: serializedFileNameNoExtension + "." + handlerName,
             runtime: options.runtime || lambda.NodeJS8d10Runtime,
             environment: options.environment,
             role: this.role.arn,
@@ -186,7 +186,7 @@ export class Function extends pulumi.ComponentResource {
 // computeCodePaths calculates an AssetMap of files to include in the Lambda package.
 async function computeCodePaths(
         closure: Promise<pulumi.runtime.SerializedFunction>,
-        serializedFileName: string,
+        serializedFileNameNoExtension: string,
         extraIncludePaths?: string[],
         extraIncludePackages?: string[],
         extraExcludePackages?: string[]): Promise<pulumi.asset.AssetMap> {
@@ -196,7 +196,7 @@ async function computeCodePaths(
     // Construct the set of paths to include in the archive for upload.
     let codePaths: pulumi.asset.AssetMap = {
         // Always include the serialized function.
-        [serializedFileName]: new pulumi.asset.StringAsset(serializedFunction.text),
+        [serializedFileNameNoExtension + ".js"]: new pulumi.asset.StringAsset(serializedFunction.text),
     };
 
     extraIncludePaths = extraIncludePaths || [];

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -158,7 +158,7 @@ export class Function extends pulumi.ComponentResource {
         }
 
         const handlerName = "handler";
-        const serializedFileName = "__index";
+        const serializedFileNameNoExtension = "__index";
 
         let closure = pulumi.runtime.serializeFunction(func, {
             serialize: finalSerialize,
@@ -166,12 +166,12 @@ export class Function extends pulumi.ComponentResource {
         });
 
         let codePaths = computeCodePaths(
-            closure, serializedFileName, options.includePaths, options.excludePackages);
+            closure, serializedFileNameNoExtension, options.includePaths, options.excludePackages);
 
         // Create the Lambda Function.
         this.lambda = new lambda.Function(name, {
             code: new pulumi.asset.AssetArchive(codePaths),
-            handler: serializedFileName + "." + handlerName,
+            handler: serializedFileNameNoExtension + "." + handlerName,
             runtime: options.runtime || lambda.NodeJS8d10Runtime,
             environment: options.environment,
             role: this.role.arn,
@@ -186,7 +186,7 @@ export class Function extends pulumi.ComponentResource {
 // computeCodePaths calculates an AssetMap of files to include in the Lambda package.
 async function computeCodePaths(
         closure: Promise<pulumi.runtime.SerializedFunction>,
-        serializedFileName: string,
+        serializedFileNameNoExtension: string,
         extraIncludePaths?: string[],
         extraIncludePackages?: string[],
         extraExcludePackages?: string[]): Promise<pulumi.asset.AssetMap> {
@@ -196,7 +196,7 @@ async function computeCodePaths(
     // Construct the set of paths to include in the archive for upload.
     let codePaths: pulumi.asset.AssetMap = {
         // Always include the serialized function.
-        [serializedFileName]: new pulumi.asset.StringAsset(serializedFunction.text),
+        [serializedFileNameNoExtension + ".js"]: new pulumi.asset.StringAsset(serializedFunction.text),
     };
 
     extraIncludePaths = extraIncludePaths || [];


### PR DESCRIPTION
Customer request from @tirke.  This enables proper .js support in the AWS cloud console:

![image](https://user-images.githubusercontent.com/4564579/42969215-5962b5be-8b5a-11e8-82e3-1e2262ea8f40.png)

Note: this will mean that any and all pulumi updates will show a change to lambdas.  