### PR TITLE
Add license items to package.json.

### DIFF
--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,6 +1,7 @@
 {
     "name": "minimal",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/serverless-raw/package.json
+++ b/examples/serverless-raw/package.json
@@ -1,6 +1,7 @@
 {
     "name": "serverless-raw",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -1,6 +1,7 @@
 {
     "name": "serverless",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/webserver-comp/package.json
+++ b/examples/webserver-comp/package.json
@@ -1,6 +1,7 @@
 {
     "name": "webserver",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/webserver/package.json
+++ b/examples/webserver/package.json
@@ -1,6 +1,7 @@
 {
     "name": "webserver",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/webserver/variants/get/package.json
+++ b/examples/webserver/variants/get/package.json
@@ -1,6 +1,7 @@
 {
     "name": "webserver",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/webserver/variants/ssh/package.json
+++ b/examples/webserver/variants/ssh/package.json
@@ -1,6 +1,7 @@
 {
     "name": "webserver",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/webserver/variants/ssh_description/package.json
+++ b/examples/webserver/variants/ssh_description/package.json
@@ -1,6 +1,7 @@
 {
     "name": "webserver",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/examples/webserver/variants/zones/package.json
+++ b/examples/webserver/variants/zones/package.json
@@ -1,6 +1,7 @@
 {
     "name": "webserver",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/tests/delete_before_create/mount_target/step1/package.json
+++ b/tests/delete_before_create/mount_target/step1/package.json
@@ -1,5 +1,6 @@
 {
     "name": "mount_target",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/tests/regression/package.json
+++ b/tests/regression/package.json
@@ -1,6 +1,7 @@
 {
     "name": "aws-regression",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/tests/serverless_functions/package.json
+++ b/tests/serverless_functions/package.json
@@ -1,6 +1,7 @@
 {
     "name": "serverlessfunctions",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {


### PR DESCRIPTION
This gets rid of all the:

```
warning package.json: License should be a valid SPDX license expression
warning @pulumi/aws-infra@${VERSION}: License should be a valid SPDX license expression
```

messages that show up while building.