### PR TITLE
elbv2: Make TargetGroup::defaultAction a single item

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -1025,7 +1025,15 @@ func Provider() tfbridge.ProviderInfo {
 					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_lb_listener":             {Tok: awsResource(elbv2Mod, "Listener")},
+			"aws_lb_listener": {
+				Tok: awsResource(elbv2Mod, "Listener"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"default_action": {
+						Name:        "defaultAction",
+						MaxItemsOne: boolRef(true),
+					},
+				},
+			},
 			"aws_lb_listener_certificate": {Tok: awsResource(elbv2Mod, "ListenerCertificate")},
 			"aws_lb_listener_rule":        {Tok: awsResource(elbv2Mod, "ListenerRule")},
 			"aws_lb_target_group": {

--- a/sdk/go/aws/elasticloadbalancingv2/listener.go
+++ b/sdk/go/aws/elasticloadbalancingv2/listener.go
@@ -18,8 +18,8 @@ type Listener struct {
 // NewListener registers a new resource with the given unique name, arguments, and options.
 func NewListener(ctx *pulumi.Context,
 	name string, args *ListenerArgs, opts ...pulumi.ResourceOpt) (*Listener, error) {
-	if args == nil || args.DefaultActions == nil {
-		return nil, errors.New("missing required argument 'DefaultActions'")
+	if args == nil || args.DefaultAction == nil {
+		return nil, errors.New("missing required argument 'DefaultAction'")
 	}
 	if args == nil || args.LoadBalancerArn == nil {
 		return nil, errors.New("missing required argument 'LoadBalancerArn'")
@@ -30,14 +30,14 @@ func NewListener(ctx *pulumi.Context,
 	inputs := make(map[string]interface{})
 	if args == nil {
 		inputs["certificateArn"] = nil
-		inputs["defaultActions"] = nil
+		inputs["defaultAction"] = nil
 		inputs["loadBalancerArn"] = nil
 		inputs["port"] = nil
 		inputs["protocol"] = nil
 		inputs["sslPolicy"] = nil
 	} else {
 		inputs["certificateArn"] = args.CertificateArn
-		inputs["defaultActions"] = args.DefaultActions
+		inputs["defaultAction"] = args.DefaultAction
 		inputs["loadBalancerArn"] = args.LoadBalancerArn
 		inputs["port"] = args.Port
 		inputs["protocol"] = args.Protocol
@@ -59,7 +59,7 @@ func GetListener(ctx *pulumi.Context,
 	if state != nil {
 		inputs["arn"] = state.Arn
 		inputs["certificateArn"] = state.CertificateArn
-		inputs["defaultActions"] = state.DefaultActions
+		inputs["defaultAction"] = state.DefaultAction
 		inputs["loadBalancerArn"] = state.LoadBalancerArn
 		inputs["port"] = state.Port
 		inputs["protocol"] = state.Protocol
@@ -93,8 +93,8 @@ func (r *Listener) CertificateArn() *pulumi.StringOutput {
 }
 
 // An Action block. Action blocks are documented below.
-func (r *Listener) DefaultActions() *pulumi.ArrayOutput {
-	return (*pulumi.ArrayOutput)(r.s.State["defaultActions"])
+func (r *Listener) DefaultAction() *pulumi.Output {
+	return r.s.State["defaultAction"]
 }
 
 // The ARN of the load balancer.
@@ -124,7 +124,7 @@ type ListenerState struct {
 	// The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 	CertificateArn interface{}
 	// An Action block. Action blocks are documented below.
-	DefaultActions interface{}
+	DefaultAction interface{}
 	// The ARN of the load balancer.
 	LoadBalancerArn interface{}
 	// The port on which the load balancer is listening.
@@ -140,7 +140,7 @@ type ListenerArgs struct {
 	// The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 	CertificateArn interface{}
 	// An Action block. Action blocks are documented below.
-	DefaultActions interface{}
+	DefaultAction interface{}
 	// The ARN of the load balancer.
 	LoadBalancerArn interface{}
 	// The port on which the load balancer is listening.

--- a/sdk/nodejs/elasticloadbalancingv2/listener.ts
+++ b/sdk/nodejs/elasticloadbalancingv2/listener.ts
@@ -32,7 +32,7 @@ export class Listener extends pulumi.CustomResource {
     /**
      * An Action block. Action blocks are documented below.
      */
-    public readonly defaultActions: pulumi.Output<{ targetGroupArn: string, type: string }[]>;
+    public readonly defaultAction: pulumi.Output<{ targetGroupArn: string, type: string }>;
     /**
      * The ARN of the load balancer.
      */
@@ -64,15 +64,15 @@ export class Listener extends pulumi.CustomResource {
             const state: ListenerState = argsOrState as ListenerState | undefined;
             inputs["arn"] = state ? state.arn : undefined;
             inputs["certificateArn"] = state ? state.certificateArn : undefined;
-            inputs["defaultActions"] = state ? state.defaultActions : undefined;
+            inputs["defaultAction"] = state ? state.defaultAction : undefined;
             inputs["loadBalancerArn"] = state ? state.loadBalancerArn : undefined;
             inputs["port"] = state ? state.port : undefined;
             inputs["protocol"] = state ? state.protocol : undefined;
             inputs["sslPolicy"] = state ? state.sslPolicy : undefined;
         } else {
             const args = argsOrState as ListenerArgs | undefined;
-            if (!args || args.defaultActions === undefined) {
-                throw new Error("Missing required property 'defaultActions'");
+            if (!args || args.defaultAction === undefined) {
+                throw new Error("Missing required property 'defaultAction'");
             }
             if (!args || args.loadBalancerArn === undefined) {
                 throw new Error("Missing required property 'loadBalancerArn'");
@@ -81,7 +81,7 @@ export class Listener extends pulumi.CustomResource {
                 throw new Error("Missing required property 'port'");
             }
             inputs["certificateArn"] = args ? args.certificateArn : undefined;
-            inputs["defaultActions"] = args ? args.defaultActions : undefined;
+            inputs["defaultAction"] = args ? args.defaultAction : undefined;
             inputs["loadBalancerArn"] = args ? args.loadBalancerArn : undefined;
             inputs["port"] = args ? args.port : undefined;
             inputs["protocol"] = args ? args.protocol : undefined;
@@ -107,7 +107,7 @@ export interface ListenerState {
     /**
      * An Action block. Action blocks are documented below.
      */
-    readonly defaultActions?: pulumi.Input<pulumi.Input<{ targetGroupArn: pulumi.Input<string>, type: pulumi.Input<string> }>[]>;
+    readonly defaultAction?: pulumi.Input<{ targetGroupArn: pulumi.Input<string>, type: pulumi.Input<string> }>;
     /**
      * The ARN of the load balancer.
      */
@@ -137,7 +137,7 @@ export interface ListenerArgs {
     /**
      * An Action block. Action blocks are documented below.
      */
-    readonly defaultActions: pulumi.Input<pulumi.Input<{ targetGroupArn: pulumi.Input<string>, type: pulumi.Input<string> }>[]>;
+    readonly defaultAction: pulumi.Input<{ targetGroupArn: pulumi.Input<string>, type: pulumi.Input<string> }>;
     /**
      * The ARN of the load balancer.
      */

--- a/sdk/python/pulumi_aws/elasticloadbalancingv2/listener.py
+++ b/sdk/python/pulumi_aws/elasticloadbalancingv2/listener.py
@@ -11,7 +11,7 @@ class Listener(pulumi.CustomResource):
     
     ~> **Note:** `aws_alb_listener` is known as `aws_lb_listener`. The functionality is identical.
     """
-    def __init__(__self__, __name__, __opts__=None, certificate_arn=None, default_actions=None, load_balancer_arn=None, port=None, protocol=None, ssl_policy=None):
+    def __init__(__self__, __name__, __opts__=None, certificate_arn=None, default_action=None, load_balancer_arn=None, port=None, protocol=None, ssl_policy=None):
         """Create a Listener resource with the given unique name, props, and options."""
         if not __name__:
             raise TypeError('Missing resource name argument (for URN creation)')
@@ -30,15 +30,15 @@ class Listener(pulumi.CustomResource):
         """
         __props__['certificateArn'] = certificate_arn
 
-        if not default_actions:
-            raise TypeError('Missing required property default_actions')
-        elif not isinstance(default_actions, list):
-            raise TypeError('Expected property default_actions to be a list')
-        __self__.default_actions = default_actions
+        if not default_action:
+            raise TypeError('Missing required property default_action')
+        elif not isinstance(default_action, dict):
+            raise TypeError('Expected property default_action to be a dict')
+        __self__.default_action = default_action
         """
         An Action block. Action blocks are documented below.
         """
-        __props__['defaultActions'] = default_actions
+        __props__['defaultAction'] = default_action
 
         if not load_balancer_arn:
             raise TypeError('Missing required property load_balancer_arn')
@@ -92,8 +92,8 @@ class Listener(pulumi.CustomResource):
             self.arn = outs['arn']
         if 'certificateArn' in outs:
             self.certificate_arn = outs['certificateArn']
-        if 'defaultActions' in outs:
-            self.default_actions = outs['defaultActions']
+        if 'defaultAction' in outs:
+            self.default_action = outs['defaultAction']
         if 'loadBalancerArn' in outs:
             self.load_balancer_arn = outs['loadBalancerArn']
         if 'port' in outs:


### PR DESCRIPTION
This pull request sets `MaxItemsOne` on the `default_action` field of `aws.elasticloadbalancingv2.TargetGroup`, and renames it to be singular. This fix should eventually be upstreamed to the HashiCorp provider repo.