### PR TITLE
Explicilty map tag => tags on aws.autoscaling.Group

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -380,6 +380,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_autoscaling_group": {
 				Tok: awsResource(autoscalingMod, "Group"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"tag": {
+						// Explicitly map tag => tags to avoid confusion with tags => tagsCollection below.
+						Name: "tags",
+					},
 					"tags": {
 						// Conflicts with the pluralized `tag` property, which is the more strongly typed option for
 						// providing tags.  We keep this dynamically typed collection of tags as an option as well, but


### PR DESCRIPTION
We have an awkward mapping of tag=>tags and tags=>tagsCollection on `aws.autoscaling.Group`.  This leads to some confusion in our tfbridge mapping.

For now, we can fix #293 by making the tag=>tags part of the mapping explicit.  Longer term, we likely need to make deeper improvements in tfbridge to handle this and/or come up with a different approach for aws.autoscaling.Group projection of tag/tags.

Fixes #293.