### PR TITLE
Add support for dotnetcore2.1 as Lambda runtime

### DIFF
--- a/overlays/nodejs/lambda/runtimes.ts
+++ b/overlays/nodejs/lambda/runtimes.ts
@@ -18,6 +18,7 @@
 export type Runtime =
     "dotnetcore1.0"  |
     "dotnetcore2.0"  |
+    "dotnetcore2.1"  |
     "go1.x"          |
     "java8"          |
     "nodejs4.3-edge" |
@@ -30,6 +31,7 @@ export type Runtime =
 
 export let DotnetCore1d0Runtime: Runtime = "dotnetcore1.0";
 export let DotnetCore2d0Runtime: Runtime = "dotnetcore2.0";
+export let DotnetCore2d1Runtime: Runtime = "dotnetcore2.1";
 export let Go1dxRuntime: Runtime = "go1.x";
 export let Java8Runtime: Runtime = "java8";
 export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";

--- a/sdk/nodejs/lambda/runtimes.ts
+++ b/sdk/nodejs/lambda/runtimes.ts
@@ -31,7 +31,7 @@ export type Runtime =
 
 export let DotnetCore1d0Runtime: Runtime = "dotnetcore1.0";
 export let DotnetCore2d0Runtime: Runtime = "dotnetcore2.0";
-export let DotnetCore2d01untime: Runtime = "dotnetcore2.1";
+export let DotnetCore2d1Runtime: Runtime = "dotnetcore2.1";
 export let Go1dxRuntime: Runtime = "go1.x";
 export let Java8Runtime: Runtime = "java8";
 export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";

--- a/sdk/nodejs/lambda/runtimes.ts
+++ b/sdk/nodejs/lambda/runtimes.ts
@@ -18,6 +18,7 @@
 export type Runtime =
     "dotnetcore1.0"  |
     "dotnetcore2.0"  |
+    "dotnetcore2.1"  |
     "go1.x"          |
     "java8"          |
     "nodejs4.3-edge" |
@@ -30,6 +31,7 @@ export type Runtime =
 
 export let DotnetCore1d0Runtime: Runtime = "dotnetcore1.0";
 export let DotnetCore2d0Runtime: Runtime = "dotnetcore2.0";
+export let DotnetCore2d01untime: Runtime = "dotnetcore2.1";
 export let Go1dxRuntime: Runtime = "go1.x";
 export let Java8Runtime: Runtime = "java8";
 export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";


### PR DESCRIPTION
Support for dotnetcore2.1 was added for Lambda July 9th, 2018. 
This PR adds that option for the lambda runtime.
[AWS Announcement](https://aws.amazon.com/about-aws/whats-new/2018/06/lambda-supports-dotnetcore-twopointone/)