### PR TITLE
Add EC2 PlacementStrategy union and overlay

### DIFF
--- a/overlays/nodejs/ec2/placementStrategy.ts
+++ b/overlays/nodejs/ec2/placementStrategy.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains two categories of exports:
+//
+//     1) A union type, PlacementStrategy, that accepts any valid Placement Strategy type
+//     2) Individual constants for each such Placement Strategy type
+//
+// These give a better developer experience and are just sugared strings.
+
+/**
+ *  A `spread` placement group places instances on distinct hardware.
+ */
+export let SpreadStrategy: PlacementStrategy = "spread";
+
+/**
+ * A `cluster` placement group is a logical grouping of instances within a single 
+ * Availability Zone that benefit from low network latency, high network throughput.
+ */
+export let ClusterStrategy: PlacementStrategy = "cluster";
+
+/**
+ * The strategy of the placement group determines how the instances are organized
+ * within the group.
+ *
+ * See https://docs.aws.amazon.com/cli/latest/reference/ec2/create-placement-group.html
+ */
+export type PlacementStrategy =
+    "spread" |
+    "cluster";

--- a/resources.go
+++ b/resources.go
@@ -839,9 +839,16 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"aws_network_interface_attachment": {Tok: awsResource(ec2Mod, "NetworkInterfaceAttachment")},
-			"aws_placement_group":              {Tok: awsResource(ec2Mod, "PlacementGroup")},
-			"aws_proxy_protocol_policy":        {Tok: awsResource(ec2Mod, "ProxyProtocolPolicy")},
-			"aws_route":                        {Tok: awsResource(ec2Mod, "Route")},
+			"aws_placement_group": {
+				Tok: awsResource(ec2Mod, "PlacementGroup"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"strategy": {
+						Type: awsType(ec2Mod+"/placementStrategy", "PlacementStrategy"),
+					},
+				},
+			},
+			"aws_proxy_protocol_policy": {Tok: awsResource(ec2Mod, "ProxyProtocolPolicy")},
+			"aws_route":                 {Tok: awsResource(ec2Mod, "Route")},
 			"aws_route_table": {
 				Tok: awsResource(ec2Mod, "RouteTable"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -1920,7 +1927,8 @@ func Provider() tfbridge.ProviderInfo {
 					},
 					"ec2": {
 						Files: []string{
-							"instanceType.ts", // InstanceType union type and constants
+							"instanceType.ts",      // InstanceType union type and constants
+							"placementStrategy.ts", // PlacementStrategy union type and constants
 						},
 					},
 					"ecs": {

--- a/sdk/nodejs/ec2/index.ts
+++ b/sdk/nodejs/ec2/index.ts
@@ -54,6 +54,7 @@ export * from "./networkInterfaceAttachment";
 export * from "./networkInterfaceSecurityGroupAttachment";
 export * from "./peeringConnectionOptions";
 export * from "./placementGroup";
+export * from "./placementStrategy";
 export * from "./proxyProtocolPolicy";
 export * from "./route";
 export * from "./routeTable";

--- a/sdk/nodejs/ec2/placementGroup.ts
+++ b/sdk/nodejs/ec2/placementGroup.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PlacementStrategy} from "./placementStrategy";
+
 /**
  * Provides an EC2 placement group. Read more about placement groups
  * in [AWS Docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html).
@@ -28,7 +30,7 @@ export class PlacementGroup extends pulumi.CustomResource {
     /**
      * The placement strategy.
      */
-    public readonly strategy: pulumi.Output<string>;
+    public readonly strategy: pulumi.Output<PlacementStrategy>;
 
     /**
      * Create a PlacementGroup resource with the given unique name, arguments, and options.
@@ -67,7 +69,7 @@ export interface PlacementGroupState {
     /**
      * The placement strategy.
      */
-    readonly strategy?: pulumi.Input<string>;
+    readonly strategy?: pulumi.Input<PlacementStrategy>;
 }
 
 /**
@@ -81,5 +83,5 @@ export interface PlacementGroupArgs {
     /**
      * The placement strategy.
      */
-    readonly strategy: pulumi.Input<string>;
+    readonly strategy: pulumi.Input<PlacementStrategy>;
 }

--- a/sdk/nodejs/ec2/placementStrategy.ts
+++ b/sdk/nodejs/ec2/placementStrategy.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains two categories of exports:
+//
+//     1) A union type, PlacementStrategy, that accepts any valid Placement Strategy type
+//     2) Individual constants for each such Placement Strategy type
+//
+// These give a better developer experience and are just sugared strings.
+
+/**
+ *  A `spread` placement group places instances on distinct hardware.
+ */
+export let SpreadStrategy: PlacementStrategy = "spread";
+
+/**
+ * A `cluster` placement group is a logical grouping of instances within a single 
+ * Availability Zone that benefit from low network latency, high network throughput.
+ */
+export let ClusterStrategy: PlacementStrategy = "cluster";
+
+/**
+ * The strategy of the placement group determines how the instances are organized
+ * within the group.
+ *
+ * See https://docs.aws.amazon.com/cli/latest/reference/ec2/create-placement-group.html
+ */
+export type PlacementStrategy =
+    "spread" |
+    "cluster";

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -229,6 +229,7 @@
         "ec2/networkInterfaceSecurityGroupAttachment.ts",
         "ec2/peeringConnectionOptions.ts",
         "ec2/placementGroup.ts",
+        "ec2/placementStrategy.ts",
         "ec2/proxyProtocolPolicy.ts",
         "ec2/route.ts",
         "ec2/routeTable.ts",


### PR DESCRIPTION
This commit adds a new overlay for nodejs, defining a union type of valid strategies for placement groups, and overrides the `strategy` property of the aws.ec2.PlacementGroup type to accept an array of these instead of raw strings.

Fixes #288.