### PR TITLE
Allow API objects in addition to IDs for several properties

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -387,6 +387,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_autoscaling_group": {
 				Tok: awsResource(autoscalingMod, "Group"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"launch_configuration": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsResource(ec2Mod, "LaunchConfiguration")},
+					},
 					"placement_group": {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsResource(ec2Mod, "PlacementGroup")},

--- a/resources.go
+++ b/resources.go
@@ -761,6 +761,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_instance": {
 				Tok: awsResource(ec2Mod, "Instance"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"iam_instance_profile": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(iamMod, "InstanceProfile")},
+					},
 					"instance_type": {
 						Type: awsType(ec2Mod+"/instanceType", "InstanceType"),
 					},

--- a/resources.go
+++ b/resources.go
@@ -387,6 +387,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_autoscaling_group": {
 				Tok: awsResource(autoscalingMod, "Group"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"placement_group": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsResource(ec2Mod, "PlacementGroup")},
+					},
 					"tag": {
 						// Explicitly map tag => tags to avoid confusion with tags => tagsCollection below.
 						Name: "tags",

--- a/resources.go
+++ b/resources.go
@@ -777,8 +777,16 @@ func Provider() tfbridge.ProviderInfo {
 					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_key_pair":             {Tok: awsResource(ec2Mod, "KeyPair")},
-			"aws_launch_configuration": {Tok: awsResource(ec2Mod, "LaunchConfiguration")},
+			"aws_key_pair": {Tok: awsResource(ec2Mod, "KeyPair")},
+			"aws_launch_configuration": {
+				Tok: awsResource(ec2Mod, "LaunchConfiguration"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"iam_instance_profile": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(iamMod, "InstanceProfile")},
+					},
+				},
+			},
 			"aws_launch_template": {
 				Tok: awsResource(ec2Mod, "LaunchTemplate"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/nodejs/autoscaling/group.ts
+++ b/sdk/nodejs/autoscaling/group.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PlacementGroup} from "../ec2/placementGroup";
 import {Tags} from "../index";
 
 /**
@@ -355,7 +356,7 @@ export interface GroupState {
     /**
      * The name of the placement group into which you'll launch your instances, if any.
      */
-    readonly placementGroup?: pulumi.Input<string>;
+    readonly placementGroup?: pulumi.Input<string | PlacementGroup>;
     /**
      * Allows setting instance protection. The
      * autoscaling group will not select instances with this setting for terminination
@@ -501,7 +502,7 @@ export interface GroupArgs {
     /**
      * The name of the placement group into which you'll launch your instances, if any.
      */
-    readonly placementGroup?: pulumi.Input<string>;
+    readonly placementGroup?: pulumi.Input<string | PlacementGroup>;
     /**
      * Allows setting instance protection. The
      * autoscaling group will not select instances with this setting for terminination

--- a/sdk/nodejs/autoscaling/group.ts
+++ b/sdk/nodejs/autoscaling/group.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {LaunchConfiguration} from "../ec2/launchConfiguration";
 import {PlacementGroup} from "../ec2/placementGroup";
 import {Tags} from "../index";
 
@@ -313,7 +314,7 @@ export interface GroupState {
     /**
      * The name of the launch configuration to use.
      */
-    readonly launchConfiguration?: pulumi.Input<string>;
+    readonly launchConfiguration?: pulumi.Input<string | LaunchConfiguration>;
     /**
      * Launch template specification to use to launch instances.
      * See Launch Template Specification below for more details.
@@ -459,7 +460,7 @@ export interface GroupArgs {
     /**
      * The name of the launch configuration to use.
      */
-    readonly launchConfiguration?: pulumi.Input<string>;
+    readonly launchConfiguration?: pulumi.Input<string | LaunchConfiguration>;
     /**
      * Launch template specification to use to launch instances.
      * See Launch Template Specification below for more details.

--- a/sdk/nodejs/ec2/instance.ts
+++ b/sdk/nodejs/ec2/instance.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {InstanceProfile} from "../iam";
 import {Tags} from "../index";
 import {InstanceType} from "./instanceType";
 
@@ -368,7 +369,7 @@ export interface InstanceState {
      * launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
      * * `ipv6_address_count`- (Optional) A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet.
      */
-    readonly iamInstanceProfile?: pulumi.Input<string>;
+    readonly iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
     /**
      * Shutdown behavior for the
      * instance. Amazon defaults this to `stop` for EBS-backed instances and
@@ -544,7 +545,7 @@ export interface InstanceArgs {
      * launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
      * * `ipv6_address_count`- (Optional) A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet.
      */
-    readonly iamInstanceProfile?: pulumi.Input<string>;
+    readonly iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
     /**
      * Shutdown behavior for the
      * instance. Amazon defaults this to `stop` for EBS-backed instances and

--- a/sdk/nodejs/ec2/launchConfiguration.ts
+++ b/sdk/nodejs/ec2/launchConfiguration.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {InstanceProfile} from "../iam";
+
 /**
  * Provides a resource to create a new launch configuration, used for autoscaling groups.
  */
@@ -198,7 +200,7 @@ export interface LaunchConfigurationState {
      * The IAM instance profile to associate
      * with launched instances.
      */
-    readonly iamInstanceProfile?: pulumi.Input<string>;
+    readonly iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
     /**
      * The EC2 image ID to launch.
      */
@@ -288,7 +290,7 @@ export interface LaunchConfigurationArgs {
      * The IAM instance profile to associate
      * with launched instances.
      */
-    readonly iamInstanceProfile?: pulumi.Input<string>;
+    readonly iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
     /**
      * The EC2 image ID to launch.
      */


### PR DESCRIPTION
This pull request allows various properties in AWS resources related to autoscaling and IAM to accept relevant API objects in addition to the string representation of their ID.

- `launchConfiguration` on `aws.autoscaling.Group` will accept an `aws.ec2.LaunchConfiguration` (Fixes #292)
- `placementGroup` on `aws.autoscaling.Group` will accept an `aws.ec2.PlacementGroup` (Fixes #290)
- `iamInstanceProfile` on `aws.ec2.Instance` and `aws.ec2.LaunchConfiguration` will accept an `aws.iam.InstanceProfile` (Fixes #289)