### PR TITLE
Add Autoscaling Metrics and MetricsGranularity union and overlay

### DIFF
--- a/overlays/nodejs/autoscaling/metrics.ts
+++ b/overlays/nodejs/autoscaling/metrics.ts
@@ -1,0 +1,49 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains four categories of exports:
+//
+//     1) A union type, MetricsGranularity, that accepts any valid metrics granularity
+//     2) Individual constants for each such metrics granularity
+//     3) A union type, Metric, that accepts any valid metrics type
+//     4) Individual constants for each such metric type
+//
+// These give a better developer experience and are just sugared strings.
+
+export let OneMinuteMetricsGranularity: MetricsGranularity = "1Minute";
+
+// See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html
+export type MetricsGranularity =
+    "1Minute";
+
+export let GroupMinSizeMetric: Metric = "GroupMinSize";
+export let GroupMaxSizeMetric: Metric = "GroupMaxSize";
+export let GroupDesiredCapacityMetric: Metric = "GroupDesiredCapacity";
+export let GroupInServiceInstancesMetric: Metric = "GroupInServiceInstances";
+export let GroupPendingInstances: Metric = "GroupPendingInstances";
+export let GroupStandbyInstances: Metric = "GroupStandbyInstances";
+export let GroupTerminatingInstances: Metric = "GroupTerminatingInstances";
+export let GroupTotalInstances: Metric = "GroupTotalInstances";
+
+// See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html
+export type Metric =
+    "GroupMinSize" |
+    "GroupMaxSize" |
+    "GroupDesiredCapacity" |
+    "GroupInServiceInstances" |
+    "GroupPendingInstances" |
+    "GroupStandbyInstances" |
+    "GroupTerminatingInstances" |
+    "GroupTotalInstances";
+

--- a/resources.go
+++ b/resources.go
@@ -395,6 +395,13 @@ func Provider() tfbridge.ProviderInfo {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsResource(ec2Mod, "PlacementGroup")},
 					},
+					"enabled_metrics": {
+						Elem: &tfbridge.SchemaInfo{Type: awsType(autoscalingMod+"/metrics", "Metric")},
+					},
+					"metrics_granularity": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(autoscalingMod+"/metrics", "MetricsGranularity")},
+					},
 					"tag": {
 						// Explicitly map tag => tags to avoid confusion with tags => tagsCollection below.
 						Name: "tags",
@@ -1910,6 +1917,7 @@ func Provider() tfbridge.ProviderInfo {
 				Modules: map[string]*tfbridge.OverlayInfo{
 					"autoscaling": {
 						Files: []string{
+							"metrics.ts",          // Metric and MetricsGranularity union types and constants
 							"notificationType.ts", // NotificationType union type and constants
 						},
 					},

--- a/sdk/nodejs/autoscaling/group.ts
+++ b/sdk/nodejs/autoscaling/group.ts
@@ -7,6 +7,7 @@ import * as utilities from "../utilities";
 import {LaunchConfiguration} from "../ec2/launchConfiguration";
 import {PlacementGroup} from "../ec2/placementGroup";
 import {Tags} from "../index";
+import {Metric, MetricsGranularity} from "./metrics";
 
 /**
  * Provides an AutoScaling Group resource.
@@ -52,7 +53,7 @@ export class Group extends pulumi.CustomResource {
      * for Capacity below.) Setting this to "0" causes
      * Terraform to skip all Capacity Waiting behavior.
      */
-    public readonly enabledMetrics: pulumi.Output<string[] | undefined>;
+    public readonly enabledMetrics: pulumi.Output<Metric[] | undefined>;
     /**
      * Allows deleting the autoscaling group without waiting
      * for all instances in the pool to terminate.  You can force an autoscaling group to delete
@@ -284,7 +285,7 @@ export interface GroupState {
      * for Capacity below.) Setting this to "0" causes
      * Terraform to skip all Capacity Waiting behavior.
      */
-    readonly enabledMetrics?: pulumi.Input<pulumi.Input<string>[]>;
+    readonly enabledMetrics?: pulumi.Input<pulumi.Input<Metric>[]>;
     /**
      * Allows deleting the autoscaling group without waiting
      * for all instances in the pool to terminate.  You can force an autoscaling group to delete
@@ -332,7 +333,7 @@ export interface GroupState {
     /**
      * The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.
      */
-    readonly metricsGranularity?: pulumi.Input<string>;
+    readonly metricsGranularity?: pulumi.Input<string | MetricsGranularity>;
     /**
      * Setting this causes Terraform to wait for
      * this number of instances to show up healthy in the ELB only on creation.
@@ -430,7 +431,7 @@ export interface GroupArgs {
      * for Capacity below.) Setting this to "0" causes
      * Terraform to skip all Capacity Waiting behavior.
      */
-    readonly enabledMetrics?: pulumi.Input<pulumi.Input<string>[]>;
+    readonly enabledMetrics?: pulumi.Input<pulumi.Input<Metric>[]>;
     /**
      * Allows deleting the autoscaling group without waiting
      * for all instances in the pool to terminate.  You can force an autoscaling group to delete
@@ -478,7 +479,7 @@ export interface GroupArgs {
     /**
      * The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.
      */
-    readonly metricsGranularity?: pulumi.Input<string>;
+    readonly metricsGranularity?: pulumi.Input<string | MetricsGranularity>;
     /**
      * Setting this causes Terraform to wait for
      * this number of instances to show up healthy in the ELB only on creation.

--- a/sdk/nodejs/autoscaling/index.ts
+++ b/sdk/nodejs/autoscaling/index.ts
@@ -5,6 +5,7 @@
 export * from "./attachment";
 export * from "./group";
 export * from "./lifecycleHook";
+export * from "./metrics";
 export * from "./notification";
 export * from "./notificationType";
 export * from "./policy";

--- a/sdk/nodejs/autoscaling/metrics.ts
+++ b/sdk/nodejs/autoscaling/metrics.ts
@@ -1,0 +1,49 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains four categories of exports:
+//
+//     1) A union type, MetricsGranularity, that accepts any valid metrics granularity
+//     2) Individual constants for each such metrics granularity
+//     3) A union type, Metric, that accepts any valid metrics type
+//     4) Individual constants for each such metric type
+//
+// These give a better developer experience and are just sugared strings.
+
+export let OneMinuteMetricsGranularity: MetricsGranularity = "1Minute";
+
+// See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html
+export type MetricsGranularity =
+    "1Minute";
+
+export let GroupMinSizeMetric: Metric = "GroupMinSize";
+export let GroupMaxSizeMetric: Metric = "GroupMaxSize";
+export let GroupDesiredCapacityMetric: Metric = "GroupDesiredCapacity";
+export let GroupInServiceInstancesMetric: Metric = "GroupInServiceInstances";
+export let GroupPendingInstances: Metric = "GroupPendingInstances";
+export let GroupStandbyInstances: Metric = "GroupStandbyInstances";
+export let GroupTerminatingInstances: Metric = "GroupTerminatingInstances";
+export let GroupTotalInstances: Metric = "GroupTotalInstances";
+
+// See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html
+export type Metric =
+    "GroupMinSize" |
+    "GroupMaxSize" |
+    "GroupDesiredCapacity" |
+    "GroupInServiceInstances" |
+    "GroupPendingInstances" |
+    "GroupStandbyInstances" |
+    "GroupTerminatingInstances" |
+    "GroupTotalInstances";
+

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -66,6 +66,7 @@
         "autoscaling/group.ts",
         "autoscaling/index.ts",
         "autoscaling/lifecycleHook.ts",
+        "autoscaling/metrics.ts",
         "autoscaling/notification.ts",
         "autoscaling/notificationType.ts",
         "autoscaling/policy.ts",


### PR DESCRIPTION
This commit adds a new overlay for nodejs, defining union types of valid metric types and granularities for autoscaling groups, and overrides the `enabledMetrics` and `metricsGranularity` propertes of the aws.autoscaling.Group` type to accept these new types instead of raw strings.

Fixes #291.