### PR TITLE
Switch to the 'dev' version of our dependencies.

### DIFF
--- a/examples/bucket/package.json
+++ b/examples/bucket/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/examples/cloudwatch/package.json
+++ b/examples/cloudwatch/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "dev"
+        "@pulumi/pulumi": "dev",
         "express": "^4.16.3",
         "aws-serverless-express": "^3.3.5"
     },

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1",
+        "@pulumi/pulumi": "dev"
         "express": "^4.16.3",
         "aws-serverless-express": "^3.3.5"
     },

--- a/examples/logGroup/package.json
+++ b/examples/logGroup/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/multiple-regions/package.json
+++ b/examples/multiple-regions/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/queue/package.json
+++ b/examples/queue/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev",
-        "@pulumi/aws": "^0.15.2-dev"
+        "@pulumi/pulumi": "dev",
+        "@pulumi/aws": "dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/examples/serverless-raw/package.json
+++ b/examples/serverless-raw/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^10.3.0"

--- a/examples/table/package.json
+++ b/examples/table/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/examples/topic/package.json
+++ b/examples/topic/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/pulumi": "dev"
         "node-fetch": "^2.2.0"
     },
     "devDependencies": {

--- a/examples/topic/package.json
+++ b/examples/topic/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "dev"
+        "@pulumi/pulumi": "dev",
         "node-fetch": "^2.2.0"
     },
     "devDependencies": {

--- a/examples/webserver-comp/package.json
+++ b/examples/webserver-comp/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/webserver/package.json
+++ b/examples/webserver/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/webserver/variants/get/package.json
+++ b/examples/webserver/variants/get/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/webserver/variants/ssh/package.json
+++ b/examples/webserver/variants/ssh/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/webserver/variants/ssh_description/package.json
+++ b/examples/webserver/variants/ssh_description/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/webserver/variants/zones/package.json
+++ b/examples/webserver/variants/zones/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/resources.go
+++ b/resources.go
@@ -1943,7 +1943,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":    "^0.15.4-dev",
+				"@pulumi/pulumi":    "dev",
 				"builtin-modules":   "3.0.0",
 				"read-package-tree": "^5.2.1",
 				"resolve":           "^1.7.1",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/pulumi": "dev",
         "builtin-modules": "3.0.0",
         "read-package-tree": "^5.2.1",
         "resolve": "^1.7.1"

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/pulumi@^0.15.4-dev":
-  version "0.15.4-dev-1537844791-g431f5b34"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537844791-g431f5b34.tgz#2c3d79515be81ab910f817376d32e8db83783cd3"
+"@pulumi/pulumi@dev":
+  version "0.15.4-dev-1537898302-g5d34e380"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537898302-g5d34e380.tgz#73e5507aa352d15602f3269c60aa1894f1d690e9"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/tests/delete_before_create/mount_target/step1/package.json
+++ b/tests/delete_before_create/mount_target/step1/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "latest",

--- a/tests/regression/package.json
+++ b/tests/regression/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^10.3.0"

--- a/tests/serverless_functions/package.json
+++ b/tests/serverless_functions/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1",
+        "@pulumi/pulumi": "dev",
         "@slack/client": "4.3.1",
         "aws-sdk": "^2.252.1",
         "express": "^4.16.3"


### PR DESCRIPTION
This prevents us from having to continually update these version numbers everywhere as we update upstream libs.  We will still need to replace these with the right non-dev values when we publish official versins.  But we had to do that anyways even when we were saying things like ~0.15.4-dev.