### PR TITLE
Change to a path-based approach to API routes in the experimental apigateway API.

### DIFF
--- a/examples/api/index.ts
+++ b/examples/api/index.ts
@@ -44,23 +44,20 @@ const lambda = new aws.lambda.Function("myfunction", {
 });
 
 const api = new x.API("myapi", {
-    routes: {
-        "/a": {
-            kind: "EventHandler",
-            method: "GET",
-            eventHandler: async (event) => {
-                return {
-                    statusCode: 200,
-                    body: "<h1>Hello world!</h1>",
-                };
-            }
+    routes: [{
+        path: "/a",
+        method: "GET",
+        eventHandler: async (event) => {
+            return {
+                statusCode: 200,
+                body: "<h1>Hello world!</h1>",
+            };
         },
-        "/b": {
-            kind: "EventHandler",
-            method: "GET",
-            eventHandler: lambda
-        },
-    },
+    }, {
+        path: "/b",
+        method: "GET",
+        eventHandler: lambda,
+    }],
 });
 
 export const url = api.url;

--- a/examples/api/index.ts
+++ b/examples/api/index.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as aws from "@pulumi/aws";
-import { x } from "@pulumi/aws/apigateway";
 import * as pulumi from "@pulumi/pulumi";
 
 const policy: aws.iam.PolicyDocument = {
@@ -43,7 +42,7 @@ const lambda = new aws.lambda.Function("myfunction", {
     runtime: aws.lambda.NodeJS8d10Runtime,
 });
 
-const api = new x.API("myapi", {
+const api = new aws.apigateway.x.API("myapi", {
     routes: [{
         path: "/a",
         method: "GET",

--- a/examples/api/index.ts
+++ b/examples/api/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as aws from "@pulumi/aws";
+import { x } from "@pulumi/aws/apigateway";
 import * as pulumi from "@pulumi/pulumi";
 
 const policy: aws.iam.PolicyDocument = {
@@ -42,16 +43,24 @@ const lambda = new aws.lambda.Function("myfunction", {
     runtime: aws.lambda.NodeJS8d10Runtime,
 });
 
-const api = new aws.apigateway.x.API("myapi", {
-    routes: [
-        { method: "GET", path: "/a", handler: async (event) => {
-            return {
-                statusCode: 200,
-                body: "<h1>Hello world!</h1>",
-            };
-        }},
-        { method: "GET", path: "/b", handler: lambda },
-    ],
+const api = new x.API("myapi", {
+    routes: {
+        "/a": {
+            kind: "EventHandler",
+            method: "GET",
+            eventHandler: async (event) => {
+                return {
+                    statusCode: 200,
+                    body: "<h1>Hello world!</h1>",
+                };
+            }
+        },
+        "/b": {
+            kind: "EventHandler",
+            method: "GET",
+            eventHandler: lambda
+        },
+    },
 });
 
 export const url = api.url;

--- a/examples/api/step2/index.ts
+++ b/examples/api/step2/index.ts
@@ -15,18 +15,16 @@
 import * as aws from "@pulumi/aws";
 
 const api = new aws.apigateway.x.API("myapi", {
-    routes: {
-        "/b": {
-            kind: "EventHandler",
-            method: "GET",
-            eventHandler: async (event) => {
-                return {
-                    statusCode: 200,
-                    body: "<h1>Hello world!</h1>",
-                };
-            }
-        },
-    }
+    routes: [{
+        path: "/b",
+        method: "GET",
+        eventHandler: async (event) => {
+            return {
+                statusCode: 200,
+                body: "<h1>Hello world!</h1>",
+            };
+        }
+    }],
 });
 
 export const url = api.url;

--- a/examples/api/step2/index.ts
+++ b/examples/api/step2/index.ts
@@ -15,14 +15,18 @@
 import * as aws from "@pulumi/aws";
 
 const api = new aws.apigateway.x.API("myapi", {
-    routes: [
-        { method: "GET", path: "/b", handler: async (event) => {
-            return {
-                statusCode: 200,
-                body: "<h1>Hello world!</h1>",
-            };
-        }},
-    ],
+    routes: {
+        "/b": {
+            kind: "EventHandler",
+            method: "GET",
+            eventHandler: async (event) => {
+                return {
+                    statusCode: 200,
+                    body: "<h1>Hello world!</h1>",
+                };
+            }
+        },
+    }
 });
 
 export const url = api.url;

--- a/examples/api/yarn.lock
+++ b/examples/api/yarn.lock
@@ -45,18 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@dev":
-  version "0.15.2-dev-1537910355-g327c12d"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1537910355-g327c12d.tgz#e1c9c4301d5093f5188526c4b6f9e592cf6bb5c4"
-  dependencies:
-    "@pulumi/pulumi" dev
-    builtin-modules "3.0.0"
-    read-package-tree "^5.2.1"
-    resolve "^1.7.1"
-
 "@pulumi/pulumi@dev":
-  version "0.15.4-dev-1537898302-g5d34e380"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537898302-g5d34e380.tgz#73e5507aa352d15602f3269c60aa1894f1d690e9"
+  version "0.15.5-dev-1538597180-g16ae1f2a"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.5-dev-1538597180-g16ae1f2a.tgz#c59922ad0df786119a037e1fabfae80808b4526c"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -68,6 +59,7 @@
     source-map-support "^0.4.16"
     ts-node "^7.0.0"
     typescript "^3.0.0"
+    upath "^1.1.0"
 
 "@types/aws-sdk@^2.7.0":
   version "2.7.0"
@@ -80,12 +72,12 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
 
 "@types/node@^10.1.0":
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.0.tgz#ddd0d67a3b6c3810dd1a59e36675fa82de5e19ae"
+  version "10.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
 
 "@types/node@^8.0.27":
-  version "8.10.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.30.tgz#2c82cbed5f79d72280c131d2acffa88fbd8dd353"
+  version "8.10.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.34.tgz#a94d9f3767fe45f211e09e49af598bb84822280c"
 
 abbrev@1:
   version "1.1.1"
@@ -126,8 +118,8 @@ ascli@~1:
     optjs "~3.2.2"
 
 aws-sdk@*:
-  version "2.322.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.322.0.tgz#d9245cbdab6134bc5967644fea85daa32fd03632"
+  version "2.327.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.327.0.tgz#0192f71f764182bd2f81a65851071ed5265121bd"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -165,10 +157,6 @@ buffer@4.9.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-builtin-modules@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.0.0.tgz#1e587d44b006620d90286cc7a9238bbc6129cab1"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -255,7 +243,7 @@ diff@^3.1.0:
 
 events@1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  resolved "http://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -443,8 +431,8 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 nan@^2.0.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
 
 needle@^2.2.1:
   version "2.2.4"
@@ -548,10 +536,6 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-parse@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -646,12 +630,6 @@ require-from-string@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
-resolve@^1.7.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  dependencies:
-    path-parse "^1.0.5"
-
 rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -712,15 +690,15 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.1.tgz#434434ff9d1726b4d9f4219d1004813d80639e30"
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
 
 spdx-expression-parse@^3.0.0:
   version "3.0.0"
@@ -756,7 +734,7 @@ string_decoder@~1.1.1:
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  resolved "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
 
@@ -796,8 +774,12 @@ ts-node@^7.0.0:
     yn "^2.0.0"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
+
+upath@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 url@0.10.3:
   version "0.10.3"

--- a/sdk/nodejs/apigateway/experimental/api.ts
+++ b/sdk/nodejs/apigateway/experimental/api.ts
@@ -71,12 +71,6 @@ export interface Response {
 
 export type Method = "ANY" | "GET" | "PUT" | "POST" | "DELETE" | "PATCH";
 
-// export enum RouteKind {
-//     EventHandler = "EventHandler",
-//     Static = "Static",
-//     Proxy = "Proxy",
-// }
-
 /**
  * A route that that APIGateway should accept and forward to some type of destination. All routes
  * have an incoming path that they match against.  However, destinations are determined by the kind
@@ -322,7 +316,6 @@ interface ApigatewayIntegration {
 }
 
 function createSwaggerSpec(name: string, opts: pulumi.ResourceOptions, routes: Routes): SwaggerSpec {
-
     // Set up the initial swagger spec.
     const swagger: SwaggerSpec = {
         swagger: "2.0",
@@ -348,7 +341,6 @@ function createSwaggerSpec(name: string, opts: pulumi.ResourceOptions, routes: R
     };
 
     // Now add all the routes to it.
-
     for (const path in routes) {
         if (routes.hasOwnProperty(path)) {
             const route = routes[path];
@@ -365,19 +357,13 @@ function createSwaggerSpec(name: string, opts: pulumi.ResourceOptions, routes: R
                     continue;
                 default:
                     const exhaustiveMatch: never = route;
-                    throw new Error('Non-exhausive match for route');
+                    throw new Error('Non-exhaustive match for route');
             }
         }
     }
 
     return swagger;
 }
-
-// function ensureSwaggerPath(swagger: SwaggerSpec, path: string) {
-//     if (!swagger.paths[path]) {
-//         swagger.paths[path] = {};
-//     }
-// }
 
 function addSwaggerOperation(swagger: SwaggerSpec, path: string, method: string, operation: SwaggerOperation) {
     if (!swagger.paths[path]) {
@@ -394,8 +380,7 @@ function addEventHandlerRouteToSwaggerSpec(
     const lambdaFunc = lambda.createFunctionFromEventHandler(
         name + sha1hash(method + ":" + path), route.eventHandler, opts);
 
-    addSwaggerOperation(swagger, path, method,
-        createSwaggerOperationForLambda(lambdaFunc));
+    addSwaggerOperation(swagger, path, method, createSwaggerOperationForLambda(lambdaFunc));
     return;
 
     function createSwaggerOperationForLambda(lambda: aws.lambda.Function): SwaggerOperation {
@@ -466,8 +451,7 @@ function addStaticRouteToSwaggerSpec(
 
         createBucketObject(key, route.localPath, route.contentType);
 
-        addSwaggerOperation(swagger, path, method,
-            createSwaggerOperationForObjectKey(key, role));
+        addSwaggerOperation(swagger, path, method, createSwaggerOperationForObjectKey(key, role));
     }
 
     function processDirectory(directory: StaticRoute) {
@@ -530,8 +514,7 @@ function addStaticRouteToSwaggerSpec(
         // Take whatever path the client wants to host this folder at, and add the
         // greedy matching predicate to the end.
         const proxyPath = directoryServerPath + "{proxy+}";
-        addSwaggerOperation(swagger, proxyPath, swaggerMethod("ANY"),
-            createSwaggerOperationForObjectKey(directoryKey, role, "proxy"));
+        addSwaggerOperation(swagger, proxyPath, swaggerMethod("ANY"), createSwaggerOperationForObjectKey(directoryKey, role, "proxy"));
     }
 
     function createSwaggerOperationForObjectKey(

--- a/sdk/nodejs/apigateway/experimental/api.ts
+++ b/sdk/nodejs/apigateway/experimental/api.ts
@@ -518,9 +518,9 @@ function addStaticRouteToSwaggerSpec(
     }
 
     function createSwaggerOperationForObjectKey(
-        objectKey: string,
-        role: aws.iam.Role,
-        pathParameter?: string): SwaggerOperation {
+            objectKey: string,
+            role: aws.iam.Role,
+            pathParameter?: string): SwaggerOperation {
 
         const region = aws.config.requireRegion();
 


### PR DESCRIPTION
I recommend reviewing with whitespace off: https://github.com/pulumi/pulumi-aws/pull/343/files?w=1

Instead of passing multiple differnet arrays of route types, callers can just supply a 'route mapping object' where the keys are the route paths they care about, and the values are the specific types of routes.