### PR TITLE
Add union type and constants for S3 Canned ACLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 Pulumi.*.yaml
 
 **/command-output/
+
+.idea/
+*.iml

--- a/resources.go
+++ b/resources.go
@@ -1621,6 +1621,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_s3_bucket": {
 				Tok: awsResource(s3Mod, "Bucket"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"acl": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(s3Mod+"/cannedAcl", "CannedAcl")},
+					},
 					"bucket": tfbridge.AutoNameTransform("bucket", 63, func(name string) string {
 						return strings.ToLower(name)
 					}),
@@ -2019,6 +2023,7 @@ func Provider() tfbridge.ProviderInfo {
 					},
 					"s3": {
 						DestFiles: []string{
+							"cannedAcl.ts", // a union type and constants for canned ACL names.
 							"s3Mixins.ts",
 						},
 					},

--- a/sdk/nodejs/s3/bucket.ts
+++ b/sdk/nodejs/s3/bucket.ts
@@ -5,6 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {Tags} from "../index";
+import {CannedAcl} from "./cannedAcl";
 
 /**
  * Provides a S3 bucket resource.
@@ -188,7 +189,7 @@ export interface BucketState {
     /**
      * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
      */
-    readonly acl?: pulumi.Input<string>;
+    readonly acl?: pulumi.Input<string | CannedAcl>;
     /**
      * The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      */
@@ -285,7 +286,7 @@ export interface BucketArgs {
     /**
      * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
      */
-    readonly acl?: pulumi.Input<string>;
+    readonly acl?: pulumi.Input<string | CannedAcl>;
     /**
      * The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      */

--- a/sdk/nodejs/s3/cannedAcl.ts
+++ b/sdk/nodejs/s3/cannedAcl.ts
@@ -1,0 +1,40 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains two categories of exports:
+//
+//     1) A union type, CannedAcl, that accepts any valid canned ACL type
+//     2) Individual constants for each such canned ACL type
+//
+// These give a better developer experience and are just sugared strings.
+
+export let PrivateAcl:                CannedAcl = "private";
+export let PublicReadAcl:             CannedAcl = "public-read";
+export let PublicReadWriteAcl:        CannedAcl = "public-read-write";
+export let AwsExecReadAcl:            CannedAcl = "aws-exec-read";
+export let AuthenticatedReadAcl:      CannedAcl = "authenticated-read";
+export let BucketOwnerReadAcl:        CannedAcl = "bucket-owner-read";
+export let BucketOwnerFullControlAcl: CannedAcl = "bucket-owner-full-control";
+export let LogDeliveryWriteAcl:       CannedAcl = "log-delivery-write";
+
+// See https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+export type CannedAcl =
+    "private" |
+    "public-read" |
+    "public-read-write" |
+    "aws-exec-read" |
+    "authenticated-read" |
+    "bucket-owner-read" |
+    "bucket-owner-full-control" |
+    "log-delivery-write"

--- a/sdk/nodejs/s3/index.ts
+++ b/sdk/nodejs/s3/index.ts
@@ -7,6 +7,7 @@ export * from "./bucketMetric";
 export * from "./bucketNotification";
 export * from "./bucketObject";
 export * from "./bucketPolicy";
+export * from "./cannedAcl";
 export * from "./getBucket";
 export * from "./getBucketObject";
 export * from "./inventory";

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -527,6 +527,7 @@
         "s3/bucketNotification.ts",
         "s3/bucketObject.ts",
         "s3/bucketPolicy.ts",
+        "s3/cannedAcl.ts",
         "s3/getBucket.ts",
         "s3/getBucketObject.ts",
         "s3/index.ts",


### PR DESCRIPTION
This pull request adds a union type and constants for S3 canned ACLs, based on the [documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).