### PR TITLE
Introduce Gopkg.template.toml

### DIFF
--- a/Gopkg.template.toml
+++ b/Gopkg.template.toml
@@ -1,0 +1,19 @@
+[[constraint]]
+  branch = "master"
+  name = "github.com/pulumi/pulumi"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/pulumi/pulumi-terraform"
+
+[[constraint]]
+  branch = "pulumi-master"
+  name = "github.com/terraform-providers/terraform-provider-aws"
+  source = "github.com/pulumi/terraform-provider-aws"
+
+  [constraint.metadata]
+    govendor-override = true
+    govendor-exclude-prefixes = [
+      "github.com/golang/protobuf",
+    ]
+


### PR DESCRIPTION
This brings the AWS repository into line with the other Terraform-backed providers (excluding GCP), and allows the workflow for updating this repository to use `govendor-override < Gopkg.template.toml > Gopkg.toml` and removes the need for removing overrides for protocol buffers.