### PR TITLE
Don't use aws.Tags for aws.autoscaling.Group::tagsCollection

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -433,9 +433,7 @@ func Provider() tfbridge.ProviderInfo {
 						// Conflicts with the pluralized `tag` property, which is the more strongly typed option for
 						// providing tags.  We keep this dynamically typed collection of tags as an option as well, but
 						// give it a different name.
-						Name:        "tagsCollection",
-						Type:        awsType(awsMod, "Tags"),
-						MaxItemsOne: boolRef(true),
+						Name: "tagsCollection",
 					},
 				},
 			},

--- a/sdk/go/aws/autoscaling/group.go
+++ b/sdk/go/aws/autoscaling/group.go
@@ -295,8 +295,8 @@ func (r *Group) Tags() *pulumi.ArrayOutput {
 }
 
 // A list of tag blocks (maps). Tags documented below.
-func (r *Group) TagsCollection() *pulumi.MapOutput {
-	return (*pulumi.MapOutput)(r.s.State["tagsCollection"])
+func (r *Group) TagsCollection() *pulumi.ArrayOutput {
+	return (*pulumi.ArrayOutput)(r.s.State["tagsCollection"])
 }
 
 // A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.

--- a/sdk/nodejs/autoscaling/group.ts
+++ b/sdk/nodejs/autoscaling/group.ts
@@ -6,7 +6,6 @@ import * as utilities from "../utilities";
 
 import {LaunchConfiguration} from "../ec2/launchConfiguration";
 import {PlacementGroup} from "../ec2/placementGroup";
-import {Tags} from "../index";
 import {Metric, MetricsGranularity} from "./metrics";
 
 /**
@@ -152,7 +151,7 @@ export class Group extends pulumi.CustomResource {
     /**
      * A list of tag blocks (maps). Tags documented below.
      */
-    public readonly tagsCollection: pulumi.Output<Tags | undefined>;
+    public readonly tagsCollection: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
      */
@@ -389,7 +388,7 @@ export interface GroupState {
     /**
      * A list of tag blocks (maps). Tags documented below.
      */
-    readonly tagsCollection?: pulumi.Input<Tags>;
+    readonly tagsCollection?: pulumi.Input<pulumi.Input<{[key: string]: any}>[]>;
     /**
      * A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
      */
@@ -538,7 +537,7 @@ export interface GroupArgs {
     /**
      * A list of tag blocks (maps). Tags documented below.
      */
-    readonly tagsCollection?: pulumi.Input<Tags>;
+    readonly tagsCollection?: pulumi.Input<pulumi.Input<{[key: string]: any}>[]>;
     /**
      * A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
      */


### PR DESCRIPTION
The existence of `tagsCollection` on `aws.autoscaling.Group` is to work around a limitation of HCLv1 configuration for Terraform, and while it is not the preferable way to define tags in Pulumi, is sometimes generated by tf2pulumi.

This commit fixes the type generation such that a list of maps with keys consisting of `key`, `value` and `propagate_at_launch` will work for tagging an autoscaling group.

Use of `tags` continues to be preferred.

Fixes #400.