### PR TITLE
Follow new patterns for component resources.

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -2125,7 +2125,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":    "^0.16.8-dev",
+				"@pulumi/pulumi":    "dev",
 				"aws-sdk":           "^2.0.0",
 				"mime":              "^2.0.0",
 				"builtin-modules":   "3.0.0",

--- a/sdk/nodejs/apigateway/experimental/api.ts
+++ b/sdk/nodejs/apigateway/experimental/api.ts
@@ -266,12 +266,7 @@ export class API extends pulumi.ComponentResource {
             stageName: stageName,
         }, { parent: this, dependsOn: permissions });
 
-        this.registerOutputs({
-            restAPI: this.restAPI,
-            deployment: this.deployment,
-            stage: this.stage,
-            url: this.url,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/cloudwatch/eventRuleMixins.ts
+++ b/sdk/nodejs/cloudwatch/eventRuleMixins.ts
@@ -73,7 +73,7 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
         name: string, eventRuleOrSchedule: eventRule.EventRule | string, handler: EventRuleEventHandler,
         args: EventRuleEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:cloudwatch:EventRuleEventSubscription", name, { }, opts);
+        super("aws:cloudwatch:EventRuleEventSubscription", name, opts);
 
         const parentOpts = { parent: this };
         if (typeof eventRuleOrSchedule === "string") {
@@ -101,11 +101,7 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
             targetId: name,
         }, parentOpts);
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-            target: this.target,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/cloudwatch/logGroupMixins.ts
+++ b/sdk/nodejs/cloudwatch/logGroupMixins.ts
@@ -76,7 +76,7 @@ export class LogGroupEventSubscription extends lambda.EventSubscription {
         name: string, logGroup: logGroup.LogGroup, handler: LogGroupEventHandler,
         args: LogGroupEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:cloudwatch:LogGroupEventSubscription", name, { logGroup: logGroup }, opts);
+        super("aws:cloudwatch:LogGroupEventSubscription", name, opts);
 
         args = args || {};
         const parentOpts = { parent: this };
@@ -95,11 +95,7 @@ export class LogGroupEventSubscription extends lambda.EventSubscription {
             logGroup: logGroup,
         }, parentOpts);
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-            logSubscriptionFilter: this.logSubscriptionFilter,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/dynamodb/dynamodbMixins.ts
+++ b/sdk/nodejs/dynamodb/dynamodbMixins.ts
@@ -67,7 +67,7 @@ export class TableEventSubscription extends lambda.EventSubscription {
         name: string, table: table.Table, handler: TableEventHandler,
         args: TableEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:dynamodb:TableEventSubscription", name, { table: table }, opts);
+        super("aws:dynamodb:TableEventSubscription", name, opts);
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);
@@ -87,11 +87,7 @@ export class TableEventSubscription extends lambda.EventSubscription {
             startingPosition: args.startingPosition,
         }, parentOpts);
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-            eventSourceMapping: this.eventSourceMapping,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/kinesis/kinesisMixins.ts
+++ b/sdk/nodejs/kinesis/kinesisMixins.ts
@@ -71,7 +71,7 @@ export class StreamEventSubscription extends lambda.EventSubscription {
         name: string, stream: stream.Stream, handler: StreamEventHandler,
         args: StreamEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:kinesis:StreamEventSubscription", name, { stream: stream }, opts);
+        super("aws:kinesis:StreamEventSubscription", name, opts);
 
         const parentOpts = { parent: this };
         this.func = createFunctionFromEventHandler(name, handler, parentOpts);
@@ -93,11 +93,7 @@ export class StreamEventSubscription extends lambda.EventSubscription {
         };
         this.eventSourceMapping = new lambda.EventSourceMapping(name, mappingArgs, parentOpts);
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-            eventSourceMapping: this.eventSourceMapping,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/lambda/lambdaMixins.ts
+++ b/sdk/nodejs/lambda/lambdaMixins.ts
@@ -227,9 +227,9 @@ export class EventSubscription extends pulumi.ComponentResource {
     public func: LambdaFunction;
 
     public constructor(
-        type: string, name: string, props: Record<string, any>, opts?: pulumi.ComponentResourceOptions) {
+        type: string, name: string, opts?: pulumi.ComponentResourceOptions) {
 
-        super(type, name, props, opts);
+        super(type, name, {}, opts);
     }
 }
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.16.8-dev",
+        "@pulumi/pulumi": "dev",
         "aws-sdk": "^2.0.0",
         "builtin-modules": "3.0.0",
         "mime": "^2.0.0",

--- a/sdk/nodejs/s3/s3Mixins.ts
+++ b/sdk/nodejs/s3/s3Mixins.ts
@@ -130,7 +130,7 @@ export class BucketEventSubscription extends lambda.EventSubscription {
         name: string, bucket: Bucket, handler: BucketEventHandler,
         args: BucketEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:s3:BucketEventSubscription", name, { bucket: bucket }, opts);
+        super("aws:s3:BucketEventSubscription", name, opts);
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);
@@ -171,10 +171,7 @@ export class BucketEventSubscription extends lambda.EventSubscription {
             provider: this.getProvider("aws::"),
         });
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/serverless/function.ts
+++ b/sdk/nodejs/serverless/function.ts
@@ -100,12 +100,11 @@ export class Function extends pulumi.ComponentResource {
      * @param func Deprecated.  Pass the function as [options.func] or [options.factoryFunc] instead.
      */
     constructor(name: string,
-        options: FunctionOptions,
-        func?: Handler,
-        opts?: pulumi.ResourceOptions,
-        serialize?: (obj: any) => boolean) {
+                options: FunctionOptions,
+                func?: Handler,
+                opts?: pulumi.ResourceOptions) {
 
-        super("aws:serverless:Function", name, { options: options }, opts);
+        super("aws:serverless:Function", name, {}, opts);
 
         opts = opts || { parent: this };
 

--- a/sdk/nodejs/sns/snsMixins.ts
+++ b/sdk/nodejs/sns/snsMixins.ts
@@ -67,7 +67,7 @@ export class TopicEventSubscription extends lambda.EventSubscription {
         name: string, topic: topic.Topic, handler: TopicEventHandler,
         args: TopicEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:sns:TopicEventSubscription", name, { }, opts);
+        super("aws:sns:TopicEventSubscription", name, opts);
 
         args = args || {};
         this.topic = topic;
@@ -88,11 +88,7 @@ export class TopicEventSubscription extends lambda.EventSubscription {
             endpoint: this.func.arn,
         }, parentOpts);
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-            subscription: this.subscription,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/sdk/nodejs/sqs/sqsMixins.ts
+++ b/sdk/nodejs/sqs/sqsMixins.ts
@@ -66,7 +66,7 @@ export class QueueEventSubscription extends lambda.EventSubscription {
         name: string, queue: queue.Queue, handler: QueueEventHandler,
         args: QueueEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:sqs:QueueEventSubscription", name, { }, opts);
+        super("aws:sqs:QueueEventSubscription", name, opts);
 
         args = args || {};
 
@@ -87,11 +87,7 @@ export class QueueEventSubscription extends lambda.EventSubscription {
             functionName: this.func.name,
         }, parentOpts);
 
-        this.registerOutputs({
-            func: this.func,
-            permission: this.permission,
-            eventSourceMapping: this.eventSourceMapping,
-        });
+        this.registerOutputs();
     }
 }
 


### PR DESCRIPTION
As per our friday meeting:

1. Components do not need to pass 'props' up to pulumi.ComponentResource (and, even if they did, pulumi.ComponentResource would ignore them thanks to https://github.com/pulumi/pulumi/pull/2296).
2. ComponentResources should call `registerOutputs` at the end of processing.  But should generally not include any properties with that call.  actually reporting outputs is really only intended for 'Stack' to do.