### PR TITLE
Include update instructions link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ the language of choice, while having Pulumi itself do the appropriate transforma
 This makes many APIs easier to use, such as defining a Lambda to execute when an S3 Bucket is manipulated,
 or a CloudWatch timer is fired.  To see some examples of this in action, please refer to the `examples/` directory.
 
-The [pulumi/pulumi-aws-serverless](https://github.com/pulumi/pulumi-aws-serverless) and
-[pulumi/pulumi-cloud](https://github.com/pulumi/pulumi-cloud) repos offer higher level abstractions that build on top
+The [pulumi/pulumi-cloud](https://github.com/pulumi/pulumi-cloud) repo offer higher level abstractions that build on top
 of this underlying capability.
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ of this underlying capability.
 
 For detailed reference documentation, please visit [the API docs](
 https://pulumi.io/reference/pkg/nodejs/@pulumi/aws/index.html).
+
+## Updating this provider
+
+The AWS Resource Provider for Pulumi is based on the Terraform Provider for
+AWS. Instructions for keeping it up to date are available [here][updating].
+
+[updating]: https://github.com/pulumi/pulumi-terraform/wiki/Updating-Pulumi-Providers-Backed-By-Terraform-Providers


### PR DESCRIPTION
This pull request updates the README file in the following ways:

1. Include a link to the instructions for updating Terraform-backed providers
2. Remove a reference to the now-deprecated `aws-serverless` repo, since the functionality is now subsumed directly into the packages in this repository.