### PR TITLE
Allow refresh changes in `multi-region` test

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -99,7 +99,10 @@ func TestExamples(t *testing.T) {
 				ExpectRefreshChanges: true,
 			}),
 			baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "serverless")}),
-			baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "multiple-regions")}),
+			baseJS.With(integration.ProgramTestOptions{
+				Dir:                  path.Join(cwd, "multiple-regions"),
+				ExpectRefreshChanges: true,
+			}),
 			// Python tests:
 			base.With(integration.ProgramTestOptions{
 				Dir: path.Join(cwd, "webserver-py"),


### PR DESCRIPTION
We've seen a few cases where `pulumi refresh` casues information about
the EC2 instance to be created.

The purpose of this test is not related to ensuring refreshes don't
happen, so I'm just changing the test such that we allow refreshes.