### PR TITLE
Remove aws.Tags overlay from resources

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2018, Pulumi Corporation.(
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -220,20 +220,10 @@ func Provider() tfbridge.ProviderInfo {
 		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// AWS Certificate Manager
-			"aws_acm_certificate": {
-				Tok: awsResource(acmMod, "Certificate"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_acm_certificate":            {Tok: awsResource(acmMod, "Certificate")},
 			"aws_acm_certificate_validation": {Tok: awsResource(acmMod, "CertificateValidation")},
 			// AWS Private Certificate Authority
-			"aws_acmpca_certificate_authority": {
-				Tok: awsResource(acmpcaMod, "CertificateAuthority"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_acmpca_certificate_authority": {Tok: awsResource(acmpcaMod, "CertificateAuthority")},
 			// AppSync
 			"aws_appsync_api_key":     {Tok: awsResource(appsyncMod, "ApiKey")},
 			"aws_appsync_graphql_api": {Tok: awsResource(appsyncMod, "GraphQLApi")},
@@ -381,7 +371,6 @@ func Provider() tfbridge.ProviderInfo {
 						Name: "restApi",
 						Type: awsType(apigatewayMod+"/restApi", "RestApi"),
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_api_gateway_usage_plan":     {Tok: awsResource(apigatewayMod, "UsagePlan")},
@@ -467,31 +456,16 @@ func Provider() tfbridge.ProviderInfo {
 			// Cloud9
 			"aws_cloud9_environment_ec2": {Tok: awsResource(cloud9Mod, "EnvironmentEC2")},
 			// CloudFormation
-			"aws_cloudformation_stack": {
-				Tok: awsResource(cloudformationMod, "Stack"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_cloudformation_stack": {Tok: awsResource(cloudformationMod, "Stack")},
 			// CloudHSM
 			"aws_cloudhsm_v2_cluster": {Tok: awsResource(cloudhsmv2Mod, "Cluster")},
 			"aws_cloudhsm_v2_hsm":     {Tok: awsResource(cloudhsmv2Mod, "Hsm")},
 			// CloudFront
-			"aws_cloudfront_distribution": {
-				Tok: awsResource(cloudfrontMod, "Distribution"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_cloudfront_distribution":           {Tok: awsResource(cloudfrontMod, "Distribution")},
 			"aws_cloudfront_public_key":             {Tok: awsResource(cloudfrontMod, "PublicKey")},
 			"aws_cloudfront_origin_access_identity": {Tok: awsResource(cloudfrontMod, "OriginAccessIdentity")},
 			// CloudTrail
-			"aws_cloudtrail": {
-				Tok: awsResource(cloudtrailMod, "Trail"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_cloudtrail": {Tok: awsResource(cloudtrailMod, "Trail")},
 			// CloudWatch
 			"aws_cloudwatch_dashboard":        {Tok: awsResource(cloudwatchMod, "Dashboard")},
 			"aws_cloudwatch_event_permission": {Tok: awsResource(cloudwatchMod, "EventPermission")},
@@ -512,9 +486,6 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_cloudwatch_log_group": {
 				IDFields: []string{"name"},
 				Tok:      awsResource(cloudwatchMod, "LogGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
 			},
 			"aws_cloudwatch_log_metric_filter":   {Tok: awsResource(cloudwatchMod, "LogMetricFilter")},
 			"aws_cloudwatch_log_resource_policy": {Tok: awsResource(cloudwatchMod, "LogResourcePolicy")},
@@ -554,12 +525,7 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			// CodeBuild
-			"aws_codebuild_project": {
-				Tok: awsResource(codebuildMod, "Project"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_codebuild_project": {Tok: awsResource(codebuildMod, "Project")},
 			"aws_codebuild_webhook": {Tok: awsResource(codebuildMod, "Webhook")},
 			// CodeDeploy
 			"aws_codedeploy_app":               {Tok: awsResource(codedeployMod, "Application")},
@@ -587,14 +553,9 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_cognito_identity_provider":              {Tok: awsResource(cognitoMod, "IdentityProvider")},
 			"aws_cognito_resource_server":                {Tok: awsResource(cognitoMod, "ResourceServer")},
 			"aws_cognito_user_group":                     {Tok: awsResource(cognitoMod, "UserGroup")},
-			"aws_cognito_user_pool": {
-				Tok: awsResource(cognitoMod, "UserPool"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_cognito_user_pool_client": {Tok: awsResource(cognitoMod, "UserPoolClient")},
-			"aws_cognito_user_pool_domain": {Tok: awsResource(cognitoMod, "UserPoolDomain")},
+			"aws_cognito_user_pool":                      {Tok: awsResource(cognitoMod, "UserPool")},
+			"aws_cognito_user_pool_client":               {Tok: awsResource(cognitoMod, "UserPoolClient")},
+			"aws_cognito_user_pool_domain":               {Tok: awsResource(cognitoMod, "UserPoolDomain")},
 			// Config
 			"aws_config_aggregate_authorization":       {Tok: awsResource(cfgMod, "AggregateAuthorization")},
 			"aws_config_config_rule":                   {Tok: awsResource(cfgMod, "Rule")},
@@ -603,30 +564,18 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_config_configuration_recorder_status": {Tok: awsResource(cfgMod, "RecorderStatus")},
 			"aws_config_delivery_channel":              {Tok: awsResource(cfgMod, "DeliveryChannel")},
 			// DataSync
-			"aws_datasync_agent": {
-				Tok: awsResource(datasyncMod, "Agent"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_datasync_agent": {Tok: awsResource(datasyncMod, "Agent")},
 			"aws_datasync_location_efs": {
 				Tok: awsResource(datasyncMod, "EfsLocation"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"efs_file_system_arn": {Type: awsType(awsMod, "ARN")},
-					"tags":                {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_datasync_location_nfs": {
-				Tok: awsResource(datasyncMod, "NfsLocation"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_datasync_location_nfs": {Tok: awsResource(datasyncMod, "NfsLocation")},
 			"aws_datasync_location_s3": {
 				Tok: awsResource(datasyncMod, "S3Location"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"s3_bucket_arn": {Type: awsType(awsMod, "ARN")},
-					"tags":          {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_datasync_task": {
@@ -635,94 +584,42 @@ func Provider() tfbridge.ProviderInfo {
 					"destination_location_arn": {Type: awsType(awsMod, "ARN")},
 					"source_location_arn":      {Type: awsType(awsMod, "ARN")},
 					"cloudwatch_log_group_arn": {Type: awsType(awsMod, "ARN")},
-					"tags":                     {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			// Data Lifecycle Manager
 			"aws_dlm_lifecycle_policy": {Tok: awsResource(dlmMod, "LifecyclePolicy")},
 			// Data Migration Service
-			"aws_dms_certificate": {Tok: awsResource(dmsMod, "Certificate")},
-			"aws_dms_endpoint": {
-				Tok: awsResource(dmsMod, "Endpoint"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_dms_replication_instance": {
-				Tok: awsResource(dmsMod, "ReplicationInstance"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_dms_replication_subnet_group": {
-				Tok: awsResource(dmsMod, "ReplicationSubnetGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_dms_replication_task": {
-				Tok: awsResource(dmsMod, "ReplicationTask"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_dms_certificate":              {Tok: awsResource(dmsMod, "Certificate")},
+			"aws_dms_endpoint":                 {Tok: awsResource(dmsMod, "Endpoint")},
+			"aws_dms_replication_instance":     {Tok: awsResource(dmsMod, "ReplicationInstance")},
+			"aws_dms_replication_subnet_group": {Tok: awsResource(dmsMod, "ReplicationSubnetGroup")},
+			"aws_dms_replication_task":         {Tok: awsResource(dmsMod, "ReplicationTask")},
 			// DAX
-			"aws_dax_cluster": {
-				Tok: awsResource(daxMod, "Cluster"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_dax_cluster":         {Tok: awsResource(daxMod, "Cluster")},
 			"aws_dax_parameter_group": {Tok: awsResource(daxMod, "ParameterGroup")},
 			"aws_dax_subnet_group":    {Tok: awsResource(daxMod, "SubnetGroup")},
 			// DeviceFarm
 			"aws_devicefarm_project": {Tok: awsResource(devicefarmMod, "Project")},
 			// DirectoryService
 			"aws_directory_service_conditional_forwarder": {Tok: awsResource(directoryserviceMod, "ConditionalForwader")},
-			"aws_directory_service_directory": {
-				Tok: awsResource(directoryserviceMod, "Directory"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_directory_service_directory":             {Tok: awsResource(directoryserviceMod, "Directory")},
 			// Direct Connect
-			"aws_dx_bgp_peer": {Tok: awsResource(dxMod, "BgpPeer")},
-			"aws_dx_connection": {
-				Tok: awsResource(dxMod, "Connection"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_dx_bgp_peer":                         {Tok: awsResource(dxMod, "BgpPeer")},
+			"aws_dx_connection":                       {Tok: awsResource(dxMod, "Connection")},
 			"aws_dx_connection_association":           {Tok: awsResource(dxMod, "ConnectionAssociation")},
 			"aws_dx_gateway":                          {Tok: awsResource(dxMod, "Gateway")},
 			"aws_dx_gateway_association":              {Tok: awsResource(dxMod, "GatewayAssociation")},
 			"aws_dx_hosted_private_virtual_interface": {Tok: awsResource(dxMod, "HostedPrivateVirtualInterface")},
 			"aws_dx_hosted_private_virtual_interface_accepter": {
 				Tok: awsResource(dxMod, "HostedPrivateVirtualInterfaceAccepter"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
 			},
 			"aws_dx_hosted_public_virtual_interface": {Tok: awsResource(dxMod, "HostedPublicVirtualInterface")},
 			"aws_dx_hosted_public_virtual_interface_accepter": {
 				Tok: awsResource(dxMod, "HostedPublicVirtualInterfaceAccepter"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
 			},
-			"aws_dx_private_virtual_interface": {
-				Tok: awsResource(dxMod, "PrivateVirtualInterface"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_dx_public_virtual_interface": {Tok: awsResource(dxMod, "PublicVirtualInterface")},
-			"aws_dx_lag": {
-				Tok: awsResource(dxMod, "LinkAggregationGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_dx_private_virtual_interface": {Tok: awsResource(dxMod, "PrivateVirtualInterface")},
+			"aws_dx_public_virtual_interface":  {Tok: awsResource(dxMod, "PublicVirtualInterface")},
+			"aws_dx_lag":                       {Tok: awsResource(dxMod, "LinkAggregationGroup")},
 			// DynamoDB
 			"aws_dynamodb_global_table": {Tok: awsResource(dynamodbMod, "GlobalTable")},
 			"aws_dynamodb_table": {
@@ -752,7 +649,6 @@ func Provider() tfbridge.ProviderInfo {
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"name":        tfbridge.AutoName("name", 40),
 					"application": {Type: awsResource(elasticbeanstalkMod, "Application")},
-					"tags":        {Type: awsType(awsMod, "Tags")},
 					"version_label": {
 						Name: "version",
 						Type: awsResource(elasticbeanstalkMod, "ApplicationVersion"),
@@ -760,24 +656,9 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			// Elastic Block Store
-			"aws_ebs_snapshot": {
-				Tok: awsResource(ebsMod, "Snapshot"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_ebs_snapshot_copy": {
-				Tok: awsResource(ebsMod, "SnapshotCopy"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_ebs_volume": {
-				Tok: awsResource(ebsMod, "Volume"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_ebs_snapshot":      {Tok: awsResource(ebsMod, "Snapshot")},
+			"aws_ebs_snapshot_copy": {Tok: awsResource(ebsMod, "SnapshotCopy")},
+			"aws_ebs_volume":        {Tok: awsResource(ebsMod, "Volume")},
 			// ElastiCache
 			"aws_elasticache_cluster": {
 				Tok: awsResource(elasticacheMod, "Cluster"),
@@ -785,7 +666,6 @@ func Provider() tfbridge.ProviderInfo {
 					"cluster_id": tfbridge.AutoNameTransform("clusterId", 20, func(name string) string {
 						return strings.ToLower(name)
 					}),
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_elasticache_parameter_group": {
@@ -796,12 +676,7 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			"aws_elasticache_replication_group": {
-				Tok: awsResource(elasticacheMod, "ReplicationGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_elasticache_replication_group": {Tok: awsResource(elasticacheMod, "ReplicationGroup")},
 			"aws_elasticache_security_group": {
 				Tok: awsResource(elasticacheMod, "SecurityGroup"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -828,9 +703,6 @@ func Provider() tfbridge.ProviderInfo {
 					IncludeArgumentsFrom:           "aws_ami",
 					IncludeAttributesFromArguments: "aws_ami",
 				},
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
 			},
 			"aws_ami_from_instance": {
 				Tok: awsResource(ec2Mod, "AmiFromInstance"),
@@ -838,22 +710,12 @@ func Provider() tfbridge.ProviderInfo {
 					IncludeAttributesFromArguments: "aws_ami",
 				},
 			},
-			"aws_ami_launch_permission": {Tok: awsResource(ec2Mod, "AmiLaunchPermission")},
-			"aws_customer_gateway": {
-				Tok: awsResource(ec2Mod, "CustomerGateway"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_ami_launch_permission":        {Tok: awsResource(ec2Mod, "AmiLaunchPermission")},
+			"aws_customer_gateway":             {Tok: awsResource(ec2Mod, "CustomerGateway")},
 			"aws_egress_only_internet_gateway": {Tok: awsResource(ec2Mod, "EgressOnlyInternetGateway")},
-			"aws_eip": {
-				Tok: awsResource(ec2Mod, "Eip"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_eip_association": {Tok: awsResource(ec2Mod, "EipAssociation")},
-			"aws_flow_log":        {Tok: awsResource(ec2Mod, "FlowLog")},
+			"aws_eip":                          {Tok: awsResource(ec2Mod, "Eip")},
+			"aws_eip_association":              {Tok: awsResource(ec2Mod, "EipAssociation")},
+			"aws_flow_log":                     {Tok: awsResource(ec2Mod, "FlowLog")},
 			"aws_instance": {
 				Tok: awsResource(ec2Mod, "Instance"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -864,15 +726,9 @@ func Provider() tfbridge.ProviderInfo {
 					"instance_type": {
 						Type: awsType(ec2Mod+"/instanceType", "InstanceType"),
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_internet_gateway": {
-				Tok: awsResource(ec2Mod, "InternetGateway"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_internet_gateway": {Tok: awsResource(ec2Mod, "InternetGateway")},
 			"aws_key_pair": {
 				Tok: awsResource(ec2Mod, "KeyPair"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -888,31 +744,20 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			"aws_launch_template": {
-				Tok: awsResource(ec2Mod, "LaunchTemplate"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_launch_template": {Tok: awsResource(ec2Mod, "LaunchTemplate")},
 			"aws_main_route_table_association": {
 				Tok: awsResource(ec2Mod, "MainRouteTableAssociation"),
 				Docs: &tfbridge.DocInfo{
 					Source: "main_route_table_assoc.html.markdown",
 				},
 			},
-			"aws_nat_gateway": {
-				Tok: awsResource(ec2Mod, "NatGateway"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_nat_gateway": {Tok: awsResource(ec2Mod, "NatGateway")},
 			"aws_network_acl": {
 				Tok: awsResource(ec2Mod, "NetworkAcl"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Use "ingress" instead of "ingresses" to match AWS APIs
 					"ingress": {Name: "ingress"},
 					"egress":  {Name: "egress"},
-					"tags":    {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_default_network_acl": {
@@ -921,16 +766,10 @@ func Provider() tfbridge.ProviderInfo {
 					// Use "ingress" instead of "ingresses" to match AWS APIs
 					"ingress": {Name: "ingress"},
 					"egress":  {Name: "egress"},
-					"tags":    {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_network_acl_rule": {Tok: awsResource(ec2Mod, "NetworkAclRule")},
-			"aws_network_interface": {
-				Tok: awsResource(ec2Mod, "NetworkInterface"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_network_acl_rule":             {Tok: awsResource(ec2Mod, "NetworkAclRule")},
+			"aws_network_interface":            {Tok: awsResource(ec2Mod, "NetworkInterface")},
 			"aws_network_interface_attachment": {Tok: awsResource(ec2Mod, "NetworkInterfaceAttachment")},
 			"aws_placement_group": {
 				Tok: awsResource(ec2Mod, "PlacementGroup"),
@@ -942,18 +781,8 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"aws_proxy_protocol_policy": {Tok: awsResource(ec2Mod, "ProxyProtocolPolicy")},
 			"aws_route":                 {Tok: awsResource(ec2Mod, "Route")},
-			"aws_route_table": {
-				Tok: awsResource(ec2Mod, "RouteTable"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_default_route_table": {
-				Tok: awsResource(ec2Mod, "DefaultRouteTable"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_route_table":           {Tok: awsResource(ec2Mod, "RouteTable")},
+			"aws_default_route_table":   {Tok: awsResource(ec2Mod, "DefaultRouteTable")},
 			"aws_ec2_capacity_reservation": {
 				Tok: awsResource(ec2Mod, "CapacityReservation"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -963,18 +792,12 @@ func Provider() tfbridge.ProviderInfo {
 					"instance_platform": {
 						Type: awsType(ec2Mod+"/instancePlatform", "InstancePlatform"),
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 					"tenancy": {
 						Type: awsType(ec2Mod+"/tenancy", "Tenancy"),
 					},
 				},
 			},
-			"aws_ec2_fleet": {
-				Tok: awsResource(ec2Mod, "Fleet"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_ec2_fleet":               {Tok: awsResource(ec2Mod, "Fleet")},
 			"aws_route_table_association": {Tok: awsResource(ec2Mod, "RouteTableAssociation")},
 			"aws_security_group": {
 				Tok: awsResource(ec2Mod, "SecurityGroup"),
@@ -983,7 +806,6 @@ func Provider() tfbridge.ProviderInfo {
 					// Use "ingress" instead of "ingresses" to match AWS APIs
 					"ingress": {Name: "ingress"},
 					"egress":  {Name: "egress"},
-					"tags":    {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_network_interface_sg_attachment": {Tok: awsResource(ec2Mod, "NetworkInterfaceSecurityGroupAttachment")},
@@ -993,7 +815,6 @@ func Provider() tfbridge.ProviderInfo {
 					// Use "ingress" instead of "ingresses" to match AWS APIs
 					"ingress": {Name: "ingress"},
 					"egress":  {Name: "egress"},
-					"tags":    {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_security_group_rule":               {Tok: awsResource(ec2Mod, "SecurityGroupRule")},
@@ -1004,53 +825,24 @@ func Provider() tfbridge.ProviderInfo {
 				Docs: &tfbridge.DocInfo{
 					IncludeArgumentsFrom: "aws_instance",
 				},
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
 			},
-			"aws_spot_fleet_request": {Tok: awsResource(ec2Mod, "SpotFleetRequest")},
-			"aws_default_subnet": {
-				Tok: awsResource(ec2Mod, "DefaultSubnet"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_subnet": {
-				Tok: awsResource(ec2Mod, "Subnet"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_spot_fleet_request":           {Tok: awsResource(ec2Mod, "SpotFleetRequest")},
+			"aws_default_subnet":               {Tok: awsResource(ec2Mod, "DefaultSubnet")},
+			"aws_subnet":                       {Tok: awsResource(ec2Mod, "Subnet")},
 			"aws_volume_attachment":            {Tok: awsResource(ec2Mod, "VolumeAttachment")},
 			"aws_vpc_dhcp_options_association": {Tok: awsResource(ec2Mod, "VpcDhcpOptionsAssociation")},
-			"aws_default_vpc_dhcp_options": {
-				Tok: awsResource(ec2Mod, "DefaultVpcDhcpOptions"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_vpc_dhcp_options": {
-				Tok: awsResource(ec2Mod, "VpcDhcpOptions"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_default_vpc_dhcp_options":     {Tok: awsResource(ec2Mod, "DefaultVpcDhcpOptions")},
+			"aws_vpc_dhcp_options":             {Tok: awsResource(ec2Mod, "VpcDhcpOptions")},
 			"aws_vpc_peering_connection": {
 				Tok: awsResource(ec2Mod, "VpcPeeringConnection"),
 				Docs: &tfbridge.DocInfo{
 					Source: "vpc_peering.html.markdown",
-				},
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_vpc_peering_connection_accepter": {
 				Tok: awsResource(ec2Mod, "VpcPeeringConnectionAccepter"),
 				Docs: &tfbridge.DocInfo{
 					Source: "vpc_peering_accepter.html.markdown",
-				},
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_vpc_peering_connection_options": {
@@ -1059,69 +851,38 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "vpc_peering_options.html.markdown",
 				},
 			},
-			"aws_default_vpc": {
-				Tok: awsResource(ec2Mod, "DefaultVpc"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_vpc": {
-				Tok: awsResource(ec2Mod, "Vpc"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_vpc_endpoint":                           {Tok: awsResource(ec2Mod, "VpcEndpoint")},
+			"aws_default_vpc":  {Tok: awsResource(ec2Mod, "DefaultVpc")},
+			"aws_vpc":          {Tok: awsResource(ec2Mod, "Vpc")},
+			"aws_vpc_endpoint": {Tok: awsResource(ec2Mod, "VpcEndpoint")},
 			"aws_vpc_endpoint_connection_notification":   {Tok: awsResource(ec2Mod, "VpcEndpointConnectionNotification")},
 			"aws_vpc_endpoint_route_table_association":   {Tok: awsResource(ec2Mod, "VpcEndpointRouteTableAssociation")},
 			"aws_vpc_endpoint_service":                   {Tok: awsResource(ec2Mod, "VpcEndpointService")},
 			"aws_vpc_endpoint_service_allowed_principal": {Tok: awsResource(ec2Mod, "VpcEndpointServiceAllowedPrinciple")},
 			"aws_vpc_endpoint_subnet_association":        {Tok: awsResource(ec2Mod, "VpcEndpointSubnetAssociation")},
 			"aws_vpc_ipv4_cidr_block_association":        {Tok: awsResource(ec2Mod, "VpcIpv4CidrBlockAssociation")},
-			"aws_vpn_connection": {
-				Tok: awsResource(ec2Mod, "VpnConnection"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_vpn_connection_route": {Tok: awsResource(ec2Mod, "VpnConnectionRoute")},
-			"aws_vpn_gateway": {
-				Tok: awsResource(ec2Mod, "VpnGateway"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_vpn_gateway_attachment":        {Tok: awsResource(ec2Mod, "VpnGatewayAttachment")},
-			"aws_vpn_gateway_route_propagation": {Tok: awsResource(ec2Mod, "VpnGatewayRoutePropagation")},
+			"aws_vpn_connection":                         {Tok: awsResource(ec2Mod, "VpnConnection")},
+			"aws_vpn_connection_route":                   {Tok: awsResource(ec2Mod, "VpnConnectionRoute")},
+			"aws_vpn_gateway":                            {Tok: awsResource(ec2Mod, "VpnGateway")},
+			"aws_vpn_gateway_attachment":                 {Tok: awsResource(ec2Mod, "VpnGatewayAttachment")},
+			"aws_vpn_gateway_route_propagation":          {Tok: awsResource(ec2Mod, "VpnGatewayRoutePropagation")},
 			// EC2 Transit Gateway
 			"aws_ec2_transit_gateway": {
 				Tok: awsResource(ec2TransitGatewayMod, "TransitGateway"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"arn":  {Type: awsType(awsMod, "ARN")},
-					"tags": {Type: awsType(awsMod, "Tags")},
+					"arn": {Type: awsType(awsMod, "ARN")},
 				},
 			},
 			"aws_ec2_transit_gateway_route": {
 				Tok: awsResource(ec2TransitGatewayMod, "Route"),
 			},
-			"aws_ec2_transit_gateway_route_table": {
-				Tok: awsResource(ec2TransitGatewayMod, "RouteTable"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_ec2_transit_gateway_route_table": {Tok: awsResource(ec2TransitGatewayMod, "RouteTable")},
 			"aws_ec2_transit_gateway_route_table_association": {
 				Tok: awsResource(ec2TransitGatewayMod, "RouteTableAssociation"),
 			},
 			"aws_ec2_transit_gateway_route_table_propagation": {
 				Tok: awsResource(ec2TransitGatewayMod, "RouteTablePropagation"),
 			},
-			"aws_ec2_transit_gateway_vpc_attachment": {
-				Tok: awsResource(ec2TransitGatewayMod, "VpcAttachment"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_ec2_transit_gateway_vpc_attachment": {Tok: awsResource(ec2TransitGatewayMod, "VpcAttachment")},
 			// Elastic Container Registry
 			"aws_ecr_repository":        {Tok: awsResource(ecrMod, "Repository")},
 			"aws_ecr_repository_policy": {Tok: awsResource(ecrMod, "RepositoryPolicy")},
@@ -1145,7 +906,6 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(efsMod, "FileSystem"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"creation_token": tfbridge.AutoName("creationToken", 255),
-					"tags":           {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_efs_mount_target": {
@@ -1153,13 +913,8 @@ func Provider() tfbridge.ProviderInfo {
 				DeleteBeforeReplace: true, // only 1 mount target per AZ.
 			},
 			// Elastic Load Balancing
-			"aws_app_cookie_stickiness_policy": {Tok: awsResource(elbMod, "AppCookieStickinessPolicy")},
-			"aws_elb": {
-				Tok: awsResource(elbMod, "LoadBalancer"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_app_cookie_stickiness_policy":        {Tok: awsResource(elbMod, "AppCookieStickinessPolicy")},
+			"aws_elb":                                 {Tok: awsResource(elbMod, "LoadBalancer")},
 			"aws_elb_attachment":                      {Tok: awsResource(elbMod, "Attachment")},
 			"aws_lb_cookie_stickiness_policy":         {Tok: awsResource(elbMod, "LoadBalancerCookieStickinessPolicy")},
 			"aws_load_balancer_policy":                {Tok: awsResource(elbMod, "LoadBalancerPolicy")},
@@ -1213,12 +968,7 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			// Load Balancing (Application and Network)
-			"aws_lb": {
-				Tok: awsResource(elbv2Mod, "LoadBalancer"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_lb": {Tok: awsResource(elbv2Mod, "LoadBalancer")},
 			"aws_lb_listener": {
 				Tok: awsResource(elbv2Mod, "Listener"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -1230,14 +980,9 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			"aws_lb_listener_certificate": {Tok: awsResource(elbv2Mod, "ListenerCertificate")},
-			"aws_lb_listener_rule":        {Tok: awsResource(elbv2Mod, "ListenerRule")},
-			"aws_lb_target_group": {
-				Tok: awsResource(elbv2Mod, "TargetGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_lb_listener_certificate":    {Tok: awsResource(elbv2Mod, "ListenerCertificate")},
+			"aws_lb_listener_rule":           {Tok: awsResource(elbv2Mod, "ListenerRule")},
+			"aws_lb_target_group":            {Tok: awsResource(elbv2Mod, "TargetGroup")},
 			"aws_lb_target_group_attachment": {Tok: awsResource(elbv2Mod, "TargetGroupAttachment")},
 			// ECS for Kubernetes
 			"aws_eks_cluster": {Tok: awsResource(eksMod, "Cluster")},
@@ -1251,7 +996,6 @@ func Provider() tfbridge.ProviderInfo {
 					"cluster_config":   {Name: "clusterConfig"},
 					"ebs_options":      {Name: "ebsOptions"},
 					"snapshot_options": {Name: "snapshotOptions"},
-					"tags":             {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_elasticsearch_domain_policy": {Tok: awsResource(elasticsearchMod, "DomainPolicy")},
@@ -1269,12 +1013,7 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			// Elastic MapReduce
-			"aws_emr_cluster": {
-				Tok: awsResource(emrMod, "Cluster"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_emr_cluster":                {Tok: awsResource(emrMod, "Cluster")},
 			"aws_emr_instance_group":         {Tok: awsResource(emrMod, "InstanceGroup")},
 			"aws_emr_security_configuration": {Tok: awsResource(emrMod, "SecurityConfiguration")},
 			// GameLift
@@ -1283,12 +1022,7 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_gamelift_fleet":              {Tok: awsResource(gameliftMod, "Fleet")},
 			"aws_gamelift_game_session_queue": {Tok: awsResource(gameliftMod, "GameSessionQueue")},
 			// Glacier
-			"aws_glacier_vault": {
-				Tok: awsResource(glacierMod, "Vault"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_glacier_vault":      {Tok: awsResource(glacierMod, "Vault")},
 			"aws_glacier_vault_lock": {Tok: awsResource(glacierMod, "VaultLock")},
 			// Glue
 			"aws_glue_catalog_database":       {Tok: awsResource(glueMod, "CatalogDatabase")},
@@ -1436,12 +1170,7 @@ func Provider() tfbridge.ProviderInfo {
 			// Inspector
 			"aws_inspector_assessment_target":   {Tok: awsResource(inspectorMod, "AssessmentTarget")},
 			"aws_inspector_assessment_template": {Tok: awsResource(inspectorMod, "AssessmentTemplate")},
-			"aws_inspector_resource_group": {
-				Tok: awsResource(inspectorMod, "ResourceGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_inspector_resource_group":      {Tok: awsResource(inspectorMod, "ResourceGroup")},
 			// IOT
 			"aws_iot_certificate": {Tok: awsResource(iotMod, "Certificate")},
 			"aws_iot_policy": {
@@ -1488,12 +1217,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			// Kinesis
 			"aws_kinesis_firehose_delivery_stream": {Tok: awsResource(kinesisMod, "FirehoseDeliveryStream")},
-			"aws_kinesis_stream": {
-				Tok: awsResource(kinesisMod, "Stream"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_kinesis_stream":                   {Tok: awsResource(kinesisMod, "Stream")},
 			"aws_kinesis_analytics_application": {
 				Tok: awsResource(kinesisMod, "AnalyticsApplication"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -1505,12 +1229,7 @@ func Provider() tfbridge.ProviderInfo {
 			// Key Management Service (KMS)
 			"aws_kms_alias": {Tok: awsResource(kmsMod, "Alias")},
 			"aws_kms_grant": {Tok: awsResource(kmsMod, "Grant")},
-			"aws_kms_key": {
-				Tok: awsResource(kmsMod, "Key"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_kms_key":   {Tok: awsResource(kmsMod, "Key")},
 			// Lambda
 			"aws_lambda_function": {
 				Tok:      awsResource(lambdaMod, "Function"),
@@ -1530,7 +1249,6 @@ func Provider() tfbridge.ProviderInfo {
 							HashField: "source_code_hash",
 						},
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_lambda_event_source_mapping": {Tok: awsResource(lambdaMod, "EventSourceMapping")},
@@ -1570,26 +1288,11 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_neptune_cluster_parameter_group": {Tok: awsResource(neptuneMod, "ClusterParameterGroup")},
 			"aws_neptune_cluster_snapshot":        {Tok: awsResource(neptuneMod, "ClusterSnapshot")},
 			"aws_neptune_event_subscription":      {Tok: awsResource(neptuneMod, "EventSubscription")},
-			"aws_neptune_parameter_group": {
-				Tok: awsResource(neptuneMod, "ParameterGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_neptune_subnet_group": {
-				Tok: awsResource(neptuneMod, "SubnetGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_neptune_parameter_group":         {Tok: awsResource(neptuneMod, "ParameterGroup")},
+			"aws_neptune_subnet_group":            {Tok: awsResource(neptuneMod, "SubnetGroup")},
 			// OpsWorks
-			"aws_opsworks_application": {Tok: awsResource(opsworksMod, "Application")},
-			"aws_opsworks_stack": {
-				Tok: awsResource(opsworksMod, "Stack"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_opsworks_application":      {Tok: awsResource(opsworksMod, "Application")},
+			"aws_opsworks_stack":            {Tok: awsResource(opsworksMod, "Stack")},
 			"aws_opsworks_java_app_layer":   {Tok: awsResource(opsworksMod, "JavaAppLayer")},
 			"aws_opsworks_haproxy_layer":    {Tok: awsResource(opsworksMod, "HaproxyLayer")},
 			"aws_opsworks_static_web_layer": {Tok: awsResource(opsworksMod, "StaticWebLayer")},
@@ -1622,36 +1325,20 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_pinpoint_gcm_channel":               {Tok: awsResource(pinpointMod, "GcmChannel")},
 			"aws_pinpoint_sms_channel":               {Tok: awsResource(pinpointMod, "SmsChannel")},
 			// Relational Database Service (RDS)
-			"aws_rds_cluster": {
-				Tok: awsResource(rdsMod, "Cluster"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_rds_cluster":          {Tok: awsResource(rdsMod, "Cluster")},
 			"aws_rds_cluster_endpoint": {Tok: awsResource(rdsMod, "ClusterEndpoint")},
-			"aws_rds_cluster_instance": {
-				Tok: awsResource(rdsMod, "ClusterInstance"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_rds_cluster_instance": {Tok: awsResource(rdsMod, "ClusterInstance")},
 			"aws_rds_cluster_parameter_group": {
 				Tok: awsResource(rdsMod, "ClusterParameterGroup"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"description": {
 						Default: managedByPulumi,
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_rds_global_cluster":  {Tok: awsResource(rdsMod, "GlobalCluster")},
-			"aws_db_cluster_snapshot": {Tok: awsResource(rdsMod, "ClusterSnapshot")},
-			"aws_db_event_subscription": {
-				Tok: awsResource(rdsMod, "EventSubscription"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_rds_global_cluster":    {Tok: awsResource(rdsMod, "GlobalCluster")},
+			"aws_db_cluster_snapshot":   {Tok: awsResource(rdsMod, "ClusterSnapshot")},
+			"aws_db_event_subscription": {Tok: awsResource(rdsMod, "EventSubscription")},
 			"aws_db_instance": {
 				Tok: awsResource(rdsMod, "Instance"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -1670,7 +1357,6 @@ func Provider() tfbridge.ProviderInfo {
 						},
 					},
 					"name": {Name: "name"},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_db_option_group": {
@@ -1679,7 +1365,6 @@ func Provider() tfbridge.ProviderInfo {
 					"option_group_description": {
 						Default: managedByPulumi,
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_db_parameter_group": {
@@ -1688,7 +1373,6 @@ func Provider() tfbridge.ProviderInfo {
 					"description": {
 						Default: managedByPulumi,
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_db_security_group": {
@@ -1697,23 +1381,12 @@ func Provider() tfbridge.ProviderInfo {
 					"description": {Default: managedByPulumi},
 					// Use "ingress" instead of "ingresses" to match AWS APIs
 					"ingress": {Name: "ingress"},
-					"tags":    {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_db_snapshot": {Tok: awsResource(rdsMod, "Snapshot")},
-			"aws_db_subnet_group": {
-				Tok: awsResource(rdsMod, "SubnetGroup"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_db_snapshot":     {Tok: awsResource(rdsMod, "Snapshot")},
+			"aws_db_subnet_group": {Tok: awsResource(rdsMod, "SubnetGroup")},
 			// RedShift
-			"aws_redshift_cluster": {
-				Tok: awsResource(redshiftMod, "Cluster"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_redshift_cluster":            {Tok: awsResource(redshiftMod, "Cluster")},
 			"aws_redshift_event_subscription": {Tok: awsResource(redshiftMod, "EventSubscription")},
 			"aws_redshift_parameter_group": {
 				Tok: awsResource(redshiftMod, "ParameterGroup"),
@@ -1738,7 +1411,6 @@ func Provider() tfbridge.ProviderInfo {
 					"description": {
 						Default: managedByPulumi,
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			// Route53
@@ -1752,25 +1424,14 @@ func Provider() tfbridge.ProviderInfo {
 					"comment": {
 						Default: managedByPulumi,
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
-			"aws_route53_health_check": {
-				Tok: awsResource(route53Mod, "HealthCheck"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_route53_health_check": {Tok: awsResource(route53Mod, "HealthCheck")},
 			// Secrets Manager
 			"aws_secretsmanager_secret":         {Tok: awsResource(secretsmanagerMod, "Secret")},
 			"aws_secretsmanager_secret_version": {Tok: awsResource(secretsmanagerMod, "SecretVersion")},
 			// Service Catalog
-			"aws_servicecatalog_portfolio": {
-				Tok: awsResource(servicecatalogMod, "Portfolio"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_servicecatalog_portfolio": {Tok: awsResource(servicecatalogMod, "Portfolio")},
 			// Security Hub
 			"aws_securityhub_account":                {Tok: awsResource(securityhubMod, "Account")},
 			"aws_securityhub_standards_subscription": {Tok: awsResource(securityhubMod, "StandardsSubscription")},
@@ -1807,7 +1468,6 @@ func Provider() tfbridge.ProviderInfo {
 					// Website only accepts a single value in the AWS API but is not marked MaxItems==1 in the TF
 					// provider.
 					"website": {Name: "website"},
-					"tags":    {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_s3_bucket_inventory":    {Tok: awsResource(s3Mod, "Inventory")},
@@ -1834,7 +1494,6 @@ func Provider() tfbridge.ProviderInfo {
 							Kind: tfbridge.FileAsset,
 						},
 					},
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_s3_bucket_policy": {
@@ -1848,26 +1507,16 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			// Systems Manager (SSM)
-			"aws_ssm_activation":  {Tok: awsResource(ssmMod, "Activation")},
-			"aws_ssm_association": {Tok: awsResource(ssmMod, "Association")},
-			"aws_ssm_document": {
-				Tok: awsResource(ssmMod, "Document"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
+			"aws_ssm_activation":                {Tok: awsResource(ssmMod, "Activation")},
+			"aws_ssm_association":               {Tok: awsResource(ssmMod, "Association")},
+			"aws_ssm_document":                  {Tok: awsResource(ssmMod, "Document")},
 			"aws_ssm_maintenance_window":        {Tok: awsResource(ssmMod, "MaintenanceWindow")},
 			"aws_ssm_maintenance_window_target": {Tok: awsResource(ssmMod, "MaintenanceWindowTarget")},
 			"aws_ssm_maintenance_window_task":   {Tok: awsResource(ssmMod, "MaintenanceWindowTask")},
 			"aws_ssm_patch_baseline":            {Tok: awsResource(ssmMod, "PatchBaseline")},
 			"aws_ssm_patch_group":               {Tok: awsResource(ssmMod, "PatchGroup")},
-			"aws_ssm_parameter": {
-				Tok: awsResource(ssmMod, "Parameter"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"tags": {Type: awsType(awsMod, "Tags")},
-				},
-			},
-			"aws_ssm_resource_data_sync": {Tok: awsResource(ssmMod, "ResourceDataSync")},
+			"aws_ssm_parameter":                 {Tok: awsResource(ssmMod, "Parameter")},
+			"aws_ssm_resource_data_sync":        {Tok: awsResource(ssmMod, "ResourceDataSync")},
 			// SimpleDB
 			"aws_simpledb_domain": {Tok: awsResource(simpledbMod, "Domain")},
 			// Simple Queuing Service (SQS)
@@ -1875,7 +1524,6 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(sqsMod, "Queue"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"name": tfbridge.AutoName("name", 80),
-					"tags": {Type: awsType(awsMod, "Tags")},
 				},
 			},
 			"aws_sqs_queue_policy": {Tok: awsResource(sqsMod, "QueuePolicy")},
@@ -2159,7 +1807,7 @@ func Provider() tfbridge.ProviderInfo {
 				DestFiles: []string{
 					"arn.ts",    // ARN typedef
 					"region.ts", // Region union type and constants
-					"tags.ts",   // Tags typedef
+					"tags.ts",   // Tags typedef (currently unused but left for compatibility)
 					"utils.ts",  // Helpers,
 				},
 				Modules: map[string]*tfbridge.OverlayInfo{

--- a/sdk/nodejs/acm/certificate.ts
+++ b/sdk/nodejs/acm/certificate.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * The ACM certificate resource allows requesting and management of certificates
  * from the Amazon Certificate Manager.
@@ -57,7 +55,7 @@ export class Certificate extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * A list of addresses that received a validation E-Mail. Only set if `EMAIL`-validation was used.
      */
@@ -129,7 +127,7 @@ export interface CertificateState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A list of addresses that received a validation E-Mail. Only set if `EMAIL`-validation was used.
      */
@@ -155,7 +153,7 @@ export interface CertificateArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
      */

--- a/sdk/nodejs/acmpca/certificateAuthority.ts
+++ b/sdk/nodejs/acmpca/certificateAuthority.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage AWS Certificate Manager Private Certificate Authorities (ACM PCA Certificate Authorities).
  * 
@@ -71,7 +69,7 @@ export class CertificateAuthority extends pulumi.CustomResource {
     /**
      * Specifies a key-value map of user-defined tags that are attached to the certificate authority.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The type of the certificate authority. Currently, this must be `SUBORDINATE`.
      */
@@ -176,7 +174,7 @@ export interface CertificateAuthorityState {
     /**
      * Specifies a key-value map of user-defined tags that are attached to the certificate authority.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of the certificate authority. Currently, this must be `SUBORDINATE`.
      */
@@ -202,7 +200,7 @@ export interface CertificateAuthorityArgs {
     /**
      * Specifies a key-value map of user-defined tags that are attached to the certificate authority.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of the certificate authority. Currently, this must be `SUBORDINATE`.
      */

--- a/sdk/nodejs/apigateway/stage.ts
+++ b/sdk/nodejs/apigateway/stage.ts
@@ -4,7 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
 import {Deployment} from "./deployment";
 import {RestApi} from "./restApi";
 
@@ -75,7 +74,7 @@ export class Stage extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * A map that defines the stage variables
      */
@@ -196,7 +195,7 @@ export interface StageState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A map that defines the stage variables
      */
@@ -251,7 +250,7 @@ export interface StageArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A map that defines the stage variables
      */

--- a/sdk/nodejs/cloudformation/stack.ts
+++ b/sdk/nodejs/cloudformation/stack.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a CloudFormation Stack resource.
  */
@@ -70,7 +68,7 @@ export class Stack extends pulumi.CustomResource {
     /**
      * A list of tags to associate with this stack.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Structure containing the template body (max size: 51,200 bytes).
      */
@@ -183,7 +181,7 @@ export interface StackState {
     /**
      * A list of tags to associate with this stack.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Structure containing the template body (max size: 51,200 bytes).
      */
@@ -246,7 +244,7 @@ export interface StackArgs {
     /**
      * A list of tags to associate with this stack.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Structure containing the template body (max size: 51,200 bytes).
      */

--- a/sdk/nodejs/cloudfront/distribution.ts
+++ b/sdk/nodejs/cloudfront/distribution.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Creates an Amazon CloudFront web distribution.
  * 
@@ -157,7 +155,7 @@ export class Distribution extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The SSL
      * configuration for this distribution (maximum
@@ -388,7 +386,7 @@ export interface DistributionState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The SSL
      * configuration for this distribution (maximum
@@ -486,7 +484,7 @@ export interface DistributionArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The SSL
      * configuration for this distribution (maximum

--- a/sdk/nodejs/cloudtrail/trail.ts
+++ b/sdk/nodejs/cloudtrail/trail.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a CloudTrail resource.
  * 
@@ -97,7 +95,7 @@ export class Trail extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the trail
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Trail resource with the given unique name, arguments, and options.
@@ -228,7 +226,7 @@ export interface TrailState {
     /**
      * A mapping of tags to assign to the trail
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -298,5 +296,5 @@ export interface TrailArgs {
     /**
      * A mapping of tags to assign to the trail
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/cloudwatch/logGroup.ts
+++ b/sdk/nodejs/cloudwatch/logGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a CloudWatch Log Group resource.
  */
@@ -48,7 +46,7 @@ export class LogGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a LogGroup resource with the given unique name, arguments, and options.
@@ -111,7 +109,7 @@ export interface LogGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -140,5 +138,5 @@ export interface LogGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/codebuild/project.ts
+++ b/sdk/nodejs/codebuild/project.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a CodeBuild Project resource. See also the [`aws_codebuild_webhook` resource](https://www.terraform.io/docs/providers/aws/r/codebuild_webhook.html), which manages the webhook to the source (e.g. the "rebuild every time a code change is pushed" option in the CodeBuild web console).
  */
@@ -81,7 +79,7 @@ export class Project extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
      */
@@ -213,7 +211,7 @@ export interface ProjectState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
      */
@@ -275,7 +273,7 @@ export interface ProjectArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
      */

--- a/sdk/nodejs/cognito/userPool.ts
+++ b/sdk/nodejs/cognito/userPool.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Cognito User Pool resource.
  */
@@ -101,7 +99,7 @@ export class UserPool extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the User Pool.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes`.
      */
@@ -257,7 +255,7 @@ export interface UserPoolState {
     /**
      * A mapping of tags to assign to the User Pool.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes`.
      */
@@ -335,7 +333,7 @@ export interface UserPoolArgs {
     /**
      * A mapping of tags to assign to the User Pool.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes`.
      */

--- a/sdk/nodejs/datasync/agent.ts
+++ b/sdk/nodejs/datasync/agent.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages an AWS DataSync Agent deployed on premises.
  * 
@@ -43,7 +41,7 @@ export class Agent extends pulumi.CustomResource {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Agent.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
 
     /**
      * Create a Agent resource with the given unique name, arguments, and options.
@@ -97,7 +95,7 @@ export interface AgentState {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Agent.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }
 
 /**
@@ -119,5 +117,5 @@ export interface AgentArgs {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Agent.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/datasync/efsLocation.ts
+++ b/sdk/nodejs/datasync/efsLocation.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN, Tags} from "../index";
+import {ARN} from "../index";
 
 /**
  * Manages an AWS DataSync EFS Location.
@@ -43,7 +43,7 @@ export class EfsLocation extends pulumi.CustomResource {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     public /*out*/ readonly uri: pulumi.Output<string>;
 
     /**
@@ -106,7 +106,7 @@ export interface EfsLocationState {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     readonly uri?: pulumi.Input<string>;
 }
 
@@ -129,5 +129,5 @@ export interface EfsLocationArgs {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/datasync/nfsLocation.ts
+++ b/sdk/nodejs/datasync/nfsLocation.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages an NFS Location within AWS DataSync.
  * 
@@ -43,7 +41,7 @@ export class NfsLocation extends pulumi.CustomResource {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     public /*out*/ readonly uri: pulumi.Output<string>;
 
     /**
@@ -109,7 +107,7 @@ export interface NfsLocationState {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     readonly uri?: pulumi.Input<string>;
 }
 
@@ -132,5 +130,5 @@ export interface NfsLocationArgs {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/datasync/s3Location.ts
+++ b/sdk/nodejs/datasync/s3Location.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN, Tags} from "../index";
+import {ARN} from "../index";
 
 /**
  * Manages an S3 Location within AWS DataSync.
@@ -41,7 +41,7 @@ export class S3Location extends pulumi.CustomResource {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     public /*out*/ readonly uri: pulumi.Output<string>;
 
     /**
@@ -107,7 +107,7 @@ export interface S3LocationState {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     readonly uri?: pulumi.Input<string>;
 }
 
@@ -130,5 +130,5 @@ export interface S3LocationArgs {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Location.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/datasync/task.ts
+++ b/sdk/nodejs/datasync/task.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN, Tags} from "../index";
+import {ARN} from "../index";
 
 /**
  * Manages an AWS DataSync Task, which represents a configuration for synchronization. Starting an execution of these DataSync Tasks (actually synchronizing files) is performed outside of this Terraform resource.
@@ -49,7 +49,7 @@ export class Task extends pulumi.CustomResource {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Task.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
 
     /**
      * Create a Task resource with the given unique name, arguments, and options.
@@ -121,7 +121,7 @@ export interface TaskState {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Task.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }
 
 /**
@@ -151,5 +151,5 @@ export interface TaskArgs {
     /**
      * Key-value pairs of resource tags to assign to the DataSync Task.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/dax/cluster.ts
+++ b/sdk/nodejs/dax/cluster.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a DAX Cluster resource.
  */
@@ -111,7 +109,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Cluster resource with the given unique name, arguments, and options.
@@ -273,7 +271,7 @@ export interface ClusterState {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -346,5 +344,5 @@ export interface ClusterArgs {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/directconnect/connection.ts
+++ b/sdk/nodejs/directconnect/connection.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Connection of Direct Connect.
  */
@@ -45,7 +43,7 @@ export class Connection extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Connection resource with the given unique name, arguments, and options.
@@ -111,7 +109,7 @@ export interface ConnectionState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -133,5 +131,5 @@ export interface ConnectionArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/directconnect/hostedPrivateVirtualInterfaceAccepter.ts
+++ b/sdk/nodejs/directconnect/hostedPrivateVirtualInterfaceAccepter.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the accepter's side of a Direct Connect hosted private virtual interface.
  * This resource accepts ownership of a private virtual interface created by another AWS account.
@@ -34,7 +32,7 @@ export class HostedPrivateVirtualInterfaceAccepter extends pulumi.CustomResource
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the Direct Connect virtual interface to accept.
      */
@@ -91,7 +89,7 @@ export interface HostedPrivateVirtualInterfaceAccepterState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the Direct Connect virtual interface to accept.
      */
@@ -113,7 +111,7 @@ export interface HostedPrivateVirtualInterfaceAccepterArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the Direct Connect virtual interface to accept.
      */

--- a/sdk/nodejs/directconnect/hostedPublicVirtualInterfaceAccepter.ts
+++ b/sdk/nodejs/directconnect/hostedPublicVirtualInterfaceAccepter.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the accepter's side of a Direct Connect hosted public virtual interface.
  * This resource accepts ownership of a public virtual interface created by another AWS account.
@@ -30,7 +28,7 @@ export class HostedPublicVirtualInterfaceAccepter extends pulumi.CustomResource 
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the Direct Connect virtual interface to accept.
      */
@@ -75,7 +73,7 @@ export interface HostedPublicVirtualInterfaceAccepterState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the Direct Connect virtual interface to accept.
      */
@@ -89,7 +87,7 @@ export interface HostedPublicVirtualInterfaceAccepterArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the Direct Connect virtual interface to accept.
      */

--- a/sdk/nodejs/directconnect/linkAggregationGroup.ts
+++ b/sdk/nodejs/directconnect/linkAggregationGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Direct Connect LAG.
  */
@@ -49,7 +47,7 @@ export class LinkAggregationGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a LinkAggregationGroup resource with the given unique name, arguments, and options.
@@ -121,7 +119,7 @@ export interface LinkAggregationGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -151,5 +149,5 @@ export interface LinkAggregationGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/directconnect/privateVirtualInterface.ts
+++ b/sdk/nodejs/directconnect/privateVirtualInterface.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Direct Connect private virtual interface resource.
  */
@@ -70,7 +68,7 @@ export class PrivateVirtualInterface extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VLAN ID.
      */
@@ -191,7 +189,7 @@ export interface PrivateVirtualInterfaceState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VLAN ID.
      */
@@ -246,7 +244,7 @@ export interface PrivateVirtualInterfaceArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VLAN ID.
      */

--- a/sdk/nodejs/directoryservice/directory.ts
+++ b/sdk/nodejs/directoryservice/directory.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Simple or Managed Microsoft directory in AWS Directory Service.
  * 
@@ -76,7 +74,7 @@ export class Directory extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The directory type (`SimpleAD`, `ADConnector` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
      */
@@ -193,7 +191,7 @@ export interface DirectoryState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The directory type (`SimpleAD`, `ADConnector` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
      */
@@ -247,7 +245,7 @@ export interface DirectoryArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The directory type (`SimpleAD`, `ADConnector` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
      */

--- a/sdk/nodejs/dms/endpoint.ts
+++ b/sdk/nodejs/dms/endpoint.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a DMS (Data Migration Service) endpoint resource. DMS endpoints can be created, updated, deleted, and imported.
  * 
@@ -88,7 +86,7 @@ export class Endpoint extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The user name to be used to login to the endpoint database.
      */
@@ -223,7 +221,7 @@ export interface EndpointState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The user name to be used to login to the endpoint database.
      */
@@ -293,7 +291,7 @@ export interface EndpointArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The user name to be used to login to the endpoint database.
      */

--- a/sdk/nodejs/dms/replicationInstance.ts
+++ b/sdk/nodejs/dms/replicationInstance.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a DMS (Data Migration Service) replication instance resource. DMS replication instances can be created, updated, deleted, and imported.
  */
@@ -85,7 +83,7 @@ export class ReplicationInstance extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * A list of VPC security group IDs to be used with the replication instance. The VPC security groups must work with the VPC containing the replication instance.
      */
@@ -217,7 +215,7 @@ export interface ReplicationInstanceState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A list of VPC security group IDs to be used with the replication instance. The VPC security groups must work with the VPC containing the replication instance.
      */
@@ -279,7 +277,7 @@ export interface ReplicationInstanceArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A list of VPC security group IDs to be used with the replication instance. The VPC security groups must work with the VPC containing the replication instance.
      */

--- a/sdk/nodejs/dms/replicationSubnetGroup.ts
+++ b/sdk/nodejs/dms/replicationSubnetGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a DMS (Data Migration Service) replication subnet group resource. DMS replication subnet groups can be created, updated, deleted, and imported.
  */
@@ -38,7 +36,7 @@ export class ReplicationSubnetGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the VPC the subnet group is in.
      */
@@ -104,7 +102,7 @@ export interface ReplicationSubnetGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the VPC the subnet group is in.
      */
@@ -130,5 +128,5 @@ export interface ReplicationSubnetGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/dms/replicationTask.ts
+++ b/sdk/nodejs/dms/replicationTask.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a DMS (Data Migration Service) replication task resource. DMS replication tasks can be created, updated, deleted, and imported.
  */
@@ -57,7 +55,7 @@ export class ReplicationTask extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The Amazon Resource Name (ARN) string that uniquely identifies the target endpoint.
      */
@@ -159,7 +157,7 @@ export interface ReplicationTaskState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The Amazon Resource Name (ARN) string that uniquely identifies the target endpoint.
      */
@@ -201,7 +199,7 @@ export interface ReplicationTaskArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The Amazon Resource Name (ARN) string that uniquely identifies the target endpoint.
      */

--- a/sdk/nodejs/ebs/snapshot.ts
+++ b/sdk/nodejs/ebs/snapshot.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Creates a Snapshot of an EBS Volume.
  */
@@ -49,7 +47,7 @@ export class Snapshot extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the snapshot
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The Volume ID of which to make a snapshot.
      */
@@ -130,7 +128,7 @@ export interface SnapshotState {
     /**
      * A mapping of tags to assign to the snapshot
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The Volume ID of which to make a snapshot.
      */
@@ -152,7 +150,7 @@ export interface SnapshotArgs {
     /**
      * A mapping of tags to assign to the snapshot
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The Volume ID of which to make a snapshot.
      */

--- a/sdk/nodejs/ebs/snapshotCopy.ts
+++ b/sdk/nodejs/ebs/snapshotCopy.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Creates a Snapshot of a snapshot.
  */
@@ -55,7 +53,7 @@ export class SnapshotCopy extends pulumi.CustomResource {
     /**
      * A mapping of tags for the snapshot.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     public /*out*/ readonly volumeId: pulumi.Output<string>;
     /**
      * The size of the drive in GiBs.
@@ -146,7 +144,7 @@ export interface SnapshotCopyState {
     /**
      * A mapping of tags for the snapshot.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     readonly volumeId?: pulumi.Input<string>;
     /**
      * The size of the drive in GiBs.
@@ -177,5 +175,5 @@ export interface SnapshotCopyArgs {
     /**
      * A mapping of tags for the snapshot.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ebs/volume.ts
+++ b/sdk/nodejs/ebs/volume.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages a single EBS volume.
  */
@@ -53,7 +51,7 @@ export class Volume extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The type of EBS volume. Can be "standard", "gp2", "io1", "sc1" or "st1" (Default: "standard").
      */
@@ -134,7 +132,7 @@ export interface VolumeState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of EBS volume. Can be "standard", "gp2", "io1", "sc1" or "st1" (Default: "standard").
      */
@@ -172,7 +170,7 @@ export interface VolumeArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of EBS volume. Can be "standard", "gp2", "io1", "sc1" or "st1" (Default: "standard").
      */

--- a/sdk/nodejs/ec2/amiCopy.ts
+++ b/sdk/nodejs/ec2/amiCopy.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * The "AMI copy" resource allows duplication of an Amazon Machine Image (AMI),
  * including cross-region copies.
@@ -102,7 +100,7 @@ export class AmiCopy extends pulumi.CustomResource {
      * for created instances. No other value is supported at this time.
      */
     public /*out*/ readonly sriovNetSupport: pulumi.Output<string>;
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Keyword to choose what virtualization mode created instances
      * will use. Can be either "paravirtual" (the default) or "hvm". The choice of virtualization type
@@ -247,7 +245,7 @@ export interface AmiCopyState {
      * for created instances. No other value is supported at this time.
      */
     readonly sriovNetSupport?: pulumi.Input<string>;
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Keyword to choose what virtualization mode created instances
      * will use. Can be either "paravirtual" (the default) or "hvm". The choice of virtualization type
@@ -296,5 +294,5 @@ export interface AmiCopyArgs {
      * same as the AWS provider region in order to create a copy within the same region.
      */
     readonly sourceAmiRegion: pulumi.Input<string>;
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/capacityReservation.ts
+++ b/sdk/nodejs/ec2/capacityReservation.ts
@@ -4,7 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
 import {InstancePlatform} from "./instancePlatform";
 import {InstanceType} from "./instanceType";
 import {Tenancy} from "./tenancy";
@@ -64,7 +63,7 @@ export class CapacityReservation extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Indicates the tenancy of the Capacity Reservation. Specify either `default` or `dedicated`.
      */
@@ -166,7 +165,7 @@ export interface CapacityReservationState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Indicates the tenancy of the Capacity Reservation. Specify either `default` or `dedicated`.
      */
@@ -216,7 +215,7 @@ export interface CapacityReservationArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Indicates the tenancy of the Capacity Reservation. Specify either `default` or `dedicated`.
      */

--- a/sdk/nodejs/ec2/customerGateway.ts
+++ b/sdk/nodejs/ec2/customerGateway.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a customer gateway inside a VPC. These objects can be connected to VPN gateways via VPN connections, and allow you to establish tunnels between your network and the VPC.
  */
@@ -33,7 +31,7 @@ export class CustomerGateway extends pulumi.CustomResource {
     /**
      * Tags to apply to the gateway.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The type of customer gateway. The only type AWS
      * supports at this time is "ipsec.1".
@@ -91,7 +89,7 @@ export interface CustomerGatewayState {
     /**
      * Tags to apply to the gateway.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of customer gateway. The only type AWS
      * supports at this time is "ipsec.1".
@@ -114,7 +112,7 @@ export interface CustomerGatewayArgs {
     /**
      * Tags to apply to the gateway.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of customer gateway. The only type AWS
      * supports at this time is "ipsec.1".

--- a/sdk/nodejs/ec2/defaultNetworkAcl.ts
+++ b/sdk/nodejs/ec2/defaultNetworkAcl.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the default AWS Network ACL. VPC Only.
  * 
@@ -70,7 +68,7 @@ export class DefaultNetworkAcl extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the associated VPC
      */
@@ -141,7 +139,7 @@ export interface DefaultNetworkAclState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the associated VPC
      */
@@ -173,5 +171,5 @@ export interface DefaultNetworkAclArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/defaultRouteTable.ts
+++ b/sdk/nodejs/ec2/defaultRouteTable.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage a Default VPC Routing Table.
  * 
@@ -71,7 +69,7 @@ export class DefaultRouteTable extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     public /*out*/ readonly vpcId: pulumi.Output<string>;
 
     /**
@@ -131,7 +129,7 @@ export interface DefaultRouteTableState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     readonly vpcId?: pulumi.Input<string>;
 }
 
@@ -154,5 +152,5 @@ export interface DefaultRouteTableArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/defaultSecurityGroup.ts
+++ b/sdk/nodejs/ec2/defaultSecurityGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the default AWS Security Group.
  * 
@@ -69,7 +67,7 @@ export class DefaultSecurityGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID. **Note that changing
      * the `vpc_id` will _not_ restore any default security group rules that were
@@ -139,7 +137,7 @@ export interface DefaultSecurityGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID. **Note that changing
      * the `vpc_id` will _not_ restore any default security group rules that were
@@ -166,7 +164,7 @@ export interface DefaultSecurityGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID. **Note that changing
      * the `vpc_id` will _not_ restore any default security group rules that were

--- a/sdk/nodejs/ec2/defaultSubnet.ts
+++ b/sdk/nodejs/ec2/defaultSubnet.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage a [default AWS VPC subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics)
  * in the current region.
@@ -53,7 +51,7 @@ export class DefaultSubnet extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID.
      */
@@ -133,7 +131,7 @@ export interface DefaultSubnetState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */
@@ -154,5 +152,5 @@ export interface DefaultSubnetArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/defaultVpc.ts
+++ b/sdk/nodejs/ec2/defaultVpc.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the [default AWS VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html)
  * in the current region.
@@ -97,7 +95,7 @@ export class DefaultVpc extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a DefaultVpc resource with the given unique name, arguments, and options.
@@ -222,7 +220,7 @@ export interface DefaultVpcState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -247,5 +245,5 @@ export interface DefaultVpcArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/defaultVpcDhcpOptions.ts
+++ b/sdk/nodejs/ec2/defaultVpcDhcpOptions.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the [default AWS DHCP Options Set](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html#AmazonDNS)
  * in the current region.
@@ -49,7 +47,7 @@ export class DefaultVpcDhcpOptions extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a DefaultVpcDhcpOptions resource with the given unique name, arguments, and options.
@@ -106,7 +104,7 @@ export interface DefaultVpcDhcpOptionsState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -124,5 +122,5 @@ export interface DefaultVpcDhcpOptionsArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/eip.ts
+++ b/sdk/nodejs/ec2/eip.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an Elastic IP resource.
  * 
@@ -58,7 +56,7 @@ export class Eip extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Boolean if the EIP is in a VPC or not.
      */
@@ -141,7 +139,7 @@ export interface EipState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Boolean if the EIP is in a VPC or not.
      */
@@ -173,7 +171,7 @@ export interface EipArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Boolean if the EIP is in a VPC or not.
      */

--- a/sdk/nodejs/ec2/fleet.ts
+++ b/sdk/nodejs/ec2/fleet.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage EC2 Fleets.
  */
@@ -45,7 +43,7 @@ export class Fleet extends pulumi.CustomResource {
     /**
      * Map of Fleet tags. To tag instances at launch, specify the tags in the Launch Template.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     /**
      * Nested argument containing target capacity configurations. Defined below.
      */
@@ -135,7 +133,7 @@ export interface FleetState {
     /**
      * Map of Fleet tags. To tag instances at launch, specify the tags in the Launch Template.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Nested argument containing target capacity configurations. Defined below.
      */
@@ -181,7 +179,7 @@ export interface FleetArgs {
     /**
      * Map of Fleet tags. To tag instances at launch, specify the tags in the Launch Template.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Nested argument containing target capacity configurations. Defined below.
      */

--- a/sdk/nodejs/ec2/instance.ts
+++ b/sdk/nodejs/ec2/instance.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {InstanceProfile} from "../iam";
-import {Tags} from "../index";
 import {InstanceType} from "./instanceType";
 
 /**
@@ -182,7 +181,7 @@ export class Instance extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
      */
@@ -470,7 +469,7 @@ export interface InstanceState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
      */
@@ -618,7 +617,7 @@ export interface InstanceArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
      */

--- a/sdk/nodejs/ec2/internetGateway.ts
+++ b/sdk/nodejs/ec2/internetGateway.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to create a VPC Internet Gateway.
  */
@@ -29,7 +27,7 @@ export class InternetGateway extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID to create in.
      */
@@ -71,7 +69,7 @@ export interface InternetGatewayState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID to create in.
      */
@@ -85,7 +83,7 @@ export interface InternetGatewayArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID to create in.
      */

--- a/sdk/nodejs/ec2/launchTemplate.ts
+++ b/sdk/nodejs/ec2/launchTemplate.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an EC2 launch template resource. Can be used to create instances or auto scaling groups.
  */
@@ -134,7 +132,7 @@ export class LaunchTemplate extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the launch template.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The Base64-encoded user data to provide when launching the instance.
      */
@@ -335,7 +333,7 @@ export interface LaunchTemplateState {
     /**
      * A mapping of tags to assign to the launch template.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The Base64-encoded user data to provide when launching the instance.
      */
@@ -450,7 +448,7 @@ export interface LaunchTemplateArgs {
     /**
      * A mapping of tags to assign to the launch template.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The Base64-encoded user data to provide when launching the instance.
      */

--- a/sdk/nodejs/ec2/natGateway.ts
+++ b/sdk/nodejs/ec2/natGateway.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to create a VPC NAT Gateway.
  */
@@ -45,7 +43,7 @@ export class NatGateway extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a NatGateway resource with the given unique name, arguments, and options.
@@ -111,7 +109,7 @@ export interface NatGatewayState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -129,5 +127,5 @@ export interface NatGatewayArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/networkAcl.ts
+++ b/sdk/nodejs/ec2/networkAcl.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an network ACL resource. You might set up network ACLs with rules similar
  * to your security groups in order to add an additional layer of security to your VPC.
@@ -53,7 +51,7 @@ export class NetworkAcl extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the associated VPC.
      */
@@ -123,7 +121,7 @@ export interface NetworkAclState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the associated VPC.
      */
@@ -154,7 +152,7 @@ export interface NetworkAclArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the associated VPC.
      */

--- a/sdk/nodejs/ec2/networkInterface.ts
+++ b/sdk/nodejs/ec2/networkInterface.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an Elastic network interface (ENI) resource.
  */
@@ -55,7 +53,7 @@ export class NetworkInterface extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a NetworkInterface resource with the given unique name, arguments, and options.
@@ -136,7 +134,7 @@ export interface NetworkInterfaceState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -175,5 +173,5 @@ export interface NetworkInterfaceArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/routeTable.ts
+++ b/sdk/nodejs/ec2/routeTable.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to create a VPC routing table.
  * 
@@ -56,7 +54,7 @@ export class RouteTable extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID.
      */
@@ -113,7 +111,7 @@ export interface RouteTableState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */
@@ -135,7 +133,7 @@ export interface RouteTableArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */

--- a/sdk/nodejs/ec2/securityGroup.ts
+++ b/sdk/nodejs/ec2/securityGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a security group resource.
  * 
@@ -79,7 +77,7 @@ export class SecurityGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID.
      */
@@ -176,7 +174,7 @@ export interface SecurityGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */
@@ -227,7 +225,7 @@ export interface SecurityGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */

--- a/sdk/nodejs/ec2/spotInstanceRequest.ts
+++ b/sdk/nodejs/ec2/spotInstanceRequest.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an EC2 Spot Instance Request resource. This allows instances to be
  * requested on the spot market.
@@ -224,7 +222,7 @@ export class SpotInstanceRequest extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
      */
@@ -571,7 +569,7 @@ export interface SpotInstanceRequestState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
      */
@@ -757,7 +755,7 @@ export interface SpotInstanceRequestArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
      */

--- a/sdk/nodejs/ec2/subnet.ts
+++ b/sdk/nodejs/ec2/subnet.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an VPC subnet resource.
  */
@@ -66,7 +64,7 @@ export class Subnet extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID.
      */
@@ -167,7 +165,7 @@ export interface SubnetState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */
@@ -210,7 +208,7 @@ export interface SubnetArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID.
      */

--- a/sdk/nodejs/ec2/vpc.ts
+++ b/sdk/nodejs/ec2/vpc.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an VPC resource.
  */
@@ -93,7 +91,7 @@ export class Vpc extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Vpc resource with the given unique name, arguments, and options.
@@ -226,7 +224,7 @@ export interface VpcState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -269,5 +267,5 @@ export interface VpcArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/vpcDhcpOptions.ts
+++ b/sdk/nodejs/ec2/vpcDhcpOptions.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a VPC DHCP Options resource.
  * * `domain_name_servers`, `netbios_name_servers`, `ntp_servers` are limited by AWS to maximum four servers only.
@@ -53,7 +51,7 @@ export class VpcDhcpOptions extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a VpcDhcpOptions resource with the given unique name, arguments, and options.
@@ -119,7 +117,7 @@ export interface VpcDhcpOptionsState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -149,5 +147,5 @@ export interface VpcDhcpOptionsArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ec2/vpcPeeringConnection.ts
+++ b/sdk/nodejs/ec2/vpcPeeringConnection.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage a VPC peering connection.
  * 
@@ -71,7 +69,7 @@ export class VpcPeeringConnection extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the requester VPC.
      */
@@ -161,7 +159,7 @@ export interface VpcPeeringConnectionState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the requester VPC.
      */
@@ -205,7 +203,7 @@ export interface VpcPeeringConnectionArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the requester VPC.
      */

--- a/sdk/nodejs/ec2/vpcPeeringConnectionAccepter.ts
+++ b/sdk/nodejs/ec2/vpcPeeringConnectionAccepter.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to manage the accepter's side of a VPC Peering Connection.
  * 
@@ -62,7 +60,7 @@ export class VpcPeeringConnectionAccepter extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the accepter VPC.
      */
@@ -151,7 +149,7 @@ export interface VpcPeeringConnectionAccepterState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the accepter VPC.
      */
@@ -183,7 +181,7 @@ export interface VpcPeeringConnectionAccepterArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC Peering Connection ID to manage.
      */

--- a/sdk/nodejs/ec2/vpnConnection.ts
+++ b/sdk/nodejs/ec2/vpnConnection.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages an EC2 VPN connection. These objects can be connected to customer gateways, and allow you to establish tunnels between your network and Amazon.
  * 
@@ -44,7 +42,7 @@ export class VpnConnection extends pulumi.CustomResource {
     /**
      * Tags to apply to the connection.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ID of the EC2 Transit Gateway.
      */
@@ -206,7 +204,7 @@ export interface VpnConnectionState {
     /**
      * Tags to apply to the connection.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the EC2 Transit Gateway.
      */
@@ -298,7 +296,7 @@ export interface VpnConnectionArgs {
     /**
      * Tags to apply to the connection.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The ID of the EC2 Transit Gateway.
      */

--- a/sdk/nodejs/ec2/vpnGateway.ts
+++ b/sdk/nodejs/ec2/vpnGateway.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to create a VPC VPN Gateway.
  */
@@ -33,7 +31,7 @@ export class VpnGateway extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The VPC ID to create in.
      */
@@ -81,7 +79,7 @@ export interface VpnGatewayState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID to create in.
      */
@@ -103,7 +101,7 @@ export interface VpnGatewayArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The VPC ID to create in.
      */

--- a/sdk/nodejs/ec2transitgateway/routeTable.ts
+++ b/sdk/nodejs/ec2transitgateway/routeTable.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages an EC2 Transit Gateway Route Table.
  */
@@ -33,7 +31,7 @@ export class RouteTable extends pulumi.CustomResource {
     /**
      * Key-value tags for the EC2 Transit Gateway Route Table.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     /**
      * Identifier of EC2 Transit Gateway.
      */
@@ -84,7 +82,7 @@ export interface RouteTableState {
     /**
      * Key-value tags for the EC2 Transit Gateway Route Table.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Identifier of EC2 Transit Gateway.
      */
@@ -98,7 +96,7 @@ export interface RouteTableArgs {
     /**
      * Key-value tags for the EC2 Transit Gateway Route Table.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Identifier of EC2 Transit Gateway.
      */

--- a/sdk/nodejs/ec2transitgateway/transitGateway.ts
+++ b/sdk/nodejs/ec2transitgateway/transitGateway.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN, Tags} from "../index";
+import {ARN} from "../index";
 
 /**
  * Manages an EC2 Transit Gateway.
@@ -65,7 +65,7 @@ export class TransitGateway extends pulumi.CustomResource {
     /**
      * Key-value tags for the EC2 Transit Gateway.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     /**
      * Whether VPN Equal Cost Multipath Protocol support is enabled. Valid values: `disable`, `enable`. Default value: `enable`.
      */
@@ -161,7 +161,7 @@ export interface TransitGatewayState {
     /**
      * Key-value tags for the EC2 Transit Gateway.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Whether VPN Equal Cost Multipath Protocol support is enabled. Valid values: `disable`, `enable`. Default value: `enable`.
      */
@@ -199,7 +199,7 @@ export interface TransitGatewayArgs {
     /**
      * Key-value tags for the EC2 Transit Gateway.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Whether VPN Equal Cost Multipath Protocol support is enabled. Valid values: `disable`, `enable`. Default value: `enable`.
      */

--- a/sdk/nodejs/ec2transitgateway/vpcAttachment.ts
+++ b/sdk/nodejs/ec2transitgateway/vpcAttachment.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages an EC2 Transit Gateway VPC Attachment. For examples of custom route table association and propagation, see the EC2 Transit Gateway Networking Examples Guide.
  */
@@ -37,7 +35,7 @@ export class VpcAttachment extends pulumi.CustomResource {
     /**
      * Key-value tags for the EC2 Transit Gateway VPC Attachment.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: string} | undefined>;
     /**
      * Boolean whether the VPC Attachment should be associated with the EC2 Transit Gateway association default route table. Default value: `true`.
      */
@@ -124,7 +122,7 @@ export interface VpcAttachmentState {
     /**
      * Key-value tags for the EC2 Transit Gateway VPC Attachment.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Boolean whether the VPC Attachment should be associated with the EC2 Transit Gateway association default route table. Default value: `true`.
      */
@@ -166,7 +164,7 @@ export interface VpcAttachmentArgs {
     /**
      * Key-value tags for the EC2 Transit Gateway VPC Attachment.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Boolean whether the VPC Attachment should be associated with the EC2 Transit Gateway association default route table. Default value: `true`.
      */

--- a/sdk/nodejs/efs/fileSystem.ts
+++ b/sdk/nodejs/efs/fileSystem.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an Elastic File System (EFS) resource.
  */
@@ -62,7 +60,7 @@ export class FileSystem extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the file system.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.
      */
@@ -151,7 +149,7 @@ export interface FileSystemState {
     /**
      * A mapping of tags to assign to the file system.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.
      */
@@ -194,7 +192,7 @@ export interface FileSystemArgs {
     /**
      * A mapping of tags to assign to the file system.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.
      */

--- a/sdk/nodejs/elasticache/cluster.ts
+++ b/sdk/nodejs/elasticache/cluster.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an ElastiCache Cluster resource, which manages a Memcached cluster or Redis instance.
  * For working with Redis (Cluster Mode Enabled) replication groups, see the
@@ -162,7 +160,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Cluster resource with the given unique name, arguments, and options.
@@ -370,7 +368,7 @@ export interface ClusterState {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -495,5 +493,5 @@ export interface ClusterArgs {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/elasticache/replicationGroup.ts
+++ b/sdk/nodejs/elasticache/replicationGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an ElastiCache Replication Group resource.
  * For working with Memcached or single primary Redis instances (Cluster Mode Disabled), see the
@@ -146,7 +144,7 @@ export class ReplicationGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Whether to enable encryption in transit.
      */
@@ -361,7 +359,7 @@ export interface ReplicationGroupState {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Whether to enable encryption in transit.
      */
@@ -482,7 +480,7 @@ export interface ReplicationGroupArgs {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Whether to enable encryption in transit.
      */

--- a/sdk/nodejs/elasticbeanstalk/environment.ts
+++ b/sdk/nodejs/elasticbeanstalk/environment.ts
@@ -4,7 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
 import {Application} from "./application";
 import {ApplicationVersion} from "./applicationVersion";
 
@@ -105,7 +104,7 @@ export class Environment extends pulumi.CustomResource {
     /**
      * A set of tags to apply to the Environment.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The name of the Elastic Beanstalk Configuration
      * template to use in deployment
@@ -279,7 +278,7 @@ export interface EnvironmentState {
     /**
      * A set of tags to apply to the Environment.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The name of the Elastic Beanstalk Configuration
      * template to use in deployment
@@ -357,7 +356,7 @@ export interface EnvironmentArgs {
     /**
      * A set of tags to apply to the Environment.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The name of the Elastic Beanstalk Configuration
      * template to use in deployment

--- a/sdk/nodejs/elasticloadbalancing/loadBalancer.ts
+++ b/sdk/nodejs/elasticloadbalancing/loadBalancer.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an Elastic Load Balancer resource, also known as a "Classic
  * Load Balancer" after the release of
@@ -112,7 +110,7 @@ export class LoadBalancer extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record)
      */
@@ -265,7 +263,7 @@ export interface LoadBalancerState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record)
      */
@@ -343,5 +341,5 @@ export interface LoadBalancerArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/elasticloadbalancingv2/loadBalancer.ts
+++ b/sdk/nodejs/elasticloadbalancingv2/loadBalancer.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Load Balancer resource.
  * 
@@ -97,7 +95,7 @@ export class LoadBalancer extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     public /*out*/ readonly vpcId: pulumi.Output<string>;
     /**
      * The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
@@ -238,7 +236,7 @@ export interface LoadBalancerState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     readonly vpcId?: pulumi.Input<string>;
     /**
      * The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
@@ -311,5 +309,5 @@ export interface LoadBalancerArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/elasticloadbalancingv2/targetGroup.ts
+++ b/sdk/nodejs/elasticloadbalancingv2/targetGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Target Group resource for use with Load Balancer resources.
  * 
@@ -71,7 +69,7 @@ export class TargetGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The type of target that you must specify when registering targets with this target group.
      * The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).
@@ -184,7 +182,7 @@ export interface TargetGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of target that you must specify when registering targets with this target group.
      * The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).
@@ -243,7 +241,7 @@ export interface TargetGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of target that you must specify when registering targets with this target group.
      * The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).

--- a/sdk/nodejs/elasticsearch/domain.ts
+++ b/sdk/nodejs/elasticsearch/domain.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages an AWS Elasticsearch Domain.
  */
@@ -87,7 +85,7 @@ export class Domain extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * VPC related options, see below. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)).
      */
@@ -215,7 +213,7 @@ export interface DomainState {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * VPC related options, see below. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)).
      */
@@ -273,7 +271,7 @@ export interface DomainArgs {
     /**
      * A mapping of tags to assign to the resource
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * VPC related options, see below. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)).
      */

--- a/sdk/nodejs/emr/cluster.ts
+++ b/sdk/nodejs/emr/cluster.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an Elastic MapReduce Cluster, a web service that makes it easy to
  * process large amounts of data efficiently. See [Amazon Elastic MapReduce Documentation](https://aws.amazon.com/documentation/elastic-mapreduce/)
@@ -120,7 +118,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * list of tags to apply to the EMR Cluster
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Switch on/off termination protection (default is off)
      */
@@ -309,7 +307,7 @@ export interface ClusterState {
     /**
      * list of tags to apply to the EMR Cluster
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Switch on/off termination protection (default is off)
      */
@@ -415,7 +413,7 @@ export interface ClusterArgs {
     /**
      * list of tags to apply to the EMR Cluster
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Switch on/off termination protection (default is off)
      */

--- a/sdk/nodejs/glacier/vault.ts
+++ b/sdk/nodejs/glacier/vault.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Glacier Vault Resource. You can refer to the [Glacier Developer Guide](https://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-vaults.html) for a full explanation of the Glacier Vault functionality
  * 
@@ -48,7 +46,7 @@ export class Vault extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Vault resource with the given unique name, arguments, and options.
@@ -109,7 +107,7 @@ export interface VaultState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -132,5 +130,5 @@ export interface VaultArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/inspector/resourceGroup.ts
+++ b/sdk/nodejs/inspector/resourceGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Inspector resource group
  */
@@ -29,7 +27,7 @@ export class ResourceGroup extends pulumi.CustomResource {
     /**
      * The tags on your EC2 Instance.
      */
-    public readonly tags: pulumi.Output<Tags>;
+    public readonly tags: pulumi.Output<{[key: string]: any}>;
 
     /**
      * Create a ResourceGroup resource with the given unique name, arguments, and options.
@@ -68,7 +66,7 @@ export interface ResourceGroupState {
     /**
      * The tags on your EC2 Instance.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -78,5 +76,5 @@ export interface ResourceGroupArgs {
     /**
      * The tags on your EC2 Instance.
      */
-    readonly tags: pulumi.Input<Tags>;
+    readonly tags: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/kinesis/stream.ts
+++ b/sdk/nodejs/kinesis/stream.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Kinesis Stream resource. Amazon Kinesis is a managed service that
  * scales elastically for real-time processing of streaming big data.
@@ -59,7 +57,7 @@ export class Stream extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Stream resource with the given unique name, arguments, and options.
@@ -137,7 +135,7 @@ export interface StreamState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -178,5 +176,5 @@ export interface StreamArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/kms/key.ts
+++ b/sdk/nodejs/kms/key.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a KMS customer master key.
  */
@@ -60,7 +58,7 @@ export class Key extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the object.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Key resource with the given unique name, arguments, and options.
@@ -141,7 +139,7 @@ export interface KeyState {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -178,5 +176,5 @@ export interface KeyArgs {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/lambda/function.ts
+++ b/sdk/nodejs/lambda/function.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN, Tags} from "../index";
+import {ARN} from "../index";
 
 /**
  * Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS. The Lambda Function itself includes source code and runtime configuration.
@@ -112,7 +112,7 @@ export class Function extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the object.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
      */
@@ -299,7 +299,7 @@ export interface FunctionState {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
      */
@@ -386,7 +386,7 @@ export interface FunctionArgs {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
      */

--- a/sdk/nodejs/neptune/parameterGroup.ts
+++ b/sdk/nodejs/neptune/parameterGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages a Neptune Parameter Group
  */
@@ -45,7 +43,7 @@ export class ParameterGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a ParameterGroup resource with the given unique name, arguments, and options.
@@ -108,7 +106,7 @@ export interface ParameterGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -134,5 +132,5 @@ export interface ParameterGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/neptune/subnetGroup.ts
+++ b/sdk/nodejs/neptune/subnetGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an Neptune subnet group resource.
  */
@@ -45,7 +43,7 @@ export class SubnetGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a SubnetGroup resource with the given unique name, arguments, and options.
@@ -108,7 +106,7 @@ export interface SubnetGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -134,5 +132,5 @@ export interface SubnetGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/opsworks/stack.ts
+++ b/sdk/nodejs/opsworks/stack.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an OpsWorks stack resource.
  */
@@ -104,7 +102,7 @@ export class Stack extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Boolean value controlling whether the custom cookbook settings are
      * enabled.
@@ -282,7 +280,7 @@ export interface StackState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Boolean value controlling whether the custom cookbook settings are
      * enabled.
@@ -383,7 +381,7 @@ export interface StackArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Boolean value controlling whether the custom cookbook settings are
      * enabled.

--- a/sdk/nodejs/rds/cluster.ts
+++ b/sdk/nodejs/rds/cluster.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages a [RDS Aurora Cluster][2]. To manage cluster instances that inherit configuration from the cluster (when not running the cluster in `serverless` engine mode), see the [`aws_rds_cluster_instance` resource](https://www.terraform.io/docs/providers/aws/r/rds_cluster_instance.html). To manage non-Aurora databases (e.g. MySQL, PostgreSQL, SQL Server, etc.), see the [`aws_db_instance` resource](https://www.terraform.io/docs/providers/aws/r/db_instance.html).
  * 
@@ -194,7 +192,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the DB cluster.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * List of VPC security groups to associate
      * with the Cluster
@@ -456,7 +454,7 @@ export interface ClusterState {
     /**
      * A mapping of tags to assign to the DB cluster.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * List of VPC security groups to associate
      * with the Cluster
@@ -601,7 +599,7 @@ export interface ClusterArgs {
     /**
      * A mapping of tags to assign to the DB cluster.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * List of VPC security groups to associate
      * with the Cluster

--- a/sdk/nodejs/rds/clusterInstance.ts
+++ b/sdk/nodejs/rds/clusterInstance.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS Cluster Resource Instance. A Cluster Instance Resource defines
  * attributes that are specific to a single instance in a [RDS Cluster][3],
@@ -167,7 +165,7 @@ export class ClusterInstance extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the instance.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Boolean indicating if this instance is writable. `False` indicates this instance is a read replica.
      */
@@ -390,7 +388,7 @@ export interface ClusterInstanceState {
     /**
      * A mapping of tags to assign to the instance.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Boolean indicating if this instance is writable. `False` indicates this instance is a read replica.
      */
@@ -509,5 +507,5 @@ export interface ClusterInstanceArgs {
     /**
      * A mapping of tags to assign to the instance.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/rds/clusterParameterGroup.ts
+++ b/sdk/nodejs/rds/clusterParameterGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS DB cluster parameter group resource. Documentation of the available parameters for various Aurora engines can be found at:
  * * [Aurora MySQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Reference.html)
@@ -51,7 +49,7 @@ export class ClusterParameterGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a ClusterParameterGroup resource with the given unique name, arguments, and options.
@@ -120,7 +118,7 @@ export interface ClusterParameterGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -150,5 +148,5 @@ export interface ClusterParameterGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/rds/eventSubscription.ts
+++ b/sdk/nodejs/rds/eventSubscription.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a DB event subscription resource.
  */
@@ -55,7 +53,7 @@ export class EventSubscription extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a EventSubscription resource with the given unique name, arguments, and options.
@@ -136,7 +134,7 @@ export interface EventSubscriptionState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -174,5 +172,5 @@ export interface EventSubscriptionArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/rds/instance.ts
+++ b/sdk/nodejs/rds/instance.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS instance resource.  A DB instance is an isolated database
  * environment in the cloud.  A DB instance can contain multiple user-created
@@ -315,7 +313,7 @@ export class Instance extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Time zone of the DB instance. `timezone` is currently
      * only supported by Microsoft SQL Server. The `timezone` can only be set on
@@ -741,7 +739,7 @@ export interface InstanceState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Time zone of the DB instance. `timezone` is currently
      * only supported by Microsoft SQL Server. The `timezone` can only be set on
@@ -1009,7 +1007,7 @@ export interface InstanceArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Time zone of the DB instance. `timezone` is currently
      * only supported by Microsoft SQL Server. The `timezone` can only be set on

--- a/sdk/nodejs/rds/optionGroup.ts
+++ b/sdk/nodejs/rds/optionGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS DB option group resource. Documentation of the available options for various RDS engines can be found at:
  * * [MariaDB Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MariaDB.Options.html)
@@ -57,7 +55,7 @@ export class OptionGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a OptionGroup resource with the given unique name, arguments, and options.
@@ -135,7 +133,7 @@ export interface OptionGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -169,5 +167,5 @@ export interface OptionGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/rds/parameterGroup.ts
+++ b/sdk/nodejs/rds/parameterGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS DB parameter group resource .Documentation of the available parameters for various RDS engines can be found at:
  * * [Aurora MySQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Reference.html)
@@ -54,7 +52,7 @@ export class ParameterGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a ParameterGroup resource with the given unique name, arguments, and options.
@@ -123,7 +121,7 @@ export interface ParameterGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -153,5 +151,5 @@ export interface ParameterGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/rds/securityGroup.ts
+++ b/sdk/nodejs/rds/securityGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS security group resource. This is only for DB instances in the
  * EC2-Classic Platform. For instances inside a VPC, use the
@@ -44,7 +42,7 @@ export class SecurityGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a SecurityGroup resource with the given unique name, arguments, and options.
@@ -101,7 +99,7 @@ export interface SecurityGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -123,5 +121,5 @@ export interface SecurityGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/rds/subnetGroup.ts
+++ b/sdk/nodejs/rds/subnetGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an RDS DB subnet group resource.
  */
@@ -45,7 +43,7 @@ export class SubnetGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a SubnetGroup resource with the given unique name, arguments, and options.
@@ -108,7 +106,7 @@ export interface SubnetGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -134,5 +132,5 @@ export interface SubnetGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/redshift/cluster.ts
+++ b/sdk/nodejs/redshift/cluster.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Redshift Cluster Resource.
  * 
@@ -177,7 +175,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.
      */
@@ -440,7 +438,7 @@ export interface ClusterState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.
      */
@@ -599,7 +597,7 @@ export interface ClusterArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.
      */

--- a/sdk/nodejs/redshift/subnetGroup.ts
+++ b/sdk/nodejs/redshift/subnetGroup.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Creates a new Amazon Redshift subnet group. You must provide a list of one or more subnets in your existing Amazon Virtual Private Cloud (Amazon VPC) when creating Amazon Redshift subnet group.
  */
@@ -37,7 +35,7 @@ export class SubnetGroup extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the resource.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a SubnetGroup resource with the given unique name, arguments, and options.
@@ -88,7 +86,7 @@ export interface SubnetGroupState {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -110,5 +108,5 @@ export interface SubnetGroupArgs {
     /**
      * A mapping of tags to assign to the resource.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/route53/healthCheck.ts
+++ b/sdk/nodejs/route53/healthCheck.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a Route53 health check.
  */
@@ -94,7 +92,7 @@ export class HealthCheck extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the health check.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The protocol to use when performing health checks. Valid values are `HTTP`, `HTTPS`, `HTTP_STR_MATCH`, `HTTPS_STR_MATCH`, `TCP`, `CALCULATED` and `CLOUDWATCH_METRIC`.
      */
@@ -236,7 +234,7 @@ export interface HealthCheckState {
     /**
      * A mapping of tags to assign to the health check.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The protocol to use when performing health checks. Valid values are `HTTP`, `HTTPS`, `HTTP_STR_MATCH`, `HTTPS_STR_MATCH`, `TCP`, `CALCULATED` and `CLOUDWATCH_METRIC`.
      */
@@ -319,7 +317,7 @@ export interface HealthCheckArgs {
     /**
      * A mapping of tags to assign to the health check.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The protocol to use when performing health checks. Valid values are `HTTP`, `HTTPS`, `HTTP_STR_MATCH`, `HTTPS_STR_MATCH`, `TCP`, `CALCULATED` and `CLOUDWATCH_METRIC`.
      */

--- a/sdk/nodejs/route53/zone.ts
+++ b/sdk/nodejs/route53/zone.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Manages a Route53 Hosted Zone.
  */
@@ -46,7 +44,7 @@ export class Zone extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the zone.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with `delegation_set_id`, `vpc_id`, and `vpc_region` in this resource and any [`aws_route53_zone_association` resource](https://www.terraform.io/docs/providers/aws/r/route53_zone_association.html) specifying the same zone ID. Detailed below.
      */
@@ -131,7 +129,7 @@ export interface ZoneState {
     /**
      * A mapping of tags to assign to the zone.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with `delegation_set_id`, `vpc_id`, and `vpc_region` in this resource and any [`aws_route53_zone_association` resource](https://www.terraform.io/docs/providers/aws/r/route53_zone_association.html) specifying the same zone ID. Detailed below.
      */
@@ -173,7 +171,7 @@ export interface ZoneArgs {
     /**
      * A mapping of tags to assign to the zone.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with `delegation_set_id`, `vpc_id`, and `vpc_region` in this resource and any [`aws_route53_zone_association` resource](https://www.terraform.io/docs/providers/aws/r/route53_zone_association.html) specifying the same zone ID. Detailed below.
      */

--- a/sdk/nodejs/s3/bucket.ts
+++ b/sdk/nodejs/s3/bucket.ts
@@ -4,7 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
 import {CannedAcl} from "./cannedAcl";
 
 /**
@@ -98,7 +97,7 @@ export class Bucket extends pulumi.CustomResource {
      * A mapping of tags that identifies subset of objects to which the rule applies.
      * The rule applies only to objects having all the tags in its tagset.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      */
@@ -258,7 +257,7 @@ export interface BucketState {
      * A mapping of tags that identifies subset of objects to which the rule applies.
      * The rule applies only to objects having all the tags in its tagset.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      */
@@ -348,7 +347,7 @@ export interface BucketArgs {
      * A mapping of tags that identifies subset of objects to which the rule applies.
      * The rule applies only to objects having all the tags in its tagset.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      */

--- a/sdk/nodejs/s3/bucketObject.ts
+++ b/sdk/nodejs/s3/bucketObject.ts
@@ -4,7 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
 import {Bucket} from "./bucket";
 
 /**
@@ -91,7 +90,7 @@ export class BucketObject extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the object.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * A unique version ID value for the object, if bucket versioning
      * is enabled.
@@ -232,7 +231,7 @@ export interface BucketObjectState {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * A unique version ID value for the object, if bucket versioning
      * is enabled.
@@ -316,7 +315,7 @@ export interface BucketObjectArgs {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * Specifies a target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
      */

--- a/sdk/nodejs/servicecatalog/portfolio.ts
+++ b/sdk/nodejs/servicecatalog/portfolio.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides a resource to create a Service Catalog Portfolio.
  */
@@ -39,7 +37,7 @@ export class Portfolio extends pulumi.CustomResource {
     /**
      * Tags to apply to the connection.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Portfolio resource with the given unique name, arguments, and options.
@@ -93,7 +91,7 @@ export interface PortfolioState {
     /**
      * Tags to apply to the connection.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -115,5 +113,5 @@ export interface PortfolioArgs {
     /**
      * Tags to apply to the connection.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/sqs/queue.ts
+++ b/sdk/nodejs/sqs/queue.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 export class Queue extends pulumi.CustomResource {
     /**
      * Get an existing Queue resource's state with the given name, ID, and optional extra
@@ -74,7 +72,7 @@ export class Queue extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the queue.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html).
      */
@@ -188,7 +186,7 @@ export interface QueueState {
     /**
      * A mapping of tags to assign to the queue.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html).
      */
@@ -250,7 +248,7 @@ export interface QueueArgs {
     /**
      * A mapping of tags to assign to the queue.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html).
      */

--- a/sdk/nodejs/ssm/document.ts
+++ b/sdk/nodejs/ssm/document.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an SSM Document resource
  * 
@@ -94,7 +92,7 @@ export class Document extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the object.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
 
     /**
      * Create a Document resource with the given unique name, arguments, and options.
@@ -229,7 +227,7 @@ export interface DocumentState {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }
 
 /**
@@ -259,5 +257,5 @@ export interface DocumentArgs {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
 }

--- a/sdk/nodejs/ssm/parameter.ts
+++ b/sdk/nodejs/ssm/parameter.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Tags} from "../index";
-
 /**
  * Provides an SSM Parameter resource.
  */
@@ -49,7 +47,7 @@ export class Parameter extends pulumi.CustomResource {
     /**
      * A mapping of tags to assign to the object.
      */
-    public readonly tags: pulumi.Output<Tags | undefined>;
+    public readonly tags: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
      */
@@ -133,7 +131,7 @@ export interface ParameterState {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
      */
@@ -175,7 +173,7 @@ export interface ParameterArgs {
     /**
      * A mapping of tags to assign to the object.
      */
-    readonly tags?: pulumi.Input<Tags>;
+    readonly tags?: pulumi.Input<{[key: string]: any}>;
     /**
      * The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
      */


### PR DESCRIPTION
Using `{ [key: string]: string }` as the type for `aws.Tags`, and projecting that for the `tags` property on AWS resources precludes tag values from being `Output`s, despite the tags that the engine supports that. Until a better solution exists, this commit removes the overlay types from the various resources.

The tags overlay and the `aws.Tags` type is kept, in case people have references to it as (for example) a variable type - it should still be compatible with the new definition.

Fixes #410.