### PR TITLE
Use latest released @pulumi/pulumi version

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -1797,7 +1797,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":    "dev",
+				"@pulumi/pulumi":    "^0.16.9",
 				"aws-sdk":           "^2.0.0",
 				"mime":              "^2.0.0",
 				"builtin-modules":   "3.0.0",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "dev",
+        "@pulumi/pulumi": "^0.16.9",
         "aws-sdk": "^2.0.0",
         "builtin-modules": "3.0.0",
         "mime": "^2.0.0",


### PR DESCRIPTION
This was set to "dev" because we wanted to use the latest version of
@pulumi/pulumi while doing co-development across these repositories.

However, we should set this back as we are planning to do another
release and we want to lock to a stable version instead of just using
`dev`.