### PR TITLE
Attach an AutoName to elasticache.ReplicationGroup::replicationGroupId

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -676,7 +676,12 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			"aws_elasticache_replication_group": {Tok: awsResource(elasticacheMod, "ReplicationGroup")},
+			"aws_elasticache_replication_group": {
+				Tok: awsResource(elasticacheMod, "ReplicationGroup"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"replication_group_id": tfbridge.AutoNameTransform("replicationGroupId", 20, strings.ToLower),
+				},
+			},
 			"aws_elasticache_security_group": {
 				Tok: awsResource(elasticacheMod, "SecurityGroup"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/go/aws/elasticache/replicationGroup.go
+++ b/sdk/go/aws/elasticache/replicationGroup.go
@@ -21,9 +21,6 @@ func NewReplicationGroup(ctx *pulumi.Context,
 	if args == nil || args.ReplicationGroupDescription == nil {
 		return nil, errors.New("missing required argument 'ReplicationGroupDescription'")
 	}
-	if args == nil || args.ReplicationGroupId == nil {
-		return nil, errors.New("missing required argument 'ReplicationGroupId'")
-	}
 	inputs := make(map[string]interface{})
 	if args == nil {
 		inputs["applyImmediately"] = nil

--- a/sdk/nodejs/elasticache/replicationGroup.ts
+++ b/sdk/nodejs/elasticache/replicationGroup.ts
@@ -196,9 +196,6 @@ export class ReplicationGroup extends pulumi.CustomResource {
             if (!args || args.replicationGroupDescription === undefined) {
                 throw new Error("Missing required property 'replicationGroupDescription'");
             }
-            if (!args || args.replicationGroupId === undefined) {
-                throw new Error("Missing required property 'replicationGroupId'");
-            }
             inputs["applyImmediately"] = args ? args.applyImmediately : undefined;
             inputs["atRestEncryptionEnabled"] = args ? args.atRestEncryptionEnabled : undefined;
             inputs["authToken"] = args ? args.authToken : undefined;
@@ -441,7 +438,7 @@ export interface ReplicationGroupArgs {
     /**
      * The replication group identifier. This parameter is stored as a lowercase string.
      */
-    readonly replicationGroupId: pulumi.Input<string>;
+    readonly replicationGroupId?: pulumi.Input<string>;
     /**
      * One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud
      */

--- a/sdk/python/pulumi_aws/elasticache/replication_group.py
+++ b/sdk/python/pulumi_aws/elasticache/replication_group.py
@@ -57,8 +57,6 @@ class ReplicationGroup(pulumi.CustomResource):
             raise TypeError('Missing required property replication_group_description')
         __props__['replication_group_description'] = replication_group_description
 
-        if not replication_group_id:
-            raise TypeError('Missing required property replication_group_id')
         __props__['replication_group_id'] = replication_group_id
 
         __props__['security_group_ids'] = security_group_ids


### PR DESCRIPTION
Fixes #426.

The documentation for the field requirements is [here].

[here]: https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html