### PR TITLE
Add provider and tfgen targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ TESTPARALLELISM := 4
 # NOTE: Since the plugin is published using the nodejs style semver version
 # We set the PLUGIN_VERSION to be the same as the version we use when building
 # the provider (e.g. x.y.z-dev-... instead of x.y.zdev...)
-build::
-	go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${TFGEN}
-	go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${PROVIDER}
+build:: provider tfgen
 	for LANGUAGE in "nodejs" "python" "go" ; do \
 		$(TFGEN) $$LANGUAGE --overlays overlays/$$LANGUAGE/ --out ${PACKDIR}/$$LANGUAGE/ || exit 3 ; \
 	done
@@ -39,6 +37,12 @@ build::
 		sed -i.bak -e "s/\$${VERSION}/$(PYPI_VERSION)/g" -e "s/\$${PLUGIN_VERSION}/$(VERSION)/g" ./bin/setup.py && \
 		rm ./bin/setup.py.bak && \
 		cd ./bin && $(PYTHON) setup.py build sdist
+
+provider::
+	go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${PROVIDER}
+
+tfgen::
+	go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${TFGEN}
 
 lint::
 	golangci-lint run


### PR DESCRIPTION
I find myself waiting on a full `make build` when I'm only adding debugging information to a provider binary fairly often - this commit splits out the Go build for the tfgen and provider binaries from the code generation and other build steps in order that it's easy to build just the provider binary while
retaining the correct version information.

Care should be taken to only make "safe" changes (e.g. adding debugging information, rather than changing the structure of resources).

If this change is acceptable I'll roll it out to the other provider repos.