### PR TITLE
Map ByteMatchSet::byteMatchTuples correctly

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -1593,6 +1593,9 @@ func Provider() tfbridge.ProviderInfo {
 					"byte_match_tuple": {
 						Name: "byte_match_tuple",
 					},
+					"byte_match_tuples": {
+						Name: "byteMatchTuples",
+					},
 				},
 			},
 			"aws_wafregional_geo_match_set":           {Tok: awsResource(wafregionalMod, "GeoMatchSet")},


### PR DESCRIPTION
Since we map the deprecated `byte_match_tuple` property to `byte_match_tuple`, we also need to map `byte_match_tuples` to `byteMatchTuples` explicitly in order that the name resolution in `getInfoForPulumiName` in tfbridge matches the field we want instead of relying on default name mangling.

Fixes #429.