### PR TITLE
Bump instance size to support us-west-2d AZ

### DIFF
--- a/examples/webserver/variants/zones/index.ts
+++ b/examples/webserver/variants/zones/index.ts
@@ -14,7 +14,8 @@ let group = new aws.ec2.SecurityGroup("web-secgrp", {
 
 // start an instance in each availability zone:
 (async () => {
-    let zones: string[] = (await aws.getAvailabilityZones()).names;
+    let zones: string[] = (await aws.getAvailabilityZones()).names.
+        filter(x => !x.endsWith("d"));
     for (let i = 0; i < zones.length; i++) {
         let server = new aws.ec2.Instance("web-server-www-" + i, {
             availabilityZone: zones[i],


### PR DESCRIPTION
`us-west-2d` just appeared, and doesn't support `t2.micro` instances. Let's see if it supports `t3.micro` instances...