### PR TITLE
Run all tests in CI

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -38,7 +38,7 @@ func TestExamples(t *testing.T) {
 		},
 	})
 
-	shortTests := []integration.ProgramTestOptions{
+	tests := []integration.ProgramTestOptions{
 		baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "minimal")}),
 		baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "express")}),
 		// TODO[pulumi/pulumi#1900]: This should be the default value, every test we have causes some sort of
@@ -113,11 +113,8 @@ func TestExamples(t *testing.T) {
 	// Run the short or long tests depending on the config.  Note that we only run long tests on
 	// travis after already running short tests.  So no need to actually run both at the same time
 	// ever.
-	var tests []integration.ProgramTestOptions
-	if testing.Short() {
-		tests = shortTests
-	} else {
-		tests = longTests
+	if !testing.Short() {
+		tests = append(tests, longTests...)
 	}
 
 	for _, ex := range tests {


### PR DESCRIPTION
We had accidentally been skipping all "Short" tests during normal test runs.