### PR TITLE
Pull in EKS Create Timeout change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for AWS Lambda Custom Runtime `aws.lambda.CustomRuntime`.
 - Update to v2.9.0 of the AWS Terraform Provider.
+- Increase create timeout for `aws.eks.Cluster` to 30 minutes.
 
 ## 0.18.3 (Released April 29th, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -29,5 +29,5 @@ require (
 replace (
 	github.com/Nvveen/Gotty => github.com/ijc25/Gotty v0.0.0-20170406111628-a8b993ba6abd
 	github.com/golang/glog => github.com/pulumi/glog v0.0.0-20180820174630-7eaa6ffb71e4
-	github.com/terraform-providers/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.3.2-0.20190506212555-206db4204c2b
+	github.com/terraform-providers/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.3.2-0.20190510204831-4acfa088d81f
 )

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ github.com/pulumi/terraform-provider-aws v1.3.2-0.20190429191616-bbd61f36ba21 h1
 github.com/pulumi/terraform-provider-aws v1.3.2-0.20190429191616-bbd61f36ba21/go.mod h1:P4xolUS6DSk3ybbbyUC58m3y8yW0IUYmNnFFxcaEkR0=
 github.com/pulumi/terraform-provider-aws v1.3.2-0.20190506212555-206db4204c2b h1:Si46D870hOAuI6ZA48YUgiiwvcxIbnEhDNlcXb9Tut4=
 github.com/pulumi/terraform-provider-aws v1.3.2-0.20190506212555-206db4204c2b/go.mod h1:bPkhn1FLIxvSvC60DimQ5HID5QYDh5ez2JYqEUgEmdI=
+github.com/pulumi/terraform-provider-aws v1.3.2-0.20190510204831-4acfa088d81f h1:yEWI72Dgn627I0PzGJQsHr9SxLRXv8oWxH3QXyGWiDc=
+github.com/pulumi/terraform-provider-aws v1.3.2-0.20190510204831-4acfa088d81f/go.mod h1:bPkhn1FLIxvSvC60DimQ5HID5QYDh5ez2JYqEUgEmdI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=


### PR DESCRIPTION
This pulls in 4acfa088d81fa3fc46e12ad9d0ebf0df5a55932f from `pulumi/terraform-provider-aws` to increase the timeout for an `aws.eks.Cluster` to 30 minutes.