### PR TITLE
Add nodejs10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for AWS Lambda Custom Runtime `aws.lambda.CustomRuntime`.
 - Update to v2.11.0 of the AWS Terraform Provider.
 - Increase create timeout for `aws.eks.Cluster` to 30 minutes.
+- Add constant for Node 10.X runtime.
 
 ## 0.18.3 (Released April 29th, 2019)
 

--- a/sdk/nodejs/lambda/runtimes.ts
+++ b/sdk/nodejs/lambda/runtimes.ts
@@ -25,6 +25,7 @@ export type Runtime =
     "nodejs4.3"      |
     "nodejs6.10"     |
     "nodejs8.10"     |
+    "nodejs10.x"     |
     "nodejs"         |
     "python2.7"      |
     "python3.6"      |
@@ -39,6 +40,7 @@ export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";
 export let NodeJS4d3Runtime: Runtime = "nodejs4.3";
 export let NodeJS6d10Runtime: Runtime = "nodejs6.10";
 export let NodeJS8d10Runtime: Runtime = "nodejs8.10";
+export let NodeJS10dXRuntime: Runtime = "nodejs10.x";
 export let NodeJSRuntime: Runtime = "nodejs";
 export let Python2d7Runtime: Runtime = "python2.7";
 export let Python3d6Runtime: Runtime = "python3.6";


### PR DESCRIPTION
AWS now supports this runtime, see:
https://aws.amazon.com/about-aws/whats-new/2019/05/aws_lambda_adds_support_for_node_js_v10/