### PR TITLE
Fixed bug, where assume-role was not working properly (#252)

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -193,13 +193,7 @@ func preConfigureCallback(vars resource.PropertyMap, c *terraform.ResourceConfig
 	// TODO[pulumi/pulumi-terraform#48] We should also be setting `config.AssumeRole*` here, but we are currently
 	// blocked on not being able to read out list-valued provider config.
 
-	creds, err := awsbase.GetCredentials(config)
-	if err != nil {
-		return errors.New("unable to discover AWS AccessKeyID and/or SecretAccessKey " +
-			"- see https://pulumi.io/install/aws.html for details on configuration")
-	}
-
-	_, err = creds.Get()
+	_, err = awsbase.GetCredentials(config)
 	if err != nil {
 		return errors.New("unable to discover AWS AccessKeyID and/or SecretAccessKey " +
 			"- see https://pulumi.io/install/aws.html for details on configuration")


### PR DESCRIPTION
From my take, the `provider` portions of the creds.Get() call have been deprecated and full credential functionality taken over by the new `awsbase.GetCredentials()` call. That seems to be the breaking change a few months ago.

The fix is to remove the call to `creds.Get()` and refactor the call to `awsbase.GetGredentials()` to get rid of the unused variable the Go compiler is complaining about.