### PR TITLE
Pass a parent along to pick up providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 * Add constants for EC2 Seurity Group Protocols
 * Add constants for ALB IpAddressType and LoadBalancer type
 * Add constants for Route53 record types
+* Subscription resources will now be parented by default by the resource they were created off of.
+  This has been implemented using 'aliases' so this will not have any effect on existing stacks.
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -1923,7 +1923,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":    "^0.17.8",
+				"@pulumi/pulumi":    "^0.17.16",
 				"aws-sdk":           "^2.0.0",
 				"mime":              "^2.0.0",
 				"builtin-modules":   "3.0.0",

--- a/sdk/nodejs/cloudwatch/eventRuleMixins.ts
+++ b/sdk/nodejs/cloudwatch/eventRuleMixins.ts
@@ -73,7 +73,10 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
         name: string, eventRuleOrSchedule: eventRule.EventRule | string, handler: EventRuleEventHandler,
         args?: EventRuleEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:cloudwatch:EventRuleEventSubscription", name, opts);
+        super("aws:cloudwatch:EventRuleEventSubscription", name, {
+            parent: typeof eventRuleOrSchedule === "string" ? undefined : eventRuleOrSchedule,
+            ...opts
+        });
 
         const parentOpts = { parent: this };
         if (typeof eventRuleOrSchedule === "string") {

--- a/sdk/nodejs/cloudwatch/eventRuleMixins.ts
+++ b/sdk/nodejs/cloudwatch/eventRuleMixins.ts
@@ -71,11 +71,16 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
 
     public constructor(
         name: string, eventRuleOrSchedule: eventRule.EventRule | string, handler: EventRuleEventHandler,
-        args?: EventRuleEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
+        args?: EventRuleEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:cloudwatch:EventRuleEventSubscription", name, {
-            parent: typeof eventRuleOrSchedule === "string" ? undefined : eventRuleOrSchedule,
-            ...opts
+        // We previously did not parent the subscription to the eventRule. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:cloudwatch:EventRuleEventSubscription";
+        const parent = typeof eventRuleOrSchedule === "string" ? undefined : eventRuleOrSchedule;
+        super(type, name, {
+            parent: parent,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
         });
 
         const parentOpts = { parent: this };

--- a/sdk/nodejs/cloudwatch/logGroupMixins.ts
+++ b/sdk/nodejs/cloudwatch/logGroupMixins.ts
@@ -76,7 +76,14 @@ export class LogGroupEventSubscription extends lambda.EventSubscription {
         name: string, logGroup: logGroup.LogGroup, handler: LogGroupEventHandler,
         args: LogGroupEventSubscriptionArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:cloudwatch:LogGroupEventSubscription", name, { parent: logGroup, ...opts });
+        // We previously did not parent the subscription to the logGroup. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:cloudwatch:LogGroupEventSubscription";
+        super(type, name, {
+            parent: logGroup,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
+        });
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/cloudwatch/logGroupMixins.ts
+++ b/sdk/nodejs/cloudwatch/logGroupMixins.ts
@@ -76,7 +76,7 @@ export class LogGroupEventSubscription extends lambda.EventSubscription {
         name: string, logGroup: logGroup.LogGroup, handler: LogGroupEventHandler,
         args: LogGroupEventSubscriptionArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:cloudwatch:LogGroupEventSubscription", name, opts);
+        super("aws:cloudwatch:LogGroupEventSubscription", name, { parent: logGroup, ...opts });
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/dynamodb/dynamodbMixins.ts
+++ b/sdk/nodejs/dynamodb/dynamodbMixins.ts
@@ -67,7 +67,7 @@ export class TableEventSubscription extends lambda.EventSubscription {
         name: string, table: table.Table, handler: TableEventHandler,
         args: TableEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:dynamodb:TableEventSubscription", name, opts);
+        super("aws:dynamodb:TableEventSubscription", name, { parent: table, ...opts });
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/dynamodb/dynamodbMixins.ts
+++ b/sdk/nodejs/dynamodb/dynamodbMixins.ts
@@ -65,7 +65,7 @@ export class TableEventSubscription extends lambda.EventSubscription {
 
     constructor(
         name: string, table: table.Table, handler: TableEventHandler,
-        args: TableEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
+        args: TableEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
 
         // We previously did not parent the subscription to the table. We now do. Provide an alias
         // so this doesn't cause resources to be destroyed/recreated for existing stacks.

--- a/sdk/nodejs/dynamodb/dynamodbMixins.ts
+++ b/sdk/nodejs/dynamodb/dynamodbMixins.ts
@@ -67,7 +67,14 @@ export class TableEventSubscription extends lambda.EventSubscription {
         name: string, table: table.Table, handler: TableEventHandler,
         args: TableEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:dynamodb:TableEventSubscription", name, { parent: table, ...opts });
+        // We previously did not parent the subscription to the table. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:dynamodb:TableEventSubscription";
+        super(type, name, {
+            parent: table,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
+        });
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/kinesis/kinesisMixins.ts
+++ b/sdk/nodejs/kinesis/kinesisMixins.ts
@@ -71,7 +71,7 @@ export class StreamEventSubscription extends lambda.EventSubscription {
         name: string, stream: stream.Stream, handler: StreamEventHandler,
         args: StreamEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:kinesis:StreamEventSubscription", name, opts);
+        super("aws:kinesis:StreamEventSubscription", name, { parent: stream, ...opts });
 
         const parentOpts = { parent: this };
         this.func = createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/kinesis/kinesisMixins.ts
+++ b/sdk/nodejs/kinesis/kinesisMixins.ts
@@ -69,9 +69,16 @@ export class StreamEventSubscription extends lambda.EventSubscription {
 
     constructor(
         name: string, stream: stream.Stream, handler: StreamEventHandler,
-        args: StreamEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
+        args: StreamEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:kinesis:StreamEventSubscription", name, { parent: stream, ...opts });
+        // We previously did not parent the subscription to the stream. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:kinesis:StreamEventSubscription";
+        super(type, name, {
+            parent: stream,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
+        });
 
         const parentOpts = { parent: this };
         this.func = createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.17.8",
+        "@pulumi/pulumi": "^0.17.16",
         "aws-sdk": "^2.0.0",
         "builtin-modules": "3.0.0",
         "mime": "^2.0.0",

--- a/sdk/nodejs/s3/s3Mixins.ts
+++ b/sdk/nodejs/s3/s3Mixins.ts
@@ -130,7 +130,7 @@ export class BucketEventSubscription extends lambda.EventSubscription {
         name: string, bucket: Bucket, handler: BucketEventHandler,
         args: BucketEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
 
-        super("aws:s3:BucketEventSubscription", name, opts);
+        super("aws:s3:BucketEventSubscription", name, { parent: bucket, ...opts });
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/s3/s3Mixins.ts
+++ b/sdk/nodejs/s3/s3Mixins.ts
@@ -128,9 +128,16 @@ export class BucketEventSubscription extends lambda.EventSubscription {
 
     public constructor(
         name: string, bucket: Bucket, handler: BucketEventHandler,
-        args: BucketEventSubscriptionArgs, opts?: pulumi.ComponentResourceOptions) {
+        args: BucketEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:s3:BucketEventSubscription", name, { parent: bucket, ...opts });
+        // We previously did not parent the subscription to the queue. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:s3:BucketEventSubscription";
+        super(type, name, {
+            parent: bucket,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
+        });
 
         const parentOpts = { parent: this };
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/sns/snsMixins.ts
+++ b/sdk/nodejs/sns/snsMixins.ts
@@ -67,7 +67,7 @@ export class TopicEventSubscription extends lambda.EventSubscription {
         name: string, topic: topic.Topic, handler: TopicEventHandler,
         args: TopicEventSubscriptionArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:sns:TopicEventSubscription", name, opts);
+        super("aws:sns:TopicEventSubscription", name, { parent: topic, ...opts });
 
         this.topic = topic;
 

--- a/sdk/nodejs/sns/snsMixins.ts
+++ b/sdk/nodejs/sns/snsMixins.ts
@@ -67,7 +67,14 @@ export class TopicEventSubscription extends lambda.EventSubscription {
         name: string, topic: topic.Topic, handler: TopicEventHandler,
         args: TopicEventSubscriptionArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:sns:TopicEventSubscription", name, { parent: topic, ...opts });
+        // We previously did not parent the subscription to the topic. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:sns:TopicEventSubscription";
+        super(type, name, {
+            parent: topic,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
+        });
 
         this.topic = topic;
 

--- a/sdk/nodejs/sqs/sqsMixins.ts
+++ b/sdk/nodejs/sqs/sqsMixins.ts
@@ -66,7 +66,14 @@ export class QueueEventSubscription extends lambda.EventSubscription {
         name: string, queue: queue.Queue, handler: QueueEventHandler,
         args: QueueEventSubscriptionArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:sqs:QueueEventSubscription", name, { parent: queue, ...opts });
+        // We previously did not parent the subscription to the queue. We now do. Provide an alias
+        // so this doesn't cause resources to be destroyed/recreated for existing stacks.
+        const type = "aws:sqs:QueueEventSubscription";
+        super(type, name, {
+            parent: queue,
+            aliases: [pulumi.createUrn(name, type, opts.parent)],
+            ...opts,
+        });
 
         const parentOpts = { parent: this };
         this.func = createFunctionFromEventHandler(name, handler, parentOpts);

--- a/sdk/nodejs/sqs/sqsMixins.ts
+++ b/sdk/nodejs/sqs/sqsMixins.ts
@@ -66,7 +66,7 @@ export class QueueEventSubscription extends lambda.EventSubscription {
         name: string, queue: queue.Queue, handler: QueueEventHandler,
         args: QueueEventSubscriptionArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
 
-        super("aws:sqs:QueueEventSubscription", name, opts);
+        super("aws:sqs:QueueEventSubscription", name, { parent: queue, ...opts });
 
         const parentOpts = { parent: this };
         this.func = createFunctionFromEventHandler(name, handler, parentOpts);


### PR DESCRIPTION
Note: this PR makes use of aliases!  I manually validated the appropraite behavior here.  Tagging @ellismg  for views on incorporating this into a fully fledged test in the future!