### PR TITLE
Disable smart quotes in generated README.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+* Fix an issue where the pulumi_aws Python package would fail to install install in some cases
+
 ## 0.18.10 (2019-06-13)
 
 Note: new constants may cause existing code to break due to the types being narrower in TypeScript.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build:: provider tfgen
 		sed -i.bak "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 	cd ${PACKDIR}/python/ && \
 		if [ $$(command -v pandoc) ]; then \
-			pandoc --from=markdown --to=rst --output=README.rst ../../README.md; \
+			pandoc --from=markdown-smart --to=rst-smart --output=README.rst ../../README.md; \
 		else \
 			echo "warning: pandoc not found, not generating README.rst"; \
 			echo "" > README.rst; \


### PR DESCRIPTION
`pandoc` will output using "smart quotes" by default, which caues the
README.rst which is included in our pyton package to include some non
ASCII characters, which blocks installs on some machines.

This change removes the use of smart quotes. The correct long term fix
is tracked by: https://github.com/pulumi/pulumi-terraform/pull/388 but
this will unblock installs of this package.