### PR TITLE
Strongly-typed S3 bucket website routingRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Add the ability to specify `elastic_search_*` `access_policies` as iam.PolicyDocument
+* Add the ability to pass a `RoutingRule` array to the `routingRules` field in `aws.s3.Bucket`'s `website` field
 
 ## 0.18.14 (2019-06-24)
 

--- a/examples/bucket/index.ts
+++ b/examples/bucket/index.ts
@@ -55,3 +55,18 @@ bucket.onObjectCreated("bucket-callback", async (event) => {
         }
     }
 });
+
+// Another bucket with some strongly-typed routingRules.
+const websiteBucket = new aws.s3.Bucket("websiteBucket", {
+    website: {
+        indexDocument: "index.html",
+        routingRules: [{
+            Condition: {
+                KeyPrefixEquals: "docs/",
+            },
+            Redirect: {
+                ReplaceKeyPrefixWith: "documents/",
+            }
+        }]
+    }
+});

--- a/examples/bucket/index.ts
+++ b/examples/bucket/index.ts
@@ -69,4 +69,4 @@ const websiteBucket = new aws.s3.Bucket("websiteBucket", {
             }
         }]
     }
-});
+}, providerOpts);

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.18.3
+	github.com/pulumi/pulumi-terraform v0.18.4-0.20190622203420-512f93e9d8c3
 	github.com/pulumi/terraform-provider-aws v1.38.1-0.20181019132727-72e8bb4fc26f // indirect
 	github.com/sirupsen/logrus v1.4.0 // indirect
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect

--- a/go.sum
+++ b/go.sum
@@ -597,6 +597,8 @@ github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d h1:ObOJ
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/pulumi/pulumi-terraform v0.18.3 h1:DHpETa+TWnthH9Sw3bHS+HxSgidB1cASkVqtQTW8jxg=
 github.com/pulumi/pulumi-terraform v0.18.3/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190622203420-512f93e9d8c3 h1:p6aCpPf5lGSVn/Wmw+Cx/fft+QUNy809aqqMM1XFXV4=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190622203420-512f93e9d8c3/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/pulumi/terraform-provider-aws v1.3.2-0.20190407171755-cf2ef8807a4b h1:2g4TbpkKIzm8wqcvnrvh5FY1I/bO5x0k5iswWSCH6Ek=
 github.com/pulumi/terraform-provider-aws v1.3.2-0.20190407171755-cf2ef8807a4b/go.mod h1:q6jzd2kIAdFH8V10Y8N3NRf4wVQ6DTCN/kjE0L9eHLY=
 github.com/pulumi/terraform-provider-aws v1.3.2-0.20190417135458-30039de05cc7 h1:aac7CF4/uYxKoGIATUPNhdWqrntHMH+pqrODc7ZcBvM=

--- a/resources.go
+++ b/resources.go
@@ -1595,7 +1595,19 @@ func Provider() tfbridge.ProviderInfo {
 					}),
 					// Website only accepts a single value in the AWS API but is not marked MaxItems==1 in the TF
 					// provider.
-					"website": {Name: "website"},
+					"website": {
+						Name: "website",
+						Elem: &tfbridge.SchemaInfo{
+							Fields: map[string]*tfbridge.SchemaInfo{
+								"routing_rules": {
+									Name:      "routingRules",
+									Type:      "string",
+									AltTypes:  []tokens.Type{awsType(s3Mod+"/routingRules", "RoutingRule[]")},
+									Transform: tfbridge.TransformJSONDocument,
+								},
+							},
+						},
+					},
 					"policy": {
 						Type:      "string",
 						AltTypes:  []tokens.Type{awsType(iamMod+"/documents", "PolicyDocument")},
@@ -2059,6 +2071,7 @@ func Provider() tfbridge.ProviderInfo {
 					"s3": {
 						DestFiles: []string{
 							"cannedAcl.ts", // a union type and constants for canned ACL names.
+							"routingRules.ts",
 							"s3Mixins.ts",
 						},
 					},

--- a/sdk/nodejs/s3/bucket.ts
+++ b/sdk/nodejs/s3/bucket.ts
@@ -6,6 +6,7 @@ import * as utilities from "../utilities";
 
 import {PolicyDocument} from "../iam/documents";
 import {CannedAcl} from "./cannedAcl";
+import {RoutingRule} from "./routingRules";
 
 /**
  * Provides a S3 bucket resource.
@@ -474,7 +475,7 @@ export interface BucketState {
     /**
      * A website object (documented below).
      */
-    readonly website?: pulumi.Input<{ errorDocument?: pulumi.Input<string>, indexDocument?: pulumi.Input<string>, redirectAllRequestsTo?: pulumi.Input<string>, routingRules?: pulumi.Input<string> }>;
+    readonly website?: pulumi.Input<{ errorDocument?: pulumi.Input<string>, indexDocument?: pulumi.Input<string>, redirectAllRequestsTo?: pulumi.Input<string>, routingRules?: pulumi.Input<string | RoutingRule[]> }>;
     /**
      * The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      */
@@ -568,7 +569,7 @@ export interface BucketArgs {
     /**
      * A website object (documented below).
      */
-    readonly website?: pulumi.Input<{ errorDocument?: pulumi.Input<string>, indexDocument?: pulumi.Input<string>, redirectAllRequestsTo?: pulumi.Input<string>, routingRules?: pulumi.Input<string> }>;
+    readonly website?: pulumi.Input<{ errorDocument?: pulumi.Input<string>, indexDocument?: pulumi.Input<string>, redirectAllRequestsTo?: pulumi.Input<string>, routingRules?: pulumi.Input<string | RoutingRule[]> }>;
     /**
      * The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      */

--- a/sdk/nodejs/s3/index.ts
+++ b/sdk/nodejs/s3/index.ts
@@ -13,4 +13,5 @@ export * from "./cannedAcl";
 export * from "./getBucket";
 export * from "./getBucketObject";
 export * from "./inventory";
+export * from "./routingRules";
 export * from "./s3Mixins";

--- a/sdk/nodejs/s3/routingRules.ts
+++ b/sdk/nodejs/s3/routingRules.ts
@@ -1,0 +1,99 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A rule that identifies a condition and the redirect that is applied when the condition is met.
+ * If a condition is not included, the rule is applied to all requests.
+ *
+ * For more details, please refer to the AWS documentation online:
+ * https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#advanced-conditional-redirects
+ */
+export interface RoutingRule {
+    /**
+     * A condition that must be met for the specified redirect to be applied.
+     * If not included, the rule is applied to all requests.
+     */
+    Condition?: Condition;
+
+    /**
+     * Provides instructions for redirecting the request. You can redirect requests to another host or another page,
+     * or you can specify another protocol to use.
+     */
+    Redirect: Redirect;
+}
+
+/**
+ * A condition that must be met for the specified redirect to be applied.
+ */
+export interface Condition {
+    /**
+     * The HTTP error code that must match for the redirect to apply. If an error occurs, and if the error code meets
+     * this value, then the specified redirect applies.
+     *
+     * `HttpErrorCodeReturnedEquals` is required if `KeyPrefixEquals` is not specified. If both `KeyPrefixEquals` and
+     * `HttpErrorCodeReturnedEquals` are specified, both must be true for the condition to be met.
+     */
+    HttpErrorCodeReturnedEquals?: string;
+
+    /**
+     * The prefix of the object key name from which requests are redirected.
+     *
+     * `KeyPrefixEquals` is required if `HttpErrorCodeReturnedEquals` is not specified. If both `KeyPrefixEquals` and
+     * `HttpErrorCodeReturnedEquals` are specified, both must be true for the condition to be met.
+     */
+    KeyPrefixEquals?: string;
+}
+
+/**
+ * Provides instructions for redirecting the request. You can redirect requests to another host or another page, or you
+ * can specify another protocol to use. At least one property must be set.
+ */
+export interface Redirect {
+    /**
+     * The hostname to be used in the Location header that is returned in the response.
+     *
+     * If another property is set, `HostName` is not required.
+     */
+    HostName?: string;
+
+    /**
+     * The HTTP redirect code to be used in the Location header that is returned in the response.
+     *
+     * If another property is set, `HttpRedirectCode` is not required.
+     */
+    HttpRedirectCode?: string;
+
+    /**
+     * The protocol, http or https, to be used in the Location header that is returned in the response.
+     *
+     * If another property is set, `Protocol` is not required.
+     */
+    Protocol?: string;
+
+    /**
+     * The prefix of the object key name that replaces the value of `KeyPrefixEquals` in the redirect request.
+     *
+     * If another property is set, `ReplaceKeyPrefixWith` is not required.
+     * It can be set only if `ReplaceKeyWith` is not set.
+     */
+    ReplaceKeyPrefixWith?: string;
+
+    /**
+     * The object key to be used in the Location header that is returned in the response.
+     *
+     * If another property is set, `ReplaceKeyWith` is not required.
+     * It can be set only if `ReplaceKeyPrefixWith` is not set.
+     */
+    ReplaceKeyWith?: string;
+}

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -669,6 +669,7 @@
         "s3/getBucketObject.ts",
         "s3/index.ts",
         "s3/inventory.ts",
+        "s3/routingRules.ts",
         "s3/s3Mixins.ts",
         "sagemaker/endpoint.ts",
         "sagemaker/endpointConfiguration.ts",


### PR DESCRIPTION
I've been working on a program that adds some redirects for the GREAT WEBSITE MIGRATION OF 2019, and wished there were stronger types for this. Decided to go ahead and add these while it was fresh in my mind...

This augments the `routingRules` property to accept a strongly-typed array of objects, which helps to know which properties can be set and avoids the need to use `JSON.stringify`. This is especially helpful as some properties can only be set if other properties are not set.

Depends on a change in `pulumi-terraform` to allow JSON arrays in `TransformJSONDocument`: https://github.com/pulumi/pulumi-terraform/pull/393

Details:
https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#routing_rules
https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#advanced-conditional-redirects (scroll down for schema)