### PR TITLE
Add aws.iam.PolicyDocument as AltType to ElasticSearch resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-___NULL___
-
+* Add the ability to specify `elastic_search_*` `access_policies` as iam.PolicyDocument
 
 ## 0.18.3 (2019-06-21)
 * Update to pulumi-terraform@3635bed3a5 which stops maps containing `.` being treated as nested maps.

--- a/resources.go
+++ b/resources.go
@@ -1022,9 +1022,23 @@ func Provider() tfbridge.ProviderInfo {
 					"cluster_config":   {Name: "clusterConfig"},
 					"ebs_options":      {Name: "ebsOptions"},
 					"snapshot_options": {Name: "snapshotOptions"},
+					"access_policies": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod+"/documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
 				},
 			},
-			"aws_elasticsearch_domain_policy": {Tok: awsResource(elasticsearchMod, "DomainPolicy")},
+			"aws_elasticsearch_domain_policy": {
+				Tok: awsResource(elasticsearchMod, "DomainPolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"access_policies": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod+"/documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
 			// Elastic Transcoder
 			"aws_elastictranscoder_pipeline": {
 				Tok: awsResource(elastictranscoderMod, "Pipeline"),

--- a/sdk/nodejs/elasticsearch/domain.ts
+++ b/sdk/nodejs/elasticsearch/domain.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PolicyDocument} from "../iam/documents";
+
 /**
  * Manages an AWS Elasticsearch Domain.
  * 
@@ -326,7 +328,7 @@ export interface DomainState {
     /**
      * IAM policy document specifying the access policies for the domain
      */
-    readonly accessPolicies?: pulumi.Input<string>;
+    readonly accessPolicies?: pulumi.Input<string | PolicyDocument>;
     /**
      * Key-value string pairs to specify advanced configuration options.
      * Note that the values for these configuration options must be strings (wrapped in quotes) or they
@@ -402,7 +404,7 @@ export interface DomainArgs {
     /**
      * IAM policy document specifying the access policies for the domain
      */
-    readonly accessPolicies?: pulumi.Input<string>;
+    readonly accessPolicies?: pulumi.Input<string | PolicyDocument>;
     /**
      * Key-value string pairs to specify advanced configuration options.
      * Note that the values for these configuration options must be strings (wrapped in quotes) or they

--- a/sdk/nodejs/elasticsearch/domainPolicy.ts
+++ b/sdk/nodejs/elasticsearch/domainPolicy.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PolicyDocument} from "../iam/documents";
+
 /**
  * Allows setting policy to an Elasticsearch domain while referencing domain attributes (e.g. ARN)
  * 
@@ -108,7 +110,7 @@ export interface DomainPolicyState {
     /**
      * IAM policy document specifying the access policies for the domain
      */
-    readonly accessPolicies?: pulumi.Input<string>;
+    readonly accessPolicies?: pulumi.Input<string | PolicyDocument>;
     /**
      * Name of the domain.
      */
@@ -122,7 +124,7 @@ export interface DomainPolicyArgs {
     /**
      * IAM policy document specifying the access policies for the domain
      */
-    readonly accessPolicies: pulumi.Input<string>;
+    readonly accessPolicies: pulumi.Input<string | PolicyDocument>;
     /**
      * Name of the domain.
      */


### PR DESCRIPTION
After researching this topic, I found that the ElasticSearch access
policies support almost everything (except NotPrincipal) of the IAM
PolicyDocument

Therefore, we can leverage the same resource

https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#policy-element-reference