### PR TITLE
Add the ability to pass an aws.iam.PolicyDocument to ECR Repo policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Add the ability to specify `elastic_search_*` `access_policies` as iam.PolicyDocument
 * Add the ability to pass a `RoutingRule` array to the `routingRules` field in `aws.s3.Bucket`'s `website` field
+* Add the ability to specify ecr_repository `policy` as iam.PolicyDocument
 
 ## 0.18.14 (2019-06-24)
 

--- a/resources.go
+++ b/resources.go
@@ -921,9 +921,18 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_ec2_transit_gateway_vpc_attachment":          {Tok: awsResource(ec2TransitGatewayMod, "VpcAttachment")},
 			"aws_ec2_transit_gateway_vpc_attachment_accepter": {Tok: awsResource(ec2TransitGatewayMod, "VpcAttachmentAccepter")},
 			// Elastic Container Registry
-			"aws_ecr_repository":        {Tok: awsResource(ecrMod, "Repository")},
-			"aws_ecr_repository_policy": {Tok: awsResource(ecrMod, "RepositoryPolicy")},
-			"aws_ecr_lifecycle_policy":  {Tok: awsResource(ecrMod, "LifecyclePolicy")},
+			"aws_ecr_repository": {Tok: awsResource(ecrMod, "Repository")},
+			"aws_ecr_repository_policy": {
+				Tok: awsResource(ecrMod, "RepositoryPolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod+"/documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
+			"aws_ecr_lifecycle_policy": {Tok: awsResource(ecrMod, "LifecyclePolicy")},
 			// Elastic Container Service
 			"aws_ecs_cluster": {Tok: awsResource(ecsMod, "Cluster")},
 			"aws_ecs_service": {

--- a/sdk/nodejs/ecr/repositoryPolicy.ts
+++ b/sdk/nodejs/ecr/repositoryPolicy.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PolicyDocument} from "../iam/documents";
+
 /**
  * Provides an Elastic Container Registry Repository Policy.
  * 
@@ -126,7 +128,7 @@ export interface RepositoryPolicyState {
     /**
      * The policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://www.terraform.io/docs/providers/aws/guides/iam-policy-documents.html)
      */
-    readonly policy?: pulumi.Input<string>;
+    readonly policy?: pulumi.Input<string | PolicyDocument>;
     /**
      * The registry ID where the repository was created.
      */
@@ -144,7 +146,7 @@ export interface RepositoryPolicyArgs {
     /**
      * The policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://www.terraform.io/docs/providers/aws/guides/iam-policy-documents.html)
      */
-    readonly policy: pulumi.Input<string>;
+    readonly policy: pulumi.Input<string | PolicyDocument>;
     /**
      * Name of the repository to apply the policy.
      */


### PR DESCRIPTION
Fixes: #631

As per this document,
https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicies.html,
we can see that the policies are the same