### PR TITLE
Add Lambda runtime constants for go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-___NULL___
+* Add Lambda runtime constants to the Go SDK.
 
 
 ## 0.18.16 (2019-06-28)

--- a/sdk/go/aws/lambda/runtime.go
+++ b/sdk/go/aws/lambda/runtime.go
@@ -1,0 +1,19 @@
+package lambda
+
+// Runtime represents a lambda runtime.
+type Runtime = string
+
+// lambda runtimes
+const (
+	RuntimeDotnetCore1d0 Runtime = "dotnetcore1.0"
+	RuntimeDotnetCore2d1         = "dotnetcore2.1"
+	RuntimeGo1dx                 = "go1.x"
+	RuntimeJava8                 = "java8"
+	RuntimeRuby2d5               = "ruby2.5"
+	RuntimeNodeJS8d10            = "nodejs8.10"
+	RuntimeNodeJS10dX            = "nodejs10.x"
+	RuntimePython2d7             = "python2.7"
+	RuntimePython3d6             = "python3.6"
+	RuntimePython3d7             = "python3.7"
+	RuntimeCustom                = "provided"
+)


### PR DESCRIPTION
I know it would be most consistent to use the same naming scheme [as with typescript](https://github.com/pulumi/pulumi-aws/blob/master/sdk/nodejs/lambda/runtimes.ts), but since Go doesn't have string type unions, it seems that this would be favorable for the consumer to discover via intellesense (typing `Runtime...` would suggest all of these constants). 