### PR TITLE
Change Route53 Record Type to have AltType of RecordType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-___NULL___
+* Add the ability for Route53 record types to use a string *or* a RecordType constant
 
 
 ## 0.18.16 (2019-06-28)

--- a/resources.go
+++ b/resources.go
@@ -1549,7 +1549,8 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(route53Mod, "Record"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"type": {
-						Type: awsResource(route53Mod, "RecordType"),
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(route53Mod+"/recordType", "RecordType")},
 					},
 				},
 			},

--- a/sdk/nodejs/route53/record.ts
+++ b/sdk/nodejs/route53/record.ts
@@ -187,7 +187,7 @@ export class Record extends pulumi.CustomResource {
     /**
      * `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
      */
-    public readonly type!: pulumi.Output<RecordType>;
+    public readonly type!: pulumi.Output<string>;
     /**
      * A block indicating a weighted routing policy. Conflicts with any other routing policy. Documented below.
      */
@@ -308,7 +308,7 @@ export interface RecordState {
     /**
      * `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
      */
-    readonly type?: pulumi.Input<RecordType>;
+    readonly type?: pulumi.Input<string | RecordType>;
     /**
      * A block indicating a weighted routing policy. Conflicts with any other routing policy. Documented below.
      */
@@ -371,7 +371,7 @@ export interface RecordArgs {
     /**
      * `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
      */
-    readonly type: pulumi.Input<RecordType>;
+    readonly type: pulumi.Input<string | RecordType>;
     /**
      * A block indicating a weighted routing policy. Conflicts with any other routing policy. Documented below.
      */


### PR DESCRIPTION
When used in conjunction with ACM, Route53 record was not able to
be used. The output type of ACM validation is a string but the input
type of Route53 record type was a RecordType

We need to allow both!

Fixes: https://github.com/pulumi/docs/pull/1243