### PR TITLE
[WIP] Support for capturing secrets in CallbackFunction

### DIFF
--- a/examples/callbackfunction-secrets/Pulumi.yaml
+++ b/examples/callbackfunction-secrets/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: callbackfunction-secrets
+description: Capturing secrets in a CallbackFunction
+runtime: nodejs
+

--- a/examples/callbackfunction-secrets/index.ts
+++ b/examples/callbackfunction-secrets/index.ts
@@ -1,0 +1,21 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const secret = pulumi.secret(42);
+const secret2 = pulumi.secret("cyrus");
+
+const b = new aws.s3.Bucket("b", {}, providerOpts);
+const handler = b.onObjectCreated("newobejct", async (ev, ctx) => {
+    console.log(secret.get());
+    console.log(ev);
+    console.log(secret2.get());
+    console.log("hello")
+}, {}, providerOpts);
+
+export const functionARN = handler.func.arn;
+export const bucketName = b.id;

--- a/examples/callbackfunction-secrets/package.json
+++ b/examples/callbackfunction-secrets/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "callbackfunction-secrets",
+    "version": "0.1.0",
+    "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "dev"
+    },
+    "devDependencies": {
+        "@types/aws-sdk": "^2.7.0",
+        "@types/node": "^10.0.0",
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/aws": "latest"
+    }
+}

--- a/examples/callbackfunction-secrets/tsconfig.json
+++ b/examples/callbackfunction-secrets/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -76,8 +76,8 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "alb-new"),
 			EditDirs: []integration.EditDir{
 				{
-					Dir:      "step2",
-					Additive: true,
+					Dir:             "step2",
+					Additive:        true,
 					ExpectNoChanges: true,
 				},
 			},
@@ -113,7 +113,30 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "serverless_functions"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				cfg := &aws.Config{
-					Region: aws.String("us-west-2"),
+					Region: aws.String(envRegion),
+				}
+				sess, err := session.NewSession(cfg)
+				if !assert.NoError(t, err) {
+					return
+				}
+				lambdaSvc := lambda.New(sess)
+				out, err := lambdaSvc.Invoke(&lambda.InvokeInput{
+					FunctionName: aws.String(stack.Outputs["functionARN"].(string)),
+				})
+				if !assert.NoError(t, err) {
+					return
+				}
+
+				if out.FunctionError != nil {
+					assert.Nil(t, out.FunctionError, "Function error: %q\n", *out.FunctionError)
+				}
+			},
+		}),
+		baseJS.With(integration.ProgramTestOptions{
+			Dir: path.Join(cwd, "callbackfunction-secrets"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				cfg := &aws.Config{
+					Region: aws.String(envRegion),
 				}
 				sess, err := session.NewSession(cfg)
 				if !assert.NoError(t, err) {
@@ -139,8 +162,8 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "alb-new-py"),
 			EditDirs: []integration.EditDir{
 				{
-					Dir:      "step2",
-					Additive: true,
+					Dir:             "step2",
+					Additive:        true,
 					ExpectNoChanges: true,
 				},
 			},
@@ -149,8 +172,8 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "rename-ses-configuration-set"),
 			EditDirs: []integration.EditDir{
 				{
-					Dir:      "step2",
-					Additive: true,
+					Dir:             "step2",
+					Additive:        true,
 					ExpectNoChanges: true,
 				},
 			},


### PR DESCRIPTION
Secrets are captured as environment variables instead of being serialied into program text.  This ensures they are encrypted at rest, do not show up in the state file, and are decrypted and provided to the running Lambda function via environment variables function implicitly by the Lambda runtime infrastructure.

An alternative we are considering, which could be added as opt-in in the future, is to go a step further and create SecretsManager secrets for each captured secret, then inject code to decrypt these using SecretsManager at runtime inside the Lambda.  This involves adding non-trivial additional infrastructure, but would provide an even stronger level of protection (for example, the secrets would not be visible in the Lambda console, and would not be decrypted until/unless actually accessed within the Lambda function).

Part of https://github.com/pulumi/pulumi/issues/2718.