### PR TITLE
Allow ec2 instanceType to be passed as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Upgrade to 1.0 of pulumi SDK
+* Allow ec2 InstanceTypes to be passed as a string as well as the typed value
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -769,7 +769,8 @@ func Provider() tfbridge.ProviderInfo {
 						AltTypes: []tokens.Type{awsType(iamMod, "InstanceProfile")},
 					},
 					"instance_type": {
-						Type: awsType(ec2Mod+"/instanceType", "InstanceType"),
+						Type:     "string",
+						AltTypes: []tokens.Type{awsType(ec2Mod+"/instanceType", "InstanceType")},
 					},
 				},
 			},

--- a/sdk/nodejs/ec2/instance.ts
+++ b/sdk/nodejs/ec2/instance.ts
@@ -152,7 +152,7 @@ export class Instance extends pulumi.CustomResource {
     /**
      * The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance.
      */
-    public readonly instanceType!: pulumi.Output<InstanceType>;
+    public readonly instanceType!: pulumi.Output<string>;
     public readonly ipv6AddressCount!: pulumi.Output<number>;
     /**
      * Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface
@@ -444,7 +444,7 @@ export interface InstanceState {
     /**
      * The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance.
      */
-    readonly instanceType?: pulumi.Input<InstanceType>;
+    readonly instanceType?: pulumi.Input<string | InstanceType>;
     readonly ipv6AddressCount?: pulumi.Input<number>;
     /**
      * Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface
@@ -619,7 +619,7 @@ export interface InstanceArgs {
     /**
      * The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance.
      */
-    readonly instanceType: pulumi.Input<InstanceType>;
+    readonly instanceType: pulumi.Input<string | InstanceType>;
     readonly ipv6AddressCount?: pulumi.Input<number>;
     /**
      * Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface


### PR DESCRIPTION
This continually trips our users up so we should allow both
string and the InstanceType constants