### PR TITLE
Add a deprecation message to NodeJS 8.x in Lambda Runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Adding an EOL deprecation message to NodeJS 8.x Lambda Runtime
+* Adding support for NodeJS12 Lambda Runtime
 
 ---
 

--- a/sdk/nodejs/lambda/runtimes.ts
+++ b/sdk/nodejs/lambda/runtimes.ts
@@ -21,32 +21,45 @@ export type Runtime =
     "dotnetcore2.1"  |
     "go1.x"          |
     "java8"          |
+    "java11"         |
     "ruby2.5"        |
     "nodejs4.3-edge" |
     "nodejs4.3"      |
     "nodejs6.10"     |
     "nodejs8.10"     |
     "nodejs10.x"     |
+    "nodejs12.x"     |
     "nodejs"         |
     "python2.7"      |
     "python3.6"      |
     "python3.7"      |
+    "python3.8"      |
     "provided"       ;
 
-export let DotnetCore1d0Runtime: Runtime = "dotnetcore1.0";
 export let DotnetCore2d1Runtime: Runtime = "dotnetcore2.1";
 export let Go1dxRuntime:         Runtime = "go1.x";
 export let Java8Runtime:         Runtime = "java8";
+export let Java11Runtime:        Runtime = "java11";
 export let Ruby2d5Runtime:       Runtime = "ruby2.5"
-export let NodeJS8d10Runtime:    Runtime = "nodejs8.10";
 export let NodeJS10dXRuntime:    Runtime = "nodejs10.x";
+export let NodeJS12dXRuntime:    Runtime = "nodejs12.x";
 export let Python2d7Runtime:     Runtime = "python2.7";
 export let Python3d6Runtime:     Runtime = "python3.6";
 export let Python3d7Runtime:     Runtime = "python3.7";
+export let Python3d8Runtime:     Runtime = "python3.8";
 export let CustomRuntime:        Runtime = "provided";
 
-/** @deprecated No longer supported */export let NodeJSRuntime: Runtime = "nodejs";
-/** @deprecated No longer supported */export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";
-/** @deprecated No longer supported */export let NodeJS4d3Runtime: Runtime = "nodejs4.3";
-/** @deprecated No longer supported */export let NodeJS6d10Runtime: Runtime = "nodejs6.10";
-/** @deprecated No longer supported */export let DotnetCore2d0Runtime: Runtime = "dotnetcore2.0";
+/** @deprecated No longer supported. New lambda functions created using this runtime will fail */
+export let NodeJSRuntime: Runtime = "nodejs";
+/** @deprecated No longer supported. New lambda functions created using this runtime will fail */
+export let NodeJS4d3EdgeRuntime: Runtime = "nodejs4.3-edge";
+/** @deprecated No longer supported. New lambda functions created using this runtime will fail */
+export let NodeJS4d3Runtime: Runtime = "nodejs4.3";
+/** @deprecated No longer supported. New lambda functions created using this runtime will fail */
+export let NodeJS6d10Runtime: Runtime = "nodejs6.10";
+/** @deprecated No longer supported. New lambda functions created using this runtime will fail */
+export let DotnetCore1d0Runtime: Runtime = "dotnetcore1.0";
+/** @deprecated No longer supported. New lambda functions created using this runtime will fail */
+export let DotnetCore2d0Runtime: Runtime = "dotnetcore2.0";
+/** @deprecated New lambdas created using this runtime will succeed until December 31, 2019, at which point they may start to fail */
+export let NodeJS8d10Runtime: Runtime = "nodejs8.10";


### PR DESCRIPTION
Related: #774

The NodeJS team have EOLed NodeJS 8.x on 31st December 2019. This
deprecation will warn our users that this is coming and that they
should move to a different runtime in advance

This commit also adds a deprecation to DotNetCore 1.0 which was
actually deprecated in AWS earlier in 2019