### PR TITLE
Update `ContainerDefinition` to latest ECS definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Update `ContainerDefinition` to latest ECS schema
 
 ---
 

--- a/sdk/nodejs/ecs/container.ts
+++ b/sdk/nodejs/ecs/container.ts
@@ -19,7 +19,7 @@
 export interface ContainerDefinition {
     command?: string[];
     cpu?: number;
-    dependsOn?: string;
+    dependsOn?: ContainerDependency[];
     disableNetworking?: boolean;
     dnsSearchDomains?: string[];
     dnsServers?: string[];
@@ -29,6 +29,7 @@ export interface ContainerDefinition {
     environment?: KeyValuePair[];
     essential?: boolean;
     extraHosts?: HostEntry[];
+    firelensConfiguration?: FirelensConfiguration;
     healthCheck?: HealthCheck;
     hostname?: string;
     image?: string;
@@ -56,10 +57,22 @@ export interface ContainerDefinition {
     workingDirectory?: string;
 }
 
+// https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html
+export interface ContainerDependency {
+    containerName?: string;
+    condition?: string;
+}
+
 // https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KeyValuePair.html
 export interface KeyValuePair {
     name: string;
     value: string;
+}
+
+// https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html
+export interface FirelensConfiguration {
+    options?: { [key: string]: string};
+    type: string;
 }
 
 /**


### PR DESCRIPTION
Align with https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html.

The change in type for `dependsOn` is a TypeScript-level breaking change, but the previous type was incorrect and would not have worked with ECS, so it is not in practice a breaking change for any working user code.

Related to https://github.com/pulumi/pulumi-awsx/issues/445, though we need to also make updates in the AWSX layer given current code structure.