### PR TITLE
Stop autonaming `aws.route53.Record` `name` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Stop auto-naming the `name` property of `aws.route53.Record` since it must be the literal domain
+  name of the record.  This is a breaking change for code which relied on the auto-naming, but such
+  code was almost certainly not behaving as intended (registering incorrect domain names).
+  [#842](https://github.com/pulumi/pulumi-aws/pull/842)
 
 ---
 

--- a/examples/route53/README.md
+++ b/examples/route53/README.md
@@ -1,3 +1,3 @@
-# examples/cloudwatch
+# examples/rout53
 
-A simple example of using the `CloudWatch` APIs.
+A simple example of using the `route53` APIs.

--- a/examples/route53/README.md
+++ b/examples/route53/README.md
@@ -1,3 +1,3 @@
-# examples/rout53
+# examples/route53
 
 A simple example of using the `route53` APIs.

--- a/examples/route53/index.ts
+++ b/examples/route53/index.ts
@@ -21,12 +21,13 @@ const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>
 const example_zone = new aws.route53.Zone("example.com", {}, providerOpts);
 
 const www_dev = new aws.route53.Record("www-dev", {
-     records: ["dev.example.com"],
-     setIdentifier: "dev",
-     ttl: 5,
-     type: aws.route53.RecordTypes.CNAME,
-     weightedRoutingPolicies: [{
-         weight: 10,
-     }],
-     zoneId: example_zone.zoneId,
+    name: "www",
+    records: ["dev.example.com"],
+    setIdentifier: "dev",
+    ttl: 5,
+    type: aws.route53.RecordTypes.CNAME,
+    weightedRoutingPolicies: [{
+        weight: 10,
+    }],
+    zoneId: example_zone.zoneId,
 }, providerOpts);

--- a/resources.go
+++ b/resources.go
@@ -1716,6 +1716,9 @@ func Provider() tfbridge.ProviderInfo {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsTypeDefaultFile(route53Mod, "RecordType")},
 					},
+					// Do not autoname Route53 records, as the "name" of these is actually the true
+					// domain name of the DNS record.
+					"name": {Name: "name"},
 				},
 			},
 			"aws_route53_resolver_endpoint":         {Tok: awsResource(route53Mod, "ResolverEndpoint")},

--- a/sdk/dotnet/Route53/Record.cs
+++ b/sdk/dotnet/Route53/Record.cs
@@ -222,8 +222,8 @@ namespace Pulumi.Aws.Route53
         /// <summary>
         /// DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
         /// </summary>
-        [Input("name")]
-        public Input<string>? Name { get; set; }
+        [Input("name", required: true)]
+        public Input<string> Name { get; set; } = null!;
 
         [Input("records")]
         private InputList<string>? _records;

--- a/sdk/go/aws/route53/record.go
+++ b/sdk/go/aws/route53/record.go
@@ -18,6 +18,9 @@ type Record struct {
 // NewRecord registers a new resource with the given unique name, arguments, and options.
 func NewRecord(ctx *pulumi.Context,
 	name string, args *RecordArgs, opts ...pulumi.ResourceOpt) (*Record, error) {
+	if args == nil || args.Name == nil {
+		return nil, errors.New("missing required argument 'Name'")
+	}
 	if args == nil || args.Type == nil {
 		return nil, errors.New("missing required argument 'Type'")
 	}

--- a/sdk/nodejs/acm/certificateValidation.ts
+++ b/sdk/nodejs/acm/certificateValidation.ts
@@ -34,6 +34,7 @@ import * as utilities from "../utilities";
  *     privateZone: false,
  * });
  * const certValidation = new aws.route53.Record("certValidation", {
+ *     name: certCertificate.domainValidationOptions[0].resourceRecordName,
  *     records: [certCertificate.domainValidationOptions[0].resourceRecordValue],
  *     ttl: 60,
  *     type: certCertificate.domainValidationOptions[0].resourceRecordType,
@@ -72,18 +73,21 @@ import * as utilities from "../utilities";
  *     privateZone: false,
  * });
  * const certValidation = new aws.route53.Record("certValidation", {
+ *     name: certCertificate.domainValidationOptions[0].resourceRecordName,
  *     records: [certCertificate.domainValidationOptions[0].resourceRecordValue],
  *     ttl: 60,
  *     type: certCertificate.domainValidationOptions[0].resourceRecordType,
  *     zoneId: zone.id,
  * });
  * const certValidationAlt1 = new aws.route53.Record("certValidationAlt1", {
+ *     name: certCertificate.domainValidationOptions[1].resourceRecordName,
  *     records: [certCertificate.domainValidationOptions[1].resourceRecordValue],
  *     ttl: 60,
  *     type: certCertificate.domainValidationOptions[1].resourceRecordType,
  *     zoneId: zone.id,
  * });
  * const certValidationAlt2 = new aws.route53.Record("certValidationAlt2", {
+ *     name: certCertificate.domainValidationOptions[2].resourceRecordName,
  *     records: [certCertificate.domainValidationOptions[2].resourceRecordValue],
  *     ttl: 60,
  *     type: certCertificate.domainValidationOptions[2].resourceRecordType,

--- a/sdk/nodejs/apigateway/domainName.ts
+++ b/sdk/nodejs/apigateway/domainName.ts
@@ -57,6 +57,7 @@ import * as utilities from "../utilities";
  *         name: exampleDomainName.cloudfrontDomainName,
  *         zoneId: exampleDomainName.cloudfrontZoneId,
  *     }],
+ *     name: exampleDomainName.domainName,
  *     type: "A",
  *     zoneId: aws_route53_zone_example.id,
  * });
@@ -84,6 +85,7 @@ import * as utilities from "../utilities";
  *         name: exampleDomainName.cloudfrontDomainName,
  *         zoneId: exampleDomainName.cloudfrontZoneId,
  *     }],
+ *     name: exampleDomainName.domainName,
  *     type: "A",
  *     zoneId: aws_route53_zone_example.id, // See aws.route53.Zone for how to create this
  * });
@@ -110,6 +112,7 @@ import * as utilities from "../utilities";
  *         name: exampleDomainName.regionalDomainName,
  *         zoneId: exampleDomainName.regionalZoneId,
  *     }],
+ *     name: exampleDomainName.domainName,
  *     type: "A",
  *     zoneId: aws_route53_zone_example.id,
  * });
@@ -140,6 +143,7 @@ import * as utilities from "../utilities";
  *         name: exampleDomainName.regionalDomainName,
  *         zoneId: exampleDomainName.regionalZoneId,
  *     }],
+ *     name: exampleDomainName.domainName,
  *     type: "A",
  *     zoneId: aws_route53_zone_example.id,
  * });

--- a/sdk/nodejs/ec2/vpcEndpoint.ts
+++ b/sdk/nodejs/ec2/vpcEndpoint.ts
@@ -80,6 +80,7 @@ import * as utilities from "../utilities";
  *     vpcId: var_vpc_id,
  * });
  * const ptfeServiceRecord = new aws.route53.Record("ptfeService", {
+ *     name: `ptfe.${internal.name!}`,
  *     records: [ptfeServiceVpcEndpoint.dnsEntries.apply(dnsEntries => (<any>dnsEntries[0])["dnsName"])],
  *     ttl: 300,
  *     type: "CNAME",

--- a/sdk/nodejs/elasticloadbalancing/getHostedZoneId.ts
+++ b/sdk/nodejs/elasticloadbalancing/getHostedZoneId.ts
@@ -23,6 +23,7 @@ import * as utilities from "../utilities";
  *         name: aws_elb_main.dnsName,
  *         zoneId: main.id,
  *     }],
+ *     name: "example.com",
  *     type: "A",
  *     zoneId: aws_route53_zone_primary.zoneId,
  * });

--- a/sdk/nodejs/elb/getHostedZoneId.ts
+++ b/sdk/nodejs/elb/getHostedZoneId.ts
@@ -23,6 +23,7 @@ import * as utilities from "../utilities";
  *         name: aws_elb_main.dnsName,
  *         zoneId: main.id,
  *     }],
+ *     name: "example.com",
  *     type: "A",
  *     zoneId: aws_route53_zone_primary.zoneId,
  * });

--- a/sdk/nodejs/route53/getZone.ts
+++ b/sdk/nodejs/route53/getZone.ts
@@ -25,6 +25,7 @@ import * as utilities from "../utilities";
  *     privateZone: true,
  * });
  * const www = new aws.route53.Record("www", {
+ *     name: `www.${selected.name!}`,
  *     records: ["10.0.0.1"],
  *     ttl: 300,
  *     type: "A",

--- a/sdk/nodejs/route53/record.ts
+++ b/sdk/nodejs/route53/record.ts
@@ -20,6 +20,7 @@ import {RecordType} from "./recordType";
  * import * as aws from "@pulumi/aws";
  * 
  * const www = new aws.route53.Record("www", {
+ *     name: "www.example.com",
  *     records: [aws_eip_lb.publicIp],
  *     ttl: 300,
  *     type: "A",
@@ -35,6 +36,7 @@ import {RecordType} from "./recordType";
  * import * as aws from "@pulumi/aws";
  * 
  * const wwwDev = new aws.route53.Record("www-dev", {
+ *     name: "www",
  *     records: ["dev.example.com"],
  *     setIdentifier: "dev",
  *     ttl: 5,
@@ -45,6 +47,7 @@ import {RecordType} from "./recordType";
  *     zoneId: aws_route53_zone_primary.zoneId,
  * });
  * const wwwLive = new aws.route53.Record("www-live", {
+ *     name: "www",
  *     records: ["live.example.com"],
  *     setIdentifier: "live",
  *     ttl: 5,
@@ -82,6 +85,7 @@ import {RecordType} from "./recordType";
  *         name: main.dnsName,
  *         zoneId: main.zoneId,
  *     }],
+ *     name: "example.com",
  *     type: "A",
  *     zoneId: aws_route53_zone_primary.zoneId,
  * });
@@ -98,6 +102,7 @@ import {RecordType} from "./recordType";
  * const exampleZone = new aws.route53.Zone("example", {});
  * const exampleRecord = new aws.route53.Record("example", {
  *     allowOverwrite: true,
+ *     name: "test.example.com",
  *     records: [
  *         exampleZone.nameServers[0],
  *         exampleZone.nameServers[1],
@@ -230,6 +235,9 @@ export class Record extends pulumi.CustomResource {
             inputs["zoneId"] = state ? state.zoneId : undefined;
         } else {
             const args = argsOrState as RecordArgs | undefined;
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.type === undefined) {
                 throw new Error("Missing required property 'type'");
             }
@@ -366,7 +374,7 @@ export interface RecordArgs {
     /**
      * DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
      */
-    readonly name?: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * A string list of records. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the configuration string (e.g. `"first255characters\"\"morecharacters"`).
      */

--- a/sdk/nodejs/route53/zone.ts
+++ b/sdk/nodejs/route53/zone.ts
@@ -37,6 +37,7 @@ import * as utilities from "../utilities";
  *     },
  * });
  * const devNs = new aws.route53.Record("dev-ns", {
+ *     name: "dev.example.com",
  *     records: [
  *         dev.nameServers[0],
  *         dev.nameServers[1],

--- a/sdk/nodejs/s3/getBucket.ts
+++ b/sdk/nodejs/s3/getBucket.ts
@@ -31,6 +31,7 @@ import * as utilities from "../utilities";
  *         name: selected.websiteDomain,
  *         zoneId: selected.hostedZoneId,
  *     }],
+ *     name: "bucket",
  *     type: "A",
  *     zoneId: testZone.id,
  * });

--- a/sdk/nodejs/ses/domainDkim.ts
+++ b/sdk/nodejs/ses/domainDkim.ts
@@ -24,6 +24,7 @@ import * as utilities from "../utilities";
  * const exampleAmazonsesDkimRecord: aws.route53.Record[] = [];
  * for (let i = 0; i < 3; i++) {
  *     exampleAmazonsesDkimRecord.push(new aws.route53.Record(`example_amazonses_dkim_record-${i}`, {
+ *         name: exampleDomainDkim.dkimTokens.apply(dkimTokens => `${dkimTokens[i]}._domainkey.example.com`),
  *         records: [exampleDomainDkim.dkimTokens.apply(dkimTokens => `${dkimTokens[i]}.dkim.amazonses.com`)],
  *         ttl: 600,
  *         type: "CNAME",

--- a/sdk/nodejs/ses/domainIdentity.ts
+++ b/sdk/nodejs/ses/domainIdentity.ts
@@ -17,6 +17,7 @@ import * as utilities from "../utilities";
  *     domain: "example.com",
  * });
  * const exampleAmazonsesVerificationRecord = new aws.route53.Record("exampleAmazonsesVerificationRecord", {
+ *     name: "_amazonses.example.com",
  *     records: [example.verificationToken],
  *     ttl: 600,
  *     type: "TXT",

--- a/sdk/nodejs/ses/domainIdentityVerification.ts
+++ b/sdk/nodejs/ses/domainIdentityVerification.ts
@@ -23,6 +23,7 @@ import * as utilities from "../utilities";
  *     domain: "example.com",
  * });
  * const exampleAmazonsesVerificationRecord = new aws.route53.Record("exampleAmazonsesVerificationRecord", {
+ *     name: pulumi.interpolate`_amazonses.${example.id}`,
  *     records: [example.verificationToken],
  *     ttl: 600,
  *     type: "TXT",

--- a/sdk/nodejs/ses/mailFrom.ts
+++ b/sdk/nodejs/ses/mailFrom.ts
@@ -25,6 +25,7 @@ import * as utilities from "../utilities";
  * });
  * // Example Route53 MX record
  * const exampleSesDomainMailFromMx = new aws.route53.Record("exampleSesDomainMailFromMx", {
+ *     name: exampleMailFrom.mailFromDomain,
  *     records: ["10 feedback-smtp.us-east-1.amazonses.com"], // Change to the region in which `aws_ses_domain_identity.example` is created
  *     ttl: 600,
  *     type: "MX",
@@ -32,6 +33,7 @@ import * as utilities from "../utilities";
  * });
  * // Example Route53 TXT record for SPF
  * const exampleSesDomainMailFromTxt = new aws.route53.Record("exampleSesDomainMailFromTxt", {
+ *     name: exampleMailFrom.mailFromDomain,
  *     records: ["v=spf1 include:amazonses.com -all"],
  *     ttl: 600,
  *     type: "TXT",

--- a/sdk/python/pulumi_aws/route53/record.py
+++ b/sdk/python/pulumi_aws/route53/record.py
@@ -157,6 +157,8 @@ class Record(pulumi.CustomResource):
             __props__['health_check_id'] = health_check_id
             __props__['latency_routing_policies'] = latency_routing_policies
             __props__['multivalue_answer_routing_policy'] = multivalue_answer_routing_policy
+            if name is None:
+                raise TypeError("Missing required property 'name'")
             __props__['name'] = name
             __props__['records'] = records
             __props__['set_identifier'] = set_identifier


### PR DESCRIPTION
This property is used as the domain name of the DNS entry - and should never be autonamed.

This is a breaking change, but any code that is broken by this is most likely not working as intended.