### PR TITLE
Change the autonaming of aws.iot.TopicRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Changing the autonaming prefix of `aws.iot.TopicRule` name parameter
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -1408,6 +1408,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_iot_topic_rule": {
 				Tok: awsResource(iotMod, "TopicRule"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": tfbridge.AutoNameWithCustomOptions("name",
+						tfbridge.AutoNameOptions{
+							Separator: "_",
+						}),
 					"cloudwatch_alarm":  {Name: "cloudwatchAlarm", MaxItemsOne: boolRef(true)},
 					"cloudwatch_metric": {Name: "cloudwatchMetric", MaxItemsOne: boolRef(true)},
 					"dynamodb":          {Name: "dynamodb", MaxItemsOne: boolRef(true)},


### PR DESCRIPTION
As reported in https://github.com/pulumi/docs/pull/2366 we need to
change how we actually autoname the TopicRule name

The name needs to adhere to a different naming regex
https://docs.aws.amazon.com/iot/latest/apireference/API_TopicRule.html