### PR TITLE
A number of resources had no support for AltTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Upgrade to v2.52.0 of the AWS Terraform Provider
+* Ensure that resource types are primitive types and move any
+  existing direct type references to be AltTypes 
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -345,8 +345,9 @@ func Provider() tfbridge.ProviderInfo {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{
 								"rest_api_id": {
-									Name: "restApi",
-									Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+									Name:     "restApi",
+									Type:     "string",
+									AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 								},
 							},
 						},
@@ -357,8 +358,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "Authorizer"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -366,8 +368,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "BasePathMapping"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -376,8 +379,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "Deployment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -395,8 +399,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "Integration"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -404,8 +409,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "IntegrationResponse"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -413,8 +419,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "Method"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -422,32 +429,36 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "MethodResponse"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				}},
 			"aws_api_gateway_method_settings": {
 				Tok: awsResource(apigatewayMod, "MethodSettings"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				}},
 			"aws_api_gateway_model": {
 				Tok: awsResource(apigatewayMod, "Model"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				}},
 			"aws_api_gateway_request_validator": {
 				Tok: awsResource(apigatewayMod, "RequestValidator"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -460,8 +471,9 @@ func Provider() tfbridge.ProviderInfo {
 					// 	Type: awsTypeDefaultFile(apigatewayMod, "Resource"),
 					// },
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -471,12 +483,14 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(apigatewayMod, "Stage"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"deployment_id": {
-						Name: "deployment",
-						Type: awsTypeDefaultFile(apigatewayMod, "Deployment"),
+						Name:     "deployment",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "Deployment")},
 					},
 					"rest_api_id": {
-						Name: "restApi",
-						Type: awsTypeDefaultFile(apigatewayMod, "RestApi"),
+						Name:     "restApi",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
 					},
 				},
 			},
@@ -622,8 +636,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(cloudwatchMod, "LogSubscriptionFilter"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"log_group_name": {
-						Name: "logGroup",
-						Type: awsResource(cloudwatchMod, "LogGroup"),
+						Name:     "logGroup",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsResource(cloudwatchMod, "LogGroup")},
 					},
 				},
 				DeleteBeforeReplace: true, // only 1 active filter is legal at once
@@ -790,7 +805,10 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_elastic_beanstalk_application_version": {
 				Tok: awsResource(elasticbeanstalkMod, "ApplicationVersion"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"application": {Type: awsResource(elasticbeanstalkMod, "Application")},
+					"application": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsResource(elasticbeanstalkMod, "Application")},
+					},
 					"bucket": {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsResource(s3Mod, "Bucket")},
@@ -801,8 +819,11 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_elastic_beanstalk_environment": {
 				Tok: awsResource(elasticbeanstalkMod, "Environment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name":        tfbridge.AutoName("name", 40),
-					"application": {Type: awsResource(elasticbeanstalkMod, "Application")},
+					"name": tfbridge.AutoName("name", 40),
+					"application": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsResource(elasticbeanstalkMod, "Application")},
+					},
 					"version_label": {
 						Name: "version",
 						Type: awsResource(elasticbeanstalkMod, "ApplicationVersion"),
@@ -1945,8 +1966,9 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: awsResource(snsMod, "TopicSubscription"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"topic_arn": {
-						Name: "topic",
-						Type: awsResource(snsMod, "Topic"),
+						Name:     "topic",
+						Type:     "string",
+						AltTypes: []tokens.Type{awsResource(snsMod, "Topic")},
 					},
 				},
 			},

--- a/sdk/go/aws/apigateway/authorizer.go
+++ b/sdk/go/aws/apigateway/authorizer.go
@@ -168,7 +168,7 @@ type authorizerArgs struct {
 	// Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
 	ProviderArns []string `pulumi:"providerArns"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
 	// Defaults to `TOKEN`.
 	Type *string `pulumi:"type"`
@@ -200,7 +200,7 @@ type AuthorizerArgs struct {
 	// Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
 	ProviderArns pulumi.StringArrayInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
 	// Defaults to `TOKEN`.
 	Type pulumi.StringPtrInput

--- a/sdk/go/aws/apigateway/basePathMapping.go
+++ b/sdk/go/aws/apigateway/basePathMapping.go
@@ -94,7 +94,7 @@ type basePathMappingArgs struct {
 	// The already-registered domain name to connect the API to.
 	DomainName string `pulumi:"domainName"`
 	// The id of the API to connect.
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 	StageName *string `pulumi:"stageName"`
 }
@@ -106,7 +106,7 @@ type BasePathMappingArgs struct {
 	// The already-registered domain name to connect the API to.
 	DomainName pulumi.StringInput
 	// The id of the API to connect.
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 	StageName pulumi.StringPtrInput
 }

--- a/sdk/go/aws/apigateway/deployment.go
+++ b/sdk/go/aws/apigateway/deployment.go
@@ -123,7 +123,7 @@ type deploymentArgs struct {
 	// The description of the deployment
 	Description *string `pulumi:"description"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The description of the stage
 	StageDescription *string `pulumi:"stageDescription"`
 	// The name of the stage. If the specified stage already exists, it will be updated to point to the new deployment. If the stage does not exist, a new one will be created and point to this deployment.
@@ -137,7 +137,7 @@ type DeploymentArgs struct {
 	// The description of the deployment
 	Description pulumi.StringPtrInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The description of the stage
 	StageDescription pulumi.StringPtrInput
 	// The name of the stage. If the specified stage already exists, it will be updated to point to the new deployment. If the stage does not exist, a new one will be created and point to this deployment.

--- a/sdk/go/aws/apigateway/integration.go
+++ b/sdk/go/aws/apigateway/integration.go
@@ -220,7 +220,7 @@ type integrationArgs struct {
 	// The API resource ID.
 	ResourceId string `pulumi:"resourceId"`
 	// The ID of the associated REST API.
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
 	TimeoutMilliseconds *int `pulumi:"timeoutMilliseconds"`
 	// The integration input's [type](https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/). Valid values are `HTTP` (for HTTP backends), `MOCK` (not calling any real backend), `AWS` (for AWS services), `AWS_PROXY` (for Lambda proxy integration) and `HTTP_PROXY` (for HTTP proxy integration). An `HTTP` or `HTTP_PROXY` integration with a `connectionType` of `VPC_LINK` is referred to as a private integration and uses a VpcLink to connect API Gateway to a network load balancer of a VPC.
@@ -264,7 +264,7 @@ type IntegrationArgs struct {
 	// The API resource ID.
 	ResourceId pulumi.StringInput
 	// The ID of the associated REST API.
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
 	TimeoutMilliseconds pulumi.IntPtrInput
 	// The integration input's [type](https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/). Valid values are `HTTP` (for HTTP backends), `MOCK` (not calling any real backend), `AWS` (for AWS services), `AWS_PROXY` (for Lambda proxy integration) and `HTTP_PROXY` (for HTTP proxy integration). An `HTTP` or `HTTP_PROXY` integration with a `connectionType` of `VPC_LINK` is referred to as a private integration and uses a VpcLink to connect API Gateway to a network load balancer of a VPC.

--- a/sdk/go/aws/apigateway/integrationResponse.go
+++ b/sdk/go/aws/apigateway/integrationResponse.go
@@ -144,7 +144,7 @@ type integrationResponseArgs struct {
 	// A map specifying the templates used to transform the integration response body
 	ResponseTemplates map[string]string `pulumi:"responseTemplates"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// Specifies the regular expression pattern used to choose
 	// an integration response based on the response from the backend. Setting this to `-` makes the integration the default one.
 	// If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched.
@@ -168,7 +168,7 @@ type IntegrationResponseArgs struct {
 	// A map specifying the templates used to transform the integration response body
 	ResponseTemplates pulumi.StringMapInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// Specifies the regular expression pattern used to choose
 	// an integration response based on the response from the backend. Setting this to `-` makes the integration the default one.
 	// If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched.

--- a/sdk/go/aws/apigateway/method.go
+++ b/sdk/go/aws/apigateway/method.go
@@ -160,7 +160,7 @@ type methodArgs struct {
 	// The API resource ID
 	ResourceId string `pulumi:"resourceId"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 }
 
 // The set of arguments for constructing a Method resource.
@@ -187,7 +187,7 @@ type MethodArgs struct {
 	// The API resource ID
 	ResourceId pulumi.StringInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 }
 
 func (MethodArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/apigateway/methodResponse.go
+++ b/sdk/go/aws/apigateway/methodResponse.go
@@ -122,7 +122,7 @@ type methodResponseArgs struct {
 	// would define that the header `X-Some-Header` can be provided on the response.
 	ResponseParameters map[string]bool `pulumi:"responseParameters"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The HTTP status code
 	StatusCode string `pulumi:"statusCode"`
 }
@@ -140,7 +140,7 @@ type MethodResponseArgs struct {
 	// would define that the header `X-Some-Header` can be provided on the response.
 	ResponseParameters pulumi.BoolMapInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The HTTP status code
 	StatusCode pulumi.StringInput
 }

--- a/sdk/go/aws/apigateway/methodSettings.go
+++ b/sdk/go/aws/apigateway/methodSettings.go
@@ -96,7 +96,7 @@ type methodSettingsArgs struct {
 	// Method path defined as `{resource_path}/{http_method}` for an individual method override, or `*/*` for overriding all methods in the stage.
 	MethodPath string `pulumi:"methodPath"`
 	// The ID of the REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The settings block, see below.
 	Settings MethodSettingsSettings `pulumi:"settings"`
 	// The name of the stage
@@ -108,7 +108,7 @@ type MethodSettingsArgs struct {
 	// Method path defined as `{resource_path}/{http_method}` for an individual method override, or `*/*` for overriding all methods in the stage.
 	MethodPath pulumi.StringInput
 	// The ID of the REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The settings block, see below.
 	Settings MethodSettingsSettingsInput
 	// The name of the stage

--- a/sdk/go/aws/apigateway/model.go
+++ b/sdk/go/aws/apigateway/model.go
@@ -100,7 +100,7 @@ type modelArgs struct {
 	// The name of the model
 	Name *string `pulumi:"name"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The schema of the model in a JSON form
 	Schema *string `pulumi:"schema"`
 }
@@ -114,7 +114,7 @@ type ModelArgs struct {
 	// The name of the model
 	Name pulumi.StringPtrInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The schema of the model in a JSON form
 	Schema pulumi.StringPtrInput
 }

--- a/sdk/go/aws/apigateway/requestValidator.go
+++ b/sdk/go/aws/apigateway/requestValidator.go
@@ -87,7 +87,7 @@ type requestValidatorArgs struct {
 	// The name of the request validator
 	Name *string `pulumi:"name"`
 	// The ID of the associated Rest API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// Boolean whether to validate request body. Defaults to `false`.
 	ValidateRequestBody *bool `pulumi:"validateRequestBody"`
 	// Boolean whether to validate request parameters. Defaults to `false`.
@@ -99,7 +99,7 @@ type RequestValidatorArgs struct {
 	// The name of the request validator
 	Name pulumi.StringPtrInput
 	// The ID of the associated Rest API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// Boolean whether to validate request body. Defaults to `false`.
 	ValidateRequestBody pulumi.BoolPtrInput
 	// Boolean whether to validate request parameters. Defaults to `false`.

--- a/sdk/go/aws/apigateway/resource.go
+++ b/sdk/go/aws/apigateway/resource.go
@@ -95,7 +95,7 @@ type resourceArgs struct {
 	// The last path segment of this API resource.
 	PathPart string `pulumi:"pathPart"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 }
 
 // The set of arguments for constructing a Resource resource.
@@ -105,7 +105,7 @@ type ResourceArgs struct {
 	// The last path segment of this API resource.
 	PathPart pulumi.StringInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/apigateway/stage.go
+++ b/sdk/go/aws/apigateway/stage.go
@@ -178,13 +178,13 @@ type stageArgs struct {
 	// The identifier of a client certificate for the stage.
 	ClientCertificateId *string `pulumi:"clientCertificateId"`
 	// The ID of the deployment that the stage points to
-	Deployment string `pulumi:"deployment"`
+	Deployment interface{} `pulumi:"deployment"`
 	// The description of the stage
 	Description *string `pulumi:"description"`
 	// The version of the associated API documentation
 	DocumentationVersion *string `pulumi:"documentationVersion"`
 	// The ID of the associated REST API
-	RestApi string `pulumi:"restApi"`
+	RestApi interface{} `pulumi:"restApi"`
 	// The name of the stage
 	StageName string `pulumi:"stageName"`
 	// A mapping of tags to assign to the resource.
@@ -207,13 +207,13 @@ type StageArgs struct {
 	// The identifier of a client certificate for the stage.
 	ClientCertificateId pulumi.StringPtrInput
 	// The ID of the deployment that the stage points to
-	Deployment pulumi.StringInput
+	Deployment pulumi.Input
 	// The description of the stage
 	Description pulumi.StringPtrInput
 	// The version of the associated API documentation
 	DocumentationVersion pulumi.StringPtrInput
 	// The ID of the associated REST API
-	RestApi pulumi.StringInput
+	RestApi pulumi.Input
 	// The name of the stage
 	StageName pulumi.StringInput
 	// A mapping of tags to assign to the resource.

--- a/sdk/go/aws/cloudwatch/logSubscriptionFilter.go
+++ b/sdk/go/aws/cloudwatch/logSubscriptionFilter.go
@@ -109,7 +109,7 @@ type logSubscriptionFilterArgs struct {
 	// A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
 	FilterPattern string `pulumi:"filterPattern"`
 	// The name of the log group to associate the subscription filter with
-	LogGroup string `pulumi:"logGroup"`
+	LogGroup interface{} `pulumi:"logGroup"`
 	// A name for the subscription filter
 	Name *string `pulumi:"name"`
 	// The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. If you use Lambda as a destination, you should skip this argument and use `lambda.Permission` resource for granting access from CloudWatch logs to the destination Lambda function. 
@@ -125,7 +125,7 @@ type LogSubscriptionFilterArgs struct {
 	// A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
 	FilterPattern pulumi.StringInput
 	// The name of the log group to associate the subscription filter with
-	LogGroup pulumi.StringInput
+	LogGroup pulumi.Input
 	// A name for the subscription filter
 	Name pulumi.StringPtrInput
 	// The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. If you use Lambda as a destination, you should skip this argument and use `lambda.Permission` resource for granting access from CloudWatch logs to the destination Lambda function. 

--- a/sdk/go/aws/elasticbeanstalk/applicationVersion.go
+++ b/sdk/go/aws/elasticbeanstalk/applicationVersion.go
@@ -128,7 +128,7 @@ func (ApplicationVersionState) ElementType() reflect.Type {
 
 type applicationVersionArgs struct {
 	// Name of the Beanstalk Application the version is associated with.
-	Application string `pulumi:"application"`
+	Application interface{} `pulumi:"application"`
 	// S3 bucket that contains the Application Version source bundle.
 	Bucket interface{} `pulumi:"bucket"`
 	// Short description of the Application Version.
@@ -147,7 +147,7 @@ type applicationVersionArgs struct {
 // The set of arguments for constructing a ApplicationVersion resource.
 type ApplicationVersionArgs struct {
 	// Name of the Beanstalk Application the version is associated with.
-	Application pulumi.StringInput
+	Application pulumi.Input
 	// S3 bucket that contains the Application Version source bundle.
 	Bucket pulumi.Input
 	// Short description of the Application Version.

--- a/sdk/go/aws/elasticbeanstalk/environment.go
+++ b/sdk/go/aws/elasticbeanstalk/environment.go
@@ -268,7 +268,7 @@ func (EnvironmentState) ElementType() reflect.Type {
 type environmentArgs struct {
 	// Name of the application that contains the version
 	// to be deployed
-	Application string `pulumi:"application"`
+	Application interface{} `pulumi:"application"`
 	// Prefix to use for the fully qualified DNS name of
 	// the Environment.
 	CnamePrefix *string `pulumi:"cnamePrefix"`
@@ -314,7 +314,7 @@ type environmentArgs struct {
 type EnvironmentArgs struct {
 	// Name of the application that contains the version
 	// to be deployed
-	Application pulumi.StringInput
+	Application pulumi.Input
 	// Prefix to use for the fully qualified DNS name of
 	// the Environment.
 	CnamePrefix pulumi.StringPtrInput

--- a/sdk/go/aws/sns/topicSubscription.go
+++ b/sdk/go/aws/sns/topicSubscription.go
@@ -146,7 +146,7 @@ type topicSubscriptionArgs struct {
 	// Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false).
 	RawMessageDelivery *bool `pulumi:"rawMessageDelivery"`
 	// The ARN of the SNS topic to subscribe to
-	Topic string `pulumi:"topic"`
+	Topic interface{} `pulumi:"topic"`
 }
 
 // The set of arguments for constructing a TopicSubscription resource.
@@ -166,7 +166,7 @@ type TopicSubscriptionArgs struct {
 	// Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false).
 	RawMessageDelivery pulumi.BoolPtrInput
 	// The ARN of the SNS topic to subscribe to
-	Topic pulumi.StringInput
+	Topic pulumi.Input
 }
 
 func (TopicSubscriptionArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/apigateway/authorizer.ts
+++ b/sdk/nodejs/apigateway/authorizer.ts
@@ -146,7 +146,7 @@ export class Authorizer extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
      * Defaults to `TOKEN`.
@@ -244,7 +244,7 @@ export interface AuthorizerState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
      * Defaults to `TOKEN`.
@@ -296,7 +296,7 @@ export interface AuthorizerArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
      * Defaults to `TOKEN`.

--- a/sdk/nodejs/apigateway/basePathMapping.ts
+++ b/sdk/nodejs/apigateway/basePathMapping.ts
@@ -71,7 +71,7 @@ export class BasePathMapping extends pulumi.CustomResource {
     /**
      * The id of the API to connect.
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * Path segment that must be prepended to the path when accessing the API via this mapping. If omitted, the API is exposed at the root of the given domain.
      */
@@ -132,7 +132,7 @@ export interface BasePathMappingState {
     /**
      * The id of the API to connect.
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * Path segment that must be prepended to the path when accessing the API via this mapping. If omitted, the API is exposed at the root of the given domain.
      */
@@ -154,7 +154,7 @@ export interface BasePathMappingArgs {
     /**
      * The id of the API to connect.
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * Path segment that must be prepended to the path when accessing the API via this mapping. If omitted, the API is exposed at the root of the given domain.
      */

--- a/sdk/nodejs/apigateway/deployment.ts
+++ b/sdk/nodejs/apigateway/deployment.ts
@@ -100,7 +100,7 @@ export class Deployment extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * The description of the stage
      */
@@ -185,7 +185,7 @@ export interface DeploymentState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * The description of the stage
      */
@@ -211,7 +211,7 @@ export interface DeploymentArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * The description of the stage
      */

--- a/sdk/nodejs/apigateway/integration.ts
+++ b/sdk/nodejs/apigateway/integration.ts
@@ -258,7 +258,7 @@ export class Integration extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API.
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
      */
@@ -405,7 +405,7 @@ export interface IntegrationState {
     /**
      * The ID of the associated REST API.
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
      */
@@ -483,7 +483,7 @@ export interface IntegrationArgs {
     /**
      * The ID of the associated REST API.
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
      */

--- a/sdk/nodejs/apigateway/integrationResponse.ts
+++ b/sdk/nodejs/apigateway/integrationResponse.ts
@@ -116,7 +116,7 @@ export class IntegrationResponse extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * Specifies the regular expression pattern used to choose
      * an integration response based on the response from the backend. Setting this to `-` makes the integration the default one.
@@ -211,7 +211,7 @@ export interface IntegrationResponseState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * Specifies the regular expression pattern used to choose
      * an integration response based on the response from the backend. Setting this to `-` makes the integration the default one.
@@ -253,7 +253,7 @@ export interface IntegrationResponseArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * Specifies the regular expression pattern used to choose
      * an integration response based on the response from the backend. Setting this to `-` makes the integration the default one.

--- a/sdk/nodejs/apigateway/method.ts
+++ b/sdk/nodejs/apigateway/method.ts
@@ -139,7 +139,7 @@ export class Method extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
 
     /**
      * Create a Method resource with the given unique name, arguments, and options.
@@ -245,7 +245,7 @@ export interface MethodState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
 }
 
 /**
@@ -294,5 +294,5 @@ export interface MethodArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
 }

--- a/sdk/nodejs/apigateway/methodResponse.ts
+++ b/sdk/nodejs/apigateway/methodResponse.ts
@@ -95,7 +95,7 @@ export class MethodResponse extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * The HTTP status code
      */
@@ -176,7 +176,7 @@ export interface MethodResponseState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * The HTTP status code
      */
@@ -208,7 +208,7 @@ export interface MethodResponseArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * The HTTP status code
      */

--- a/sdk/nodejs/apigateway/methodSettings.ts
+++ b/sdk/nodejs/apigateway/methodSettings.ts
@@ -99,7 +99,7 @@ export class MethodSettings extends pulumi.CustomResource {
     /**
      * The ID of the REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * The settings block, see below.
      */
@@ -166,7 +166,7 @@ export interface MethodSettingsState {
     /**
      * The ID of the REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * The settings block, see below.
      */
@@ -188,7 +188,7 @@ export interface MethodSettingsArgs {
     /**
      * The ID of the REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * The settings block, see below.
      */

--- a/sdk/nodejs/apigateway/model.ts
+++ b/sdk/nodejs/apigateway/model.ts
@@ -75,7 +75,7 @@ export class Model extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * The schema of the model in a JSON form
      */
@@ -142,7 +142,7 @@ export interface ModelState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * The schema of the model in a JSON form
      */
@@ -168,7 +168,7 @@ export interface ModelArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * The schema of the model in a JSON form
      */

--- a/sdk/nodejs/apigateway/requestValidator.ts
+++ b/sdk/nodejs/apigateway/requestValidator.ts
@@ -60,7 +60,7 @@ export class RequestValidator extends pulumi.CustomResource {
     /**
      * The ID of the associated Rest API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * Boolean whether to validate request body. Defaults to `false`.
      */
@@ -118,7 +118,7 @@ export interface RequestValidatorState {
     /**
      * The ID of the associated Rest API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * Boolean whether to validate request body. Defaults to `false`.
      */
@@ -140,7 +140,7 @@ export interface RequestValidatorArgs {
     /**
      * The ID of the associated Rest API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * Boolean whether to validate request body. Defaults to `false`.
      */

--- a/sdk/nodejs/apigateway/resource.ts
+++ b/sdk/nodejs/apigateway/resource.ts
@@ -71,7 +71,7 @@ export class Resource extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -135,7 +135,7 @@ export interface ResourceState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
 }
 
 /**
@@ -153,5 +153,5 @@ export interface ResourceArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
 }

--- a/sdk/nodejs/apigateway/stage.ts
+++ b/sdk/nodejs/apigateway/stage.ts
@@ -133,7 +133,7 @@ export class Stage extends pulumi.CustomResource {
     /**
      * The ID of the deployment that the stage points to
      */
-    public readonly deployment!: pulumi.Output<Deployment>;
+    public readonly deployment!: pulumi.Output<string>;
     /**
      * The description of the stage
      */
@@ -156,7 +156,7 @@ export class Stage extends pulumi.CustomResource {
     /**
      * The ID of the associated REST API
      */
-    public readonly restApi!: pulumi.Output<RestApi>;
+    public readonly restApi!: pulumi.Output<string>;
     /**
      * The name of the stage
      */
@@ -267,7 +267,7 @@ export interface StageState {
     /**
      * The ID of the deployment that the stage points to
      */
-    readonly deployment?: pulumi.Input<Deployment>;
+    readonly deployment?: pulumi.Input<string | Deployment>;
     /**
      * The description of the stage
      */
@@ -290,7 +290,7 @@ export interface StageState {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi?: pulumi.Input<RestApi>;
+    readonly restApi?: pulumi.Input<string | RestApi>;
     /**
      * The name of the stage
      */
@@ -333,7 +333,7 @@ export interface StageArgs {
     /**
      * The ID of the deployment that the stage points to
      */
-    readonly deployment: pulumi.Input<Deployment>;
+    readonly deployment: pulumi.Input<string | Deployment>;
     /**
      * The description of the stage
      */
@@ -345,7 +345,7 @@ export interface StageArgs {
     /**
      * The ID of the associated REST API
      */
-    readonly restApi: pulumi.Input<RestApi>;
+    readonly restApi: pulumi.Input<string | RestApi>;
     /**
      * The name of the stage
      */

--- a/sdk/nodejs/cloudwatch/logSubscriptionFilter.ts
+++ b/sdk/nodejs/cloudwatch/logSubscriptionFilter.ts
@@ -70,7 +70,7 @@ export class LogSubscriptionFilter extends pulumi.CustomResource {
     /**
      * The name of the log group to associate the subscription filter with
      */
-    public readonly logGroup!: pulumi.Output<LogGroup>;
+    public readonly logGroup!: pulumi.Output<string>;
     /**
      * A name for the subscription filter
      */
@@ -146,7 +146,7 @@ export interface LogSubscriptionFilterState {
     /**
      * The name of the log group to associate the subscription filter with
      */
-    readonly logGroup?: pulumi.Input<LogGroup>;
+    readonly logGroup?: pulumi.Input<string | LogGroup>;
     /**
      * A name for the subscription filter
      */
@@ -176,7 +176,7 @@ export interface LogSubscriptionFilterArgs {
     /**
      * The name of the log group to associate the subscription filter with
      */
-    readonly logGroup: pulumi.Input<LogGroup>;
+    readonly logGroup: pulumi.Input<string | LogGroup>;
     /**
      * A name for the subscription filter
      */

--- a/sdk/nodejs/elasticbeanstalk/applicationVersion.ts
+++ b/sdk/nodejs/elasticbeanstalk/applicationVersion.ts
@@ -77,7 +77,7 @@ export class ApplicationVersion extends pulumi.CustomResource {
     /**
      * Name of the Beanstalk Application the version is associated with.
      */
-    public readonly application!: pulumi.Output<Application>;
+    public readonly application!: pulumi.Output<string>;
     /**
      * The ARN assigned by AWS for this Elastic Beanstalk Application.
      */
@@ -166,7 +166,7 @@ export interface ApplicationVersionState {
     /**
      * Name of the Beanstalk Application the version is associated with.
      */
-    readonly application?: pulumi.Input<Application>;
+    readonly application?: pulumi.Input<string | Application>;
     /**
      * The ARN assigned by AWS for this Elastic Beanstalk Application.
      */
@@ -205,7 +205,7 @@ export interface ApplicationVersionArgs {
     /**
      * Name of the Beanstalk Application the version is associated with.
      */
-    readonly application: pulumi.Input<Application>;
+    readonly application: pulumi.Input<string | Application>;
     /**
      * S3 bucket that contains the Application Version source bundle.
      */

--- a/sdk/nodejs/elasticbeanstalk/environment.ts
+++ b/sdk/nodejs/elasticbeanstalk/environment.ts
@@ -110,7 +110,7 @@ export class Environment extends pulumi.CustomResource {
      * Name of the application that contains the version
      * to be deployed
      */
-    public readonly application!: pulumi.Output<Application>;
+    public readonly application!: pulumi.Output<string>;
     public /*out*/ readonly arn!: pulumi.Output<string>;
     /**
      * The autoscaling groups used by this Environment.
@@ -297,7 +297,7 @@ export interface EnvironmentState {
      * Name of the application that contains the version
      * to be deployed
      */
-    readonly application?: pulumi.Input<Application>;
+    readonly application?: pulumi.Input<string | Application>;
     readonly arn?: pulumi.Input<string>;
     /**
      * The autoscaling groups used by this Environment.
@@ -404,7 +404,7 @@ export interface EnvironmentArgs {
      * Name of the application that contains the version
      * to be deployed
      */
-    readonly application: pulumi.Input<Application>;
+    readonly application: pulumi.Input<string | Application>;
     /**
      * Prefix to use for the fully qualified DNS name of
      * the Environment.

--- a/sdk/nodejs/sns/topicSubscription.ts
+++ b/sdk/nodejs/sns/topicSubscription.ts
@@ -84,7 +84,7 @@ export class TopicSubscription extends pulumi.CustomResource {
     /**
      * The ARN of the SNS topic to subscribe to
      */
-    public readonly topic!: pulumi.Output<Topic>;
+    public readonly topic!: pulumi.Output<string>;
 
     /**
      * Create a TopicSubscription resource with the given unique name, arguments, and options.
@@ -178,7 +178,7 @@ export interface TopicSubscriptionState {
     /**
      * The ARN of the SNS topic to subscribe to
      */
-    readonly topic?: pulumi.Input<Topic>;
+    readonly topic?: pulumi.Input<string | Topic>;
 }
 
 /**
@@ -216,5 +216,5 @@ export interface TopicSubscriptionArgs {
     /**
      * The ARN of the SNS topic to subscribe to
      */
-    readonly topic: pulumi.Input<Topic>;
+    readonly topic: pulumi.Input<string | Topic>;
 }


### PR DESCRIPTION
The strategy we have is that a type should fall back to a primitive

an example of this would be for aws ec2 instancetypes, if we don't allow
strings then we will have to deploy the provider before we allow a user
to pick up the latest instance types