### PR TITLE
CloudWatch scheduled events typo?

### DIFF
--- a/sdk/nodejs/cloudwatch/eventRuleMixins.ts
+++ b/sdk/nodejs/cloudwatch/eventRuleMixins.ts
@@ -97,7 +97,7 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);
 
         this.permission = new lambda.Permission(name, {
-            action: "lambda:invokeFunction",
+            action: "lambda:InvokeFunction",
             function: this.func,
             principal: "events.amazonaws.com",
             sourceArn: this.eventRule.arn,

--- a/sdk/nodejs/cloudwatch/logGroupMixins.ts
+++ b/sdk/nodejs/cloudwatch/logGroupMixins.ts
@@ -93,7 +93,7 @@ export class LogGroupEventSubscription extends lambda.EventSubscription {
         region = region || config.region;
 
         this.permission = new lambda.Permission(name, {
-            action: "lambda:invokeFunction",
+            action: "lambda:InvokeFunction",
             function: this.func,
             principal: pulumi.interpolate`logs.${region}.amazonaws.com`,
             sourceArn: logGroup.arn,

--- a/sdk/nodejs/sns/snsMixins.ts
+++ b/sdk/nodejs/sns/snsMixins.ts
@@ -82,7 +82,7 @@ export class TopicEventSubscription extends lambda.EventSubscription {
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);
 
         this.permission = new lambda.Permission(name, {
-            action: "lambda:invokeFunction",
+            action: "lambda:InvokeFunction",
             function: this.func,
             principal: "sns.amazonaws.com",
             sourceArn: topic.id,


### PR DESCRIPTION
I was having issues trying to get my `aws.cloudwatch.onSchedule()` to execute my `aws.lambda.CallbackFunction`. Could this be the cause and if so, would these other instances be broken as well? I can't figure out how to run the code locally so I just figured it might be easier to show this to more knowledgeable people.