### PR TITLE
update tag matching for travis release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
-if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR branch =~ ^release/ OR tag IS present
+if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR branch =~ ^release/ OR tag =~ ^v\d+.*
 language: go
 go: 1.13.x
 sudo: true # give us 7.5GB and >2 bursted cores.


### PR DESCRIPTION
Replicating: https://github.com/pulumi/pulumi/pull/4219

Accommodates the new module release pattern that includes tags for `vX.X.X` `sdk/vX.X.X`. 