### PR TITLE
IAM: Principals: Added ECS-tasks principal

### DIFF
--- a/sdk/nodejs/iam/principals.ts
+++ b/sdk/nodejs/iam/principals.ts
@@ -121,6 +121,12 @@ export module Principals {
     export const EcsPrincipal: Principal = {Service: "ecs.amazonaws.com"};
 
     /**
+     * Service Principal for Elastic Container Service Tasks
+     * Usage: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+    */
+    export const EcsTasksPrincipal: Principal = {Service: "ecs-tasks.amazonaws.com"};
+
+    /**
      * Service Principal for Edge Lambda
      */
     export const EdgeLambdaPrincipal: Principal = {Service: "edgelambda.amazonaws.com"};


### PR DESCRIPTION
Just found it this is missing in the list. Nice to see that there are constants for it 👍 

I refrained to add this also outside the `Principals` modules as this is deprecated since PR https://github.com/pulumi/pulumi-aws/pull/600.

I think this small addition might not worth to be in the changelog. If you think otherwise, please tell me.