### PR TITLE
Switch deprecated Buffer constructor to Buffer.from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Switch deprecated Buffer constructor to Buffer.from in LogGroup.onDecodedEvent
 
 ---
 

--- a/sdk/nodejs/cloudwatch/logGroupMixins.ts
+++ b/sdk/nodejs/cloudwatch/logGroupMixins.ts
@@ -148,7 +148,7 @@ logGroup.LogGroup.prototype.onDecodedEvent = function(this: logGroup.LogGroup, n
 
 async function decodeLogGroupEvent(event: LogGroupEvent): Promise<DecodedLogGroupEvent> {
     const zlib = await import("zlib");
-    const payload = new Buffer(event.awslogs.data, "base64");
+    const payload = Buffer.from(event.awslogs.data, "base64");
 
     return new Promise<DecodedLogGroupEvent>((resolve, reject) => {
         zlib.gunzip(payload, function(err, result) {


### PR DESCRIPTION
When I create a Cloudwatch LogGroup subscription like:
```
logGroup.then(lg => lg.onDecodedEvent('example', (event) => {
        console.log(JSON.stringify(event));
    }, {filterPattern: 'Download'}, {provider}));
```

I see this warning in the lambda's logs:
```
ERROR	(node:8) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```