### PR TITLE
Add new region Africa (Cape Town) af-south-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* Add new region South Africa (Cape Town) af-south-1
 * Add ManagedPolicies.AmazonEC2SpotFleetTaggingRole
 * Add Principals.BatchPrincipal
 * Add Principals.SpotFleetPrincipal

--- a/sdk/nodejs/region.ts
+++ b/sdk/nodejs/region.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export let AFSouth1Region: Region     = "af-south-1";
 export let APEast1Region: Region      = "ap-east-1";
 export let APNortheast1Region: Region = "ap-northeast-1";
 export let APNortheast2Region: Region = "ap-northeast-2";
@@ -37,6 +38,7 @@ export let USWest2Region: Region      = "us-west-2";
  * A Region represents any valid Amazon region that may be targeted with deployments.
  */
 export type Region =
+    "af-south-1"     |
     "ap-east-1"      |
     "ap-northeast-1" |
     "ap-northeast-2" |


### PR DESCRIPTION
I added a new region for Africa (Cape Town) af-south-1. 

I don't know if it's as easy as _just_ changing it in the `.ts` files. I have searched the repository for definitions alike in `.go`, `.py`, and `.cs` but did not find any.