### PR TITLE
Use more specific imports to allow deep imports to only pull in a sub…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Fixed TypeScript definitions to allow deep imports to improve build times (ie `import * as s3 from '@pulumi/aws/s3'`)
 
 ---
 

--- a/sdk/nodejs/datasync/efsLocation.ts
+++ b/sdk/nodejs/datasync/efsLocation.ts
@@ -6,7 +6,7 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Manages an AWS DataSync EFS Location.

--- a/sdk/nodejs/datasync/s3Location.ts
+++ b/sdk/nodejs/datasync/s3Location.ts
@@ -6,7 +6,7 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Manages an S3 Location within AWS DataSync.

--- a/sdk/nodejs/datasync/task.ts
+++ b/sdk/nodejs/datasync/task.ts
@@ -6,7 +6,7 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Manages an AWS DataSync Task, which represents a configuration for synchronization. Starting an execution of these DataSync Tasks (actually synchronizing files) is performed outside of this resource.

--- a/sdk/nodejs/ec2transitgateway/transitGateway.ts
+++ b/sdk/nodejs/ec2transitgateway/transitGateway.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Manages an EC2 Transit Gateway.

--- a/sdk/nodejs/iam/groupPolicyAttachment.ts
+++ b/sdk/nodejs/iam/groupPolicyAttachment.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 import {Group} from "./index";
 
 /**

--- a/sdk/nodejs/iam/policyAttachment.ts
+++ b/sdk/nodejs/iam/policyAttachment.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 import {Group, Role, User} from "./index";
 
 /**

--- a/sdk/nodejs/iam/rolePolicyAttachment.ts
+++ b/sdk/nodejs/iam/rolePolicyAttachment.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 import {Role} from "./index";
 
 /**

--- a/sdk/nodejs/iam/userPolicyAttachment.ts
+++ b/sdk/nodejs/iam/userPolicyAttachment.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 import {User} from "./index";
 
 /**

--- a/sdk/nodejs/iot/policyAttachment.ts
+++ b/sdk/nodejs/iot/policyAttachment.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 import {Policy} from "./index";
 
 /**

--- a/sdk/nodejs/iot/thingPrincipalAttachment.ts
+++ b/sdk/nodejs/iot/thingPrincipalAttachment.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Attaches Principal to AWS IoT Thing.

--- a/sdk/nodejs/kinesis/analyticsApplication.ts
+++ b/sdk/nodejs/kinesis/analyticsApplication.ts
@@ -6,7 +6,7 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Provides a Kinesis Analytics Application resource. Kinesis Analytics is a managed service that

--- a/sdk/nodejs/lambda/function.ts
+++ b/sdk/nodejs/lambda/function.ts
@@ -6,7 +6,7 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS, enabling serverless backend solutions. The Lambda Function itself includes source code and runtime configuration.

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -6,7 +6,7 @@ import * as inputs from "./types/input";
 import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
-import {Region} from "./index";
+import {Region} from "./region";
 
 /**
  * The provider type for the aws package. By default, resources use package-wide configuration

--- a/sdk/nodejs/sns/topic.ts
+++ b/sdk/nodejs/sns/topic.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {ARN} from "..";
+import {ARN} from "../arn";
 
 /**
  * Provides an SNS topic resource


### PR DESCRIPTION
…set of TypeScript files

This increases build performance dramatically.

For a sample project which created a S3 Bucket and a Lambda here


##Before
```
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";

export const blogsTable = new aws.dynamodb.Table('some-table', {
    attributes: [
        {
            name: 'PK',
            type: 'S',
        },
        {
            name: 'SK',
            type: 'S',
        },
    ],
    billingMode: 'PAY_PER_REQUEST',
    hashKey: 'PK',
    rangeKey: 'SK',
    readCapacity: 5,
    writeCapacity: 5,
})

// Create an AWS resource (S3 Bucket)
const bucket = new aws.s3.Bucket("my-bucket");

// Export the name of the bucket
export const bucketName = bucket.id;

new aws.lambda.CallbackFunction('callback', {
    callback: async () => {
    },
})
```

Stats

```
pulumi-module-example node_modules/.bin/tsc --extendedDiagnostics
Files:                       1466
Lines:                     616374
Nodes:                    1713503
Identifiers:               616003
Symbols:                   388012
Types:                     146551
Memory used:              675092K
Assignability cache size:   45298
Identity cache size:            3
Subtype cache size:             0
I/O Read time:              0.79s
Parse time:                 2.84s
Program time:               4.50s
Bind time:                  0.91s
Check time:                 3.16s
transformTime time:         0.01s
Source Map time:            0.00s
commentTime time:           0.00s
I/O Write time:             0.00s
printTime time:             0.01s
Emit time:                  0.01s
Total time:                 8.59
```

## After 

```
import * as pulumi from "@pulumi/pulumi";
import * as s3 from "@pulumi/aws/s3";
import * as lambda from '@pulumi/aws/lambda'
import * as dynamodb from '@pulumi/aws/dynamodb'

export const blogsTable = new dynamodb.Table('some-table', {
    attributes: [
        {
            name: 'PK',
            type: 'S',
        },
        {
            name: 'SK',
            type: 'S',
        },
    ],
    billingMode: 'PAY_PER_REQUEST',
    hashKey: 'PK',
    rangeKey: 'SK',
    readCapacity: 5,
    writeCapacity: 5,
})

// Create an AWS resource (S3 Bucket)
const bucket = new s3.Bucket("my-bucket");

// Export the name of the bucket
export const bucketName = bucket.id;

new lambda.CallbackFunction('callback', {
    callback: async () => {
    },
})
```

Stats
```
pulumi-module-example node_modules/.bin/tsc --extendedDiagnostics 
Files:                        210
Lines:                      87083
Nodes:                     275249
Identifiers:                96759
Symbols:                    76109
Types:                      25847
Memory used:              139730K
Assignability cache size:   38203
Identity cache size:            3
Subtype cache size:             0
I/O Read time:              0.02s
Parse time:                 0.47s
Program time:               0.64s
Bind time:                  0.26s
Check time:                 1.23s
transformTime time:         0.01s
Source Map time:            0.00s
commentTime time:           0.00s
I/O Write time:             0.00s
printTime time:             0.01s
Emit time:                  0.01s
Total time:                 2.15s
```

The AWS-SDK has similar issues, but is a bit harder to unpick