### PR TITLE
Fix aws.Tags interface to match updated codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Update `aws.Tags` interface to reflect changes from version `2.10.0`
 
 ---
 

--- a/sdk/nodejs/tags.ts
+++ b/sdk/nodejs/tags.ts
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as pulumi from "@pulumi/pulumi";
+
 /**
  * Tags represents a set of key-value string pairs to which can be applied
  * to an AWS resource.
  */
 export interface Tags {
-    [name: string]: string;
+    [name: string]: pulumi.Input<string>;
 }


### PR DESCRIPTION
The recent `2.10` release included a change that caused the `tags` on resources to change shape.