### PR TITLE
Update ContainerDefinition.Secret valueFrom to pulumi.Input

### DIFF
--- a/sdk/nodejs/ecs/container.ts
+++ b/sdk/nodejs/ecs/container.ts
@@ -259,7 +259,7 @@ export interface Secret {
      * task you are launching, then you can use either the full ARN or name of the parameter. If the
      * parameter exists in a different Region, then the full ARN must be specified.
      */
-    valueFrom: string;
+    valueFrom: pulumi.Input<string>;
 }
 
 /**


### PR DESCRIPTION
Hey team, 
I recently stumbled upon a use case of building a stack that also creates the secrets in secrets manager and `valueFrom` would fail for the `pulumi.Output<string>` type

An example use case to reproduce the error
```ts
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";
import * as awsx from "@pulumi/awsx";

const testSecret = new aws.secretsmanager.Secret("test-secret", {
    namePrefix: "test-secret",
});

new aws.secretsmanager.SecretVersion("test-secret-version", {
    secretId: testSecret.id,
    secretString: "test",
});

const cluster = new awsx.ecs.Cluster("ecs-cluster");
const service = new awsx.ecs.FargateService("farget-service", {
    platformVersion: '1.3.0',
    cluster: cluster,
    desiredCount: 1,
    taskDefinitionArgs: {
        executionRole: executionRole,
        containers: {
            echoServer: {
                image: "busybox:latest",
                memory: 512,
                secrets: [
                    { name: "TEST", valueFrom: testSecret.arn }
                ]
            },
        },
    },
});
```