### PR TITLE
utils.ts causes a circular reference

### DIFF
--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Directly import awsMixins.  We want to execute the code within it, but we don't want to import or
-// export any values from it.  Specifically, awsMixins adds a *getter* property (called "runtime")
-// to this @pulumi/aws module. If we actually *import* or *export* that property, the getter will
-// execute, which is not what we want at all.  Instead, we want to really just expose that we have
-// this "runtime" property on the typing, and we want to execute the code that jams the getter on.
-
-import "./awsMixins";
-
 import * as pulumi from "@pulumi/pulumi";
 import * as crypto from "crypto";
 


### PR DESCRIPTION
An example of this is cloudwatch eventRuleMixin, which references lambda.ts, which imports utils.ts, which imports the root mixin file, which requires everything.

This causes a runtime error with classes.

I am unsure about the impacts of removing this, as far as I can tell it is imported from index.ts, meaning if you import `@pulumi/aws` the side effect of adding the proxied .sdk will still happen. But there may be other things I cannot spot