### PR TITLE
Fix typo in CrawlerS3Target documentation for path field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* Fix typo in CrawlerS3Target documentation for path field, correcting the description of the target to crawl (should be S3 bucket, not DynamoDB table)
 * Upgrade to v3.10.0 of the AWS Terraform Provider
 * Disable autonaming on `directoryservice.Directory` as the `name` needs to be a fully qualified name for the directory
 * Schematize enums, generate new constants and update existing constants for Nodejs. [#1151](https://github.com/pulumi/pulumi-aws/pull/1151)
@@ -30,7 +31,7 @@ CHANGELOG
 * Upgrade to pulumi-terraform-bridge v2.9.2
 * Upgrade to Pulumi v2.10.1
 * Upgrade to v3.6.0 of the AWS Terraform Provider
-
+                                        
 ## 3.2.1 (2020-08-26)
 * Upgrade to pulumi-terraform-bridge v2.7.3
 

--- a/sdk/dotnet/Glue/Inputs/CrawlerS3TargetArgs.cs
+++ b/sdk/dotnet/Glue/Inputs/CrawlerS3TargetArgs.cs
@@ -31,7 +31,7 @@ namespace Pulumi.Aws.Glue.Inputs
         }
 
         /// <summary>
-        /// The name of the DynamoDB table to crawl.
+        /// The name of the S3 bucket to crawl.
         /// </summary>
         [Input("path", required: true)]
         public Input<string> Path { get; set; } = null!;

--- a/sdk/dotnet/Glue/Inputs/CrawlerS3TargetGetArgs.cs
+++ b/sdk/dotnet/Glue/Inputs/CrawlerS3TargetGetArgs.cs
@@ -31,7 +31,7 @@ namespace Pulumi.Aws.Glue.Inputs
         }
 
         /// <summary>
-        /// The name of the DynamoDB table to crawl.
+        /// The name of the S3 bucket to crawl.
         /// </summary>
         [Input("path", required: true)]
         public Input<string> Path { get; set; } = null!;

--- a/sdk/dotnet/Glue/Outputs/CrawlerS3Target.cs
+++ b/sdk/dotnet/Glue/Outputs/CrawlerS3Target.cs
@@ -22,7 +22,7 @@ namespace Pulumi.Aws.Glue.Outputs
         /// </summary>
         public readonly ImmutableArray<string> Exclusions;
         /// <summary>
-        /// The name of the DynamoDB table to crawl.
+        /// The name of the S3 bucket to crawl.
         /// </summary>
         public readonly string Path;
 

--- a/sdk/go/aws/glue/pulumiTypes.go
+++ b/sdk/go/aws/glue/pulumiTypes.go
@@ -2212,7 +2212,7 @@ type CrawlerS3Target struct {
 	ConnectionName *string `pulumi:"connectionName"`
 	// A list of glob patterns used to exclude from the crawl.
 	Exclusions []string `pulumi:"exclusions"`
-	// The name of the DynamoDB table to crawl.
+	// The name of the S3 bucket to crawl.
 	Path string `pulumi:"path"`
 }
 
@@ -2232,7 +2232,7 @@ type CrawlerS3TargetArgs struct {
 	ConnectionName pulumi.StringPtrInput `pulumi:"connectionName"`
 	// A list of glob patterns used to exclude from the crawl.
 	Exclusions pulumi.StringArrayInput `pulumi:"exclusions"`
-	// The name of the DynamoDB table to crawl.
+	// The name of the S3 bucket to crawl.
 	Path pulumi.StringInput `pulumi:"path"`
 }
 
@@ -2297,7 +2297,7 @@ func (o CrawlerS3TargetOutput) Exclusions() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v CrawlerS3Target) []string { return v.Exclusions }).(pulumi.StringArrayOutput)
 }
 
-// The name of the DynamoDB table to crawl.
+// The name of the S3 bucket to crawl.
 func (o CrawlerS3TargetOutput) Path() pulumi.StringOutput {
 	return o.ApplyT(func(v CrawlerS3Target) string { return v.Path }).(pulumi.StringOutput)
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -10997,7 +10997,7 @@ export namespace glue {
          */
         exclusions?: pulumi.Input<pulumi.Input<string>[]>;
         /**
-         * The name of the DynamoDB table to crawl.
+         * The name of the S3 bucket to crawl.
          */
         path: pulumi.Input<string>;
     }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -12282,7 +12282,7 @@ export namespace glue {
          */
         exclusions?: string[];
         /**
-         * The name of the DynamoDB table to crawl.
+         * The name of the S3 bucket to crawl.
          */
         path: string;
     }

--- a/sdk/python/pulumi_aws/glue/_inputs.py
+++ b/sdk/python/pulumi_aws/glue/_inputs.py
@@ -928,7 +928,7 @@ class CrawlerS3TargetArgs:
                  connection_name: Optional[pulumi.Input[str]] = None,
                  exclusions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
-        :param pulumi.Input[str] path: The name of the DynamoDB table to crawl.
+        :param pulumi.Input[str] path: The name of the S3 bucket to crawl.
         :param pulumi.Input[str] connection_name: The name of the connection to use to connect to the JDBC target.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] exclusions: A list of glob patterns used to exclude from the crawl.
         """
@@ -942,7 +942,7 @@ class CrawlerS3TargetArgs:
     @pulumi.getter
     def path(self) -> pulumi.Input[str]:
         """
-        The name of the DynamoDB table to crawl.
+        The name of the S3 bucket to crawl.
         """
         return pulumi.get(self, "path")
 

--- a/sdk/python/pulumi_aws/glue/outputs.py
+++ b/sdk/python/pulumi_aws/glue/outputs.py
@@ -775,7 +775,7 @@ class CrawlerS3Target(dict):
                  connection_name: Optional[str] = None,
                  exclusions: Optional[Sequence[str]] = None):
         """
-        :param str path: The name of the DynamoDB table to crawl.
+        :param str path: The name of the S3 bucket to crawl.
         :param str connection_name: The name of the connection to use to connect to the JDBC target.
         :param Sequence[str] exclusions: A list of glob patterns used to exclude from the crawl.
         """
@@ -789,7 +789,7 @@ class CrawlerS3Target(dict):
     @pulumi.getter
     def path(self) -> str:
         """
-        The name of the DynamoDB table to crawl.
+        The name of the S3 bucket to crawl.
         """
         return pulumi.get(self, "path")
 


### PR DESCRIPTION
Hello!
This is a fix for a typo I found when writing my infrastructure code for AWS Glue. Documentation for `path` field changed, correcting the description of the target to crawl (should be S3 bucket, not DynamoDB table)