### PR TITLE
Remove explicit deprecation messages

### DIFF
--- a/sdk/nodejs/iam/managedPolicies.ts
+++ b/sdk/nodejs/iam/managedPolicies.ts
@@ -15,534 +15,534 @@
 /* tslint:disable:max-line-length ordered-imports variable-name */
 import {ARN} from "../arn";
 
-/** @deprecated Use ManagedPolicy instead. */
+/** Use ManagedPolicy instead. */
 export module ManagedPolicies {
-    /** @deprecated Use ManagedPolicy.AWSAccountActivityAccess instead. */
+    /** Use ManagedPolicy.AWSAccountActivityAccess instead. */
     export const AWSAccountActivityAccess: ARN = "arn:aws:iam::aws:policy/AWSAccountActivityAccess";
-    /** @deprecated Use ManagedPolicy.AWSAccountUsageReportAccess instead. */
+    /** Use ManagedPolicy.AWSAccountUsageReportAccess instead. */
     export const AWSAccountUsageReportAccess: ARN = "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess";
-    /** @deprecated Use ManagedPolicy.AWSAgentlessDiscoveryService instead. */
+    /** Use ManagedPolicy.AWSAgentlessDiscoveryService instead. */
     export const AWSAgentlessDiscoveryService: ARN = "arn:aws:iam::aws:policy/AWSAgentlessDiscoveryService";
-    /** @deprecated Use ManagedPolicy.AWSApplicationDiscoveryAgentAccess instead. */
+    /** Use ManagedPolicy.AWSApplicationDiscoveryAgentAccess instead. */
     export const AWSApplicationDiscoveryAgentAccess: ARN = "arn:aws:iam::aws:policy/AWSApplicationDiscoveryAgentAccess";
-    /** @deprecated Use ManagedPolicy.AWSApplicationDiscoveryServiceFullAccess instead. */
+    /** Use ManagedPolicy.AWSApplicationDiscoveryServiceFullAccess instead. */
     export const AWSApplicationDiscoveryServiceFullAccess: ARN = "arn:aws:iam::aws:policy/AWSApplicationDiscoveryServiceFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSBatchFullAccess instead. */
+    /** Use ManagedPolicy.AWSBatchFullAccess instead. */
     export const AWSBatchFullAccess: ARN = "arn:aws:iam::aws:policy/AWSBatchFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSBatchServiceRole instead. */
+    /** Use ManagedPolicy.AWSBatchServiceRole instead. */
     export const AWSBatchServiceRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole";
-    /** @deprecated Use ManagedPolicy.AWSCertificateManagerFullAccess instead. */
+    /** Use ManagedPolicy.AWSCertificateManagerFullAccess instead. */
     export const AWSCertificateManagerFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCertificateManagerFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCertificateManagerReadOnly instead. */
+    /** Use ManagedPolicy.AWSCertificateManagerReadOnly instead. */
     export const AWSCertificateManagerReadOnly: ARN = "arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly";
-    /** @deprecated Use ManagedPolicy.AWSCloudFormationReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSCloudFormationReadOnlyAccess instead. */
     export const AWSCloudFormationReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSCloudHSMFullAccess instead. */
+    /** Use ManagedPolicy.AWSCloudHSMFullAccess instead. */
     export const AWSCloudHSMFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCloudHSMFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCloudHSMReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSCloudHSMReadOnlyAccess instead. */
     export const AWSCloudHSMReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSCloudHSMReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSCloudHSMRole instead. */
+    /** Use ManagedPolicy.AWSCloudHSMRole instead. */
     export const AWSCloudHSMRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSCloudHSMRole";
-    /** @deprecated Use ManagedPolicy.AWSCloudTrailFullAccess instead. */
+    /** Use ManagedPolicy.AWSCloudTrailFullAccess instead. */
     export const AWSCloudTrailFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCloudTrailFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCloudTrailReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSCloudTrailReadOnlyAccess instead. */
     export const AWSCloudTrailReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeBuildAdminAccess instead. */
+    /** Use ManagedPolicy.AWSCodeBuildAdminAccess instead. */
     export const AWSCodeBuildAdminAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeBuildDeveloperAccess instead. */
+    /** Use ManagedPolicy.AWSCodeBuildDeveloperAccess instead. */
     export const AWSCodeBuildDeveloperAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeBuildReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSCodeBuildReadOnlyAccess instead. */
     export const AWSCodeBuildReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeBuildReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeCommitFullAccess instead. */
+    /** Use ManagedPolicy.AWSCodeCommitFullAccess instead. */
     export const AWSCodeCommitFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeCommitPowerUser instead. */
+    /** Use ManagedPolicy.AWSCodeCommitPowerUser instead. */
     export const AWSCodeCommitPowerUser: ARN = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser";
-    /** @deprecated Use ManagedPolicy.AWSCodeCommitReadOnly instead. */
+    /** Use ManagedPolicy.AWSCodeCommitReadOnly instead. */
     export const AWSCodeCommitReadOnly: ARN = "arn:aws:iam::aws:policy/AWSCodeCommitReadOnly";
-    /** @deprecated Use ManagedPolicy.AWSCodeDeployDeployerAccess instead. */
+    /** Use ManagedPolicy.AWSCodeDeployDeployerAccess instead. */
     export const AWSCodeDeployDeployerAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeDeployDeployerAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeDeployFullAccess instead. */
+    /** Use ManagedPolicy.AWSCodeDeployFullAccess instead. */
     export const AWSCodeDeployFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeDeployReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSCodeDeployReadOnlyAccess instead. */
     export const AWSCodeDeployReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeDeployReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeDeployRole instead. */
+    /** Use ManagedPolicy.AWSCodeDeployRole instead. */
     export const AWSCodeDeployRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole";
-    /** @deprecated Use ManagedPolicy.AWSCodeDeployRoleForECS instead. */
+    /** Use ManagedPolicy.AWSCodeDeployRoleForECS instead. */
     export const AWSCodeDeployRoleForECS: ARN = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS";
-    /** @deprecated Use ManagedPolicy.AWSCodePipelineApproverAccess instead. */
+    /** Use ManagedPolicy.AWSCodePipelineApproverAccess instead. */
     export const AWSCodePipelineApproverAccess: ARN = "arn:aws:iam::aws:policy/AWSCodePipelineApproverAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodePipelineCustomActionAccess instead. */
+    /** Use ManagedPolicy.AWSCodePipelineCustomActionAccess instead. */
     export const AWSCodePipelineCustomActionAccess: ARN = "arn:aws:iam::aws:policy/AWSCodePipelineCustomActionAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodePipelineFullAccess instead. */
+    /** Use ManagedPolicy.AWSCodePipelineFullAccess instead. */
     export const AWSCodePipelineFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodePipelineReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSCodePipelineReadOnlyAccess instead. */
     export const AWSCodePipelineReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSCodePipelineReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeStarFullAccess instead. */
+    /** Use ManagedPolicy.AWSCodeStarFullAccess instead. */
     export const AWSCodeStarFullAccess: ARN = "arn:aws:iam::aws:policy/AWSCodeStarFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSCodeStarServiceRole instead. */
+    /** Use ManagedPolicy.AWSCodeStarServiceRole instead. */
     export const AWSCodeStarServiceRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSCodeStarServiceRole";
-    /** @deprecated Use ManagedPolicy.AWSConfigRole instead. */
+    /** Use ManagedPolicy.AWSConfigRole instead. */
     export const AWSConfigRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSConfigRole";
-    /** @deprecated Use ManagedPolicy.AWSConfigRulesExecutionRole instead. */
+    /** Use ManagedPolicy.AWSConfigRulesExecutionRole instead. */
     export const AWSConfigRulesExecutionRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSConfigRulesExecutionRole";
-    /** @deprecated Use ManagedPolicy.AWSConfigUserAccess instead. */
+    /** Use ManagedPolicy.AWSConfigUserAccess instead. */
     export const AWSConfigUserAccess: ARN = "arn:aws:iam::aws:policy/AWSConfigUserAccess";
-    /** @deprecated Use ManagedPolicy. AWSConnector instead. */
+    /** Use ManagedPolicy. AWSConnector instead. */
     export const AWSConnector: ARN = "arn:aws:iam::aws:policy/AWSConnector";
-    /** @deprecated Use ManagedPolicy.AWSDataPipelineRole instead. */
+    /** Use ManagedPolicy.AWSDataPipelineRole instead. */
     export const AWSDataPipelineRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole";
-    /** @deprecated Use ManagedPolicy.AWSDataPipeline_FullAccess instead. */
+    /** Use ManagedPolicy.AWSDataPipeline_FullAccess instead. */
     export const AWSDataPipeline_FullAccess: ARN = "arn:aws:iam::aws:policy/AWSDataPipeline_FullAccess";
-    /** @deprecated Use ManagedPolicy.AWSDataPipeline_PowerUser instead. */
+    /** Use ManagedPolicy.AWSDataPipeline_PowerUser instead. */
     export const AWSDataPipeline_PowerUser: ARN = "arn:aws:iam::aws:policy/AWSDataPipeline_PowerUser";
-    /** @deprecated Use ManagedPolicy.AWSDeviceFarmFullAccess instead. */
+    /** Use ManagedPolicy.AWSDeviceFarmFullAccess instead. */
     export const AWSDeviceFarmFullAccess: ARN = "arn:aws:iam::aws:policy/AWSDeviceFarmFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSDirectConnectFullAccess instead. */
+    /** Use ManagedPolicy.AWSDirectConnectFullAccess instead. */
     export const AWSDirectConnectFullAccess: ARN = "arn:aws:iam::aws:policy/AWSDirectConnectFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSDirectConnectReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSDirectConnectReadOnlyAccess instead. */
     export const AWSDirectConnectReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSDirectoryServiceFullAccess instead. */
+    /** Use ManagedPolicy.AWSDirectoryServiceFullAccess instead. */
     export const AWSDirectoryServiceFullAccess: ARN = "arn:aws:iam::aws:policy/AWSDirectoryServiceFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSDirectoryServiceReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSDirectoryServiceReadOnlyAccess instead. */
     export const AWSDirectoryServiceReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSDirectoryServiceReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkCustomPlatformforEC2Role instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkCustomPlatformforEC2Role instead. */
     export const AWSElasticBeanstalkCustomPlatformforEC2Role: ARN = "arn:aws:iam::aws:policy/AWSElasticBeanstalkCustomPlatformforEC2Role";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkEnhancedHealth instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkEnhancedHealth instead. */
     export const AWSElasticBeanstalkEnhancedHealth: ARN = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkFullAccess instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkFullAccess instead. */
     export const AWSElasticBeanstalkFullAccess: ARN = "arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkMulticontainerDocker instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkMulticontainerDocker instead. */
     export const AWSElasticBeanstalkMulticontainerDocker: ARN = "arn:aws:iam::aws:policy/AWSElasticBeanstalkMulticontainerDocker";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkReadOnlyAccess instead. */
     export const AWSElasticBeanstalkReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSElasticBeanstalkReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkService instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkService instead. */
     export const AWSElasticBeanstalkService: ARN = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkWebTier instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkWebTier instead. */
     export const AWSElasticBeanstalkWebTier: ARN = "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier";
-    /** @deprecated Use ManagedPolicy.AWSElasticBeanstalkWorkerTier instead. */
+    /** Use ManagedPolicy.AWSElasticBeanstalkWorkerTier instead. */
     export const AWSElasticBeanstalkWorkerTier: ARN = "arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier";
-    /** @deprecated Use ManagedPolicy.AWSGreengrassFullAccess instead. */
+    /** Use ManagedPolicy.AWSGreengrassFullAccess instead. */
     export const AWSGreengrassFullAccess: ARN = "arn:aws:iam::aws:policy/AWSGreengrassFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSGreengrassResourceAccessRolePolicy instead. */
+    /** Use ManagedPolicy.AWSGreengrassResourceAccessRolePolicy instead. */
     export const AWSGreengrassResourceAccessRolePolicy: ARN = "arn:aws:iam::aws:policy/service-role/AWSGreengrassResourceAccessRolePolicy";
-    /** @deprecated Use ManagedPolicy.AWSHealthFullAccess instead. */
+    /** Use ManagedPolicy.AWSHealthFullAccess instead. */
     export const AWSHealthFullAccess: ARN = "arn:aws:iam::aws:policy/AWSHealthFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSImportExportFullAccess instead. */
+    /** Use ManagedPolicy.AWSImportExportFullAccess instead. */
     export const AWSImportExportFullAccess: ARN = "arn:aws:iam::aws:policy/AWSImportExportFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSImportExportReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSImportExportReadOnlyAccess instead. */
     export const AWSImportExportReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSImportExportReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSIoTConfigAccess instead. */
+    /** Use ManagedPolicy.AWSIoTConfigAccess instead. */
     export const AWSIoTConfigAccess: ARN = "arn:aws:iam::aws:policy/AWSIoTConfigAccess";
-    /** @deprecated Use ManagedPolicy.AWSIoTConfigReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSIoTConfigReadOnlyAccess instead. */
     export const AWSIoTConfigReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSIoTConfigReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSIoTDataAccess instead. */
+    /** Use ManagedPolicy.AWSIoTDataAccess instead. */
     export const AWSIoTDataAccess: ARN = "arn:aws:iam::aws:policy/AWSIoTDataAccess";
-    /** @deprecated Use ManagedPolicy.AWSIoTFullAccess instead. */
+    /** Use ManagedPolicy.AWSIoTFullAccess instead. */
     export const AWSIoTFullAccess: ARN = "arn:aws:iam::aws:policy/AWSIoTFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSIoTLogging instead. */
+    /** Use ManagedPolicy.AWSIoTLogging instead. */
     export const AWSIoTLogging: ARN = "arn:aws:iam::aws:policy/service-role/AWSIoTLogging";
-    /** @deprecated Use ManagedPolicy.AWSIoTRuleActions instead. */
+    /** Use ManagedPolicy.AWSIoTRuleActions instead. */
     export const AWSIoTRuleActions: ARN = "arn:aws:iam::aws:policy/service-role/AWSIoTRuleActions";
-    /** @deprecated Use ManagedPolicy.AWSKeyManagementServicePowerUser instead. */
+    /** Use ManagedPolicy.AWSKeyManagementServicePowerUser instead. */
     export const AWSKeyManagementServicePowerUser: ARN = "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser";
-    /** @deprecated Use ManagedPolicy.AWSLambdaBasicExecutionRole instead. */
+    /** Use ManagedPolicy.AWSLambdaBasicExecutionRole instead. */
     export const AWSLambdaBasicExecutionRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole";
-    /** @deprecated Use ManagedPolicy.AWSLambdaDynamoDBExecutionRole instead. */
+    /** Use ManagedPolicy.AWSLambdaDynamoDBExecutionRole instead. */
     export const AWSLambdaDynamoDBExecutionRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole";
-    /** @deprecated Use ManagedPolicy.AWSLambdaENIManagementAccess instead. */
+    /** Use ManagedPolicy.AWSLambdaENIManagementAccess instead. */
     export const AWSLambdaENIManagementAccess: ARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess";
-    /** @deprecated Use ManagedPolicy.AWSLambdaExecute instead. */
+    /** Use ManagedPolicy.AWSLambdaExecute instead. */
     export const AWSLambdaExecute: ARN = "arn:aws:iam::aws:policy/AWSLambdaExecute";
-    /** @deprecated Use ManagedPolicy.AWSLambdaFullAccess instead. */
+    /** Use ManagedPolicy.AWSLambdaFullAccess instead. */
     export const AWSLambdaFullAccess: ARN = "arn:aws:iam::aws:policy/AWSLambdaFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSLambdaInvocationDynamoDB instead. */
+    /** Use ManagedPolicy.AWSLambdaInvocationDynamoDB instead. */
     export const AWSLambdaInvocationDynamoDB: ARN = "arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB";
-    /** @deprecated Use ManagedPolicy.AWSLambdaKinesisExecutionRole instead. */
+    /** Use ManagedPolicy.AWSLambdaKinesisExecutionRole instead. */
     export const AWSLambdaKinesisExecutionRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole";
-    /** @deprecated Use ManagedPolicy.AWSLambdaReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSLambdaReadOnlyAccess instead. */
     export const AWSLambdaReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSLambdaRole instead. */
+    /** Use ManagedPolicy.AWSLambdaRole instead. */
     export const AWSLambdaRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaRole";
-    /** @deprecated Use ManagedPolicy.AWSLambdaVPCAccessExecutionRole instead. */
+    /** Use ManagedPolicy.AWSLambdaVPCAccessExecutionRole instead. */
     export const AWSLambdaVPCAccessExecutionRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole";
-    /** @deprecated Use ManagedPolicy.AWSMarketplaceFullAccess instead. */
+    /** Use ManagedPolicy.AWSMarketplaceFullAccess instead. */
     export const AWSMarketplaceFullAccess: ARN = "arn:aws:iam::aws:policy/AWSMarketplaceFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSMarketplaceGetEntitlements instead. */
+    /** Use ManagedPolicy.AWSMarketplaceGetEntitlements instead. */
     export const AWSMarketplaceGetEntitlements: ARN = "arn:aws:iam::aws:policy/AWSMarketplaceGetEntitlements";
-    /** @deprecated Use ManagedPolicy.AWSMarketplaceManageSubscriptions instead. */
+    /** Use ManagedPolicy.AWSMarketplaceManageSubscriptions instead. */
     export const AWSMarketplaceManageSubscriptions: ARN = "arn:aws:iam::aws:policy/AWSMarketplaceManageSubscriptions";
-    /** @deprecated Use ManagedPolicy.AWSMarketplaceMeteringFullAccess instead. */
+    /** Use ManagedPolicy.AWSMarketplaceMeteringFullAccess instead. */
     export const AWSMarketplaceMeteringFullAccess: ARN = "arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSMarketplaceReadonly instead. */
+    /** Use ManagedPolicy.AWSMarketplaceReadonly instead. */
     export const AWSMarketplaceReadonly: ARN = "arn:aws:iam::aws:policy/AWSMarketplaceRead-only";
-    /** @deprecated Use ManagedPolicy.AWSMobileHub_FullAccess instead. */
+    /** Use ManagedPolicy.AWSMobileHub_FullAccess instead. */
     export const AWSMobileHub_FullAccess: ARN = "arn:aws:iam::aws:policy/AWSMobileHub_FullAccess";
-    /** @deprecated Use ManagedPolicy.AWSMobileHub_ReadOnly instead. */
+    /** Use ManagedPolicy.AWSMobileHub_ReadOnly instead. */
     export const AWSMobileHub_ReadOnly: ARN = "arn:aws:iam::aws:policy/AWSMobileHub_ReadOnly";
-    /** @deprecated Use ManagedPolicy.AWSMobileHub_ServiceUseOnly instead. */
+    /** Use ManagedPolicy.AWSMobileHub_ServiceUseOnly instead. */
     export const AWSMobileHub_ServiceUseOnly: ARN = "arn:aws:iam::aws:policy/service-role/AWSMobileHub_ServiceUseOnly";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksCMInstanceProfileRole instead. */
+    /** Use ManagedPolicy.AWSOpsWorksCMInstanceProfileRole instead. */
     export const AWSOpsWorksCMInstanceProfileRole: ARN = "arn:aws:iam::aws:policy/AWSOpsWorksCMInstanceProfileRole";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksCMServiceRole instead. */
+    /** Use ManagedPolicy.AWSOpsWorksCMServiceRole instead. */
     export const AWSOpsWorksCMServiceRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSOpsWorksCMServiceRole";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksCloudWatchLogs instead. */
+    /** Use ManagedPolicy.AWSOpsWorksCloudWatchLogs instead. */
     export const AWSOpsWorksCloudWatchLogs: ARN = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksFullAccess instead. */
+    /** Use ManagedPolicy.AWSOpsWorksFullAccess instead. */
     export const AWSOpsWorksFullAccess: ARN = "arn:aws:iam::aws:policy/AWSOpsWorksFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksInstanceRegistration instead. */
+    /** Use ManagedPolicy.AWSOpsWorksInstanceRegistration instead. */
     export const AWSOpsWorksInstanceRegistration: ARN = "arn:aws:iam::aws:policy/AWSOpsWorksInstanceRegistration";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksRegisterCLI instead. */
+    /** Use ManagedPolicy.AWSOpsWorksRegisterCLI instead. */
     export const AWSOpsWorksRegisterCLI: ARN = "arn:aws:iam::aws:policy/AWSOpsWorksRegisterCLI";
-    /** @deprecated Use ManagedPolicy.AWSOpsWorksRole instead. */
+    /** Use ManagedPolicy.AWSOpsWorksRole instead. */
     export const AWSOpsWorksRole: ARN = "arn:aws:iam::aws:policy/service-role/AWSOpsWorksRole";
-    /** @deprecated Use ManagedPolicy.AWSQuickSightDescribeRDS instead. */
+    /** Use ManagedPolicy.AWSQuickSightDescribeRDS instead. */
     export const AWSQuickSightDescribeRDS: ARN = "arn:aws:iam::aws:policy/service-role/AWSQuickSightDescribeRDS";
-    /** @deprecated Use ManagedPolicy.AWSQuickSightDescribeRedshift instead. */
+    /** Use ManagedPolicy.AWSQuickSightDescribeRedshift instead. */
     export const AWSQuickSightDescribeRedshift: ARN = "arn:aws:iam::aws:policy/service-role/AWSQuickSightDescribeRedshift";
-    /** @deprecated Use ManagedPolicy.AWSQuickSightListIAM instead. */
+    /** Use ManagedPolicy.AWSQuickSightListIAM instead. */
     export const AWSQuickSightListIAM: ARN = "arn:aws:iam::aws:policy/service-role/AWSQuickSightListIAM";
-    /** @deprecated Use ManagedPolicy.AWSQuicksightAthenaAccess instead. */
+    /** Use ManagedPolicy.AWSQuicksightAthenaAccess instead. */
     export const AWSQuicksightAthenaAccess: ARN = "arn:aws:iam::aws:policy/service-role/AWSQuicksightAthenaAccess";
-    /** @deprecated Use ManagedPolicy.AWSStepFunctionsConsoleFullAccess instead. */
+    /** Use ManagedPolicy.AWSStepFunctionsConsoleFullAccess instead. */
     export const AWSStepFunctionsConsoleFullAccess: ARN = "arn:aws:iam::aws:policy/AWSStepFunctionsConsoleFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSStepFunctionsFullAccess instead. */
+    /** Use ManagedPolicy.AWSStepFunctionsFullAccess instead. */
     export const AWSStepFunctionsFullAccess: ARN = "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSStepFunctionsReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSStepFunctionsReadOnlyAccess instead. */
     export const AWSStepFunctionsReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSStepFunctionsReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSStorageGatewayFullAccess instead. */
+    /** Use ManagedPolicy.AWSStorageGatewayFullAccess instead. */
     export const AWSStorageGatewayFullAccess: ARN = "arn:aws:iam::aws:policy/AWSStorageGatewayFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSStorageGatewayReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSStorageGatewayReadOnlyAccess instead. */
     export const AWSStorageGatewayReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSStorageGatewayReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSSupportAccess instead. */
+    /** Use ManagedPolicy.AWSSupportAccess instead. */
     export const AWSSupportAccess: ARN = "arn:aws:iam::aws:policy/AWSSupportAccess";
-    /** @deprecated Use ManagedPolicy.AWSWAFFullAccess instead. */
+    /** Use ManagedPolicy.AWSWAFFullAccess instead. */
     export const AWSWAFFullAccess: ARN = "arn:aws:iam::aws:policy/AWSWAFFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSWAFReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSWAFReadOnlyAccess instead. */
     export const AWSWAFReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSWAFReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSXrayFullAccess instead. */
+    /** Use ManagedPolicy.AWSXrayFullAccess instead. */
     export const AWSXrayFullAccess: ARN = "arn:aws:iam::aws:policy/AWSXrayFullAccess";
-    /** @deprecated Use ManagedPolicy.AWSXrayReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSXrayReadOnlyAccess instead. */
     export const AWSXrayReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSXrayWriteOnlyAccess instead. */
+    /** Use ManagedPolicy.AWSXrayWriteOnlyAccess instead. */
     export const AWSXrayWriteOnlyAccess: ARN = "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AWSXRayDaemonWriteAccess instead. */
+    /** Use ManagedPolicy.AWSXRayDaemonWriteAccess instead. */
     export const AWSXRayDaemonWriteAccess: ARN = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess";
-    /** @deprecated Use ManagedPolicy.AdministratorAccess instead. */
+    /** Use ManagedPolicy.AdministratorAccess instead. */
     export const AdministratorAccess: ARN = "arn:aws:iam::aws:policy/AdministratorAccess";
-    /** @deprecated Use ManagedPolicy.AmazonAPIGatewayAdministrator instead. */
+    /** Use ManagedPolicy.AmazonAPIGatewayAdministrator instead. */
     export const AmazonAPIGatewayAdministrator: ARN = "arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator";
-    /** @deprecated Use ManagedPolicy.AmazonAPIGatewayInvokeFullAccess instead. */
+    /** Use ManagedPolicy.AmazonAPIGatewayInvokeFullAccess instead. */
     export const AmazonAPIGatewayInvokeFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonAPIGatewayPushToCloudWatchLogs instead. */
+    /** Use ManagedPolicy.AmazonAPIGatewayPushToCloudWatchLogs instead. */
     export const AmazonAPIGatewayPushToCloudWatchLogs: ARN = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs";
-    /** @deprecated Use ManagedPolicy.AmazonAppStreamFullAccess instead. */
+    /** Use ManagedPolicy.AmazonAppStreamFullAccess instead. */
     export const AmazonAppStreamFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonAppStreamFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonAppStreamReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonAppStreamReadOnlyAccess instead. */
     export const AmazonAppStreamReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonAppStreamReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonAppStreamServiceAccess instead. */
+    /** Use ManagedPolicy.AmazonAppStreamServiceAccess instead. */
     export const AmazonAppStreamServiceAccess: ARN = "arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess";
-    /** @deprecated Use ManagedPolicy.AmazonAthenaFullAccess instead. */
+    /** Use ManagedPolicy.AmazonAthenaFullAccess instead. */
     export const AmazonAthenaFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonCloudDirectoryFullAccess instead. */
+    /** Use ManagedPolicy.AmazonCloudDirectoryFullAccess instead. */
     export const AmazonCloudDirectoryFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonCloudDirectoryFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonCloudDirectoryReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonCloudDirectoryReadOnlyAccess instead. */
     export const AmazonCloudDirectoryReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonCloudDirectoryReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonCognitoDeveloperAuthenticatedIdentities instead. */
+    /** Use ManagedPolicy.AmazonCognitoDeveloperAuthenticatedIdentities instead. */
     export const AmazonCognitoDeveloperAuthenticatedIdentities: ARN = "arn:aws:iam::aws:policy/AmazonCognitoDeveloperAuthenticatedIdentities";
-    /** @deprecated Use ManagedPolicy.AmazonCognitoPowerUser instead. */
+    /** Use ManagedPolicy.AmazonCognitoPowerUser instead. */
     export const AmazonCognitoPowerUser: ARN = "arn:aws:iam::aws:policy/AmazonCognitoPowerUser";
-    /** @deprecated Use ManagedPolicy.AmazonCognitoReadOnly instead. */
+    /** Use ManagedPolicy.AmazonCognitoReadOnly instead. */
     export const AmazonCognitoReadOnly: ARN = "arn:aws:iam::aws:policy/AmazonCognitoReadOnly";
-    /** @deprecated Use ManagedPolicy.AmazonDMSCloudWatchLogsRole instead. */
+    /** Use ManagedPolicy.AmazonDMSCloudWatchLogsRole instead. */
     export const AmazonDMSCloudWatchLogsRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole";
-    /** @deprecated Use ManagedPolicy.AmazonDMSRedshiftS3Role instead. */
+    /** Use ManagedPolicy.AmazonDMSRedshiftS3Role instead. */
     export const AmazonDMSRedshiftS3Role: ARN = "arn:aws:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role";
-    /** @deprecated Use ManagedPolicy.AmazonDMSVPCManagementRole instead. */
+    /** Use ManagedPolicy.AmazonDMSVPCManagementRole instead. */
     export const AmazonDMSVPCManagementRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole";
-    /** @deprecated Use ManagedPolicy.AmazonDRSVPCManagement instead. */
+    /** Use ManagedPolicy.AmazonDRSVPCManagement instead. */
     export const AmazonDRSVPCManagement: ARN = "arn:aws:iam::aws:policy/AmazonDRSVPCManagement";
-    /** @deprecated Use ManagedPolicy.AmazonDynamoDBFullAccess instead. */
+    /** Use ManagedPolicy.AmazonDynamoDBFullAccess instead. */
     export const AmazonDynamoDBFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonDynamoDBFullAccesswithDataPipeline instead. */
+    /** Use ManagedPolicy.AmazonDynamoDBFullAccesswithDataPipeline instead. */
     export const AmazonDynamoDBFullAccesswithDataPipeline: ARN = "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccesswithDataPipeline";
-    /** @deprecated Use ManagedPolicy.AmazonDynamoDBReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonDynamoDBReadOnlyAccess instead. */
     export const AmazonDynamoDBReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerRegistryFullAccess instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerRegistryFullAccess instead. */
     export const AmazonEC2ContainerRegistryFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerRegistryPowerUser instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerRegistryPowerUser instead. */
     export const AmazonEC2ContainerRegistryPowerUser: ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerRegistryReadOnly instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerRegistryReadOnly instead. */
     export const AmazonEC2ContainerRegistryReadOnly: ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerServiceAutoscaleRole instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerServiceAutoscaleRole instead. */
     export const AmazonEC2ContainerServiceAutoscaleRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerServiceFullAccess instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerServiceFullAccess instead. */
     export const AmazonEC2ContainerServiceFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerServiceRole instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerServiceRole instead. */
     export const AmazonEC2ContainerServiceRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ContainerServiceforEC2Role instead. */
+    /** Use ManagedPolicy.AmazonEC2ContainerServiceforEC2Role instead. */
     export const AmazonEC2ContainerServiceforEC2Role: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role";
-    /** @deprecated Use ManagedPolicy.AmazonEC2FullAccess instead. */
+    /** Use ManagedPolicy.AmazonEC2FullAccess instead. */
     export const AmazonEC2FullAccess: ARN = "arn:aws:iam::aws:policy/AmazonEC2FullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonEC2ReadOnlyAccess instead. */
     export const AmazonEC2ReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonEC2ReportsAccess instead. */
+    /** Use ManagedPolicy.AmazonEC2ReportsAccess instead. */
     export const AmazonEC2ReportsAccess: ARN = "arn:aws:iam::aws:policy/AmazonEC2ReportsAccess";
-    /** @deprecated Use ManagedPolicy.AmazonEC2RoleforAWSCodeDeploy instead. */
+    /** Use ManagedPolicy.AmazonEC2RoleforAWSCodeDeploy instead. */
     export const AmazonEC2RoleforAWSCodeDeploy: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforAWSCodeDeploy";
-    /** @deprecated Use ManagedPolicy.AmazonEC2RoleforDataPipelineRole instead. */
+    /** Use ManagedPolicy.AmazonEC2RoleforDataPipelineRole instead. */
     export const AmazonEC2RoleforDataPipelineRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforDataPipelineRole";
-    /** @deprecated Use ManagedPolicy.AmazonEC2RoleforSSM instead. */
+    /** Use ManagedPolicy.AmazonEC2RoleforSSM instead. */
     export const AmazonEC2RoleforSSM: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM";
-    /** @deprecated Use ManagedPolicy.AmazonEC2SpotFleetAutoscaleRole instead. */
+    /** Use ManagedPolicy.AmazonEC2SpotFleetAutoscaleRole instead. */
     export const AmazonEC2SpotFleetAutoscaleRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole";
-    /** @deprecated Use ManagedPolicy.AmazonEC2SpotFleetRole instead. */
+    /** Use ManagedPolicy.AmazonEC2SpotFleetRole instead. */
     export const AmazonEC2SpotFleetRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole";
-    /** @deprecated Use ManagedPolicy.AmazonEC2SpotFleetTaggingRole instead. */
+    /** Use ManagedPolicy.AmazonEC2SpotFleetTaggingRole instead. */
     export const AmazonEC2SpotFleetTaggingRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole";
-    /** @deprecated Use ManagedPolicy.AmazonESFullAccess instead. */
+    /** Use ManagedPolicy.AmazonESFullAccess instead. */
     export const AmazonESFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonESFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonESReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonESReadOnlyAccess instead. */
     export const AmazonESReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonESReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElastiCacheFullAccess instead. */
+    /** Use ManagedPolicy.AmazonElastiCacheFullAccess instead. */
     export const AmazonElastiCacheFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElastiCacheReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonElastiCacheReadOnlyAccess instead. */
     export const AmazonElastiCacheReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticFileSystemFullAccess instead. */
+    /** Use ManagedPolicy.AmazonElasticFileSystemFullAccess instead. */
     export const AmazonElasticFileSystemFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticFileSystemReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonElasticFileSystemReadOnlyAccess instead. */
     export const AmazonElasticFileSystemReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonElasticFileSystemReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticMapReduceFullAccess instead. */
+    /** Use ManagedPolicy.AmazonElasticMapReduceFullAccess instead. */
     export const AmazonElasticMapReduceFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonElasticMapReduceFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticMapReduceReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonElasticMapReduceReadOnlyAccess instead. */
     export const AmazonElasticMapReduceReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonElasticMapReduceReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticMapReduceRole instead. */
+    /** Use ManagedPolicy.AmazonElasticMapReduceRole instead. */
     export const AmazonElasticMapReduceRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole";
-    /** @deprecated Use ManagedPolicy.AmazonElasticMapReduceforAutoScalingRole instead. */
+    /** Use ManagedPolicy.AmazonElasticMapReduceforAutoScalingRole instead. */
     export const AmazonElasticMapReduceforAutoScalingRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole";
-    /** @deprecated Use ManagedPolicy.AmazonElasticMapReduceforEC2Role instead. */
+    /** Use ManagedPolicy.AmazonElasticMapReduceforEC2Role instead. */
     export const AmazonElasticMapReduceforEC2Role: ARN = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role";
-    /** @deprecated Use ManagedPolicy.AmazonElasticTranscoderFullAccess instead. */
+    /** Use ManagedPolicy.AmazonElasticTranscoderFullAccess instead. */
     export const AmazonElasticTranscoderFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonElasticTranscoderFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticTranscoderJobsSubmitter instead. */
+    /** Use ManagedPolicy.AmazonElasticTranscoderJobsSubmitter instead. */
     export const AmazonElasticTranscoderJobsSubmitter: ARN = "arn:aws:iam::aws:policy/AmazonElasticTranscoderJobsSubmitter";
-    /** @deprecated Use ManagedPolicy.AmazonElasticTranscoderReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonElasticTranscoderReadOnlyAccess instead. */
     export const AmazonElasticTranscoderReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonElasticTranscoderReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonElasticTranscoderRole instead. */
+    /** Use ManagedPolicy.AmazonElasticTranscoderRole instead. */
     export const AmazonElasticTranscoderRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonElasticTranscoderRole";
-    /** @deprecated Use ManagedPolicy.AmazonGlacierFullAccess instead. */
+    /** Use ManagedPolicy.AmazonGlacierFullAccess instead. */
     export const AmazonGlacierFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonGlacierFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonGlacierReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonGlacierReadOnlyAccess instead. */
     export const AmazonGlacierReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonGlacierReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonInspectorFullAccess instead. */
+    /** Use ManagedPolicy.AmazonInspectorFullAccess instead. */
     export const AmazonInspectorFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonInspectorFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonInspectorReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonInspectorReadOnlyAccess instead. */
     export const AmazonInspectorReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonInspectorReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonKinesisAnalyticsFullAccess instead. */
+    /** Use ManagedPolicy.AmazonKinesisAnalyticsFullAccess instead. */
     export const AmazonKinesisAnalyticsFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonKinesisAnalyticsFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonKinesisAnalyticsReadOnly instead. */
+    /** Use ManagedPolicy.AmazonKinesisAnalyticsReadOnly instead. */
     export const AmazonKinesisAnalyticsReadOnly: ARN = "arn:aws:iam::aws:policy/AmazonKinesisAnalyticsReadOnly";
-    /** @deprecated Use ManagedPolicy.AmazonKinesisFirehoseFullAccess instead. */
+    /** Use ManagedPolicy.AmazonKinesisFirehoseFullAccess instead. */
     export const AmazonKinesisFirehoseFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonKinesisFirehoseReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonKinesisFirehoseReadOnlyAccess instead. */
     export const AmazonKinesisFirehoseReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonKinesisFullAccess instead. */
+    /** Use ManagedPolicy.AmazonKinesisFullAccess instead. */
     export const AmazonKinesisFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonKinesisFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonKinesisReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonKinesisReadOnlyAccess instead. */
     export const AmazonKinesisReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonLexFullAccess instead. */
+    /** Use ManagedPolicy.AmazonLexFullAccess instead. */
     export const AmazonLexFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonLexFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonLexReadOnly instead. */
+    /** Use ManagedPolicy.AmazonLexReadOnly instead. */
     export const AmazonLexReadOnly: ARN = "arn:aws:iam::aws:policy/AmazonLexReadOnly";
-    /** @deprecated Use ManagedPolicy.AmazonLexRunBotsOnly instead. */
+    /** Use ManagedPolicy.AmazonLexRunBotsOnly instead. */
     export const AmazonLexRunBotsOnly: ARN = "arn:aws:iam::aws:policy/AmazonLexRunBotsOnly";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningBatchPredictionsAccess instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningBatchPredictionsAccess instead. */
     export const AmazonMachineLearningBatchPredictionsAccess: ARN = "arn:aws:iam::aws:policy/AmazonMachineLearningBatchPredictionsAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningCreateOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningCreateOnlyAccess instead. */
     export const AmazonMachineLearningCreateOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonMachineLearningCreateOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningFullAccess instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningFullAccess instead. */
     export const AmazonMachineLearningFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonMachineLearningFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningManageRealTimeEndpointOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningManageRealTimeEndpointOnlyAccess instead. */
     export const AmazonMachineLearningManageRealTimeEndpointOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonMachineLearningManageRealTimeEndpointOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningReadOnlyAccess instead. */
     export const AmazonMachineLearningReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonMachineLearningReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningRealTimePredictionOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningRealTimePredictionOnlyAccess instead. */
     export const AmazonMachineLearningRealTimePredictionOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonMachineLearningRealTimePredictionOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMachineLearningRoleforRedshiftDataSource instead. */
+    /** Use ManagedPolicy.AmazonMachineLearningRoleforRedshiftDataSource instead. */
     export const AmazonMachineLearningRoleforRedshiftDataSource: ARN = "arn:aws:iam::aws:policy/service-role/AmazonMachineLearningRoleforRedshiftDataSource";
-    /** @deprecated Use ManagedPolicy.AmazonMechanicalTurkFullAccess instead. */
+    /** Use ManagedPolicy.AmazonMechanicalTurkFullAccess instead. */
     export const AmazonMechanicalTurkFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonMechanicalTurkFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMechanicalTurkReadOnly instead. */
+    /** Use ManagedPolicy.AmazonMechanicalTurkReadOnly instead. */
     export const AmazonMechanicalTurkReadOnly: ARN = "arn:aws:iam::aws:policy/AmazonMechanicalTurkReadOnly";
-    /** @deprecated Use ManagedPolicy.AmazonMobileAnalyticsFinancialReportAccess instead. */
+    /** Use ManagedPolicy.AmazonMobileAnalyticsFinancialReportAccess instead. */
     export const AmazonMobileAnalyticsFinancialReportAccess: ARN = "arn:aws:iam::aws:policy/AmazonMobileAnalyticsFinancialReportAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMobileAnalyticsFullAccess instead. */
+    /** Use ManagedPolicy.AmazonMobileAnalyticsFullAccess instead. */
     export const AmazonMobileAnalyticsFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonMobileAnalyticsFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMobileAnalyticsNonfinancialReportAccess instead. */
+    /** Use ManagedPolicy.AmazonMobileAnalyticsNonfinancialReportAccess instead. */
     export const AmazonMobileAnalyticsNonfinancialReportAccess: ARN = "arn:aws:iam::aws:policy/AmazonMobileAnalyticsNon-financialReportAccess";
-    /** @deprecated Use ManagedPolicy.AmazonMobileAnalyticsWriteOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonMobileAnalyticsWriteOnlyAccess instead. */
     export const AmazonMobileAnalyticsWriteOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonMobileAnalyticsWriteOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonPollyFullAccess instead. */
+    /** Use ManagedPolicy.AmazonPollyFullAccess instead. */
     export const AmazonPollyFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonPollyFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonPollyReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonPollyReadOnlyAccess instead. */
     export const AmazonPollyReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonPollyReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRDSDirectoryServiceAccess instead. */
+    /** Use ManagedPolicy.AmazonRDSDirectoryServiceAccess instead. */
     export const AmazonRDSDirectoryServiceAccess: ARN = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRDSEnhancedMonitoringRole instead. */
+    /** Use ManagedPolicy.AmazonRDSEnhancedMonitoringRole instead. */
     export const AmazonRDSEnhancedMonitoringRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole";
-    /** @deprecated Use ManagedPolicy.AmazonRDSDataFullAccess instead. */
+    /** Use ManagedPolicy.AmazonRDSDataFullAccess instead. */
     export const AmazonRDSDataFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonRDSDataFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRDSFullAccess instead. */
+    /** Use ManagedPolicy.AmazonRDSFullAccess instead. */
     export const AmazonRDSFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonRDSFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRDSReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonRDSReadOnlyAccess instead. */
     export const AmazonRDSReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRedshiftFullAccess instead. */
+    /** Use ManagedPolicy.AmazonRedshiftFullAccess instead. */
     export const AmazonRedshiftFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonRedshiftFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRedshiftReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonRedshiftReadOnlyAccess instead. */
     export const AmazonRedshiftReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonRedshiftReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRekognitionFullAccess instead. */
+    /** Use ManagedPolicy.AmazonRekognitionFullAccess instead. */
     export const AmazonRekognitionFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonRekognitionFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRekognitionReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonRekognitionReadOnlyAccess instead. */
     export const AmazonRekognitionReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonRekognitionReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRoute53DomainsFullAccess instead. */
+    /** Use ManagedPolicy.AmazonRoute53DomainsFullAccess instead. */
     export const AmazonRoute53DomainsFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonRoute53DomainsFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRoute53DomainsReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonRoute53DomainsReadOnlyAccess instead. */
     export const AmazonRoute53DomainsReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonRoute53DomainsReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRoute53FullAccess instead. */
+    /** Use ManagedPolicy.AmazonRoute53FullAccess instead. */
     export const AmazonRoute53FullAccess: ARN = "arn:aws:iam::aws:policy/AmazonRoute53FullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonRoute53ReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonRoute53ReadOnlyAccess instead. */
     export const AmazonRoute53ReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonS3FullAccess instead. */
+    /** Use ManagedPolicy.AmazonS3FullAccess instead. */
     export const AmazonS3FullAccess: ARN = "arn:aws:iam::aws:policy/AmazonS3FullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonS3ReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonS3ReadOnlyAccess instead. */
     export const AmazonS3ReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSESFullAccess instead. */
+    /** Use ManagedPolicy.AmazonSESFullAccess instead. */
     export const AmazonSESFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonSESFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSESReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonSESReadOnlyAccess instead. */
     export const AmazonSESReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonSESReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSNSFullAccess instead. */
+    /** Use ManagedPolicy.AmazonSNSFullAccess instead. */
     export const AmazonSNSFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonSNSFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSNSReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonSNSReadOnlyAccess instead. */
     export const AmazonSNSReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonSNSReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSNSRole instead. */
+    /** Use ManagedPolicy.AmazonSNSRole instead. */
     export const AmazonSNSRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonSNSRole";
-    /** @deprecated Use ManagedPolicy.AmazonSQSFullAccess instead. */
+    /** Use ManagedPolicy.AmazonSQSFullAccess instead. */
     export const AmazonSQSFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonSQSFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSQSReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonSQSReadOnlyAccess instead. */
     export const AmazonSQSReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonSQSReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSSMAutomationRole instead. */
+    /** Use ManagedPolicy.AmazonSSMAutomationRole instead. */
     export const AmazonSSMAutomationRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole";
-    /** @deprecated Use ManagedPolicy.AmazonSSMFullAccess instead. */
+    /** Use ManagedPolicy.AmazonSSMFullAccess instead. */
     export const AmazonSSMFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonSSMFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSSMMaintenanceWindowRole instead. */
+    /** Use ManagedPolicy.AmazonSSMMaintenanceWindowRole instead. */
     export const AmazonSSMMaintenanceWindowRole: ARN = "arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole";
-    /** @deprecated Use ManagedPolicy.AmazonSSMReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonSSMReadOnlyAccess instead. */
     export const AmazonSSMReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonSSMManagedInstanceCore instead. */
+    /** Use ManagedPolicy.AmazonSSMManagedInstanceCore instead. */
     export const AmazonSSMManagedInstanceCore: ARN = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore";
-    /** @deprecated Use ManagedPolicy.AmazonVPCFullAccess instead. */
+    /** Use ManagedPolicy.AmazonVPCFullAccess instead. */
     export const AmazonVPCFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonVPCFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonVPCReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonVPCReadOnlyAccess instead. */
     export const AmazonVPCReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonWorkMailFullAccess instead. */
+    /** Use ManagedPolicy.AmazonWorkMailFullAccess instead. */
     export const AmazonWorkMailFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonWorkMailFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonWorkMailReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonWorkMailReadOnlyAccess instead. */
     export const AmazonWorkMailReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonWorkMailReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AmazonWorkSpacesAdmin instead. */
+    /** Use ManagedPolicy.AmazonWorkSpacesAdmin instead. */
     export const AmazonWorkSpacesAdmin: ARN = "arn:aws:iam::aws:policy/AmazonWorkSpacesAdmin";
-    /** @deprecated Use ManagedPolicy.AmazonWorkSpacesApplicationManagerAdminAccess instead. */
+    /** Use ManagedPolicy.AmazonWorkSpacesApplicationManagerAdminAccess instead. */
     export const AmazonWorkSpacesApplicationManagerAdminAccess: ARN = "arn:aws:iam::aws:policy/AmazonWorkSpacesApplicationManagerAdminAccess";
-    /** @deprecated Use ManagedPolicy.AmazonZocaloFullAccess instead. */
+    /** Use ManagedPolicy.AmazonZocaloFullAccess instead. */
     export const AmazonZocaloFullAccess: ARN = "arn:aws:iam::aws:policy/AmazonZocaloFullAccess";
-    /** @deprecated Use ManagedPolicy.AmazonZocaloReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AmazonZocaloReadOnlyAccess instead. */
     export const AmazonZocaloReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AmazonZocaloReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.ApplicationAutoScalingForAmazonAppStreamAccess instead. */
+    /** Use ManagedPolicy.ApplicationAutoScalingForAmazonAppStreamAccess instead. */
     export const ApplicationAutoScalingForAmazonAppStreamAccess: ARN = "arn:aws:iam::aws:policy/service-role/ApplicationAutoScalingForAmazonAppStreamAccess";
-    /** @deprecated Use ManagedPolicy.AutoScalingConsoleFullAccess instead. */
+    /** Use ManagedPolicy.AutoScalingConsoleFullAccess instead. */
     export const AutoScalingConsoleFullAccess: ARN = "arn:aws:iam::aws:policy/AutoScalingConsoleFullAccess";
-    /** @deprecated Use ManagedPolicy.AutoScalingConsoleReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AutoScalingConsoleReadOnlyAccess instead. */
     export const AutoScalingConsoleReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AutoScalingConsoleReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.AutoScalingFullAccess instead. */
+    /** Use ManagedPolicy.AutoScalingFullAccess instead. */
     export const AutoScalingFullAccess: ARN = "arn:aws:iam::aws:policy/AutoScalingFullAccess";
-    /** @deprecated Use ManagedPolicy.AutoScalingNotificationAccessRole instead. */
+    /** Use ManagedPolicy.AutoScalingNotificationAccessRole instead. */
     export const AutoScalingNotificationAccessRole: ARN = "arn:aws:iam::aws:policy/service-role/AutoScalingNotificationAccessRole";
-    /** @deprecated Use ManagedPolicy.AutoScalingReadOnlyAccess instead. */
+    /** Use ManagedPolicy.AutoScalingReadOnlyAccess instead. */
     export const AutoScalingReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/AutoScalingReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy. Billing instead. */
+    /** Use ManagedPolicy. Billing instead. */
     export const Billing: ARN = "arn:aws:iam::aws:policy/job-function/Billing";
-    /** @deprecated Use ManagedPolicy.CloudFrontFullAccess instead. */
+    /** Use ManagedPolicy.CloudFrontFullAccess instead. */
     export const CloudFrontFullAccess: ARN = "arn:aws:iam::aws:policy/CloudFrontFullAccess";
-    /** @deprecated Use ManagedPolicy.CloudFrontReadOnlyAccess instead. */
+    /** Use ManagedPolicy.CloudFrontReadOnlyAccess instead. */
     export const CloudFrontReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.CloudSearchFullAccess instead. */
+    /** Use ManagedPolicy.CloudSearchFullAccess instead. */
     export const CloudSearchFullAccess: ARN = "arn:aws:iam::aws:policy/CloudSearchFullAccess";
-    /** @deprecated Use ManagedPolicy.CloudSearchReadOnlyAccess instead. */
+    /** Use ManagedPolicy.CloudSearchReadOnlyAccess instead. */
     export const CloudSearchReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/CloudSearchReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchActionsEC2Access instead. */
+    /** Use ManagedPolicy.CloudWatchActionsEC2Access instead. */
     export const CloudWatchActionsEC2Access: ARN = "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access";
-    /** @deprecated Use ManagedPolicy.CloudWatchEventsBuiltInTargetExecutionAccess instead. */
+    /** Use ManagedPolicy.CloudWatchEventsBuiltInTargetExecutionAccess instead. */
     export const CloudWatchEventsBuiltInTargetExecutionAccess: ARN = "arn:aws:iam::aws:policy/service-role/CloudWatchEventsBuiltInTargetExecutionAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchEventsFullAccess instead. */
+    /** Use ManagedPolicy.CloudWatchEventsFullAccess instead. */
     export const CloudWatchEventsFullAccess: ARN = "arn:aws:iam::aws:policy/CloudWatchEventsFullAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchEventsInvocationAccess instead. */
+    /** Use ManagedPolicy.CloudWatchEventsInvocationAccess instead. */
     export const CloudWatchEventsInvocationAccess: ARN = "arn:aws:iam::aws:policy/service-role/CloudWatchEventsInvocationAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchEventsReadOnlyAccess instead. */
+    /** Use ManagedPolicy.CloudWatchEventsReadOnlyAccess instead. */
     export const CloudWatchEventsReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/CloudWatchEventsReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchFullAccess instead. */
+    /** Use ManagedPolicy.CloudWatchFullAccess instead. */
     export const CloudWatchFullAccess: ARN = "arn:aws:iam::aws:policy/CloudWatchFullAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchLogsFullAccess instead. */
+    /** Use ManagedPolicy.CloudWatchLogsFullAccess instead. */
     export const CloudWatchLogsFullAccess: ARN = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchLogsReadOnlyAccess instead. */
+    /** Use ManagedPolicy.CloudWatchLogsReadOnlyAccess instead. */
     export const CloudWatchLogsReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.CloudWatchReadOnlyAccess instead. */
+    /** Use ManagedPolicy.CloudWatchReadOnlyAccess instead. */
     export const CloudWatchReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.DataScientist instead. */
+    /** Use ManagedPolicy.DataScientist instead. */
     export const DataScientist: ARN = "arn:aws:iam::aws:policy/job-function/DataScientist";
-    /** @deprecated Use ManagedPolicy.DatabaseAdministrator instead. */
+    /** Use ManagedPolicy.DatabaseAdministrator instead. */
     export const DatabaseAdministrator: ARN = "arn:aws:iam::aws:policy/job-function/DatabaseAdministrator";
-    /** @deprecated Use ManagedPolicy.IAMFullAccess instead. */
+    /** Use ManagedPolicy.IAMFullAccess instead. */
     export const IAMFullAccess: ARN = "arn:aws:iam::aws:policy/IAMFullAccess";
-    /** @deprecated Use ManagedPolicy.IAMReadOnlyAccess instead. */
+    /** Use ManagedPolicy.IAMReadOnlyAccess instead. */
     export const IAMReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/IAMReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.IAMSelfManageServiceSpecificCredentials instead. */
+    /** Use ManagedPolicy.IAMSelfManageServiceSpecificCredentials instead. */
     export const IAMSelfManageServiceSpecificCredentials: ARN = "arn:aws:iam::aws:policy/IAMSelfManageServiceSpecificCredentials";
-    /** @deprecated Use ManagedPolicy.IAMUserChangePassword instead. */
+    /** Use ManagedPolicy.IAMUserChangePassword instead. */
     export const IAMUserChangePassword: ARN = "arn:aws:iam::aws:policy/IAMUserChangePassword";
-    /** @deprecated Use ManagedPolicy.IAMUserSSHKeys instead. */
+    /** Use ManagedPolicy.IAMUserSSHKeys instead. */
     export const IAMUserSSHKeys: ARN = "arn:aws:iam::aws:policy/IAMUserSSHKeys";
-    /** @deprecated Use ManagedPolicy.NetworkAdministrator instead. */
+    /** Use ManagedPolicy.NetworkAdministrator instead. */
     export const NetworkAdministrator: ARN = "arn:aws:iam::aws:policy/job-function/NetworkAdministrator";
-    /** @deprecated Use ManagedPolicy.PowerUserAccess instead. */
+    /** Use ManagedPolicy.PowerUserAccess instead. */
     export const PowerUserAccess: ARN = "arn:aws:iam::aws:policy/PowerUserAccess";
-    /** @deprecated Use ManagedPolicy.RDSCloudHsmAuthorizationRole instead. */
+    /** Use ManagedPolicy.RDSCloudHsmAuthorizationRole instead. */
     export const RDSCloudHsmAuthorizationRole: ARN = "arn:aws:iam::aws:policy/service-role/RDSCloudHsmAuthorizationRole";
-    /** @deprecated Use ManagedPolicy.ReadOnlyAccess instead. */
+    /** Use ManagedPolicy.ReadOnlyAccess instead. */
     export const ReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/ReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.ResourceGroupsandTagEditorFullAccess instead. */
+    /** Use ManagedPolicy.ResourceGroupsandTagEditorFullAccess instead. */
     export const ResourceGroupsandTagEditorFullAccess: ARN = "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorFullAccess";
-    /** @deprecated Use ManagedPolicy.ResourceGroupsandTagEditorReadOnlyAccess instead. */
+    /** Use ManagedPolicy.ResourceGroupsandTagEditorReadOnlyAccess instead. */
     export const ResourceGroupsandTagEditorReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.SecurityAudit instead. */
+    /** Use ManagedPolicy.SecurityAudit instead. */
     export const SecurityAudit: ARN = "arn:aws:iam::aws:policy/SecurityAudit";
-    /** @deprecated Use ManagedPolicy.ServerMigrationConnector instead. */
+    /** Use ManagedPolicy.ServerMigrationConnector instead. */
     export const ServerMigrationConnector: ARN = "arn:aws:iam::aws:policy/ServerMigrationConnector";
-    /** @deprecated Use ManagedPolicy.ServerMigrationServiceRole instead. */
+    /** Use ManagedPolicy.ServerMigrationServiceRole instead. */
     export const ServerMigrationServiceRole: ARN = "arn:aws:iam::aws:policy/service-role/ServerMigrationServiceRole";
-    /** @deprecated Use ManagedPolicy.ServiceCatalogAdminFullAccess instead. */
+    /** Use ManagedPolicy.ServiceCatalogAdminFullAccess instead. */
     export const ServiceCatalogAdminFullAccess: ARN = "arn:aws:iam::aws:policy/ServiceCatalogAdminFullAccess";
-    /** @deprecated Use ManagedPolicy.ServiceCatalogAdminReadOnlyAccess instead. */
+    /** Use ManagedPolicy.ServiceCatalogAdminReadOnlyAccess instead. */
     export const ServiceCatalogAdminReadOnlyAccess: ARN = "arn:aws:iam::aws:policy/ServiceCatalogAdminReadOnlyAccess";
-    /** @deprecated Use ManagedPolicy.ServiceCatalogEndUserAccess instead. */
+    /** Use ManagedPolicy.ServiceCatalogEndUserAccess instead. */
     export const ServiceCatalogEndUserAccess: ARN = "arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess";
-    /** @deprecated Use ManagedPolicy.ServiceCatalogEndUserFullAccess instead. */
+    /** Use ManagedPolicy.ServiceCatalogEndUserFullAccess instead. */
     export const ServiceCatalogEndUserFullAccess: ARN = "arn:aws:iam::aws:policy/ServiceCatalogEndUserFullAccess";
-    /** @deprecated Use ManagedPolicy.SimpleWorkflowFullAccess instead. */
+    /** Use ManagedPolicy.SimpleWorkflowFullAccess instead. */
     export const SimpleWorkflowFullAccess: ARN = "arn:aws:iam::aws:policy/SimpleWorkflowFullAccess";
-    /** @deprecated Use ManagedPolicy. SupportUser instead. */
+    /** Use ManagedPolicy. SupportUser instead. */
     export const SupportUser: ARN = "arn:aws:iam::aws:policy/job-function/SupportUser";
-    /** @deprecated Use ManagedPolicy.SystemAdministrator instead. */
+    /** Use ManagedPolicy.SystemAdministrator instead. */
     export const SystemAdministrator: ARN = "arn:aws:iam::aws:policy/job-function/SystemAdministrator";
-    /** @deprecated Use ManagedPolicy.VMImportExportRoleForAWSConnector instead. */
+    /** Use ManagedPolicy.VMImportExportRoleForAWSConnector instead. */
     export const VMImportExportRoleForAWSConnector: ARN = "arn:aws:iam::aws:policy/service-role/VMImportExportRoleForAWSConnector";
-    /** @deprecated Use ManagedPolicy.ViewOnlyAccess instead. */
+    /** Use ManagedPolicy.ViewOnlyAccess instead. */
     export const ViewOnlyAccess: ARN = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess";
 }


### PR DESCRIPTION
I removed the explicit deprecation messages from the other enums but had missed ManagedPolicies. Removing the deprecation messages since the old constants are still valid.

Related to: https://github.com/pulumi/pulumi-aws/pull/1166