### PR TITLE
Setting Provider defaults to remove slow calls to AWS STS and Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Update Provider defaults:
+  * `skipCredentialsValidation` now defaults to `true`.
+  * `skipGetEc2Platforms` now defaults to `true`.
+  * `skipMetadataApiCheck` now defaults to `true`.
+  * `skipRegionValidation` now defaults to `true`.
 
 ---
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -281,6 +281,26 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"AWS_PROFILE"},
 				},
 			},
+			"skip_get_ec2_platforms": {
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
+			"skip_region_validation": {
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
+			"skip_credentials_validation": {
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
+			"skip_metadata_api_check": {
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
 		},
 		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -67,20 +67,20 @@ namespace Pulumi.Aws
         /// Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
         /// available/implemented.
         /// </summary>
-        public static bool? SkipCredentialsValidation { get; set; } = __config.GetBoolean("skipCredentialsValidation");
+        public static bool? SkipCredentialsValidation { get; set; } = __config.GetBoolean("skipCredentialsValidation") ?? true;
 
         /// <summary>
         /// Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
         /// </summary>
-        public static bool? SkipGetEc2Platforms { get; set; } = __config.GetBoolean("skipGetEc2Platforms");
+        public static bool? SkipGetEc2Platforms { get; set; } = __config.GetBoolean("skipGetEc2Platforms") ?? true;
 
-        public static bool? SkipMetadataApiCheck { get; set; } = __config.GetBoolean("skipMetadataApiCheck");
+        public static bool? SkipMetadataApiCheck { get; set; } = __config.GetBoolean("skipMetadataApiCheck") ?? true;
 
         /// <summary>
         /// Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
         /// not public (yet).
         /// </summary>
-        public static bool? SkipRegionValidation { get; set; } = __config.GetBoolean("skipRegionValidation");
+        public static bool? SkipRegionValidation { get; set; } = __config.GetBoolean("skipRegionValidation") ?? true;
 
         /// <summary>
         /// Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -167,6 +167,10 @@ namespace Pulumi.Aws
         {
             Profile = Utilities.GetEnv("AWS_PROFILE");
             Region = Utilities.GetEnv("AWS_REGION", "AWS_DEFAULT_REGION");
+            SkipCredentialsValidation = true;
+            SkipGetEc2Platforms = true;
+            SkipMetadataApiCheck = true;
+            SkipRegionValidation = true;
         }
     }
 }

--- a/sdk/go/aws/config/config.go
+++ b/sdk/go/aws/config/config.go
@@ -78,21 +78,37 @@ func GetSharedCredentialsFile(ctx *pulumi.Context) string {
 // Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
 // available/implemented.
 func GetSkipCredentialsValidation(ctx *pulumi.Context) bool {
-	return config.GetBool(ctx, "aws:skipCredentialsValidation")
+	v, err := config.TryBool(ctx, "aws:skipCredentialsValidation")
+	if err == nil {
+		return v
+	}
+	return true
 }
 
 // Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
 func GetSkipGetEc2Platforms(ctx *pulumi.Context) bool {
-	return config.GetBool(ctx, "aws:skipGetEc2Platforms")
+	v, err := config.TryBool(ctx, "aws:skipGetEc2Platforms")
+	if err == nil {
+		return v
+	}
+	return true
 }
 func GetSkipMetadataApiCheck(ctx *pulumi.Context) bool {
-	return config.GetBool(ctx, "aws:skipMetadataApiCheck")
+	v, err := config.TryBool(ctx, "aws:skipMetadataApiCheck")
+	if err == nil {
+		return v
+	}
+	return true
 }
 
 // Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
 // not public (yet).
 func GetSkipRegionValidation(ctx *pulumi.Context) bool {
-	return config.GetBool(ctx, "aws:skipRegionValidation")
+	v, err := config.TryBool(ctx, "aws:skipRegionValidation")
+	if err == nil {
+		return v
+	}
+	return true
 }
 
 // Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.

--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -31,6 +31,18 @@ func NewProvider(ctx *pulumi.Context,
 	if args.Region == nil {
 		args.Region = pulumi.StringPtr(getEnvOrDefault("", nil, "AWS_REGION", "AWS_DEFAULT_REGION").(string))
 	}
+	if args.SkipCredentialsValidation == nil {
+		args.SkipCredentialsValidation = pulumi.BoolPtr(true)
+	}
+	if args.SkipGetEc2Platforms == nil {
+		args.SkipGetEc2Platforms = pulumi.BoolPtr(true)
+	}
+	if args.SkipMetadataApiCheck == nil {
+		args.SkipMetadataApiCheck = pulumi.BoolPtr(true)
+	}
+	if args.SkipRegionValidation == nil {
+		args.SkipRegionValidation = pulumi.BoolPtr(true)
+	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:aws", name, args, &resource, opts...)
 	if err != nil {

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -55,17 +55,17 @@ export let sharedCredentialsFile: string | undefined = __config.get("sharedCrede
  * Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
  * available/implemented.
  */
-export let skipCredentialsValidation: boolean | undefined = __config.getObject<boolean>("skipCredentialsValidation");
+export let skipCredentialsValidation: boolean | undefined = __config.getObject<boolean>("skipCredentialsValidation") || true;
 /**
  * Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
  */
-export let skipGetEc2Platforms: boolean | undefined = __config.getObject<boolean>("skipGetEc2Platforms");
-export let skipMetadataApiCheck: boolean | undefined = __config.getObject<boolean>("skipMetadataApiCheck");
+export let skipGetEc2Platforms: boolean | undefined = __config.getObject<boolean>("skipGetEc2Platforms") || true;
+export let skipMetadataApiCheck: boolean | undefined = __config.getObject<boolean>("skipMetadataApiCheck") || true;
 /**
  * Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
  * not public (yet).
  */
-export let skipRegionValidation: boolean | undefined = __config.getObject<boolean>("skipRegionValidation");
+export let skipRegionValidation: boolean | undefined = __config.getObject<boolean>("skipRegionValidation") || true;
 /**
  * Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
  */

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -52,10 +52,10 @@ export class Provider extends pulumi.ProviderResource {
             inputs["s3ForcePathStyle"] = pulumi.output(args ? args.s3ForcePathStyle : undefined).apply(JSON.stringify);
             inputs["secretKey"] = args ? args.secretKey : undefined;
             inputs["sharedCredentialsFile"] = args ? args.sharedCredentialsFile : undefined;
-            inputs["skipCredentialsValidation"] = pulumi.output(args ? args.skipCredentialsValidation : undefined).apply(JSON.stringify);
-            inputs["skipGetEc2Platforms"] = pulumi.output(args ? args.skipGetEc2Platforms : undefined).apply(JSON.stringify);
-            inputs["skipMetadataApiCheck"] = pulumi.output(args ? args.skipMetadataApiCheck : undefined).apply(JSON.stringify);
-            inputs["skipRegionValidation"] = pulumi.output(args ? args.skipRegionValidation : undefined).apply(JSON.stringify);
+            inputs["skipCredentialsValidation"] = pulumi.output((args ? args.skipCredentialsValidation : undefined) || true).apply(JSON.stringify);
+            inputs["skipGetEc2Platforms"] = pulumi.output((args ? args.skipGetEc2Platforms : undefined) || true).apply(JSON.stringify);
+            inputs["skipMetadataApiCheck"] = pulumi.output((args ? args.skipMetadataApiCheck : undefined) || true).apply(JSON.stringify);
+            inputs["skipRegionValidation"] = pulumi.output((args ? args.skipRegionValidation : undefined) || true).apply(JSON.stringify);
             inputs["skipRequestingAccountId"] = pulumi.output(args ? args.skipRequestingAccountId : undefined).apply(JSON.stringify);
             inputs["token"] = args ? args.token : undefined;
         }

--- a/sdk/python/pulumi_aws/config/vars.py
+++ b/sdk/python/pulumi_aws/config/vars.py
@@ -88,20 +88,20 @@ shared_credentials_file = __config__.get('sharedCredentialsFile')
 The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
 """
 
-skip_credentials_validation = __config__.get('skipCredentialsValidation')
+skip_credentials_validation = __config__.get('skipCredentialsValidation') or True
 """
 Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
 available/implemented.
 """
 
-skip_get_ec2_platforms = __config__.get('skipGetEc2Platforms')
+skip_get_ec2_platforms = __config__.get('skipGetEc2Platforms') or True
 """
 Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
 """
 
-skip_metadata_api_check = __config__.get('skipMetadataApiCheck')
+skip_metadata_api_check = __config__.get('skipMetadataApiCheck') or True
 
-skip_region_validation = __config__.get('skipRegionValidation')
+skip_region_validation = __config__.get('skipRegionValidation') or True
 """
 Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
 not public (yet).

--- a/sdk/python/pulumi_aws/provider.py
+++ b/sdk/python/pulumi_aws/provider.py
@@ -99,9 +99,17 @@ class Provider(pulumi.ProviderResource):
             __props__['s3_force_path_style'] = pulumi.Output.from_input(s3_force_path_style).apply(pulumi.runtime.to_json) if s3_force_path_style is not None else None
             __props__['secret_key'] = secret_key
             __props__['shared_credentials_file'] = shared_credentials_file
+            if skip_credentials_validation is None:
+                skip_credentials_validation = True
             __props__['skip_credentials_validation'] = pulumi.Output.from_input(skip_credentials_validation).apply(pulumi.runtime.to_json) if skip_credentials_validation is not None else None
+            if skip_get_ec2_platforms is None:
+                skip_get_ec2_platforms = True
             __props__['skip_get_ec2_platforms'] = pulumi.Output.from_input(skip_get_ec2_platforms).apply(pulumi.runtime.to_json) if skip_get_ec2_platforms is not None else None
+            if skip_metadata_api_check is None:
+                skip_metadata_api_check = True
             __props__['skip_metadata_api_check'] = pulumi.Output.from_input(skip_metadata_api_check).apply(pulumi.runtime.to_json) if skip_metadata_api_check is not None else None
+            if skip_region_validation is None:
+                skip_region_validation = True
             __props__['skip_region_validation'] = pulumi.Output.from_input(skip_region_validation).apply(pulumi.runtime.to_json) if skip_region_validation is not None else None
             __props__['skip_requesting_account_id'] = pulumi.Output.from_input(skip_requesting_account_id).apply(pulumi.runtime.to_json) if skip_requesting_account_id is not None else None
             __props__['token'] = token


### PR DESCRIPTION
Fixes: #873

* `skipCredentialsValidation` now defaults to `true`.
* `skipGetEc2Platforms` now defaults to `true`.
* `skipMetadataApiCheck` now defaults to `true`.
* `skipRegionValidation` now defaults to `true`.

It's important to note that this does not require the replacement of either default or named provider:

```
pulumi up --yes
Previewing update (dev)

View Live: https://app.pulumi.com/stack72/provider-change/dev/previews/cb4c2428-a6a2-40fe-aabc-814509e782a4

     Type                     Name                 Plan
 +   pulumi:pulumi:Stack      provider-change-dev  create
 +   ├─ pulumi:providers:aws  my-provider          create
 +   ├─ aws:s3:Bucket         stack72-bucket       create
 +   └─ aws:s3:Bucket         stack72-bucket-2     create

Resources:
    + 4 to create

Updating (dev)

View Live: https://app.pulumi.com/stack72/provider-change/dev/updates/13

     Type                     Name                 Status
 +   pulumi:pulumi:Stack      provider-change-dev  created
 +   ├─ pulumi:providers:aws  my-provider          created
 +   ├─ aws:s3:Bucket         stack72-bucket-2     created
 +   └─ aws:s3:Bucket         stack72-bucket       created

Outputs:
    bucket1Name: "stack72-bucket-3021538"
    bucket2Name: "stack72-bucket-2-e5e84ca"

Resources:
    + 4 created

Duration: 19s


~/code/provider-change
pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/stack72/provider-change/dev/previews/93b423fc-c366-4c44-a852-b2c613221470

     Type                     Name                 Plan       Info
     pulumi:pulumi:Stack      provider-change-dev
 ~   └─ pulumi:providers:aws  my-provider          update     [diff: +skipCredentialsValidation,skipGetEc2Platforms,skipMetadataApiCheck,skipRegionValidation]

Resources:
    ~ 1 to update
    3 unchanged

Do you want to perform this update? yes
Updating (dev)

View Live: https://app.pulumi.com/stack72/provider-change/dev/updates/14

     Type                     Name                 Status      Info
     pulumi:pulumi:Stack      provider-change-dev
 ~   └─ pulumi:providers:aws  my-provider          updated     [diff: +skipCredentialsValidation,skipGetEc2Platforms,skipMetadataApiCheck,skipRegionValidation]

Outputs:
    bucket1Name: "stack72-bucket-3021538"
    bucket2Name: "stack72-bucket-2-e5e84ca"

Resources:
    ~ 1 updated
    3 unchanged

Duration: 4s
```