### PR TITLE
Fix autonaming for cluster_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+* Update auto-naming rules for RDS Cluster `clusterIdentifier` to follow specifications.
 
 ---
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1778,7 +1778,9 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_rds_cluster": {
 				Tok: awsResource(rdsMod, "Cluster"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"cluster_identifier": tfbridge.AutoName("clusterIdentifier", 255, "-"),
+					"cluster_identifier": tfbridge.AutoNameTransform("clusterIdentifier", 63, func(name string) string {
+						return strings.ToLower(name)
+					}),
 					"engine": {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsType(rdsMod, "EngineType", "EngineType")},


### PR DESCRIPTION
Related to: https://github.com/pulumi/pulumi-aws/issues/1299

Auto-naming rules derived from: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.CreateInstance.html#w483aac13c11c15b5:~:text=The%20DB%20cluster%20identifier%20has%20the,first%20character%20must%20be%20a%20letter.