### PR TITLE
Revert autonaming of db clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-* Update auto-naming rules for RDS Cluster `clusterIdentifier` to follow specifications.
+* Revert auto-naming of RDS Cluster `clusterIdentifier`.
 
 ---
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1778,6 +1778,9 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_rds_cluster": {
 				Tok: awsResource(rdsMod, "Cluster"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"cluster_identifier": tfbridge.AutoNameTransform("clusterIdentifier", 63, func(name string) string {
+						return strings.ToLower(name)
+					}),
 					"engine": {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsType(rdsMod, "EngineType", "EngineType")},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1778,9 +1778,6 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_rds_cluster": {
 				Tok: awsResource(rdsMod, "Cluster"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"cluster_identifier": tfbridge.AutoNameTransform("clusterIdentifier", 63, func(name string) string {
-						return strings.ToLower(name)
-					}),
 					"engine": {
 						Type:     "string",
 						AltTypes: []tokens.Type{awsType(rdsMod, "EngineType", "EngineType")},

--- a/sdk/dotnet/Rds/Cluster.cs
+++ b/sdk/dotnet/Rds/Cluster.cs
@@ -49,6 +49,7 @@ namespace Pulumi.Aws.Rds
     ///                 "us-west-2c",
     ///             },
     ///             BackupRetentionPeriod = 5,
+    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             DatabaseName = "mydb",
     ///             Engine = "aurora-mysql",
     ///             EngineVersion = "5.7.mysql_aurora.2.03.2",
@@ -79,6 +80,7 @@ namespace Pulumi.Aws.Rds
     ///                 "us-west-2c",
     ///             },
     ///             BackupRetentionPeriod = 5,
+    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             DatabaseName = "mydb",
     ///             MasterPassword = "bar",
     ///             MasterUsername = "foo",
@@ -107,6 +109,7 @@ namespace Pulumi.Aws.Rds
     ///                 "us-west-2c",
     ///             },
     ///             BackupRetentionPeriod = 5,
+    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             DatabaseName = "mydb",
     ///             Engine = "aurora-postgresql",
     ///             MasterPassword = "bar",
@@ -131,6 +134,7 @@ namespace Pulumi.Aws.Rds
     ///     {
     ///         var example = new Aws.Rds.Cluster("example", new Aws.Rds.ClusterArgs
     ///         {
+    ///             ClusterIdentifier = "example",
     ///             DbSubnetGroupName = aws_db_subnet_group.Example.Name,
     ///             EngineMode = "multimaster",
     ///             MasterPassword = "barbarbarbar",

--- a/sdk/dotnet/Rds/Cluster.cs
+++ b/sdk/dotnet/Rds/Cluster.cs
@@ -49,7 +49,6 @@ namespace Pulumi.Aws.Rds
     ///                 "us-west-2c",
     ///             },
     ///             BackupRetentionPeriod = 5,
-    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             DatabaseName = "mydb",
     ///             Engine = "aurora-mysql",
     ///             EngineVersion = "5.7.mysql_aurora.2.03.2",
@@ -80,7 +79,6 @@ namespace Pulumi.Aws.Rds
     ///                 "us-west-2c",
     ///             },
     ///             BackupRetentionPeriod = 5,
-    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             DatabaseName = "mydb",
     ///             MasterPassword = "bar",
     ///             MasterUsername = "foo",
@@ -109,7 +107,6 @@ namespace Pulumi.Aws.Rds
     ///                 "us-west-2c",
     ///             },
     ///             BackupRetentionPeriod = 5,
-    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             DatabaseName = "mydb",
     ///             Engine = "aurora-postgresql",
     ///             MasterPassword = "bar",
@@ -134,7 +131,6 @@ namespace Pulumi.Aws.Rds
     ///     {
     ///         var example = new Aws.Rds.Cluster("example", new Aws.Rds.ClusterArgs
     ///         {
-    ///             ClusterIdentifier = "example",
     ///             DbSubnetGroupName = aws_db_subnet_group.Example.Name,
     ///             EngineMode = "multimaster",
     ///             MasterPassword = "barbarbarbar",

--- a/sdk/dotnet/Rds/ClusterEndpoint.cs
+++ b/sdk/dotnet/Rds/ClusterEndpoint.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Rds
     ///     {
     ///         var @default = new Aws.Rds.Cluster("default", new Aws.Rds.ClusterArgs
     ///         {
-    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             AvailabilityZones = 
     ///             {
     ///                 "us-west-2a",

--- a/sdk/dotnet/Rds/ClusterEndpoint.cs
+++ b/sdk/dotnet/Rds/ClusterEndpoint.cs
@@ -25,6 +25,7 @@ namespace Pulumi.Aws.Rds
     ///     {
     ///         var @default = new Aws.Rds.Cluster("default", new Aws.Rds.ClusterArgs
     ///         {
+    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             AvailabilityZones = 
     ///             {
     ///                 "us-west-2a",

--- a/sdk/dotnet/Rds/ClusterInstance.cs
+++ b/sdk/dotnet/Rds/ClusterInstance.cs
@@ -38,7 +38,6 @@ namespace Pulumi.Aws.Rds
     ///     {
     ///         var @default = new Aws.Rds.Cluster("default", new Aws.Rds.ClusterArgs
     ///         {
-    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             AvailabilityZones = 
     ///             {
     ///                 "us-west-2a",

--- a/sdk/dotnet/Rds/ClusterInstance.cs
+++ b/sdk/dotnet/Rds/ClusterInstance.cs
@@ -38,6 +38,7 @@ namespace Pulumi.Aws.Rds
     ///     {
     ///         var @default = new Aws.Rds.Cluster("default", new Aws.Rds.ClusterArgs
     ///         {
+    ///             ClusterIdentifier = "aurora-cluster-demo",
     ///             AvailabilityZones = 
     ///             {
     ///                 "us-west-2a",

--- a/sdk/dotnet/Rds/GetClusterSnapshot.cs
+++ b/sdk/dotnet/Rds/GetClusterSnapshot.cs
@@ -38,6 +38,7 @@ namespace Pulumi.Aws.Rds
         ///         // a new dev database.
         ///         var auroraCluster = new Aws.Rds.Cluster("auroraCluster", new Aws.Rds.ClusterArgs
         ///         {
+        ///             ClusterIdentifier = "development_cluster",
         ///             SnapshotIdentifier = developmentFinalSnapshot.Apply(developmentFinalSnapshot =&gt; developmentFinalSnapshot.Id),
         ///             DbSubnetGroupName = "my_db_subnet_group",
         ///         });

--- a/sdk/dotnet/Rds/GetClusterSnapshot.cs
+++ b/sdk/dotnet/Rds/GetClusterSnapshot.cs
@@ -38,7 +38,6 @@ namespace Pulumi.Aws.Rds
         ///         // a new dev database.
         ///         var auroraCluster = new Aws.Rds.Cluster("auroraCluster", new Aws.Rds.ClusterArgs
         ///         {
-        ///             ClusterIdentifier = "development_cluster",
         ///             SnapshotIdentifier = developmentFinalSnapshot.Apply(developmentFinalSnapshot =&gt; developmentFinalSnapshot.Id),
         ///             DbSubnetGroupName = "my_db_subnet_group",
         ///         });

--- a/sdk/go/aws/rds/cluster.go
+++ b/sdk/go/aws/rds/cluster.go
@@ -49,6 +49,7 @@ import (
 // 				pulumi.String("us-west-2c"),
 // 			},
 // 			BackupRetentionPeriod: pulumi.Int(5),
+// 			ClusterIdentifier:     pulumi.String("aurora-cluster-demo"),
 // 			DatabaseName:          pulumi.String("mydb"),
 // 			Engine:                pulumi.String("aurora-mysql"),
 // 			EngineVersion:         pulumi.String("5.7.mysql_aurora.2.03.2"),
@@ -82,6 +83,7 @@ import (
 // 				pulumi.String("us-west-2c"),
 // 			},
 // 			BackupRetentionPeriod: pulumi.Int(5),
+// 			ClusterIdentifier:     pulumi.String("aurora-cluster-demo"),
 // 			DatabaseName:          pulumi.String("mydb"),
 // 			MasterPassword:        pulumi.String("bar"),
 // 			MasterUsername:        pulumi.String("foo"),
@@ -113,6 +115,7 @@ import (
 // 				pulumi.String("us-west-2c"),
 // 			},
 // 			BackupRetentionPeriod: pulumi.Int(5),
+// 			ClusterIdentifier:     pulumi.String("aurora-cluster-demo"),
 // 			DatabaseName:          pulumi.String("mydb"),
 // 			Engine:                pulumi.String("aurora-postgresql"),
 // 			MasterPassword:        pulumi.String("bar"),
@@ -141,6 +144,7 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := rds.NewCluster(ctx, "example", &rds.ClusterArgs{
+// 			ClusterIdentifier: pulumi.String("example"),
 // 			DbSubnetGroupName: pulumi.Any(aws_db_subnet_group.Example.Name),
 // 			EngineMode:        pulumi.String("multimaster"),
 // 			MasterPassword:    pulumi.String("barbarbarbar"),

--- a/sdk/go/aws/rds/cluster.go
+++ b/sdk/go/aws/rds/cluster.go
@@ -49,7 +49,6 @@ import (
 // 				pulumi.String("us-west-2c"),
 // 			},
 // 			BackupRetentionPeriod: pulumi.Int(5),
-// 			ClusterIdentifier:     pulumi.String("aurora-cluster-demo"),
 // 			DatabaseName:          pulumi.String("mydb"),
 // 			Engine:                pulumi.String("aurora-mysql"),
 // 			EngineVersion:         pulumi.String("5.7.mysql_aurora.2.03.2"),
@@ -83,7 +82,6 @@ import (
 // 				pulumi.String("us-west-2c"),
 // 			},
 // 			BackupRetentionPeriod: pulumi.Int(5),
-// 			ClusterIdentifier:     pulumi.String("aurora-cluster-demo"),
 // 			DatabaseName:          pulumi.String("mydb"),
 // 			MasterPassword:        pulumi.String("bar"),
 // 			MasterUsername:        pulumi.String("foo"),
@@ -115,7 +113,6 @@ import (
 // 				pulumi.String("us-west-2c"),
 // 			},
 // 			BackupRetentionPeriod: pulumi.Int(5),
-// 			ClusterIdentifier:     pulumi.String("aurora-cluster-demo"),
 // 			DatabaseName:          pulumi.String("mydb"),
 // 			Engine:                pulumi.String("aurora-postgresql"),
 // 			MasterPassword:        pulumi.String("bar"),
@@ -144,7 +141,6 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := rds.NewCluster(ctx, "example", &rds.ClusterArgs{
-// 			ClusterIdentifier: pulumi.String("example"),
 // 			DbSubnetGroupName: pulumi.Any(aws_db_subnet_group.Example.Name),
 // 			EngineMode:        pulumi.String("multimaster"),
 // 			MasterPassword:    pulumi.String("barbarbarbar"),

--- a/sdk/go/aws/rds/clusterEndpoint.go
+++ b/sdk/go/aws/rds/clusterEndpoint.go
@@ -27,6 +27,7 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := rds.NewCluster(ctx, "_default", &rds.ClusterArgs{
+// 			ClusterIdentifier: pulumi.String("aurora-cluster-demo"),
 // 			AvailabilityZones: pulumi.StringArray{
 // 				pulumi.String("us-west-2a"),
 // 				pulumi.String("us-west-2b"),

--- a/sdk/go/aws/rds/clusterEndpoint.go
+++ b/sdk/go/aws/rds/clusterEndpoint.go
@@ -27,7 +27,6 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := rds.NewCluster(ctx, "_default", &rds.ClusterArgs{
-// 			ClusterIdentifier: pulumi.String("aurora-cluster-demo"),
 // 			AvailabilityZones: pulumi.StringArray{
 // 				pulumi.String("us-west-2a"),
 // 				pulumi.String("us-west-2b"),

--- a/sdk/go/aws/rds/clusterInstance.go
+++ b/sdk/go/aws/rds/clusterInstance.go
@@ -41,7 +41,6 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := rds.NewCluster(ctx, "_default", &rds.ClusterArgs{
-// 			ClusterIdentifier: pulumi.String("aurora-cluster-demo"),
 // 			AvailabilityZones: pulumi.StringArray{
 // 				pulumi.String("us-west-2a"),
 // 				pulumi.String("us-west-2b"),

--- a/sdk/go/aws/rds/clusterInstance.go
+++ b/sdk/go/aws/rds/clusterInstance.go
@@ -41,6 +41,7 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := rds.NewCluster(ctx, "_default", &rds.ClusterArgs{
+// 			ClusterIdentifier: pulumi.String("aurora-cluster-demo"),
 // 			AvailabilityZones: pulumi.StringArray{
 // 				pulumi.String("us-west-2a"),
 // 				pulumi.String("us-west-2b"),

--- a/sdk/go/aws/rds/getClusterSnapshot.go
+++ b/sdk/go/aws/rds/getClusterSnapshot.go
@@ -34,7 +34,6 @@ import (
 // 			return err
 // 		}
 // 		auroraCluster, err := rds.NewCluster(ctx, "auroraCluster", &rds.ClusterArgs{
-// 			ClusterIdentifier:  pulumi.String("development_cluster"),
 // 			SnapshotIdentifier: pulumi.String(developmentFinalSnapshot.Id),
 // 			DbSubnetGroupName:  pulumi.String("my_db_subnet_group"),
 // 		})

--- a/sdk/go/aws/rds/getClusterSnapshot.go
+++ b/sdk/go/aws/rds/getClusterSnapshot.go
@@ -34,6 +34,7 @@ import (
 // 			return err
 // 		}
 // 		auroraCluster, err := rds.NewCluster(ctx, "auroraCluster", &rds.ClusterArgs{
+// 			ClusterIdentifier:  pulumi.String("development_cluster"),
 // 			SnapshotIdentifier: pulumi.String(developmentFinalSnapshot.Id),
 // 			DbSubnetGroupName:  pulumi.String("my_db_subnet_group"),
 // 		})

--- a/sdk/nodejs/rds/cluster.ts
+++ b/sdk/nodejs/rds/cluster.ts
@@ -39,7 +39,6 @@ import * as utilities from "../utilities";
  *         "us-west-2c",
  *     ],
  *     backupRetentionPeriod: 5,
- *     clusterIdentifier: "aurora-cluster-demo",
  *     databaseName: "mydb",
  *     engine: "aurora-mysql",
  *     engineVersion: "5.7.mysql_aurora.2.03.2",
@@ -61,7 +60,6 @@ import * as utilities from "../utilities";
  *         "us-west-2c",
  *     ],
  *     backupRetentionPeriod: 5,
- *     clusterIdentifier: "aurora-cluster-demo",
  *     databaseName: "mydb",
  *     masterPassword: "bar",
  *     masterUsername: "foo",
@@ -81,7 +79,6 @@ import * as utilities from "../utilities";
  *         "us-west-2c",
  *     ],
  *     backupRetentionPeriod: 5,
- *     clusterIdentifier: "aurora-cluster-demo",
  *     databaseName: "mydb",
  *     engine: "aurora-postgresql",
  *     masterPassword: "bar",
@@ -98,7 +95,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.rds.Cluster("example", {
- *     clusterIdentifier: "example",
  *     dbSubnetGroupName: aws_db_subnet_group.example.name,
  *     engineMode: "multimaster",
  *     masterPassword: "barbarbarbar",

--- a/sdk/nodejs/rds/cluster.ts
+++ b/sdk/nodejs/rds/cluster.ts
@@ -39,6 +39,7 @@ import * as utilities from "../utilities";
  *         "us-west-2c",
  *     ],
  *     backupRetentionPeriod: 5,
+ *     clusterIdentifier: "aurora-cluster-demo",
  *     databaseName: "mydb",
  *     engine: "aurora-mysql",
  *     engineVersion: "5.7.mysql_aurora.2.03.2",
@@ -60,6 +61,7 @@ import * as utilities from "../utilities";
  *         "us-west-2c",
  *     ],
  *     backupRetentionPeriod: 5,
+ *     clusterIdentifier: "aurora-cluster-demo",
  *     databaseName: "mydb",
  *     masterPassword: "bar",
  *     masterUsername: "foo",
@@ -79,6 +81,7 @@ import * as utilities from "../utilities";
  *         "us-west-2c",
  *     ],
  *     backupRetentionPeriod: 5,
+ *     clusterIdentifier: "aurora-cluster-demo",
  *     databaseName: "mydb",
  *     engine: "aurora-postgresql",
  *     masterPassword: "bar",
@@ -95,6 +98,7 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.rds.Cluster("example", {
+ *     clusterIdentifier: "example",
  *     dbSubnetGroupName: aws_db_subnet_group.example.name,
  *     engineMode: "multimaster",
  *     masterPassword: "barbarbarbar",

--- a/sdk/nodejs/rds/clusterEndpoint.ts
+++ b/sdk/nodejs/rds/clusterEndpoint.ts
@@ -15,6 +15,7 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const _default = new aws.rds.Cluster("default", {
+ *     clusterIdentifier: "aurora-cluster-demo",
  *     availabilityZones: [
  *         "us-west-2a",
  *         "us-west-2b",

--- a/sdk/nodejs/rds/clusterEndpoint.ts
+++ b/sdk/nodejs/rds/clusterEndpoint.ts
@@ -15,7 +15,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const _default = new aws.rds.Cluster("default", {
- *     clusterIdentifier: "aurora-cluster-demo",
  *     availabilityZones: [
  *         "us-west-2a",
  *         "us-west-2b",

--- a/sdk/nodejs/rds/clusterInstance.ts
+++ b/sdk/nodejs/rds/clusterInstance.ts
@@ -30,7 +30,6 @@ import {EngineType} from "./index";
  * import * as aws from "@pulumi/aws";
  *
  * const _default = new aws.rds.Cluster("default", {
- *     clusterIdentifier: "aurora-cluster-demo",
  *     availabilityZones: [
  *         "us-west-2a",
  *         "us-west-2b",

--- a/sdk/nodejs/rds/clusterInstance.ts
+++ b/sdk/nodejs/rds/clusterInstance.ts
@@ -30,6 +30,7 @@ import {EngineType} from "./index";
  * import * as aws from "@pulumi/aws";
  *
  * const _default = new aws.rds.Cluster("default", {
+ *     clusterIdentifier: "aurora-cluster-demo",
  *     availabilityZones: [
  *         "us-west-2a",
  *         "us-west-2b",

--- a/sdk/nodejs/rds/getClusterSnapshot.ts
+++ b/sdk/nodejs/rds/getClusterSnapshot.ts
@@ -24,7 +24,6 @@ import * as utilities from "../utilities";
  * // Use the last snapshot of the dev database before it was destroyed to create
  * // a new dev database.
  * const auroraCluster = new aws.rds.Cluster("auroraCluster", {
- *     clusterIdentifier: "development_cluster",
  *     snapshotIdentifier: developmentFinalSnapshot.then(developmentFinalSnapshot => developmentFinalSnapshot.id),
  *     dbSubnetGroupName: "my_db_subnet_group",
  * });

--- a/sdk/nodejs/rds/getClusterSnapshot.ts
+++ b/sdk/nodejs/rds/getClusterSnapshot.ts
@@ -24,6 +24,7 @@ import * as utilities from "../utilities";
  * // Use the last snapshot of the dev database before it was destroyed to create
  * // a new dev database.
  * const auroraCluster = new aws.rds.Cluster("auroraCluster", {
+ *     clusterIdentifier: "development_cluster",
  *     snapshotIdentifier: developmentFinalSnapshot.then(developmentFinalSnapshot => developmentFinalSnapshot.id),
  *     dbSubnetGroupName: "my_db_subnet_group",
  * });

--- a/sdk/python/pulumi_aws/rds/cluster.py
+++ b/sdk/python/pulumi_aws/rds/cluster.py
@@ -93,6 +93,7 @@ class Cluster(pulumi.CustomResource):
                 "us-west-2c",
             ],
             backup_retention_period=5,
+            cluster_identifier="aurora-cluster-demo",
             database_name="mydb",
             engine="aurora-mysql",
             engine_version="5.7.mysql_aurora.2.03.2",
@@ -113,6 +114,7 @@ class Cluster(pulumi.CustomResource):
                 "us-west-2c",
             ],
             backup_retention_period=5,
+            cluster_identifier="aurora-cluster-demo",
             database_name="mydb",
             master_password="bar",
             master_username="foo",
@@ -131,6 +133,7 @@ class Cluster(pulumi.CustomResource):
                 "us-west-2c",
             ],
             backup_retention_period=5,
+            cluster_identifier="aurora-cluster-demo",
             database_name="mydb",
             engine="aurora-postgresql",
             master_password="bar",
@@ -146,6 +149,7 @@ class Cluster(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.rds.Cluster("example",
+            cluster_identifier="example",
             db_subnet_group_name=aws_db_subnet_group["example"]["name"],
             engine_mode="multimaster",
             master_password="barbarbarbar",

--- a/sdk/python/pulumi_aws/rds/cluster.py
+++ b/sdk/python/pulumi_aws/rds/cluster.py
@@ -93,7 +93,6 @@ class Cluster(pulumi.CustomResource):
                 "us-west-2c",
             ],
             backup_retention_period=5,
-            cluster_identifier="aurora-cluster-demo",
             database_name="mydb",
             engine="aurora-mysql",
             engine_version="5.7.mysql_aurora.2.03.2",
@@ -114,7 +113,6 @@ class Cluster(pulumi.CustomResource):
                 "us-west-2c",
             ],
             backup_retention_period=5,
-            cluster_identifier="aurora-cluster-demo",
             database_name="mydb",
             master_password="bar",
             master_username="foo",
@@ -133,7 +131,6 @@ class Cluster(pulumi.CustomResource):
                 "us-west-2c",
             ],
             backup_retention_period=5,
-            cluster_identifier="aurora-cluster-demo",
             database_name="mydb",
             engine="aurora-postgresql",
             master_password="bar",
@@ -149,7 +146,6 @@ class Cluster(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.rds.Cluster("example",
-            cluster_identifier="example",
             db_subnet_group_name=aws_db_subnet_group["example"]["name"],
             engine_mode="multimaster",
             master_password="barbarbarbar",

--- a/sdk/python/pulumi_aws/rds/cluster_endpoint.py
+++ b/sdk/python/pulumi_aws/rds/cluster_endpoint.py
@@ -35,6 +35,7 @@ class ClusterEndpoint(pulumi.CustomResource):
         import pulumi_aws as aws
 
         default = aws.rds.Cluster("default",
+            cluster_identifier="aurora-cluster-demo",
             availability_zones=[
                 "us-west-2a",
                 "us-west-2b",

--- a/sdk/python/pulumi_aws/rds/cluster_endpoint.py
+++ b/sdk/python/pulumi_aws/rds/cluster_endpoint.py
@@ -35,7 +35,6 @@ class ClusterEndpoint(pulumi.CustomResource):
         import pulumi_aws as aws
 
         default = aws.rds.Cluster("default",
-            cluster_identifier="aurora-cluster-demo",
             availability_zones=[
                 "us-west-2a",
                 "us-west-2b",

--- a/sdk/python/pulumi_aws/rds/cluster_instance.py
+++ b/sdk/python/pulumi_aws/rds/cluster_instance.py
@@ -64,7 +64,6 @@ class ClusterInstance(pulumi.CustomResource):
         import pulumi_aws as aws
 
         default = aws.rds.Cluster("default",
-            cluster_identifier="aurora-cluster-demo",
             availability_zones=[
                 "us-west-2a",
                 "us-west-2b",

--- a/sdk/python/pulumi_aws/rds/cluster_instance.py
+++ b/sdk/python/pulumi_aws/rds/cluster_instance.py
@@ -64,6 +64,7 @@ class ClusterInstance(pulumi.CustomResource):
         import pulumi_aws as aws
 
         default = aws.rds.Cluster("default",
+            cluster_identifier="aurora-cluster-demo",
             availability_zones=[
                 "us-west-2a",
                 "us-west-2b",

--- a/sdk/python/pulumi_aws/rds/get_cluster_snapshot.py
+++ b/sdk/python/pulumi_aws/rds/get_cluster_snapshot.py
@@ -289,6 +289,7 @@ def get_cluster_snapshot(db_cluster_identifier: Optional[str] = None,
     # Use the last snapshot of the dev database before it was destroyed to create
     # a new dev database.
     aurora_cluster = aws.rds.Cluster("auroraCluster",
+        cluster_identifier="development_cluster",
         snapshot_identifier=development_final_snapshot.id,
         db_subnet_group_name="my_db_subnet_group")
     aurora_cluster_instance = aws.rds.ClusterInstance("auroraClusterInstance",

--- a/sdk/python/pulumi_aws/rds/get_cluster_snapshot.py
+++ b/sdk/python/pulumi_aws/rds/get_cluster_snapshot.py
@@ -289,7 +289,6 @@ def get_cluster_snapshot(db_cluster_identifier: Optional[str] = None,
     # Use the last snapshot of the dev database before it was destroyed to create
     # a new dev database.
     aurora_cluster = aws.rds.Cluster("auroraCluster",
-        cluster_identifier="development_cluster",
         snapshot_identifier=development_final_snapshot.id,
         db_subnet_group_name="my_db_subnet_group")
     aurora_cluster_instance = aws.rds.ClusterInstance("auroraClusterInstance",


### PR DESCRIPTION
I tested to make sure this isn't breaking for folks who might've made a cluster during the in-between versions by creating an rds cluster with v3.23.0 and then updating it using a locally built version after making this change. The cluster updates with no changes since the pulumi-autonaming is preserved  as an input property in state and therefore tf autonaming never comes up.

Fixes: https://github.com/pulumi/pulumi-aws/issues/1299