### PR TITLE
Prepend 'alias/' to KMS Key Alias autoname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Add support for autonaming `aws.kms.Alias` by appending `alias/` prefix
 
 ---
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -414,6 +414,19 @@ func TestAccFifoSqsQueueTs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccKmsAliasTs(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:           filepath.Join(getCwd(t), "kms-alias"),
+			RunUpdateTest: false,
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				assert.Contains(t, stack.Outputs["autonamedAlias"].(string), "alias/")
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	envRegion := getEnvRegion(t)
 	base := getBaseOptions()

--- a/examples/kms-alias/Pulumi.yaml
+++ b/examples/kms-alias/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: kms-alias
+runtime: nodejs
+description: Example to show autonaming of Kms Alias resources

--- a/examples/kms-alias/index.ts
+++ b/examples/kms-alias/index.ts
@@ -1,0 +1,30 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const key = new aws.kms.Key("key", {}, providerOpts);
+const aliasAutoPrefixedWithAlias = new aws.kms.Alias("should-be-prefixed", {targetKeyId: key.keyId}, providerOpts);
+
+const aliasWithDedicatedName = new aws.kms.Alias("wont-be-autonamed", {
+    targetKeyId: key.keyId,
+    name: "alias/my-decicated-name"
+}, providerOpts);
+
+export const autonamedAlias = aliasAutoPrefixedWithAlias.name;
+export const decidatedAlias = aliasWithDedicatedName.name;

--- a/examples/kms-alias/package.json
+++ b/examples/kms-alias/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "kms-alias",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/aws-sdk": "^2.7.0",
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/kms-alias/tsconfig.json
+++ b/examples/kms-alias/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1745,7 +1745,25 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_kinesisanalyticsv2_application":          {Tok: awsResource(kinesisAnalyticsMod, "Application")},
 			"aws_kinesisanalyticsv2_application_snapshot": {Tok: awsResource(kinesisAnalyticsMod, "ApplicationSnapshot")},
 			// Key Management Service (KMS)
-			"aws_kms_alias":        {Tok: awsResource(kmsMod, "Alias")},
+			"aws_kms_alias": {
+				Tok: awsResource(kmsMod, "Alias"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": tfbridge.AutoNameWithCustomOptions("name", tfbridge.AutoNameOptions{
+						Separator: "-",
+						Maxlen:    238,
+						Randlen:   7,
+						// KMS Key alias names must be prefixed with "alias/" - see format documentation at
+						// https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html
+						PostTransform: func(res *tfbridge.PulumiResource, name string) (string, error) {
+							if strings.HasPrefix(name, "alias/") {
+								return name, nil
+							}
+
+							return fmt.Sprintf("alias/%s", name), nil
+						},
+					}),
+				},
+			},
 			"aws_kms_ciphertext":   {Tok: awsResource(kmsMod, "Ciphertext")},
 			"aws_kms_external_key": {Tok: awsResource(kmsMod, "ExternalKey")},
 			"aws_kms_grant":        {Tok: awsResource(kmsMod, "Grant")},


### PR DESCRIPTION
This commit adds custom options for autonaming of aws.kms.Alias
resources, in order to prepend "alias/" to the key name if it is not
already part of the logical resource name.

This permits autonaming of keys without diverging from established
logical naming patterns.