### PR TITLE
add app sync principal for nodejs sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
-
+* Add Principal for AppSync in nodejs SDK
 ---
 
 ## 4.4.1 (2021-05-17)

--- a/sdk/nodejs/iam/principals.ts
+++ b/sdk/nodejs/iam/principals.ts
@@ -26,6 +26,11 @@ export module Principals {
     export const ApiGatewayPrincipal: Principal = {Service: "apigateway.amazonaws.com"};
 
     /**
+     * Service Principal for AppSync Gateway
+     */
+     export const AppSyncPrincipal: Principal = {Service: "appsync.amazonaws.com"};
+
+    /**
      * Service Principal for Athena
      */
     export const AthenaPrincipal: Principal = {Service: "athena.amazonaws.com"};


### PR DESCRIPTION
Adds Principal for AWS AppSync to nodejs SDK.

This is required when creating a DataSource for AppSync.

https://docs.aws.amazon.com/appsync/latest/devguide/attaching-a-data-source.html