### PR TITLE
Revert "[breaking] Remap `aws.serviceCatalog.TagOptionResourceAssociation` `resourceName` to be `associatedResourceName`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-* Rename `aws.serviceCatalog.TagOptionResourceAssocition` `resourceName` to be `associatedResourceName` in all languages.  
-  This is a **breaking change** but is due to `resourceName` being a reserved parameter name in Pulumi and thus causing
-  compilation problems in some of our SDKs.
+_(none)_
+
 ---
 
 ## 4.7.0 (2021-06-04)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2136,11 +2136,6 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_servicecatalog_provisioning_artifact": {Tok: awsResource(servicecatalogMod, "ProvisioningArtifact")},
 			"aws_servicecatalog_tag_option_resource_association": {
 				Tok: awsResource(servicecatalogMod, "TagOptionResourceAssociation"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"resource_name": {
-						Name: "associatedResourceName",
-					},
-				},
 			},
 			"aws_servicecatalog_principal_portfolio_association": {
 				Tok: awsResource(servicecatalogMod, "PrincipalPortfolioAssociation"),

--- a/sdk/dotnet/ServiceCatalog/TagOptionResourceAssociation.cs
+++ b/sdk/dotnet/ServiceCatalog/TagOptionResourceAssociation.cs
@@ -47,12 +47,6 @@ namespace Pulumi.Aws.ServiceCatalog
     public partial class TagOptionResourceAssociation : Pulumi.CustomResource
     {
         /// <summary>
-        /// Description of the resource.
-        /// </summary>
-        [Output("associatedResourceName")]
-        public Output<string> AssociatedResourceName { get; private set; } = null!;
-
-        /// <summary>
         /// ARN of the resource.
         /// </summary>
         [Output("resourceArn")]
@@ -75,6 +69,12 @@ namespace Pulumi.Aws.ServiceCatalog
         /// </summary>
         [Output("resourceId")]
         public Output<string> ResourceId { get; private set; } = null!;
+
+        /// <summary>
+        /// Description of the resource.
+        /// </summary>
+        [Output("resourceName")]
+        public Output<string> ResourceName { get; private set; } = null!;
 
         /// <summary>
         /// Tag Option identifier.
@@ -148,12 +148,6 @@ namespace Pulumi.Aws.ServiceCatalog
     public sealed class TagOptionResourceAssociationState : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Description of the resource.
-        /// </summary>
-        [Input("associatedResourceName")]
-        public Input<string>? AssociatedResourceName { get; set; }
-
-        /// <summary>
         /// ARN of the resource.
         /// </summary>
         [Input("resourceArn")]
@@ -176,6 +170,12 @@ namespace Pulumi.Aws.ServiceCatalog
         /// </summary>
         [Input("resourceId")]
         public Input<string>? ResourceId { get; set; }
+
+        /// <summary>
+        /// Description of the resource.
+        /// </summary>
+        [Input("resourceName")]
+        public Input<string>? ResourceName { get; set; }
 
         /// <summary>
         /// Tag Option identifier.

--- a/sdk/go/aws/servicecatalog/tagOptionResourceAssociation.go
+++ b/sdk/go/aws/servicecatalog/tagOptionResourceAssociation.go
@@ -50,8 +50,6 @@ import (
 type TagOptionResourceAssociation struct {
 	pulumi.CustomResourceState
 
-	// Description of the resource.
-	AssociatedResourceName pulumi.StringOutput `pulumi:"associatedResourceName"`
 	// ARN of the resource.
 	ResourceArn pulumi.StringOutput `pulumi:"resourceArn"`
 	// Creation time of the resource.
@@ -60,6 +58,8 @@ type TagOptionResourceAssociation struct {
 	ResourceDescription pulumi.StringOutput `pulumi:"resourceDescription"`
 	// Resource identifier.
 	ResourceId pulumi.StringOutput `pulumi:"resourceId"`
+	// Description of the resource.
+	ResourceName pulumi.StringOutput `pulumi:"resourceName"`
 	// Tag Option identifier.
 	TagOptionId pulumi.StringOutput `pulumi:"tagOptionId"`
 }
@@ -99,8 +99,6 @@ func GetTagOptionResourceAssociation(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering TagOptionResourceAssociation resources.
 type tagOptionResourceAssociationState struct {
-	// Description of the resource.
-	AssociatedResourceName *string `pulumi:"associatedResourceName"`
 	// ARN of the resource.
 	ResourceArn *string `pulumi:"resourceArn"`
 	// Creation time of the resource.
@@ -109,13 +107,13 @@ type tagOptionResourceAssociationState struct {
 	ResourceDescription *string `pulumi:"resourceDescription"`
 	// Resource identifier.
 	ResourceId *string `pulumi:"resourceId"`
+	// Description of the resource.
+	ResourceName *string `pulumi:"resourceName"`
 	// Tag Option identifier.
 	TagOptionId *string `pulumi:"tagOptionId"`
 }
 
 type TagOptionResourceAssociationState struct {
-	// Description of the resource.
-	AssociatedResourceName pulumi.StringPtrInput
 	// ARN of the resource.
 	ResourceArn pulumi.StringPtrInput
 	// Creation time of the resource.
@@ -124,6 +122,8 @@ type TagOptionResourceAssociationState struct {
 	ResourceDescription pulumi.StringPtrInput
 	// Resource identifier.
 	ResourceId pulumi.StringPtrInput
+	// Description of the resource.
+	ResourceName pulumi.StringPtrInput
 	// Tag Option identifier.
 	TagOptionId pulumi.StringPtrInput
 }

--- a/sdk/nodejs/servicecatalog/tagOptionResourceAssociation.ts
+++ b/sdk/nodejs/servicecatalog/tagOptionResourceAssociation.ts
@@ -59,10 +59,6 @@ export class TagOptionResourceAssociation extends pulumi.CustomResource {
     }
 
     /**
-     * Description of the resource.
-     */
-    public /*out*/ readonly associatedResourceName!: pulumi.Output<string>;
-    /**
      * ARN of the resource.
      */
     public /*out*/ readonly resourceArn!: pulumi.Output<string>;
@@ -78,6 +74,10 @@ export class TagOptionResourceAssociation extends pulumi.CustomResource {
      * Resource identifier.
      */
     public readonly resourceId!: pulumi.Output<string>;
+    /**
+     * Description of the resource.
+     */
+    public /*out*/ readonly resourceName!: pulumi.Output<string>;
     /**
      * Tag Option identifier.
      */
@@ -96,11 +96,11 @@ export class TagOptionResourceAssociation extends pulumi.CustomResource {
         opts = opts || {};
         if (opts.id) {
             const state = argsOrState as TagOptionResourceAssociationState | undefined;
-            inputs["associatedResourceName"] = state ? state.associatedResourceName : undefined;
             inputs["resourceArn"] = state ? state.resourceArn : undefined;
             inputs["resourceCreatedTime"] = state ? state.resourceCreatedTime : undefined;
             inputs["resourceDescription"] = state ? state.resourceDescription : undefined;
             inputs["resourceId"] = state ? state.resourceId : undefined;
+            inputs["resourceName"] = state ? state.resourceName : undefined;
             inputs["tagOptionId"] = state ? state.tagOptionId : undefined;
         } else {
             const args = argsOrState as TagOptionResourceAssociationArgs | undefined;
@@ -112,10 +112,10 @@ export class TagOptionResourceAssociation extends pulumi.CustomResource {
             }
             inputs["resourceId"] = args ? args.resourceId : undefined;
             inputs["tagOptionId"] = args ? args.tagOptionId : undefined;
-            inputs["associatedResourceName"] = undefined /*out*/;
             inputs["resourceArn"] = undefined /*out*/;
             inputs["resourceCreatedTime"] = undefined /*out*/;
             inputs["resourceDescription"] = undefined /*out*/;
+            inputs["resourceName"] = undefined /*out*/;
         }
         if (!opts.version) {
             opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});
@@ -128,10 +128,6 @@ export class TagOptionResourceAssociation extends pulumi.CustomResource {
  * Input properties used for looking up and filtering TagOptionResourceAssociation resources.
  */
 export interface TagOptionResourceAssociationState {
-    /**
-     * Description of the resource.
-     */
-    associatedResourceName?: pulumi.Input<string>;
     /**
      * ARN of the resource.
      */
@@ -148,6 +144,10 @@ export interface TagOptionResourceAssociationState {
      * Resource identifier.
      */
     resourceId?: pulumi.Input<string>;
+    /**
+     * Description of the resource.
+     */
+    resourceName?: pulumi.Input<string>;
     /**
      * Tag Option identifier.
      */

--- a/sdk/python/pulumi_aws/servicecatalog/tag_option_resource_association.py
+++ b/sdk/python/pulumi_aws/servicecatalog/tag_option_resource_association.py
@@ -51,23 +51,21 @@ class TagOptionResourceAssociationArgs:
 @pulumi.input_type
 class _TagOptionResourceAssociationState:
     def __init__(__self__, *,
-                 associated_resource_name: Optional[pulumi.Input[str]] = None,
                  resource_arn: Optional[pulumi.Input[str]] = None,
                  resource_created_time: Optional[pulumi.Input[str]] = None,
                  resource_description: Optional[pulumi.Input[str]] = None,
                  resource_id: Optional[pulumi.Input[str]] = None,
+                 resource_name: Optional[pulumi.Input[str]] = None,
                  tag_option_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering TagOptionResourceAssociation resources.
-        :param pulumi.Input[str] associated_resource_name: Description of the resource.
         :param pulumi.Input[str] resource_arn: ARN of the resource.
         :param pulumi.Input[str] resource_created_time: Creation time of the resource.
         :param pulumi.Input[str] resource_description: Description of the resource.
         :param pulumi.Input[str] resource_id: Resource identifier.
+        :param pulumi.Input[str] resource_name: Description of the resource.
         :param pulumi.Input[str] tag_option_id: Tag Option identifier.
         """
-        if associated_resource_name is not None:
-            pulumi.set(__self__, "associated_resource_name", associated_resource_name)
         if resource_arn is not None:
             pulumi.set(__self__, "resource_arn", resource_arn)
         if resource_created_time is not None:
@@ -76,20 +74,10 @@ class _TagOptionResourceAssociationState:
             pulumi.set(__self__, "resource_description", resource_description)
         if resource_id is not None:
             pulumi.set(__self__, "resource_id", resource_id)
+        if resource_name is not None:
+            pulumi.set(__self__, "resource_name", resource_name)
         if tag_option_id is not None:
             pulumi.set(__self__, "tag_option_id", tag_option_id)
-
-    @property
-    @pulumi.getter(name="associatedResourceName")
-    def associated_resource_name(self) -> Optional[pulumi.Input[str]]:
-        """
-        Description of the resource.
-        """
-        return pulumi.get(self, "associated_resource_name")
-
-    @associated_resource_name.setter
-    def associated_resource_name(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "associated_resource_name", value)
 
     @property
     @pulumi.getter(name="resourceArn")
@@ -138,6 +126,18 @@ class _TagOptionResourceAssociationState:
     @resource_id.setter
     def resource_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "resource_id", value)
+
+    @property
+    @pulumi.getter(name="resourceName")
+    def resource_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Description of the resource.
+        """
+        return pulumi.get(self, "resource_name")
+
+    @resource_name.setter
+    def resource_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "resource_name", value)
 
     @property
     @pulumi.getter(name="tagOptionId")
@@ -256,10 +256,10 @@ class TagOptionResourceAssociation(pulumi.CustomResource):
             if tag_option_id is None and not opts.urn:
                 raise TypeError("Missing required property 'tag_option_id'")
             __props__.__dict__["tag_option_id"] = tag_option_id
-            __props__.__dict__["associated_resource_name"] = None
             __props__.__dict__["resource_arn"] = None
             __props__.__dict__["resource_created_time"] = None
             __props__.__dict__["resource_description"] = None
+            __props__.__dict__["resource_name"] = None
         super(TagOptionResourceAssociation, __self__).__init__(
             'aws:servicecatalog/tagOptionResourceAssociation:TagOptionResourceAssociation',
             resource_name,
@@ -270,11 +270,11 @@ class TagOptionResourceAssociation(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            associated_resource_name: Optional[pulumi.Input[str]] = None,
             resource_arn: Optional[pulumi.Input[str]] = None,
             resource_created_time: Optional[pulumi.Input[str]] = None,
             resource_description: Optional[pulumi.Input[str]] = None,
             resource_id: Optional[pulumi.Input[str]] = None,
+            resource_name: Optional[pulumi.Input[str]] = None,
             tag_option_id: Optional[pulumi.Input[str]] = None) -> 'TagOptionResourceAssociation':
         """
         Get an existing TagOptionResourceAssociation resource's state with the given name, id, and optional extra
@@ -283,32 +283,24 @@ class TagOptionResourceAssociation(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] associated_resource_name: Description of the resource.
         :param pulumi.Input[str] resource_arn: ARN of the resource.
         :param pulumi.Input[str] resource_created_time: Creation time of the resource.
         :param pulumi.Input[str] resource_description: Description of the resource.
         :param pulumi.Input[str] resource_id: Resource identifier.
+        :param pulumi.Input[str] resource_name: Description of the resource.
         :param pulumi.Input[str] tag_option_id: Tag Option identifier.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = _TagOptionResourceAssociationState.__new__(_TagOptionResourceAssociationState)
 
-        __props__.__dict__["associated_resource_name"] = associated_resource_name
         __props__.__dict__["resource_arn"] = resource_arn
         __props__.__dict__["resource_created_time"] = resource_created_time
         __props__.__dict__["resource_description"] = resource_description
         __props__.__dict__["resource_id"] = resource_id
+        __props__.__dict__["resource_name"] = resource_name
         __props__.__dict__["tag_option_id"] = tag_option_id
         return TagOptionResourceAssociation(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="associatedResourceName")
-    def associated_resource_name(self) -> pulumi.Output[str]:
-        """
-        Description of the resource.
-        """
-        return pulumi.get(self, "associated_resource_name")
 
     @property
     @pulumi.getter(name="resourceArn")
@@ -341,6 +333,14 @@ class TagOptionResourceAssociation(pulumi.CustomResource):
         Resource identifier.
         """
         return pulumi.get(self, "resource_id")
+
+    @property
+    @pulumi.getter(name="resourceName")
+    def resource_name(self) -> pulumi.Output[str]:
+        """
+        Description of the resource.
+        """
+        return pulumi.get(self, "resource_name")
 
     @property
     @pulumi.getter(name="tagOptionId")


### PR DESCRIPTION
Reverts pulumi/pulumi-aws#1520