### PR TITLE
updated examples/express lambda to use callbackFactory instead of deprecated aws.serverless....

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _(none)_
 * Upgrade to v3.63.0 of the AWS Terraform Provider
 
 ## 4.24.1 (2021-10-11)
-* Ensure `aws.lb.TargetGroup`, `aws.alb.TargetGroup`, `aws.elasticloadbalancingv2.TargetGroup` and 
+* Ensure `aws.lb.TargetGroup`, `aws.alb.TargetGroup`, `aws.elasticloadbalancingv2.TargetGroup` and
  `aws.applicationloadbalancing.TargetGroup` have their `deregistrationDelay` parameter set to the correct type of `int` not `string`
 
 ## 4.24.0 (2021-10-08)
@@ -19,7 +19,7 @@ _(none)_
 
 ## 4.23.0 (2021-10-06)
 * Upgrade to v3.61.0 of the AWS Terraform Provider
-  * **Please note**, `aws.ec2.getDedicatedHost` no longer supports the `instanceState` output. 
+  * **Please note**, `aws.ec2.getDedicatedHost` no longer supports the `instanceState` output.
 * Add the ability to set `maximumBatchingWindowInSeconds` as part of `aws.sqs.QueueEventSubscription` in NodeJS SDK
 * Add the ability to set `functionResponseTypes` as part of `aws.dynamodb.TableEventSubscription` in NodeJS SDK
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ added to make development easier and to help avoid common mistakes, and to get s
 
 ### Serverless Functions
 
-The `aws.serverless.Function` class allows you to create an AWS lambda function directly out of a JavaScript/TypeScript
+The `aws.lambda.CallbackFunction` class allows you to create an AWS lambda function directly out of a JavaScript/TypeScript
 function object of the right signature.  This allows a Pulumi program to simply define a lambda using a simple lambda in
 the language of choice, while having Pulumi itself do the appropriate transformation into the final AWS Lambda resource.
 

--- a/examples/express/index.ts
+++ b/examples/express/index.ts
@@ -9,27 +9,27 @@ import * as middleware from "aws-serverless-express/middleware";
 const config = new pulumi.Config("aws");
 const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
 
-let hello = "Hello, world!";
-let lambda = new aws.serverless.Function(
-  "mylambda", {
-    factoryFunc: () => {
-      const app = express();
-      app.use(middleware.eventContext());
-      let ctx;
+const hello = "Hello, world!";
 
-      app.get("/", (req, res) => {
-        console.log("Invoked url: " + req.url);
-        res.json( { message: hello + "\n\nSucceeded with " + ctx.getRemainingTimeInMillis() + "ms remaining.\n" });
-      });
+const lambda = new aws.lambda.CallbackFunction<any, any>("mylambda", {
+  callbackFactory: () => {
+    const app = express();
+    app.use(middleware.eventContext());
+    let ctx;
 
-      const server = serverlessExpress.createServer(app);
+    app.get("/", (req, res) => {
+      console.log("Invoked url: " + req.url);
+      res.json({ message: hello + "\n\nSucceeded with " + ctx.getRemainingTimeInMillis() + "ms remaining.\n" });
+    });
 
-      return (event, context) => {
-        console.log("Lambda invoked");
-        console.log("Invoked function: " + context.invokedFunctionArn);
-        console.log("Proxying to express");
-        ctx = context;
-        serverlessExpress.proxy(server, event, <any>context);
-      }
+    const server = serverlessExpress.createServer(app);
+
+    return (event, context) => {
+      console.log("Lambda invoked");
+      console.log("Invoked function: " + context.invokedFunctionArn);
+      console.log("Proxying to express");
+      ctx = context;
+      serverlessExpress.proxy(server, event, <any>context);
     }
-  }, undefined, providerOpts);
+  }
+}, providerOpts);

--- a/examples/serverless/index.ts
+++ b/examples/serverless/index.ts
@@ -39,16 +39,15 @@ let music = new aws.dynamodb.Table("music", {
   ],
 }, providerOpts);
 
-let hello = "Hello, world!";
-let lambda = new aws.serverless.Function(
-  "mylambda",
-  { },
-  (event, context, callback) => {
+const hello = "Hello, world!";
+
+const lambda = new aws.lambda.CallbackFunction("mylambda", {
+  callback: (event, context, callback) => {
     console.log("Music table hash key is: " + music.hashKey);
     console.log("Invoked function: " + context.invokedFunctionArn);
     callback(null, {
       statusCode: 200,
       body: hello + "\n\nSucceeed with " + context.getRemainingTimeInMillis() + "ms remaining.\n",
     });
-  },
-  providerOpts);
+  }
+}, providerOpts);

--- a/examples/serverless_functions/index.ts
+++ b/examples/serverless_functions/index.ts
@@ -17,18 +17,21 @@ function getContentType() {
   return mime.contentType(".js");
 }
 
-const testFunc = new aws.serverless.Function("f", {
-  includePaths: ['./Pulumi.yaml'],
-}, async (ev, ctx, cb) => {
-  // These variables exist only to ensure that capturing modules doesn't cause any problems.
-  var _awsSdk = awsSdk;
-  var _express = express;
-  var _os = os;
-  var _slack = slack;
+const testFunc = new aws.lambda.CallbackFunction("f", {
+  codePathOptions: {
+    extraIncludePaths: ["./Pulumi.yaml"]
+  },
+  callback: (event, context, callback) => {
+    // These variables exist only to ensure that capturing modules doesn't cause any problems.
+    var _awsSdk = awsSdk;
+    var _express = express;
+    var _os = os;
+    var _slack = slack;
 
-  var answer = other.answer;
-  console.log(answer);
-  getContentType();
+    var answer = other.answer;
+    console.log(answer);
+    getContentType();
+  }
 }, providerOpts);
 
-exports.functionARN = testFunc.lambda.arn;
+export const functionARN = testFunc.arn;

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -58,7 +58,7 @@ added to make development easier and to help avoid common mistakes, and to get s
 
 ### Serverless Functions
 
-The `aws.serverless.Function` class allows you to create an AWS lambda function directly out of a JavaScript/TypeScript
+The `aws.lambda.CallbackFunction` class allows you to create an AWS lambda function directly out of a JavaScript/TypeScript
 function object of the right signature.  This allows a Pulumi program to simply define a lambda using a simple lambda in
 the language of choice, while having Pulumi itself do the appropriate transformation into the final AWS Lambda resource.
 


### PR DESCRIPTION
Updated the README and a few TS examples to remove the ```aws.serverless.Function``` object in favor of ```aws.lambda.CallbackFuntion```