### PR TITLE
Updating AWS APN to pass pulumi not terraform

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -26,6 +26,7 @@ builds:
   - linux
   ldflags:
   - -X github.com/pulumi/pulumi-aws/provider/v4/pkg/version.Version={{.Tag}}
+  - -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion={{.Tag}}
   main: ./cmd/pulumi-resource-aws/
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
   - linux
   ldflags:
   - -X github.com/pulumi/pulumi-aws/provider/v4/pkg/version.Version={{.Tag}}
+  - -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion={{.Tag}}
   main: ./cmd/pulumi-resource-aws/
 changelog:
   skip: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Ensure that resources do not allow `tagsAll` to be set - it should be an output only. This is technically a "breaking"
-  change but these properties were never actually able to set set.
+  change but these properties were never actually able to be set.
+* Ensuring that the correct APN is being passed as part of requests to AWS.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ tfgen:: install_plugins
 	$(WORKING_DIR)/bin/${TFGEN} schema --out provider/cmd/${PROVIDER}
 	(cd provider && VERSION=$(VERSION) go generate cmd/${PROVIDER}/main.go)
 
-provider:: tfgen install_plugins # build the provider binary
-	(cd provider && go build -a -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
+provider:: #tfgen install_plugins # build the provider binary
+	(cd provider && go build -a -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION} -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
 build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet # build all the sdks
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tfgen:: install_plugins
 	$(WORKING_DIR)/bin/${TFGEN} schema --out provider/cmd/${PROVIDER}
 	(cd provider && VERSION=$(VERSION) go generate cmd/${PROVIDER}/main.go)
 
-provider:: #tfgen install_plugins # build the provider binary
+provider:: tfgen install_plugins # build the provider binary
 	(cd provider && go build -a -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION} -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
 build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet # build all the sdks

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -14,5 +14,5 @@ require (
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210402103405-f5979773e8ba
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
-	github.com/terraform-providers/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819164919-091f234ec3d0
+	github.com/terraform-providers/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819174743-d41d3437cc92
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -892,6 +892,10 @@ github.com/pulumi/terraform-provider-aws v1.38.1-0.20210816112209-d0fcff9ca469 h
 github.com/pulumi/terraform-provider-aws v1.38.1-0.20210816112209-d0fcff9ca469/go.mod h1:gxKJ3Fy8p8dUItTHpcYiMfVFRpBHw2wHXOhajUlzyCE=
 github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819164919-091f234ec3d0 h1:j8t107ioA95kKyMQse/cMtKSfFt3m+JQjmw5XxD32VE=
 github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819164919-091f234ec3d0/go.mod h1:gxKJ3Fy8p8dUItTHpcYiMfVFRpBHw2wHXOhajUlzyCE=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819171859-90741c18d5e6 h1:xF2jXntJMGXpof/aPJfHag831Putm0EgHB8Byt0+D+4=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819171859-90741c18d5e6/go.mod h1:gxKJ3Fy8p8dUItTHpcYiMfVFRpBHw2wHXOhajUlzyCE=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819174743-d41d3437cc92 h1:fyk27gnWFLwmiXY+qH3M8y7FAO7Iu8++56KrI7R+9KM=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20210819174743-d41d3437cc92/go.mod h1:gxKJ3Fy8p8dUItTHpcYiMfVFRpBHw2wHXOhajUlzyCE=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=


### PR DESCRIPTION
Fixes: #1553

We now pass:

```
User-Agent: APN/1.0 Pulumi/1.0 Pulumi-Aws/4.17.0-alpha.1629393364+0b9d696e.dirty (+https://www.pulumi.com) aws-sdk-go/1.40.20 (go1.16.4; darwin; amd64)
```


Rather than:

```
User-Agent: APN/1.0 Hashicorp/1.0 Terraform/1.0.5 (+https://terraform.io) aws-sdk-go/1.40.20 (go1.16.4; darwin; amd64)
```
