### PR TITLE
Support updates to dynamodb and sqs NodeJS mixins for use in lambda.EventSourceMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Add the ability to set `maximumBatchingWindowInSeconds` as part of `aws.sqs.QueueEventSubscription` in NodeJS SDK
+* Add the ability to set `functionResponseTypes` as part of `aws.dynamodb.TableEventSubscription` in NodeJS SDK
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Add the ability to set `maximumBatchingWindowInSeconds` as part of `aws.sqs.QueueEventSubscription` in NodeJS SDK
 
 ---
 

--- a/sdk/nodejs/dynamodb/dynamodbMixins.ts
+++ b/sdk/nodejs/dynamodb/dynamodbMixins.ts
@@ -40,6 +40,12 @@ export interface TableEventSubscriptionArgs {
     readonly destinationConfig?: pulumi.Input<types.input.lambda.EventSourceMappingDestinationConfig>;
 
     /**
+     * A list of current response type enums applied to the event source mapping. Where valid values are:
+     * * `ReportBatchItemFailures`
+     */
+    readonly functionResponseTypes?: string[];
+
+    /**
      * The maximum amount of time to gather records before invoking the function, in seconds. Records will continue to buffer
      * until either maximum_batching_window_in_seconds expires or batch_size has been met. Defaults to as soon as records
      * are available in the stream. If the batch it reads from the stream only has one record in it, Lambda only sends one record to the function.
@@ -140,6 +146,7 @@ export class TableEventSubscription extends lambda.EventSubscription {
             maximumRetryAttempts: args.maximumRetryAttempts,
             parallelizationFactor: args.parallelizationFactor,
             startingPosition: args.startingPosition,
+            functionResponseTypes: args.functionResponseTypes,
         }, parentOpts);
 
         this.table = table;

--- a/sdk/nodejs/sqs/sqsMixins.ts
+++ b/sdk/nodejs/sqs/sqsMixins.ts
@@ -54,6 +54,12 @@ export type QueueEventSubscriptionArgs = {
      * See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html for more details.
      */
     batchSize?: number;
+
+    /**
+     * The maximum amount of time, in seconds, that AWS Lambda spends gathering records before invoking the function.
+     * The default setting is 0.
+     */
+    maximumBatchingWindowInSeconds?: number;
  };
 
 export class QueueEventSubscription extends lambda.EventSubscription {
@@ -87,6 +93,7 @@ export class QueueEventSubscription extends lambda.EventSubscription {
 
         this.eventSourceMapping = new lambda.EventSourceMapping(name, {
             batchSize: args.batchSize,
+            maximumBatchingWindowInSeconds: args.maximumBatchingWindowInSeconds,
             enabled: true,
             eventSourceArn: queue.arn,
             functionName: this.func.name,


### PR DESCRIPTION
Fixes: #1634
Fixes: #1642

- Add ability to set maximumBatchingWindowInSeconds to aws.sqs.QueueEventSubscription NodeJS SDK mixin
- Add the ability to set functionResponseTypes as part of aws.dynamodb.TableEventSubscription in NodeJS SDK
