### PR TITLE
Fix regression in management of aws.mq.Broker this was due to an incorrect mapping in the provider SchemaInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Fix regression in management of `aws.mq.Broker` this was due to an incorrect mapping in the provider SchemaInfo
 
 ---
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1941,7 +1941,7 @@ func Provider() tfbridge.ProviderInfo {
 					// 1-50 characters long, must contain only letters, numbers, dashes, and underscores, and must not
 					// contain white spaces, brackets, wildcard characters, or special characters.
 					// https://awscli.amazonaws.com/v2/documentation/api/latest/reference/mq/create-broker.html#options
-					"brokerName": tfbridge.AutoName("brokerName", 55, "-"),
+					"broker_name": tfbridge.AutoName("brokerName", 55, "-"),
 				},
 			},
 			"aws_mq_configuration": {Tok: awsResource(mqMod, "Configuration")},

--- a/sdk/dotnet/Mq/Broker.cs
+++ b/sdk/dotnet/Mq/Broker.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Aws.Mq
     ///     {
     ///         var example = new Aws.Mq.Broker("example", new Aws.Mq.BrokerArgs
     ///         {
-    ///             BrokerName = "example",
     ///             Configuration = new Aws.Mq.Inputs.BrokerConfigurationArgs
     ///             {
     ///                 Id = aws_mq_configuration.Test.Id,
@@ -71,7 +70,6 @@ namespace Pulumi.Aws.Mq
     ///     {
     ///         var example = new Aws.Mq.Broker("example", new Aws.Mq.BrokerArgs
     ///         {
-    ///             BrokerName = "example",
     ///             Configuration = new Aws.Mq.Inputs.BrokerConfigurationArgs
     ///             {
     ///                 Id = aws_mq_configuration.Test.Id,
@@ -320,8 +318,8 @@ namespace Pulumi.Aws.Mq
         /// <summary>
         /// Name of the broker.
         /// </summary>
-        [Input("brokerName", required: true)]
-        public Input<string> BrokerName { get; set; } = null!;
+        [Input("brokerName")]
+        public Input<string>? BrokerName { get; set; }
 
         /// <summary>
         /// Configuration block for broker configuration. Applies to `engine_type` of `ActiveMQ` only. Detailed below.

--- a/sdk/go/aws/mq/broker.go
+++ b/sdk/go/aws/mq/broker.go
@@ -33,7 +33,6 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := mq.NewBroker(ctx, "example", &mq.BrokerArgs{
-// 			BrokerName: pulumi.String("example"),
 // 			Configuration: &mq.BrokerConfigurationArgs{
 // 				Id:       pulumi.Any(aws_mq_configuration.Test.Id),
 // 				Revision: pulumi.Any(aws_mq_configuration.Test.Latest_revision),
@@ -73,7 +72,6 @@ import (
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
 // 		_, err := mq.NewBroker(ctx, "example", &mq.BrokerArgs{
-// 			BrokerName: pulumi.String("example"),
 // 			Configuration: &mq.BrokerConfigurationArgs{
 // 				Id:       pulumi.Any(aws_mq_configuration.Test.Id),
 // 				Revision: pulumi.Any(aws_mq_configuration.Test.Latest_revision),
@@ -174,9 +172,6 @@ func NewBroker(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.BrokerName == nil {
-		return nil, errors.New("invalid value for required argument 'BrokerName'")
-	}
 	if args.EngineType == nil {
 		return nil, errors.New("invalid value for required argument 'EngineType'")
 	}
@@ -338,7 +333,7 @@ type brokerArgs struct {
 	// Whether to automatically upgrade to new minor versions of brokers as Amazon MQ makes releases available.
 	AutoMinorVersionUpgrade *bool `pulumi:"autoMinorVersionUpgrade"`
 	// Name of the broker.
-	BrokerName string `pulumi:"brokerName"`
+	BrokerName *string `pulumi:"brokerName"`
 	// Configuration block for broker configuration. Applies to `engineType` of `ActiveMQ` only. Detailed below.
 	Configuration *BrokerConfiguration `pulumi:"configuration"`
 	// Deployment mode of the broker. Valid values are `SINGLE_INSTANCE`, `ACTIVE_STANDBY_MULTI_AZ`, and `CLUSTER_MULTI_AZ`. Default is `SINGLE_INSTANCE`.
@@ -380,7 +375,7 @@ type BrokerArgs struct {
 	// Whether to automatically upgrade to new minor versions of brokers as Amazon MQ makes releases available.
 	AutoMinorVersionUpgrade pulumi.BoolPtrInput
 	// Name of the broker.
-	BrokerName pulumi.StringInput
+	BrokerName pulumi.StringPtrInput
 	// Configuration block for broker configuration. Applies to `engineType` of `ActiveMQ` only. Detailed below.
 	Configuration BrokerConfigurationPtrInput
 	// Deployment mode of the broker. Valid values are `SINGLE_INSTANCE`, `ACTIVE_STANDBY_MULTI_AZ`, and `CLUSTER_MULTI_AZ`. Default is `SINGLE_INSTANCE`.

--- a/sdk/nodejs/mq/broker.ts
+++ b/sdk/nodejs/mq/broker.ts
@@ -22,7 +22,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.mq.Broker("example", {
- *     brokerName: "example",
  *     configuration: {
  *         id: aws_mq_configuration.test.id,
  *         revision: aws_mq_configuration.test.latest_revision,
@@ -46,7 +45,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.mq.Broker("example", {
- *     brokerName: "example",
  *     configuration: {
  *         id: aws_mq_configuration.test.id,
  *         revision: aws_mq_configuration.test.latest_revision,
@@ -236,9 +234,6 @@ export class Broker extends pulumi.CustomResource {
             inputs["users"] = state ? state.users : undefined;
         } else {
             const args = argsOrState as BrokerArgs | undefined;
-            if ((!args || args.brokerName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'brokerName'");
-            }
             if ((!args || args.engineType === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'engineType'");
             }
@@ -405,7 +400,7 @@ export interface BrokerArgs {
     /**
      * Name of the broker.
      */
-    brokerName: pulumi.Input<string>;
+    brokerName?: pulumi.Input<string>;
     /**
      * Configuration block for broker configuration. Applies to `engineType` of `ActiveMQ` only. Detailed below.
      */

--- a/sdk/python/pulumi_aws/mq/broker.py
+++ b/sdk/python/pulumi_aws/mq/broker.py
@@ -15,7 +15,6 @@ __all__ = ['BrokerArgs', 'Broker']
 @pulumi.input_type
 class BrokerArgs:
     def __init__(__self__, *,
-                 broker_name: pulumi.Input[str],
                  engine_type: pulumi.Input[str],
                  engine_version: pulumi.Input[str],
                  host_instance_type: pulumi.Input[str],
@@ -23,6 +22,7 @@ class BrokerArgs:
                  apply_immediately: Optional[pulumi.Input[bool]] = None,
                  authentication_strategy: Optional[pulumi.Input[str]] = None,
                  auto_minor_version_upgrade: Optional[pulumi.Input[bool]] = None,
+                 broker_name: Optional[pulumi.Input[str]] = None,
                  configuration: Optional[pulumi.Input['BrokerConfigurationArgs']] = None,
                  deployment_mode: Optional[pulumi.Input[str]] = None,
                  encryption_options: Optional[pulumi.Input['BrokerEncryptionOptionsArgs']] = None,
@@ -36,7 +36,6 @@ class BrokerArgs:
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Broker resource.
-        :param pulumi.Input[str] broker_name: Name of the broker.
         :param pulumi.Input[str] engine_type: Type of broker engine. Valid values are `ActiveMQ` and `RabbitMQ`.
         :param pulumi.Input[str] engine_version: Version of the broker engine. See the [AmazonMQ Broker Engine docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html) for supported versions. For example, `5.15.0`.
         :param pulumi.Input[str] host_instance_type: Broker's instance type. For example, `mq.t3.micro`, `mq.m5.large`.
@@ -44,6 +43,7 @@ class BrokerArgs:
         :param pulumi.Input[bool] apply_immediately: Specifies whether any broker modifications are applied immediately, or during the next maintenance window. Default is `false`.
         :param pulumi.Input[str] authentication_strategy: Authentication strategy used to secure the broker. Valid values are `simple` and `ldap`. `ldap` is not supported for `engine_type` `RabbitMQ`.
         :param pulumi.Input[bool] auto_minor_version_upgrade: Whether to automatically upgrade to new minor versions of brokers as Amazon MQ makes releases available.
+        :param pulumi.Input[str] broker_name: Name of the broker.
         :param pulumi.Input['BrokerConfigurationArgs'] configuration: Configuration block for broker configuration. Applies to `engine_type` of `ActiveMQ` only. Detailed below.
         :param pulumi.Input[str] deployment_mode: Deployment mode of the broker. Valid values are `SINGLE_INSTANCE`, `ACTIVE_STANDBY_MULTI_AZ`, and `CLUSTER_MULTI_AZ`. Default is `SINGLE_INSTANCE`.
         :param pulumi.Input['BrokerEncryptionOptionsArgs'] encryption_options: Configuration block containing encryption options. Detailed below.
@@ -56,7 +56,6 @@ class BrokerArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: List of subnet IDs in which to launch the broker. A `SINGLE_INSTANCE` deployment requires one subnet. An `ACTIVE_STANDBY_MULTI_AZ` deployment requires multiple subnets.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Map of tags to assign to the broker. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
-        pulumi.set(__self__, "broker_name", broker_name)
         pulumi.set(__self__, "engine_type", engine_type)
         pulumi.set(__self__, "engine_version", engine_version)
         pulumi.set(__self__, "host_instance_type", host_instance_type)
@@ -67,6 +66,8 @@ class BrokerArgs:
             pulumi.set(__self__, "authentication_strategy", authentication_strategy)
         if auto_minor_version_upgrade is not None:
             pulumi.set(__self__, "auto_minor_version_upgrade", auto_minor_version_upgrade)
+        if broker_name is not None:
+            pulumi.set(__self__, "broker_name", broker_name)
         if configuration is not None:
             pulumi.set(__self__, "configuration", configuration)
         if deployment_mode is not None:
@@ -89,18 +90,6 @@ class BrokerArgs:
             pulumi.set(__self__, "subnet_ids", subnet_ids)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter(name="brokerName")
-    def broker_name(self) -> pulumi.Input[str]:
-        """
-        Name of the broker.
-        """
-        return pulumi.get(self, "broker_name")
-
-    @broker_name.setter
-    def broker_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "broker_name", value)
 
     @property
     @pulumi.getter(name="engineType")
@@ -185,6 +174,18 @@ class BrokerArgs:
     @auto_minor_version_upgrade.setter
     def auto_minor_version_upgrade(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "auto_minor_version_upgrade", value)
+
+    @property
+    @pulumi.getter(name="brokerName")
+    def broker_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the broker.
+        """
+        return pulumi.get(self, "broker_name")
+
+    @broker_name.setter
+    def broker_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "broker_name", value)
 
     @property
     @pulumi.getter
@@ -743,7 +744,6 @@ class Broker(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.mq.Broker("example",
-            broker_name="example",
             configuration=aws.mq.BrokerConfigurationArgs(
                 id=aws_mq_configuration["test"]["id"],
                 revision=aws_mq_configuration["test"]["latest_revision"],
@@ -766,7 +766,6 @@ class Broker(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.mq.Broker("example",
-            broker_name="example",
             configuration=aws.mq.BrokerConfigurationArgs(
                 id=aws_mq_configuration["test"]["id"],
                 revision=aws_mq_configuration["test"]["latest_revision"],
@@ -835,7 +834,6 @@ class Broker(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.mq.Broker("example",
-            broker_name="example",
             configuration=aws.mq.BrokerConfigurationArgs(
                 id=aws_mq_configuration["test"]["id"],
                 revision=aws_mq_configuration["test"]["latest_revision"],
@@ -858,7 +856,6 @@ class Broker(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.mq.Broker("example",
-            broker_name="example",
             configuration=aws.mq.BrokerConfigurationArgs(
                 id=aws_mq_configuration["test"]["id"],
                 revision=aws_mq_configuration["test"]["latest_revision"],
@@ -931,8 +928,6 @@ class Broker(pulumi.CustomResource):
             __props__.__dict__["apply_immediately"] = apply_immediately
             __props__.__dict__["authentication_strategy"] = authentication_strategy
             __props__.__dict__["auto_minor_version_upgrade"] = auto_minor_version_upgrade
-            if broker_name is None and not opts.urn:
-                raise TypeError("Missing required property 'broker_name'")
             __props__.__dict__["broker_name"] = broker_name
             __props__.__dict__["configuration"] = configuration
             __props__.__dict__["deployment_mode"] = deployment_mode


### PR DESCRIPTION
Fixes: #1686

Before:
```
     Type                 Name                Plan       Info
 +   pulumi:pulumi:Stack  test-mk-broker-dev  create
     └─ aws:mq:Broker     test                           2 errors

Diagnostics:
  aws:mq:Broker (test):
    error: aws:mq/broker:Broker resource 'test' has a problem: Missing required argument: The argument "broker_name" is required, but no definition was found.. Examine values at 'Broker.BrokerName'.
    error: aws:mq/broker:Broker resource 'test' has a problem: Invalid or unknown key. Examine values at 'Broker.BrokerName'.
```


After:
```
View Live: https://app.pulumi.com/stack72/test-mk-broker/dev/previews/98b3b496-659c-4949-9abd-777029c318e3

     Type                 Name                Plan
 +   pulumi:pulumi:Stack  test-mk-broker-dev  create
 +   └─ aws:mq:Broker     test                create

Resources:
    + 2 to create

Do you want to perform this update? yes
Updating (dev)

View Live: https://app.pulumi.com/stack72/test-mk-broker/dev/updates/1

     Type                 Name                Status
 +   pulumi:pulumi:Stack  test-mk-broker-dev  created
 +   └─ aws:mq:Broker     test                created

Resources:
    + 2 created

Duration: 12m32s
```

The issue was the fact that the mapped override wasn't using the TF Name - it was using our internal naming

so brokerName -> broker_name to fix the bug