### PR TITLE
support g4ad.xlarge and g4ad.2xlarge instance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
-
----
+* Add support for g4ad.xlarge and g4ad.2xlarge EC2 instance types.
 
 ## 4.31.0 (2021-12-03)
 * Upgrade to v3.68.0 of the AWS Terraform Provider

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -3064,6 +3064,8 @@ func Provider() tfbridge.ProviderInfo {
 					{Name: "G3_8XLarge", Value: "g3.8xlarge"},
 					{Name: "G3s_XLarge", Value: "g3s.xlarge"},
 					{Name: "G4ad_16XLarge", Value: "g4ad.16xlarge"},
+					{Name: "G4ad_XLarge", Value: "g4ad.xlarge"},
+					{Name: "G4ad_2XLarge", Value: "g4ad.2xlarge"},
 					{Name: "G4ad_4XLarge", Value: "g4ad.4xlarge"},
 					{Name: "G4ad_8XLarge", Value: "g4ad.8xlarge"},
 					{Name: "G4dn_12XLarge", Value: "g4dn.12xlarge"},
@@ -3174,7 +3176,6 @@ func Provider() tfbridge.ProviderInfo {
 					{Name: "M5zn_Large", Value: "m5zn.large"},
 					{Name: "M5zn_Metal", Value: "m5zn.metal"},
 					{Name: "M5zn_XLarge", Value: "m5zn.xlarge"},
-
 					{Name: "M6g_12XLarge", Value: "m6g.12xlarge"},
 					{Name: "M6g_16XLarge", Value: "m6g.16xlarge"},
 					{Name: "M6g_2XLarge", Value: "m6g.2xlarge"},

--- a/sdk/dotnet/Ec2/Enums.cs
+++ b/sdk/dotnet/Ec2/Enums.cs
@@ -153,6 +153,8 @@ namespace Pulumi.Aws.Ec2
         public static InstanceType G3_8XLarge { get; } = new InstanceType("g3.8xlarge");
         public static InstanceType G3s_XLarge { get; } = new InstanceType("g3s.xlarge");
         public static InstanceType G4ad_16XLarge { get; } = new InstanceType("g4ad.16xlarge");
+        public static InstanceType G4ad_XLarge { get; } = new InstanceType("g4ad.xlarge");
+        public static InstanceType G4ad_2XLarge { get; } = new InstanceType("g4ad.2xlarge");
         public static InstanceType G4ad_4XLarge { get; } = new InstanceType("g4ad.4xlarge");
         public static InstanceType G4ad_8XLarge { get; } = new InstanceType("g4ad.8xlarge");
         public static InstanceType G4dn_12XLarge { get; } = new InstanceType("g4dn.12xlarge");

--- a/sdk/go/aws/ec2/pulumiEnums.go
+++ b/sdk/go/aws/ec2/pulumiEnums.go
@@ -285,6 +285,8 @@ const (
 	InstanceType_G3_8XLarge    = InstanceType("g3.8xlarge")
 	InstanceType_G3s_XLarge    = InstanceType("g3s.xlarge")
 	InstanceType_G4ad_16XLarge = InstanceType("g4ad.16xlarge")
+	InstanceType_G4ad_XLarge   = InstanceType("g4ad.xlarge")
+	InstanceType_G4ad_2XLarge  = InstanceType("g4ad.2xlarge")
 	InstanceType_G4ad_4XLarge  = InstanceType("g4ad.4xlarge")
 	InstanceType_G4ad_8XLarge  = InstanceType("g4ad.8xlarge")
 	InstanceType_G4dn_12XLarge = InstanceType("g4dn.12xlarge")

--- a/sdk/nodejs/types/enums/ec2/index.ts
+++ b/sdk/nodejs/types/enums/ec2/index.ts
@@ -118,6 +118,8 @@ export const InstanceType = {
     G3_8XLarge: "g3.8xlarge",
     G3s_XLarge: "g3s.xlarge",
     G4ad_16XLarge: "g4ad.16xlarge",
+    G4ad_XLarge: "g4ad.xlarge",
+    G4ad_2XLarge: "g4ad.2xlarge",
     G4ad_4XLarge: "g4ad.4xlarge",
     G4ad_8XLarge: "g4ad.8xlarge",
     G4dn_12XLarge: "g4dn.12xlarge",

--- a/sdk/python/pulumi_aws/ec2/_enums.py
+++ b/sdk/python/pulumi_aws/ec2/_enums.py
@@ -127,6 +127,8 @@ class InstanceType(str, Enum):
     G3_8_X_LARGE = "g3.8xlarge"
     G3S_X_LARGE = "g3s.xlarge"
     G4AD_16_X_LARGE = "g4ad.16xlarge"
+    G4AD_X_LARGE = "g4ad.xlarge"
+    G4AD_2_X_LARGE = "g4ad.2xlarge"
     G4AD_4_X_LARGE = "g4ad.4xlarge"
     G4AD_8_X_LARGE = "g4ad.8xlarge"
     G4DN_12_X_LARGE = "g4dn.12xlarge"


### PR DESCRIPTION
Add `g4ad.xlarge` and `g4ad.2xlarge` EC2 instance types.

Requested in https://github.com/pulumi/pulumi-aws/issues/1674