### PR TITLE
fix labelling of ecs cluster names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
-
----
+* Fix labelling of ECS cluster name parameters.
 
 ## 4.31.0 (2021-12-03)
 * Upgrade to v3.68.0 of the AWS Terraform Provider

--- a/sdk/dotnet/Ecs/Cluster.cs
+++ b/sdk/dotnet/Ecs/Cluster.cs
@@ -113,7 +113,7 @@ namespace Pulumi.Aws.Ecs
         public Output<ImmutableArray<Outputs.ClusterDefaultCapacityProviderStrategy>> DefaultCapacityProviderStrategies { get; private set; } = null!;
 
         /// <summary>
-        /// Name of the setting to manage. Valid values: `containerInsights`.
+        /// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         /// </summary>
         [Output("name")]
         public Output<string> Name { get; private set; } = null!;
@@ -207,7 +207,7 @@ namespace Pulumi.Aws.Ecs
         }
 
         /// <summary>
-        /// Name of the setting to manage. Valid values: `containerInsights`.
+        /// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }
@@ -276,7 +276,7 @@ namespace Pulumi.Aws.Ecs
         }
 
         /// <summary>
-        /// Name of the setting to manage. Valid values: `containerInsights`.
+        /// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/sdk/go/aws/ecs/cluster.go
+++ b/sdk/go/aws/ecs/cluster.go
@@ -103,7 +103,7 @@ type Cluster struct {
 	Configuration ClusterConfigurationPtrOutput `pulumi:"configuration"`
 	// Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 	DefaultCapacityProviderStrategies ClusterDefaultCapacityProviderStrategyArrayOutput `pulumi:"defaultCapacityProviderStrategies"`
-	// Name of the setting to manage. Valid values: `containerInsights`.
+	// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
 	Name pulumi.StringOutput `pulumi:"name"`
 	// Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 	Settings ClusterSettingArrayOutput `pulumi:"settings"`
@@ -148,7 +148,7 @@ type clusterState struct {
 	Configuration *ClusterConfiguration `pulumi:"configuration"`
 	// Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 	DefaultCapacityProviderStrategies []ClusterDefaultCapacityProviderStrategy `pulumi:"defaultCapacityProviderStrategies"`
-	// Name of the setting to manage. Valid values: `containerInsights`.
+	// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
 	Name *string `pulumi:"name"`
 	// Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 	Settings []ClusterSetting  `pulumi:"settings"`
@@ -165,7 +165,7 @@ type ClusterState struct {
 	Configuration ClusterConfigurationPtrInput
 	// Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 	DefaultCapacityProviderStrategies ClusterDefaultCapacityProviderStrategyArrayInput
-	// Name of the setting to manage. Valid values: `containerInsights`.
+	// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
 	Name pulumi.StringPtrInput
 	// Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 	Settings ClusterSettingArrayInput
@@ -184,7 +184,7 @@ type clusterArgs struct {
 	Configuration *ClusterConfiguration `pulumi:"configuration"`
 	// Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 	DefaultCapacityProviderStrategies []ClusterDefaultCapacityProviderStrategy `pulumi:"defaultCapacityProviderStrategies"`
-	// Name of the setting to manage. Valid values: `containerInsights`.
+	// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
 	Name *string `pulumi:"name"`
 	// Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 	Settings []ClusterSetting  `pulumi:"settings"`
@@ -199,7 +199,7 @@ type ClusterArgs struct {
 	Configuration ClusterConfigurationPtrInput
 	// Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 	DefaultCapacityProviderStrategies ClusterDefaultCapacityProviderStrategyArrayInput
-	// Name of the setting to manage. Valid values: `containerInsights`.
+	// The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
 	Name pulumi.StringPtrInput
 	// Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 	Settings ClusterSettingArrayInput

--- a/sdk/nodejs/ecs/cluster.ts
+++ b/sdk/nodejs/ecs/cluster.ts
@@ -98,7 +98,7 @@ export class Cluster extends pulumi.CustomResource {
      */
     public readonly defaultCapacityProviderStrategies!: pulumi.Output<outputs.ecs.ClusterDefaultCapacityProviderStrategy[] | undefined>;
     /**
-     * Name of the setting to manage. Valid values: `containerInsights`.
+     * The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
      */
     public readonly name!: pulumi.Output<string>;
     /**
@@ -168,7 +168,7 @@ export interface ClusterState {
      */
     defaultCapacityProviderStrategies?: pulumi.Input<pulumi.Input<inputs.ecs.ClusterDefaultCapacityProviderStrategy>[]>;
     /**
-     * Name of the setting to manage. Valid values: `containerInsights`.
+     * The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
      */
     name?: pulumi.Input<string>;
     /**
@@ -196,7 +196,7 @@ export interface ClusterArgs {
      */
     defaultCapacityProviderStrategies?: pulumi.Input<pulumi.Input<inputs.ecs.ClusterDefaultCapacityProviderStrategy>[]>;
     /**
-     * Name of the setting to manage. Valid values: `containerInsights`.
+     * The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
      */
     name?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_aws/ecs/cluster.py
+++ b/sdk/python/pulumi_aws/ecs/cluster.py
@@ -26,7 +26,7 @@ class ClusterArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] capacity_providers: List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
         :param pulumi.Input['ClusterConfigurationArgs'] configuration: The execute command configuration for the cluster. Detailed below.
         :param pulumi.Input[Sequence[pulumi.Input['ClusterDefaultCapacityProviderStrategyArgs']]] default_capacity_provider_strategies: Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
-        :param pulumi.Input[str] name: Name of the setting to manage. Valid values: `containerInsights`.
+        :param pulumi.Input[str] name: The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         :param pulumi.Input[Sequence[pulumi.Input['ClusterSettingArgs']]] settings: Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
         """
         if capacity_providers is not None:
@@ -82,7 +82,7 @@ class ClusterArgs:
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[str]]:
         """
-        Name of the setting to manage. Valid values: `containerInsights`.
+        The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         """
         return pulumi.get(self, "name")
 
@@ -129,7 +129,7 @@ class _ClusterState:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] capacity_providers: List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
         :param pulumi.Input['ClusterConfigurationArgs'] configuration: The execute command configuration for the cluster. Detailed below.
         :param pulumi.Input[Sequence[pulumi.Input['ClusterDefaultCapacityProviderStrategyArgs']]] default_capacity_provider_strategies: Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
-        :param pulumi.Input[str] name: Name of the setting to manage. Valid values: `containerInsights`.
+        :param pulumi.Input[str] name: The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         :param pulumi.Input[Sequence[pulumi.Input['ClusterSettingArgs']]] settings: Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
         """
         if arn is not None:
@@ -201,7 +201,7 @@ class _ClusterState:
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[str]]:
         """
-        Name of the setting to manage. Valid values: `containerInsights`.
+        The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         """
         return pulumi.get(self, "name")
 
@@ -302,7 +302,7 @@ class Cluster(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] capacity_providers: List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
         :param pulumi.Input[pulumi.InputType['ClusterConfigurationArgs']] configuration: The execute command configuration for the cluster. Detailed below.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterDefaultCapacityProviderStrategyArgs']]]] default_capacity_provider_strategies: Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
-        :param pulumi.Input[str] name: Name of the setting to manage. Valid values: `containerInsights`.
+        :param pulumi.Input[str] name: The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterSettingArgs']]]] settings: Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
         """
         ...
@@ -426,7 +426,7 @@ class Cluster(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] capacity_providers: List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
         :param pulumi.Input[pulumi.InputType['ClusterConfigurationArgs']] configuration: The execute command configuration for the cluster. Detailed below.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterDefaultCapacityProviderStrategyArgs']]]] default_capacity_provider_strategies: Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
-        :param pulumi.Input[str] name: Name of the setting to manage. Valid values: `containerInsights`.
+        :param pulumi.Input[str] name: The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterSettingArgs']]]] settings: Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
@@ -479,7 +479,7 @@ class Cluster(pulumi.CustomResource):
     @pulumi.getter
     def name(self) -> pulumi.Output[str]:
         """
-        Name of the setting to manage. Valid values: `containerInsights`.
+        The name of the cluster (up to 255 letters, numbers, hyphens, and underscores).
         """
         return pulumi.get(self, "name")
 


### PR DESCRIPTION
The same comments were used to describe the names of cluster settings as the names of the ECS clusters themselves. This PR fixes that as requested in https://github.com/pulumi/pulumi-aws/issues/1678 .