### PR TITLE
aws.sns.SmsPreferences monthlySpendLimit should be an int

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2598,14 +2598,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			// Simple Notification Service (SNS)
 			"aws_sns_platform_application": {Tok: awsResource(snsMod, "PlatformApplication")},
-			"aws_sns_sms_preferences": {
-				Tok: awsResource(snsMod, "SmsPreferences"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					"monthly_spend_limit": {
-						Type: "string",
-					},
-				},
-			},
+			"aws_sns_sms_preferences":      {Tok: awsResource(snsMod, "SmsPreferences")},
 			"aws_sns_topic": {
 				Tok: awsResource(snsMod, "Topic"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/dotnet/Sns/SmsPreferences.cs
+++ b/sdk/dotnet/Sns/SmsPreferences.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Aws.Sns
         /// The maximum amount in USD that you are willing to spend each month to send SMS messages.
         /// </summary>
         [Output("monthlySpendLimit")]
-        public Output<string> MonthlySpendLimit { get; private set; } = null!;
+        public Output<int> MonthlySpendLimit { get; private set; } = null!;
 
         /// <summary>
         /// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
@@ -143,7 +143,7 @@ namespace Pulumi.Aws.Sns
         /// The maximum amount in USD that you are willing to spend each month to send SMS messages.
         /// </summary>
         [Input("monthlySpendLimit")]
-        public Input<string>? MonthlySpendLimit { get; set; }
+        public Input<int>? MonthlySpendLimit { get; set; }
 
         /// <summary>
         /// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
@@ -186,7 +186,7 @@ namespace Pulumi.Aws.Sns
         /// The maximum amount in USD that you are willing to spend each month to send SMS messages.
         /// </summary>
         [Input("monthlySpendLimit")]
-        public Input<string>? MonthlySpendLimit { get; set; }
+        public Input<int>? MonthlySpendLimit { get; set; }
 
         /// <summary>
         /// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.

--- a/sdk/go/aws/sns/smsPreferences.go
+++ b/sdk/go/aws/sns/smsPreferences.go
@@ -44,7 +44,7 @@ type SmsPreferences struct {
 	// The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
 	DeliveryStatusSuccessSamplingRate pulumi.StringPtrOutput `pulumi:"deliveryStatusSuccessSamplingRate"`
 	// The maximum amount in USD that you are willing to spend each month to send SMS messages.
-	MonthlySpendLimit pulumi.StringOutput `pulumi:"monthlySpendLimit"`
+	MonthlySpendLimit pulumi.IntOutput `pulumi:"monthlySpendLimit"`
 	// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
 	UsageReportS3Bucket pulumi.StringPtrOutput `pulumi:"usageReportS3Bucket"`
 }
@@ -87,7 +87,7 @@ type smsPreferencesState struct {
 	// The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
 	DeliveryStatusSuccessSamplingRate *string `pulumi:"deliveryStatusSuccessSamplingRate"`
 	// The maximum amount in USD that you are willing to spend each month to send SMS messages.
-	MonthlySpendLimit *string `pulumi:"monthlySpendLimit"`
+	MonthlySpendLimit *int `pulumi:"monthlySpendLimit"`
 	// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
 	UsageReportS3Bucket *string `pulumi:"usageReportS3Bucket"`
 }
@@ -102,7 +102,7 @@ type SmsPreferencesState struct {
 	// The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
 	DeliveryStatusSuccessSamplingRate pulumi.StringPtrInput
 	// The maximum amount in USD that you are willing to spend each month to send SMS messages.
-	MonthlySpendLimit pulumi.StringPtrInput
+	MonthlySpendLimit pulumi.IntPtrInput
 	// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
 	UsageReportS3Bucket pulumi.StringPtrInput
 }
@@ -121,7 +121,7 @@ type smsPreferencesArgs struct {
 	// The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
 	DeliveryStatusSuccessSamplingRate *string `pulumi:"deliveryStatusSuccessSamplingRate"`
 	// The maximum amount in USD that you are willing to spend each month to send SMS messages.
-	MonthlySpendLimit *string `pulumi:"monthlySpendLimit"`
+	MonthlySpendLimit *int `pulumi:"monthlySpendLimit"`
 	// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
 	UsageReportS3Bucket *string `pulumi:"usageReportS3Bucket"`
 }
@@ -137,7 +137,7 @@ type SmsPreferencesArgs struct {
 	// The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
 	DeliveryStatusSuccessSamplingRate pulumi.StringPtrInput
 	// The maximum amount in USD that you are willing to spend each month to send SMS messages.
-	MonthlySpendLimit pulumi.StringPtrInput
+	MonthlySpendLimit pulumi.IntPtrInput
 	// The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
 	UsageReportS3Bucket pulumi.StringPtrInput
 }

--- a/sdk/nodejs/sns/smsPreferences.ts
+++ b/sdk/nodejs/sns/smsPreferences.ts
@@ -63,7 +63,7 @@ export class SmsPreferences extends pulumi.CustomResource {
     /**
      * The maximum amount in USD that you are willing to spend each month to send SMS messages.
      */
-    public readonly monthlySpendLimit!: pulumi.Output<string>;
+    public readonly monthlySpendLimit!: pulumi.Output<number>;
     /**
      * The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
      */
@@ -125,7 +125,7 @@ export interface SmsPreferencesState {
     /**
      * The maximum amount in USD that you are willing to spend each month to send SMS messages.
      */
-    monthlySpendLimit?: pulumi.Input<string>;
+    monthlySpendLimit?: pulumi.Input<number>;
     /**
      * The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
      */
@@ -155,7 +155,7 @@ export interface SmsPreferencesArgs {
     /**
      * The maximum amount in USD that you are willing to spend each month to send SMS messages.
      */
-    monthlySpendLimit?: pulumi.Input<string>;
+    monthlySpendLimit?: pulumi.Input<number>;
     /**
      * The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
      */

--- a/sdk/python/pulumi_aws/sns/sms_preferences.py
+++ b/sdk/python/pulumi_aws/sns/sms_preferences.py
@@ -17,7 +17,7 @@ class SmsPreferencesArgs:
                  default_sms_type: Optional[pulumi.Input[str]] = None,
                  delivery_status_iam_role_arn: Optional[pulumi.Input[str]] = None,
                  delivery_status_success_sampling_rate: Optional[pulumi.Input[str]] = None,
-                 monthly_spend_limit: Optional[pulumi.Input[str]] = None,
+                 monthly_spend_limit: Optional[pulumi.Input[int]] = None,
                  usage_report_s3_bucket: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a SmsPreferences resource.
@@ -25,7 +25,7 @@ class SmsPreferencesArgs:
         :param pulumi.Input[str] default_sms_type: The type of SMS message that you will send by default. Possible values are: Promotional, Transactional
         :param pulumi.Input[str] delivery_status_iam_role_arn: The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs.
         :param pulumi.Input[str] delivery_status_success_sampling_rate: The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
-        :param pulumi.Input[str] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
+        :param pulumi.Input[int] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
         :param pulumi.Input[str] usage_report_s3_bucket: The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
         """
         if default_sender_id is not None:
@@ -91,14 +91,14 @@ class SmsPreferencesArgs:
 
     @property
     @pulumi.getter(name="monthlySpendLimit")
-    def monthly_spend_limit(self) -> Optional[pulumi.Input[str]]:
+    def monthly_spend_limit(self) -> Optional[pulumi.Input[int]]:
         """
         The maximum amount in USD that you are willing to spend each month to send SMS messages.
         """
         return pulumi.get(self, "monthly_spend_limit")
 
     @monthly_spend_limit.setter
-    def monthly_spend_limit(self, value: Optional[pulumi.Input[str]]):
+    def monthly_spend_limit(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "monthly_spend_limit", value)
 
     @property
@@ -121,7 +121,7 @@ class _SmsPreferencesState:
                  default_sms_type: Optional[pulumi.Input[str]] = None,
                  delivery_status_iam_role_arn: Optional[pulumi.Input[str]] = None,
                  delivery_status_success_sampling_rate: Optional[pulumi.Input[str]] = None,
-                 monthly_spend_limit: Optional[pulumi.Input[str]] = None,
+                 monthly_spend_limit: Optional[pulumi.Input[int]] = None,
                  usage_report_s3_bucket: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering SmsPreferences resources.
@@ -129,7 +129,7 @@ class _SmsPreferencesState:
         :param pulumi.Input[str] default_sms_type: The type of SMS message that you will send by default. Possible values are: Promotional, Transactional
         :param pulumi.Input[str] delivery_status_iam_role_arn: The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs.
         :param pulumi.Input[str] delivery_status_success_sampling_rate: The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
-        :param pulumi.Input[str] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
+        :param pulumi.Input[int] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
         :param pulumi.Input[str] usage_report_s3_bucket: The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
         """
         if default_sender_id is not None:
@@ -195,14 +195,14 @@ class _SmsPreferencesState:
 
     @property
     @pulumi.getter(name="monthlySpendLimit")
-    def monthly_spend_limit(self) -> Optional[pulumi.Input[str]]:
+    def monthly_spend_limit(self) -> Optional[pulumi.Input[int]]:
         """
         The maximum amount in USD that you are willing to spend each month to send SMS messages.
         """
         return pulumi.get(self, "monthly_spend_limit")
 
     @monthly_spend_limit.setter
-    def monthly_spend_limit(self, value: Optional[pulumi.Input[str]]):
+    def monthly_spend_limit(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "monthly_spend_limit", value)
 
     @property
@@ -227,7 +227,7 @@ class SmsPreferences(pulumi.CustomResource):
                  default_sms_type: Optional[pulumi.Input[str]] = None,
                  delivery_status_iam_role_arn: Optional[pulumi.Input[str]] = None,
                  delivery_status_success_sampling_rate: Optional[pulumi.Input[str]] = None,
-                 monthly_spend_limit: Optional[pulumi.Input[str]] = None,
+                 monthly_spend_limit: Optional[pulumi.Input[int]] = None,
                  usage_report_s3_bucket: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -248,7 +248,7 @@ class SmsPreferences(pulumi.CustomResource):
         :param pulumi.Input[str] default_sms_type: The type of SMS message that you will send by default. Possible values are: Promotional, Transactional
         :param pulumi.Input[str] delivery_status_iam_role_arn: The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs.
         :param pulumi.Input[str] delivery_status_success_sampling_rate: The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
-        :param pulumi.Input[str] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
+        :param pulumi.Input[int] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
         :param pulumi.Input[str] usage_report_s3_bucket: The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
         """
         ...
@@ -288,7 +288,7 @@ class SmsPreferences(pulumi.CustomResource):
                  default_sms_type: Optional[pulumi.Input[str]] = None,
                  delivery_status_iam_role_arn: Optional[pulumi.Input[str]] = None,
                  delivery_status_success_sampling_rate: Optional[pulumi.Input[str]] = None,
-                 monthly_spend_limit: Optional[pulumi.Input[str]] = None,
+                 monthly_spend_limit: Optional[pulumi.Input[int]] = None,
                  usage_report_s3_bucket: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:
@@ -322,7 +322,7 @@ class SmsPreferences(pulumi.CustomResource):
             default_sms_type: Optional[pulumi.Input[str]] = None,
             delivery_status_iam_role_arn: Optional[pulumi.Input[str]] = None,
             delivery_status_success_sampling_rate: Optional[pulumi.Input[str]] = None,
-            monthly_spend_limit: Optional[pulumi.Input[str]] = None,
+            monthly_spend_limit: Optional[pulumi.Input[int]] = None,
             usage_report_s3_bucket: Optional[pulumi.Input[str]] = None) -> 'SmsPreferences':
         """
         Get an existing SmsPreferences resource's state with the given name, id, and optional extra
@@ -335,7 +335,7 @@ class SmsPreferences(pulumi.CustomResource):
         :param pulumi.Input[str] default_sms_type: The type of SMS message that you will send by default. Possible values are: Promotional, Transactional
         :param pulumi.Input[str] delivery_status_iam_role_arn: The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs.
         :param pulumi.Input[str] delivery_status_success_sampling_rate: The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value must be between 0 and 100.
-        :param pulumi.Input[str] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
+        :param pulumi.Input[int] monthly_spend_limit: The maximum amount in USD that you are willing to spend each month to send SMS messages.
         :param pulumi.Input[str] usage_report_s3_bucket: The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
@@ -384,7 +384,7 @@ class SmsPreferences(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="monthlySpendLimit")
-    def monthly_spend_limit(self) -> pulumi.Output[str]:
+    def monthly_spend_limit(self) -> pulumi.Output[int]:
         """
         The maximum amount in USD that you are willing to spend each month to send SMS messages.
         """


### PR DESCRIPTION
Fixes: #1808

We remove the string override to ensure we are passing an int
to the AWS API as expected
