### PR TITLE
various fixes

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -13,7 +13,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f
-	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220207204032-050b6cb90178
+	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220214163510-aaaca2feed0b
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -721,8 +721,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f h1:YWtQ7xeRQvB9h5Uwtrl9wDKRKkyLTXWBzU7x0c9VOZ4=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f/go.mod h1:grseeRo9g3yNkYW09iFlV8LG78jTa1ssBgouogQg/RU=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220207204032-050b6cb90178 h1:k7vz6FhXXKb7Vp0dq1hrYT5LQNkWhwjrCS7qLTSJSUA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220207204032-050b6cb90178/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220214163510-aaaca2feed0b h1:/iHHp2zF72cW4NFau3EaauM1B02m2nXY7H7OF4adzsQ=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220214163510-aaaca2feed0b/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -862,9 +862,24 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_codebuild_report_group":      {Tok: awsResource(codebuildMod, "ReportGroup")},
 			"aws_codebuild_resource_policy":   {Tok: awsResource(codebuildMod, "ResourcePolicy")},
 			// CodeDeploy
-			"aws_codedeploy_app":               {Tok: awsResource(codedeployMod, "Application")},
-			"aws_codedeploy_deployment_config": {Tok: awsResource(codedeployMod, "DeploymentConfig")},
-			"aws_codedeploy_deployment_group":  {Tok: awsResource(codedeployMod, "DeploymentGroup")},
+			"aws_codedeploy_app": {Tok: awsResource(codedeployMod, "Application")},
+			"aws_codedeploy_deployment_config": {
+				Tok: awsResource(codedeployMod, "DeploymentConfig"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"deployment_config_name": {
+						Default: &tfbridge.DefaultInfo{
+							// This is taken from
+							// https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeployment.html
+							From: tfbridge.FromName(tfbridge.AutoNameOptions{
+								Separator: "_",
+								Maxlen:    100,
+								Randlen:   7,
+							}),
+						},
+					},
+				},
+			},
+			"aws_codedeploy_deployment_group": {Tok: awsResource(codedeployMod, "DeploymentGroup")},
 			// CodeCommit
 			"aws_codecommit_repository": {
 				Tok: awsResource(codecommitMod, "Repository"),

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20211105002759-77bad27d9f23
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220207204032-050b6cb90178
+replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220214163510-aaaca2feed0b

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -316,8 +316,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220207204032-050b6cb90178 h1:k7vz6FhXXKb7Vp0dq1hrYT5LQNkWhwjrCS7qLTSJSUA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220207204032-050b6cb90178/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220214163510-aaaca2feed0b h1:/iHHp2zF72cW4NFau3EaauM1B02m2nXY7H7OF4adzsQ=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220214163510-aaaca2feed0b/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/sdk/dotnet/CodeDeploy/DeploymentConfig.cs
+++ b/sdk/dotnet/CodeDeploy/DeploymentConfig.cs
@@ -181,7 +181,7 @@ namespace Pulumi.Aws.CodeDeploy
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public DeploymentConfig(string name, DeploymentConfigArgs args, CustomResourceOptions? options = null)
+        public DeploymentConfig(string name, DeploymentConfigArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:codedeploy/deploymentConfig:DeploymentConfig", name, args ?? new DeploymentConfigArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -228,8 +228,8 @@ namespace Pulumi.Aws.CodeDeploy
         /// <summary>
         /// The name of the deployment config.
         /// </summary>
-        [Input("deploymentConfigName", required: true)]
-        public Input<string> DeploymentConfigName { get; set; } = null!;
+        [Input("deploymentConfigName")]
+        public Input<string>? DeploymentConfigName { get; set; }
 
         /// <summary>
         /// A minimum_healthy_hosts block. Required for `Server` compute platform. Minimum Healthy Hosts are documented below.

--- a/sdk/go/aws/codedeploy/deploymentConfig.go
+++ b/sdk/go/aws/codedeploy/deploymentConfig.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -155,12 +154,9 @@ type DeploymentConfig struct {
 func NewDeploymentConfig(ctx *pulumi.Context,
 	name string, args *DeploymentConfigArgs, opts ...pulumi.ResourceOption) (*DeploymentConfig, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &DeploymentConfigArgs{}
 	}
 
-	if args.DeploymentConfigName == nil {
-		return nil, errors.New("invalid value for required argument 'DeploymentConfigName'")
-	}
 	var resource DeploymentConfig
 	err := ctx.RegisterResource("aws:codedeploy/deploymentConfig:DeploymentConfig", name, args, &resource, opts...)
 	if err != nil {
@@ -216,7 +212,7 @@ type deploymentConfigArgs struct {
 	// The compute platform can be `Server`, `Lambda`, or `ECS`. Default is `Server`.
 	ComputePlatform *string `pulumi:"computePlatform"`
 	// The name of the deployment config.
-	DeploymentConfigName string `pulumi:"deploymentConfigName"`
+	DeploymentConfigName *string `pulumi:"deploymentConfigName"`
 	// A minimumHealthyHosts block. Required for `Server` compute platform. Minimum Healthy Hosts are documented below.
 	MinimumHealthyHosts *DeploymentConfigMinimumHealthyHosts `pulumi:"minimumHealthyHosts"`
 	// A trafficRoutingConfig block. Traffic Routing Config is documented below.
@@ -228,7 +224,7 @@ type DeploymentConfigArgs struct {
 	// The compute platform can be `Server`, `Lambda`, or `ECS`. Default is `Server`.
 	ComputePlatform pulumi.StringPtrInput
 	// The name of the deployment config.
-	DeploymentConfigName pulumi.StringInput
+	DeploymentConfigName pulumi.StringPtrInput
 	// A minimumHealthyHosts block. Required for `Server` compute platform. Minimum Healthy Hosts are documented below.
 	MinimumHealthyHosts DeploymentConfigMinimumHealthyHostsPtrInput
 	// A trafficRoutingConfig block. Traffic Routing Config is documented below.

--- a/sdk/nodejs/codedeploy/deploymentConfig.ts
+++ b/sdk/nodejs/codedeploy/deploymentConfig.ts
@@ -144,7 +144,7 @@ export class DeploymentConfig extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: DeploymentConfigArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: DeploymentConfigArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: DeploymentConfigArgs | DeploymentConfigState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -157,9 +157,6 @@ export class DeploymentConfig extends pulumi.CustomResource {
             resourceInputs["trafficRoutingConfig"] = state ? state.trafficRoutingConfig : undefined;
         } else {
             const args = argsOrState as DeploymentConfigArgs | undefined;
-            if ((!args || args.deploymentConfigName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'deploymentConfigName'");
-            }
             resourceInputs["computePlatform"] = args ? args.computePlatform : undefined;
             resourceInputs["deploymentConfigName"] = args ? args.deploymentConfigName : undefined;
             resourceInputs["minimumHealthyHosts"] = args ? args.minimumHealthyHosts : undefined;
@@ -208,7 +205,7 @@ export interface DeploymentConfigArgs {
     /**
      * The name of the deployment config.
      */
-    deploymentConfigName: pulumi.Input<string>;
+    deploymentConfigName?: pulumi.Input<string>;
     /**
      * A minimumHealthyHosts block. Required for `Server` compute platform. Minimum Healthy Hosts are documented below.
      */

--- a/sdk/python/pulumi_aws/codedeploy/deployment_config.py
+++ b/sdk/python/pulumi_aws/codedeploy/deployment_config.py
@@ -15,36 +15,25 @@ __all__ = ['DeploymentConfigArgs', 'DeploymentConfig']
 @pulumi.input_type
 class DeploymentConfigArgs:
     def __init__(__self__, *,
-                 deployment_config_name: pulumi.Input[str],
                  compute_platform: Optional[pulumi.Input[str]] = None,
+                 deployment_config_name: Optional[pulumi.Input[str]] = None,
                  minimum_healthy_hosts: Optional[pulumi.Input['DeploymentConfigMinimumHealthyHostsArgs']] = None,
                  traffic_routing_config: Optional[pulumi.Input['DeploymentConfigTrafficRoutingConfigArgs']] = None):
         """
         The set of arguments for constructing a DeploymentConfig resource.
-        :param pulumi.Input[str] deployment_config_name: The name of the deployment config.
         :param pulumi.Input[str] compute_platform: The compute platform can be `Server`, `Lambda`, or `ECS`. Default is `Server`.
+        :param pulumi.Input[str] deployment_config_name: The name of the deployment config.
         :param pulumi.Input['DeploymentConfigMinimumHealthyHostsArgs'] minimum_healthy_hosts: A minimum_healthy_hosts block. Required for `Server` compute platform. Minimum Healthy Hosts are documented below.
         :param pulumi.Input['DeploymentConfigTrafficRoutingConfigArgs'] traffic_routing_config: A traffic_routing_config block. Traffic Routing Config is documented below.
         """
-        pulumi.set(__self__, "deployment_config_name", deployment_config_name)
         if compute_platform is not None:
             pulumi.set(__self__, "compute_platform", compute_platform)
+        if deployment_config_name is not None:
+            pulumi.set(__self__, "deployment_config_name", deployment_config_name)
         if minimum_healthy_hosts is not None:
             pulumi.set(__self__, "minimum_healthy_hosts", minimum_healthy_hosts)
         if traffic_routing_config is not None:
             pulumi.set(__self__, "traffic_routing_config", traffic_routing_config)
-
-    @property
-    @pulumi.getter(name="deploymentConfigName")
-    def deployment_config_name(self) -> pulumi.Input[str]:
-        """
-        The name of the deployment config.
-        """
-        return pulumi.get(self, "deployment_config_name")
-
-    @deployment_config_name.setter
-    def deployment_config_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "deployment_config_name", value)
 
     @property
     @pulumi.getter(name="computePlatform")
@@ -57,6 +46,18 @@ class DeploymentConfigArgs:
     @compute_platform.setter
     def compute_platform(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "compute_platform", value)
+
+    @property
+    @pulumi.getter(name="deploymentConfigName")
+    def deployment_config_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the deployment config.
+        """
+        return pulumi.get(self, "deployment_config_name")
+
+    @deployment_config_name.setter
+    def deployment_config_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "deployment_config_name", value)
 
     @property
     @pulumi.getter(name="minimumHealthyHosts")
@@ -271,7 +272,7 @@ class DeploymentConfig(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: DeploymentConfigArgs,
+                 args: Optional[DeploymentConfigArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Provides a CodeDeploy deployment config for an application
@@ -384,8 +385,6 @@ class DeploymentConfig(pulumi.CustomResource):
             __props__ = DeploymentConfigArgs.__new__(DeploymentConfigArgs)
 
             __props__.__dict__["compute_platform"] = compute_platform
-            if deployment_config_name is None and not opts.urn:
-                raise TypeError("Missing required property 'deployment_config_name'")
             __props__.__dict__["deployment_config_name"] = deployment_config_name
             __props__.__dict__["minimum_healthy_hosts"] = minimum_healthy_hosts
             __props__.__dict__["traffic_routing_config"] = traffic_routing_config


### PR DESCRIPTION
- aws.codedeploy.DeploymentConfig can take advantage of autonaming
- Upgrade to v3.74.2 of the AWS Terraform Provider

Fixes: #1818
Fixes: #1807