### PR TITLE
enable dotnet6 runtime for AWS Lambda Functions

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -13,7 +13,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f
-	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220218162015-b899359f0783
+	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220310114353-ce4b7cb805ba
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -723,8 +723,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f h1:YWtQ7xeRQvB9h5Uwtrl9wDKRKkyLTXWBzU7x0c9VOZ4=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f/go.mod h1:grseeRo9g3yNkYW09iFlV8LG78jTa1ssBgouogQg/RU=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220218162015-b899359f0783 h1:2bAen4yNfUTjsTBkJMlkVbxpV9rXbnngRZZO2guQqEo=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220218162015-b899359f0783/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220310114353-ce4b7cb805ba h1:gr7xPcVgmEYiMlwkFgsO/ogb76SZFPMSnLlwgCTup6Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220310114353-ce4b7cb805ba/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20211105002759-77bad27d9f23
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220218162015-b899359f0783
+replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220310114353-ce4b7cb805ba

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -316,8 +316,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220218162015-b899359f0783 h1:2bAen4yNfUTjsTBkJMlkVbxpV9rXbnngRZZO2guQqEo=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220218162015-b899359f0783/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220310114353-ce4b7cb805ba h1:gr7xPcVgmEYiMlwkFgsO/ogb76SZFPMSnLlwgCTup6Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220310114353-ce4b7cb805ba/go.mod h1:rHl178J069db+QkflQK6ePE66l2sYpZ0zWqmQh77SD4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
Fixes: #1845

Before:

```
Diagnostics:
  aws:lambda:Function (basicLambda):
    error: aws:lambda/function:Function resource 'basicLambda' has a problem: expected runtime to be one of [nodejs nodejs4.3 nodejs6.10 nodejs8.10 nodejs10.x nodejs12.x nodejs14.x java8 java8.al2 java11 python2.7 python3.6 python3.7 python3.8 python3.9 dotnetcore1.0 dotnetcore2.0 dotnetcore2.1 dotnetcore3.1 nodejs4.3-edge go1.x ruby2.5 ruby2.7 provided provided.al2], got dotnet6. Examine values at 'Function.Runtime'.
```

After:

```
▶ pulumi up
Updating (test-function-runtime6)

View Live: https://app.pulumi.com/stack72/lambda/test-function-runtime6/updates/1

     Type                    Name                           Status
 +   pulumi:pulumi:Stack     lambda-test-function-runtime6  created
 +   ├─ aws:iam:Role         lambdaRole                     created
 +   ├─ aws:iam:RolePolicy   lambdaLogPolicy                created
 +   └─ aws:lambda:Function  basicLambda                    created

Outputs:
    Lambda: "arn:aws:lambda:us-east-1:894850187425:function:basicLambda-6eccb9e"

Resources:
    + 4 created

Duration: 23s
```

<img width="1287" alt="Screenshot 2022-03-10 at 12 16 36" src="https://user-images.githubusercontent.com/227823/157660542-c28f7097-cd76-4991-b127-89a15725a839.png">

Checking it works

```
▶ aws lambda invoke \
    --function-name $(pulumi stack output Lambda -C ./pulumi) \
    --region $(pulumi config get aws:region -C ./pulumi) \
    --cli-binary-format raw-in-base64-out \
    --payload '"foo"' \
    output.json

pulumi/examples/aws-cs-lambda  master ✗                                                                                                                                                                                     2d21h ⚑ ◒
▶ cat output.json
"FOO"%
```﻿
