### PR TITLE
Add `secretOptions` to LogConfiguration

### DIFF
--- a/sdk/nodejs/ecs/container.ts
+++ b/sdk/nodejs/ecs/container.ts
@@ -172,6 +172,7 @@ export interface Device {
 export interface LogConfiguration {
     logDriver:  LogDriver;
     options?: { [key: string]: pulumi.Input<string> };
+    secretOptions?: { name: pulumi.Input<string>, valueFrom: pulumi.Input<string> }[];
 }
 
 // See `logdriver` at http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html


### PR DESCRIPTION
`secretOptions` is silently passed through to the underlying logConfiguration anyways. See https://github.com/pulumi/pulumi-aws/issues/1345. This just adjusts the typings to support it.