### PR TITLE
Support functionResponseTypes for Kinesis

### DIFF
--- a/sdk/nodejs/kinesis/kinesisMixins.ts
+++ b/sdk/nodejs/kinesis/kinesisMixins.ts
@@ -38,6 +38,12 @@ export interface StreamEventSubscriptionArgs {
     readonly destinationConfig?: pulumi.Input<types.input.lambda.EventSourceMappingDestinationConfig>;
 
     /**
+     * A list of current response type enums applied to the event source mapping. Where valid values are:
+     * * `ReportBatchItemFailures`
+     */
+    readonly functionResponseTypes?: string[];
+    
+    /**
      * The maximum amount of time to gather records before invoking the function, in seconds. Records will continue to buffer
      * until either maximum_batching_window_in_seconds expires or batch_size has been met. Defaults to as soon as records
      * are available in the stream. If the batch it reads from the stream only has one record in it, Lambda only sends one record to the function.
@@ -136,6 +142,7 @@ export class StreamEventSubscription extends lambda.EventSubscription {
             parallelizationFactor: args.parallelizationFactor,
             startingPosition: args.startingPosition,
             startingPositionTimestamp: args.startingPositionTimestamp,
+            functionResponseTypes: args.functionResponseTypes,
         };
         this.eventSourceMapping = new lambda.EventSourceMapping(name, mappingArgs, parentOpts);
 


### PR DESCRIPTION
Per the guidelines here - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html

Similar to this PR - https://github.com/pulumi/pulumi-aws/pull/1644