### PR TITLE
aws.s3.Bucket: Alias the legacy Bucket to the V2 Bucket

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -253,6 +253,10 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 	return ""
 }
 
+func stringRef(s string) *string {
+	return &s
+}
+
 // preConfigureCallback validates that AWS credentials can be successfully discovered. This emulates the credentials
 // configuration subset of `github.com/terraform-providers/terraform-provider-aws/aws.providerConfigure`.  We do this
 // before passing control to the TF provider to ensure we can report actionable errors.
@@ -2414,6 +2418,11 @@ func Provider() tfbridge.ProviderInfo {
 					"bucket": tfbridge.AutoNameTransform("bucket", 63, func(name string) string {
 						return strings.ToLower(name)
 					}),
+				},
+				Aliases: []tfbridge.AliasInfo{
+					{
+						Type: stringRef("aws:s3/bucket:Bucket"),
+					},
 				},
 			},
 			"aws_s3_bucket_accelerate_configuration":             {Tok: awsResource(s3Mod, "BucketAccelerateConfigurationV2")},

--- a/sdk/dotnet/S3/BucketV2.cs
+++ b/sdk/dotnet/S3/BucketV2.cs
@@ -266,6 +266,10 @@ namespace Pulumi.Aws.S3
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                Aliases =
+                {
+                    new Pulumi.Alias { Type = "aws:s3/bucket:Bucket"},
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/go/aws/s3/bucketV2.go
+++ b/sdk/go/aws/s3/bucketV2.go
@@ -184,6 +184,12 @@ func NewBucketV2(ctx *pulumi.Context,
 		args = &BucketV2Args{}
 	}
 
+	aliases := pulumi.Aliases([]pulumi.Alias{
+		{
+			Type: pulumi.String("aws:s3/bucket:Bucket"),
+		},
+	})
+	opts = append(opts, aliases)
 	var resource BucketV2
 	err := ctx.RegisterResource("aws:s3/bucketV2:BucketV2", name, args, &resource, opts...)
 	if err != nil {

--- a/sdk/nodejs/s3/bucketV2.ts
+++ b/sdk/nodejs/s3/bucketV2.ts
@@ -298,6 +298,8 @@ export class BucketV2 extends pulumi.CustomResource {
             resourceInputs["websites"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const aliasOpts = { aliases: [{ type: "aws:s3/bucket:Bucket" }] };
+        opts = pulumi.mergeOptions(opts, aliasOpts);
         super(BucketV2.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_aws/s3/bucket_v2.py
+++ b/sdk/python/pulumi_aws/s3/bucket_v2.py
@@ -806,6 +806,8 @@ class BucketV2(pulumi.CustomResource):
             __props__.__dict__["website_domain"] = None
             __props__.__dict__["website_endpoint"] = None
             __props__.__dict__["websites"] = None
+        alias_opts = pulumi.ResourceOptions(aliases=[pulumi.Alias(type_="aws:s3/bucket:Bucket")])
+        opts = pulumi.ResourceOptions.merge(opts, alias_opts)
         super(BucketV2, __self__).__init__(
             'aws:s3/bucketV2:BucketV2',
             resource_name,


### PR DESCRIPTION
This will allow a user to be able to migrate from the old
type of bucket to the new type
