### PR TITLE
aws.eks.Cluster: Fix regression in certificateAuthority

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -13,7 +13,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87
-	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220324164819-d23c49ad6559
+	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -757,8 +757,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87 h1:Reqyb/CbcDwThvBRzA62H7cvuCqgTJuGNt+F6mnmXJ4=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87/go.mod h1:FjM9DXWfP0w/AeOtJoSKHBZ01LqmaO6uP4bXhv3fekw=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220324164819-d23c49ad6559 h1:ReVmBiSC2G+oWqe5+TlqCQ62EoB2AjrNC8XxbQu0Dms=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220324164819-d23c49ad6559/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082 h1:Yx5tJEgRKlAQso7nB8KOmO9KKe03N+sstTGTgqVjNjY=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -4318,9 +4318,6 @@ func Provider() tfbridge.ProviderInfo {
 			"aws_eks_cluster": {
 				Tok: awsDataSource(eksMod, "getCluster"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"certificate_authority": {
-						MaxItemsOne: boolRef(true),
-					},
 					"vpc_config": {
 						MaxItemsOne: boolRef(true),
 					},

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20211105002759-77bad27d9f23
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220324164819-d23c49ad6559
+replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -344,8 +344,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220324164819-d23c49ad6559 h1:ReVmBiSC2G+oWqe5+TlqCQ62EoB2AjrNC8XxbQu0Dms=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220324164819-d23c49ad6559/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082 h1:Yx5tJEgRKlAQso7nB8KOmO9KKe03N+sstTGTgqVjNjY=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -43,7 +43,7 @@ namespace Pulumi.Aws.Eks
     ///             },
     ///         });
     ///         this.Endpoint = example.Endpoint;
-    ///         this.Kubeconfig_certificate_authority_data = example.CertificateAuthorities.Apply(certificateAuthorities =&gt; certificateAuthorities[0].Data);
+    ///         this.Kubeconfig_certificate_authority_data = example.CertificateAuthority;
     ///     }
     /// 
     ///     [Output("endpoint")]
@@ -157,6 +157,12 @@ namespace Pulumi.Aws.Eks
         /// </summary>
         [Output("certificateAuthorities")]
         public Output<ImmutableArray<Outputs.ClusterCertificateAuthority>> CertificateAuthorities { get; private set; } = null!;
+
+        /// <summary>
+        /// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        /// </summary>
+        [Output("certificateAuthority")]
+        public Output<string> CertificateAuthority { get; private set; } = null!;
 
         /// <summary>
         /// Unix epoch timestamp in seconds for when the cluster was created.
@@ -372,6 +378,12 @@ namespace Pulumi.Aws.Eks
             get => _certificateAuthorities ?? (_certificateAuthorities = new InputList<Inputs.ClusterCertificateAuthorityGetArgs>());
             set => _certificateAuthorities = value;
         }
+
+        /// <summary>
+        /// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        /// </summary>
+        [Input("certificateAuthority")]
+        public Input<string>? CertificateAuthority { get; set; }
 
         /// <summary>
         /// Unix epoch timestamp in seconds for when the cluster was created.

--- a/sdk/dotnet/Eks/GetCluster.cs
+++ b/sdk/dotnet/Eks/GetCluster.cs
@@ -31,7 +31,7 @@ namespace Pulumi.Aws.Eks
         ///             Name = "example",
         ///         }));
         ///         this.Endpoint = example.Apply(example =&gt; example.Endpoint);
-        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthority?.Data);
+        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthority);
         ///         this.Identity_oidc_issuer = example.Apply(example =&gt; example.Identities?[0]?.Oidcs?[0]?.Issuer);
         ///     }
         /// 
@@ -69,7 +69,7 @@ namespace Pulumi.Aws.Eks
         ///             Name = "example",
         ///         }));
         ///         this.Endpoint = example.Apply(example =&gt; example.Endpoint);
-        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthority?.Data);
+        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthority);
         ///         this.Identity_oidc_issuer = example.Apply(example =&gt; example.Identities?[0]?.Oidcs?[0]?.Issuer);
         ///     }
         /// 
@@ -150,7 +150,11 @@ namespace Pulumi.Aws.Eks
         /// <summary>
         /// Nested attribute containing `certificate-authority-data` for your cluster.
         /// </summary>
-        public readonly Outputs.GetClusterCertificateAuthorityResult CertificateAuthority;
+        public readonly ImmutableArray<Outputs.GetClusterCertificateAuthorityResult> CertificateAuthorities;
+        /// <summary>
+        /// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        /// </summary>
+        public readonly string CertificateAuthority;
         /// <summary>
         /// The Unix epoch time stamp in seconds for when the cluster was created.
         /// </summary>
@@ -205,7 +209,9 @@ namespace Pulumi.Aws.Eks
         private GetClusterResult(
             string arn,
 
-            Outputs.GetClusterCertificateAuthorityResult certificateAuthority,
+            ImmutableArray<Outputs.GetClusterCertificateAuthorityResult> certificateAuthorities,
+
+            string certificateAuthority,
 
             string createdAt,
 
@@ -234,6 +240,7 @@ namespace Pulumi.Aws.Eks
             Outputs.GetClusterVpcConfigResult vpcConfig)
         {
             Arn = arn;
+            CertificateAuthorities = certificateAuthorities;
             CertificateAuthority = certificateAuthority;
             CreatedAt = createdAt;
             EnabledClusterLogTypes = enabledClusterLogTypes;

--- a/sdk/go/aws/eks/cluster.go
+++ b/sdk/go/aws/eks/cluster.go
@@ -42,9 +42,7 @@ import (
 // 			return err
 // 		}
 // 		ctx.Export("endpoint", example.Endpoint)
-// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthorities.ApplyT(func(certificateAuthorities []eks.ClusterCertificateAuthority) (string, error) {
-// 			return certificateAuthorities[0].Data, nil
-// 		}).(pulumi.StringOutput))
+// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthority)
 // 		return nil
 // 	})
 // }
@@ -146,6 +144,8 @@ type Cluster struct {
 	Arn pulumi.StringOutput `pulumi:"arn"`
 	// Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 	CertificateAuthorities ClusterCertificateAuthorityArrayOutput `pulumi:"certificateAuthorities"`
+	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+	CertificateAuthority pulumi.StringOutput `pulumi:"certificateAuthority"`
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt pulumi.StringOutput `pulumi:"createdAt"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
@@ -215,6 +215,8 @@ type clusterState struct {
 	Arn *string `pulumi:"arn"`
 	// Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 	CertificateAuthorities []ClusterCertificateAuthority `pulumi:"certificateAuthorities"`
+	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+	CertificateAuthority *string `pulumi:"certificateAuthority"`
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt *string `pulumi:"createdAt"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
@@ -250,6 +252,8 @@ type ClusterState struct {
 	Arn pulumi.StringPtrInput
 	// Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 	CertificateAuthorities ClusterCertificateAuthorityArrayInput
+	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+	CertificateAuthority pulumi.StringPtrInput
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt pulumi.StringPtrInput
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).

--- a/sdk/go/aws/eks/getCluster.go
+++ b/sdk/go/aws/eks/getCluster.go
@@ -31,7 +31,7 @@ import (
 // 			return err
 // 		}
 // 		ctx.Export("endpoint", example.Endpoint)
-// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthority.Data)
+// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthority)
 // 		ctx.Export("identity-oidc-issuer", example.Identities[0].Oidcs[0].Issuer)
 // 		return nil
 // 	})
@@ -59,7 +59,9 @@ type LookupClusterResult struct {
 	// The Amazon Resource Name (ARN) of the cluster.
 	Arn string `pulumi:"arn"`
 	// Nested attribute containing `certificate-authority-data` for your cluster.
-	CertificateAuthority GetClusterCertificateAuthority `pulumi:"certificateAuthority"`
+	CertificateAuthorities []GetClusterCertificateAuthority `pulumi:"certificateAuthorities"`
+	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+	CertificateAuthority string `pulumi:"certificateAuthority"`
 	// The Unix epoch time stamp in seconds for when the cluster was created.
 	CreatedAt string `pulumi:"createdAt"`
 	// The enabled control plane logs.
@@ -129,8 +131,13 @@ func (o LookupClusterResultOutput) Arn() pulumi.StringOutput {
 }
 
 // Nested attribute containing `certificate-authority-data` for your cluster.
-func (o LookupClusterResultOutput) CertificateAuthority() GetClusterCertificateAuthorityOutput {
-	return o.ApplyT(func(v LookupClusterResult) GetClusterCertificateAuthority { return v.CertificateAuthority }).(GetClusterCertificateAuthorityOutput)
+func (o LookupClusterResultOutput) CertificateAuthorities() GetClusterCertificateAuthorityArrayOutput {
+	return o.ApplyT(func(v LookupClusterResult) []GetClusterCertificateAuthority { return v.CertificateAuthorities }).(GetClusterCertificateAuthorityArrayOutput)
+}
+
+// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+func (o LookupClusterResultOutput) CertificateAuthority() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupClusterResult) string { return v.CertificateAuthority }).(pulumi.StringOutput)
 }
 
 // The Unix epoch time stamp in seconds for when the cluster was created.

--- a/sdk/go/aws/eks/pulumiTypes.go
+++ b/sdk/go/aws/eks/pulumiTypes.go
@@ -2390,6 +2390,31 @@ func (i GetClusterCertificateAuthorityArgs) ToGetClusterCertificateAuthorityOutp
 	return pulumi.ToOutputWithContext(ctx, i).(GetClusterCertificateAuthorityOutput)
 }
 
+// GetClusterCertificateAuthorityArrayInput is an input type that accepts GetClusterCertificateAuthorityArray and GetClusterCertificateAuthorityArrayOutput values.
+// You can construct a concrete instance of `GetClusterCertificateAuthorityArrayInput` via:
+//
+//          GetClusterCertificateAuthorityArray{ GetClusterCertificateAuthorityArgs{...} }
+type GetClusterCertificateAuthorityArrayInput interface {
+	pulumi.Input
+
+	ToGetClusterCertificateAuthorityArrayOutput() GetClusterCertificateAuthorityArrayOutput
+	ToGetClusterCertificateAuthorityArrayOutputWithContext(context.Context) GetClusterCertificateAuthorityArrayOutput
+}
+
+type GetClusterCertificateAuthorityArray []GetClusterCertificateAuthorityInput
+
+func (GetClusterCertificateAuthorityArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]GetClusterCertificateAuthority)(nil)).Elem()
+}
+
+func (i GetClusterCertificateAuthorityArray) ToGetClusterCertificateAuthorityArrayOutput() GetClusterCertificateAuthorityArrayOutput {
+	return i.ToGetClusterCertificateAuthorityArrayOutputWithContext(context.Background())
+}
+
+func (i GetClusterCertificateAuthorityArray) ToGetClusterCertificateAuthorityArrayOutputWithContext(ctx context.Context) GetClusterCertificateAuthorityArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(GetClusterCertificateAuthorityArrayOutput)
+}
+
 type GetClusterCertificateAuthorityOutput struct{ *pulumi.OutputState }
 
 func (GetClusterCertificateAuthorityOutput) ElementType() reflect.Type {
@@ -2407,6 +2432,26 @@ func (o GetClusterCertificateAuthorityOutput) ToGetClusterCertificateAuthorityOu
 // The base64 encoded certificate data required to communicate with your cluster. Add this to the `certificate-authority-data` section of the `kubeconfig` file for your cluster.
 func (o GetClusterCertificateAuthorityOutput) Data() pulumi.StringOutput {
 	return o.ApplyT(func(v GetClusterCertificateAuthority) string { return v.Data }).(pulumi.StringOutput)
+}
+
+type GetClusterCertificateAuthorityArrayOutput struct{ *pulumi.OutputState }
+
+func (GetClusterCertificateAuthorityArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]GetClusterCertificateAuthority)(nil)).Elem()
+}
+
+func (o GetClusterCertificateAuthorityArrayOutput) ToGetClusterCertificateAuthorityArrayOutput() GetClusterCertificateAuthorityArrayOutput {
+	return o
+}
+
+func (o GetClusterCertificateAuthorityArrayOutput) ToGetClusterCertificateAuthorityArrayOutputWithContext(ctx context.Context) GetClusterCertificateAuthorityArrayOutput {
+	return o
+}
+
+func (o GetClusterCertificateAuthorityArrayOutput) Index(i pulumi.IntInput) GetClusterCertificateAuthorityOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) GetClusterCertificateAuthority {
+		return vs[0].([]GetClusterCertificateAuthority)[vs[1].(int)]
+	}).(GetClusterCertificateAuthorityOutput)
 }
 
 type GetClusterIdentity struct {
@@ -3385,6 +3430,7 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*NodeGroupUpdateConfigInput)(nil)).Elem(), NodeGroupUpdateConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*NodeGroupUpdateConfigPtrInput)(nil)).Elem(), NodeGroupUpdateConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetClusterCertificateAuthorityInput)(nil)).Elem(), GetClusterCertificateAuthorityArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*GetClusterCertificateAuthorityArrayInput)(nil)).Elem(), GetClusterCertificateAuthorityArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetClusterIdentityInput)(nil)).Elem(), GetClusterIdentityArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetClusterIdentityArrayInput)(nil)).Elem(), GetClusterIdentityArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetClusterIdentityOidcInput)(nil)).Elem(), GetClusterIdentityOidcArgs{})
@@ -3435,6 +3481,7 @@ func init() {
 	pulumi.RegisterOutputType(NodeGroupUpdateConfigOutput{})
 	pulumi.RegisterOutputType(NodeGroupUpdateConfigPtrOutput{})
 	pulumi.RegisterOutputType(GetClusterCertificateAuthorityOutput{})
+	pulumi.RegisterOutputType(GetClusterCertificateAuthorityArrayOutput{})
 	pulumi.RegisterOutputType(GetClusterIdentityOutput{})
 	pulumi.RegisterOutputType(GetClusterIdentityArrayOutput{})
 	pulumi.RegisterOutputType(GetClusterIdentityOidcOutput{})

--- a/sdk/nodejs/eks/cluster.ts
+++ b/sdk/nodejs/eks/cluster.ts
@@ -30,7 +30,7 @@ import * as utilities from "../utilities";
  *     ],
  * });
  * export const endpoint = example.endpoint;
- * export const kubeconfig_certificate_authority_data = example.certificateAuthorities.apply(certificateAuthorities => certificateAuthorities[0].data);
+ * export const kubeconfig_certificate_authority_data = example.certificateAuthority;
  * ```
  * ### Example IAM Role for EKS Cluster
  *
@@ -130,6 +130,10 @@ export class Cluster extends pulumi.CustomResource {
      */
     public /*out*/ readonly certificateAuthorities!: pulumi.Output<outputs.eks.ClusterCertificateAuthority[]>;
     /**
+     * The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+     */
+    public /*out*/ readonly certificateAuthority!: pulumi.Output<string>;
+    /**
      * Unix epoch timestamp in seconds for when the cluster was created.
      */
     public /*out*/ readonly createdAt!: pulumi.Output<string>;
@@ -201,6 +205,7 @@ export class Cluster extends pulumi.CustomResource {
             const state = argsOrState as ClusterState | undefined;
             resourceInputs["arn"] = state ? state.arn : undefined;
             resourceInputs["certificateAuthorities"] = state ? state.certificateAuthorities : undefined;
+            resourceInputs["certificateAuthority"] = state ? state.certificateAuthority : undefined;
             resourceInputs["createdAt"] = state ? state.createdAt : undefined;
             resourceInputs["enabledClusterLogTypes"] = state ? state.enabledClusterLogTypes : undefined;
             resourceInputs["encryptionConfig"] = state ? state.encryptionConfig : undefined;
@@ -233,6 +238,7 @@ export class Cluster extends pulumi.CustomResource {
             resourceInputs["vpcConfig"] = args ? args.vpcConfig : undefined;
             resourceInputs["arn"] = undefined /*out*/;
             resourceInputs["certificateAuthorities"] = undefined /*out*/;
+            resourceInputs["certificateAuthority"] = undefined /*out*/;
             resourceInputs["createdAt"] = undefined /*out*/;
             resourceInputs["endpoint"] = undefined /*out*/;
             resourceInputs["identities"] = undefined /*out*/;
@@ -257,6 +263,10 @@ export interface ClusterState {
      * Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
      */
     certificateAuthorities?: pulumi.Input<pulumi.Input<inputs.eks.ClusterCertificateAuthority>[]>;
+    /**
+     * The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+     */
+    certificateAuthority?: pulumi.Input<string>;
     /**
      * Unix epoch timestamp in seconds for when the cluster was created.
      */

--- a/sdk/nodejs/eks/getCluster.ts
+++ b/sdk/nodejs/eks/getCluster.ts
@@ -18,7 +18,7 @@ import * as utilities from "../utilities";
  *     name: "example",
  * });
  * export const endpoint = example.then(example => example.endpoint);
- * export const kubeconfig_certificate_authority_data = example.then(example => example.certificateAuthority?.data);
+ * export const kubeconfig_certificate_authority_data = example.then(example => example.certificateAuthority);
  * export const identity_oidc_issuer = example.then(example => example.identities?[0]?.oidcs?[0]?.issuer);
  * ```
  */
@@ -59,7 +59,11 @@ export interface GetClusterResult {
     /**
      * Nested attribute containing `certificate-authority-data` for your cluster.
      */
-    readonly certificateAuthority: outputs.eks.GetClusterCertificateAuthority;
+    readonly certificateAuthorities: outputs.eks.GetClusterCertificateAuthority[];
+    /**
+     * The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+     */
+    readonly certificateAuthority: string;
     /**
      * The Unix epoch time stamp in seconds for when the cluster was created.
      */

--- a/sdk/python/pulumi_aws/eks/cluster.py
+++ b/sdk/python/pulumi_aws/eks/cluster.py
@@ -151,6 +151,7 @@ class _ClusterState:
     def __init__(__self__, *,
                  arn: Optional[pulumi.Input[str]] = None,
                  certificate_authorities: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterCertificateAuthorityArgs']]]] = None,
+                 certificate_authority: Optional[pulumi.Input[str]] = None,
                  created_at: Optional[pulumi.Input[str]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  encryption_config: Optional[pulumi.Input['ClusterEncryptionConfigArgs']] = None,
@@ -169,6 +170,7 @@ class _ClusterState:
         Input properties used for looking up and filtering Cluster resources.
         :param pulumi.Input[str] arn: ARN of the cluster.
         :param pulumi.Input[Sequence[pulumi.Input['ClusterCertificateAuthorityArgs']]] certificate_authorities: Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
+        :param pulumi.Input[str] certificate_authority: The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         :param pulumi.Input[str] created_at: Unix epoch timestamp in seconds for when the cluster was created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
         :param pulumi.Input['ClusterEncryptionConfigArgs'] encryption_config: Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
@@ -188,6 +190,8 @@ class _ClusterState:
             pulumi.set(__self__, "arn", arn)
         if certificate_authorities is not None:
             pulumi.set(__self__, "certificate_authorities", certificate_authorities)
+        if certificate_authority is not None:
+            pulumi.set(__self__, "certificate_authority", certificate_authority)
         if created_at is not None:
             pulumi.set(__self__, "created_at", created_at)
         if enabled_cluster_log_types is not None:
@@ -240,6 +244,18 @@ class _ClusterState:
     @certificate_authorities.setter
     def certificate_authorities(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterCertificateAuthorityArgs']]]]):
         pulumi.set(self, "certificate_authorities", value)
+
+    @property
+    @pulumi.getter(name="certificateAuthority")
+    def certificate_authority(self) -> Optional[pulumi.Input[str]]:
+        """
+        The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        """
+        return pulumi.get(self, "certificate_authority")
+
+    @certificate_authority.setter
+    def certificate_authority(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "certificate_authority", value)
 
     @property
     @pulumi.getter(name="createdAt")
@@ -447,7 +463,7 @@ class Cluster(pulumi.CustomResource):
                     aws_iam_role_policy_attachment["example-AmazonEKSVPCResourceController"],
                 ]))
         pulumi.export("endpoint", example.endpoint)
-        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authorities[0].data)
+        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
         ```
         ### Example IAM Role for EKS Cluster
 
@@ -549,7 +565,7 @@ class Cluster(pulumi.CustomResource):
                     aws_iam_role_policy_attachment["example-AmazonEKSVPCResourceController"],
                 ]))
         pulumi.export("endpoint", example.endpoint)
-        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authorities[0].data)
+        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
         ```
         ### Example IAM Role for EKS Cluster
 
@@ -660,6 +676,7 @@ class Cluster(pulumi.CustomResource):
             __props__.__dict__["vpc_config"] = vpc_config
             __props__.__dict__["arn"] = None
             __props__.__dict__["certificate_authorities"] = None
+            __props__.__dict__["certificate_authority"] = None
             __props__.__dict__["created_at"] = None
             __props__.__dict__["endpoint"] = None
             __props__.__dict__["identities"] = None
@@ -678,6 +695,7 @@ class Cluster(pulumi.CustomResource):
             opts: Optional[pulumi.ResourceOptions] = None,
             arn: Optional[pulumi.Input[str]] = None,
             certificate_authorities: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCertificateAuthorityArgs']]]]] = None,
+            certificate_authority: Optional[pulumi.Input[str]] = None,
             created_at: Optional[pulumi.Input[str]] = None,
             enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
             encryption_config: Optional[pulumi.Input[pulumi.InputType['ClusterEncryptionConfigArgs']]] = None,
@@ -701,6 +719,7 @@ class Cluster(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] arn: ARN of the cluster.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCertificateAuthorityArgs']]]] certificate_authorities: Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
+        :param pulumi.Input[str] certificate_authority: The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         :param pulumi.Input[str] created_at: Unix epoch timestamp in seconds for when the cluster was created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
         :param pulumi.Input[pulumi.InputType['ClusterEncryptionConfigArgs']] encryption_config: Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
@@ -722,6 +741,7 @@ class Cluster(pulumi.CustomResource):
 
         __props__.__dict__["arn"] = arn
         __props__.__dict__["certificate_authorities"] = certificate_authorities
+        __props__.__dict__["certificate_authority"] = certificate_authority
         __props__.__dict__["created_at"] = created_at
         __props__.__dict__["enabled_cluster_log_types"] = enabled_cluster_log_types
         __props__.__dict__["encryption_config"] = encryption_config
@@ -753,6 +773,14 @@ class Cluster(pulumi.CustomResource):
         Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
         """
         return pulumi.get(self, "certificate_authorities")
+
+    @property
+    @pulumi.getter(name="certificateAuthority")
+    def certificate_authority(self) -> pulumi.Output[str]:
+        """
+        The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        """
+        return pulumi.get(self, "certificate_authority")
 
     @property
     @pulumi.getter(name="createdAt")

--- a/sdk/python/pulumi_aws/eks/get_cluster.py
+++ b/sdk/python/pulumi_aws/eks/get_cluster.py
@@ -21,12 +21,15 @@ class GetClusterResult:
     """
     A collection of values returned by getCluster.
     """
-    def __init__(__self__, arn=None, certificate_authority=None, created_at=None, enabled_cluster_log_types=None, endpoint=None, id=None, identities=None, kubernetes_network_configs=None, name=None, platform_version=None, role_arn=None, status=None, tags=None, version=None, vpc_config=None):
+    def __init__(__self__, arn=None, certificate_authorities=None, certificate_authority=None, created_at=None, enabled_cluster_log_types=None, endpoint=None, id=None, identities=None, kubernetes_network_configs=None, name=None, platform_version=None, role_arn=None, status=None, tags=None, version=None, vpc_config=None):
         if arn and not isinstance(arn, str):
             raise TypeError("Expected argument 'arn' to be a str")
         pulumi.set(__self__, "arn", arn)
-        if certificate_authority and not isinstance(certificate_authority, dict):
-            raise TypeError("Expected argument 'certificate_authority' to be a dict")
+        if certificate_authorities and not isinstance(certificate_authorities, list):
+            raise TypeError("Expected argument 'certificate_authorities' to be a list")
+        pulumi.set(__self__, "certificate_authorities", certificate_authorities)
+        if certificate_authority and not isinstance(certificate_authority, str):
+            raise TypeError("Expected argument 'certificate_authority' to be a str")
         pulumi.set(__self__, "certificate_authority", certificate_authority)
         if created_at and not isinstance(created_at, str):
             raise TypeError("Expected argument 'created_at' to be a str")
@@ -77,10 +80,18 @@ class GetClusterResult:
         return pulumi.get(self, "arn")
 
     @property
-    @pulumi.getter(name="certificateAuthority")
-    def certificate_authority(self) -> 'outputs.GetClusterCertificateAuthorityResult':
+    @pulumi.getter(name="certificateAuthorities")
+    def certificate_authorities(self) -> Sequence['outputs.GetClusterCertificateAuthorityResult']:
         """
         Nested attribute containing `certificate-authority-data` for your cluster.
+        """
+        return pulumi.get(self, "certificate_authorities")
+
+    @property
+    @pulumi.getter(name="certificateAuthority")
+    def certificate_authority(self) -> str:
+        """
+        The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         """
         return pulumi.get(self, "certificate_authority")
 
@@ -193,6 +204,7 @@ class AwaitableGetClusterResult(GetClusterResult):
             yield self
         return GetClusterResult(
             arn=self.arn,
+            certificate_authorities=self.certificate_authorities,
             certificate_authority=self.certificate_authority,
             created_at=self.created_at,
             enabled_cluster_log_types=self.enabled_cluster_log_types,
@@ -223,7 +235,7 @@ def get_cluster(name: Optional[str] = None,
 
     example = aws.eks.get_cluster(name="example")
     pulumi.export("endpoint", example.endpoint)
-    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority.data)
+    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
     pulumi.export("identity-oidc-issuer", example.identities[0].oidcs[0].issuer)
     ```
 
@@ -242,6 +254,7 @@ def get_cluster(name: Optional[str] = None,
 
     return AwaitableGetClusterResult(
         arn=__ret__.arn,
+        certificate_authorities=__ret__.certificate_authorities,
         certificate_authority=__ret__.certificate_authority,
         created_at=__ret__.created_at,
         enabled_cluster_log_types=__ret__.enabled_cluster_log_types,
@@ -273,7 +286,7 @@ def get_cluster_output(name: Optional[pulumi.Input[str]] = None,
 
     example = aws.eks.get_cluster(name="example")
     pulumi.export("endpoint", example.endpoint)
-    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority.data)
+    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
     pulumi.export("identity-oidc-issuer", example.identities[0].oidcs[0].issuer)
     ```
 


### PR DESCRIPTION
Fixes: #1892

As part of the major version upgrade, we introduced a regression where
certificate authority became a list. This meant that the parameter
name changed from certificateAuthority to certificateAuthorities

This broke the state when trying to get the certificate authority
for use in connecting to the cluster

We now have 2 parameters - the original certificateAuthority AND the
new certificateAuthorities

All existing state will continue to work as expected now

I expect to see this as a "breaking change" in the getCluster function as we broke that on the major version upgrade