### PR TITLE
aws.eks.cluster: Ensure that certificateAuthority is backward compatible

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -13,7 +13,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87
-	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082
+	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -757,8 +757,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87 h1:Reqyb/CbcDwThvBRzA62H7cvuCqgTJuGNt+F6mnmXJ4=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87/go.mod h1:FjM9DXWfP0w/AeOtJoSKHBZ01LqmaO6uP4bXhv3fekw=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082 h1:Yx5tJEgRKlAQso7nB8KOmO9KKe03N+sstTGTgqVjNjY=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2 h1:o4tgNxegV2prw2DK1pxXttIjVMM64AXfzKYKWlXuFSI=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1516,7 +1516,14 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			// ECS for Kubernetes
-			"aws_eks_cluster": {Tok: awsResource(eksMod, "Cluster")},
+			"aws_eks_cluster": {
+				Tok: awsResource(eksMod, "Cluster"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"certificate_authority": {
+						MaxItemsOne: boolRef(true),
+					},
+				},
+			},
 			"aws_eks_node_group": {
 				Tok: awsResource(eksMod, "NodeGroup"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20211105002759-77bad27d9f23
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082
+replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -344,8 +344,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082 h1:Yx5tJEgRKlAQso7nB8KOmO9KKe03N+sstTGTgqVjNjY=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220406092001-c9de35a89082/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2 h1:o4tgNxegV2prw2DK1pxXttIjVMM64AXfzKYKWlXuFSI=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -43,7 +43,7 @@ namespace Pulumi.Aws.Eks
     ///             },
     ///         });
     ///         this.Endpoint = example.Endpoint;
-    ///         this.Kubeconfig_certificate_authority_data = example.CertificateAuthority;
+    ///         this.Kubeconfig_certificate_authority_data = example.CertificateAuthority.Apply(certificateAuthority =&gt; certificateAuthority.Data);
     ///     }
     /// 
     ///     [Output("endpoint")]
@@ -162,7 +162,7 @@ namespace Pulumi.Aws.Eks
         /// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         /// </summary>
         [Output("certificateAuthority")]
-        public Output<string> CertificateAuthority { get; private set; } = null!;
+        public Output<Outputs.ClusterCertificateAuthority> CertificateAuthority { get; private set; } = null!;
 
         /// <summary>
         /// Unix epoch timestamp in seconds for when the cluster was created.
@@ -383,7 +383,7 @@ namespace Pulumi.Aws.Eks
         /// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         /// </summary>
         [Input("certificateAuthority")]
-        public Input<string>? CertificateAuthority { get; set; }
+        public Input<Inputs.ClusterCertificateAuthorityGetArgs>? CertificateAuthority { get; set; }
 
         /// <summary>
         /// Unix epoch timestamp in seconds for when the cluster was created.

--- a/sdk/dotnet/Eks/GetCluster.cs
+++ b/sdk/dotnet/Eks/GetCluster.cs
@@ -31,7 +31,7 @@ namespace Pulumi.Aws.Eks
         ///             Name = "example",
         ///         }));
         ///         this.Endpoint = example.Apply(example =&gt; example.Endpoint);
-        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthority);
+        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthorities?[0]?.Data);
         ///         this.Identity_oidc_issuer = example.Apply(example =&gt; example.Identities?[0]?.Oidcs?[0]?.Issuer);
         ///     }
         /// 
@@ -69,7 +69,7 @@ namespace Pulumi.Aws.Eks
         ///             Name = "example",
         ///         }));
         ///         this.Endpoint = example.Apply(example =&gt; example.Endpoint);
-        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthority);
+        ///         this.Kubeconfig_certificate_authority_data = example.Apply(example =&gt; example.CertificateAuthorities?[0]?.Data);
         ///         this.Identity_oidc_issuer = example.Apply(example =&gt; example.Identities?[0]?.Oidcs?[0]?.Issuer);
         ///     }
         /// 
@@ -152,10 +152,6 @@ namespace Pulumi.Aws.Eks
         /// </summary>
         public readonly ImmutableArray<Outputs.GetClusterCertificateAuthorityResult> CertificateAuthorities;
         /// <summary>
-        /// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-        /// </summary>
-        public readonly string CertificateAuthority;
-        /// <summary>
         /// The Unix epoch time stamp in seconds for when the cluster was created.
         /// </summary>
         public readonly string CreatedAt;
@@ -211,8 +207,6 @@ namespace Pulumi.Aws.Eks
 
             ImmutableArray<Outputs.GetClusterCertificateAuthorityResult> certificateAuthorities,
 
-            string certificateAuthority,
-
             string createdAt,
 
             ImmutableArray<string> enabledClusterLogTypes,
@@ -241,7 +235,6 @@ namespace Pulumi.Aws.Eks
         {
             Arn = arn;
             CertificateAuthorities = certificateAuthorities;
-            CertificateAuthority = certificateAuthority;
             CreatedAt = createdAt;
             EnabledClusterLogTypes = enabledClusterLogTypes;
             Endpoint = endpoint;

--- a/sdk/go/aws/eks/cluster.go
+++ b/sdk/go/aws/eks/cluster.go
@@ -42,7 +42,9 @@ import (
 // 			return err
 // 		}
 // 		ctx.Export("endpoint", example.Endpoint)
-// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthority)
+// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthority.ApplyT(func(certificateAuthority eks.ClusterCertificateAuthority) (string, error) {
+// 			return certificateAuthority.Data, nil
+// 		}).(pulumi.StringOutput))
 // 		return nil
 // 	})
 // }
@@ -145,7 +147,7 @@ type Cluster struct {
 	// Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 	CertificateAuthorities ClusterCertificateAuthorityArrayOutput `pulumi:"certificateAuthorities"`
 	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-	CertificateAuthority pulumi.StringOutput `pulumi:"certificateAuthority"`
+	CertificateAuthority ClusterCertificateAuthorityOutput `pulumi:"certificateAuthority"`
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt pulumi.StringOutput `pulumi:"createdAt"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
@@ -216,7 +218,7 @@ type clusterState struct {
 	// Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 	CertificateAuthorities []ClusterCertificateAuthority `pulumi:"certificateAuthorities"`
 	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-	CertificateAuthority *string `pulumi:"certificateAuthority"`
+	CertificateAuthority *ClusterCertificateAuthority `pulumi:"certificateAuthority"`
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt *string `pulumi:"createdAt"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
@@ -253,7 +255,7 @@ type ClusterState struct {
 	// Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 	CertificateAuthorities ClusterCertificateAuthorityArrayInput
 	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-	CertificateAuthority pulumi.StringPtrInput
+	CertificateAuthority ClusterCertificateAuthorityPtrInput
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt pulumi.StringPtrInput
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).

--- a/sdk/go/aws/eks/getCluster.go
+++ b/sdk/go/aws/eks/getCluster.go
@@ -31,7 +31,7 @@ import (
 // 			return err
 // 		}
 // 		ctx.Export("endpoint", example.Endpoint)
-// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthority)
+// 		ctx.Export("kubeconfig-certificate-authority-data", example.CertificateAuthorities[0].Data)
 // 		ctx.Export("identity-oidc-issuer", example.Identities[0].Oidcs[0].Issuer)
 // 		return nil
 // 	})
@@ -60,8 +60,6 @@ type LookupClusterResult struct {
 	Arn string `pulumi:"arn"`
 	// Nested attribute containing `certificate-authority-data` for your cluster.
 	CertificateAuthorities []GetClusterCertificateAuthority `pulumi:"certificateAuthorities"`
-	// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-	CertificateAuthority string `pulumi:"certificateAuthority"`
 	// The Unix epoch time stamp in seconds for when the cluster was created.
 	CreatedAt string `pulumi:"createdAt"`
 	// The enabled control plane logs.
@@ -133,11 +131,6 @@ func (o LookupClusterResultOutput) Arn() pulumi.StringOutput {
 // Nested attribute containing `certificate-authority-data` for your cluster.
 func (o LookupClusterResultOutput) CertificateAuthorities() GetClusterCertificateAuthorityArrayOutput {
 	return o.ApplyT(func(v LookupClusterResult) []GetClusterCertificateAuthority { return v.CertificateAuthorities }).(GetClusterCertificateAuthorityArrayOutput)
-}
-
-// The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-func (o LookupClusterResultOutput) CertificateAuthority() pulumi.StringOutput {
-	return o.ApplyT(func(v LookupClusterResult) string { return v.CertificateAuthority }).(pulumi.StringOutput)
 }
 
 // The Unix epoch time stamp in seconds for when the cluster was created.

--- a/sdk/go/aws/eks/pulumiTypes.go
+++ b/sdk/go/aws/eks/pulumiTypes.go
@@ -43,6 +43,47 @@ func (i ClusterCertificateAuthorityArgs) ToClusterCertificateAuthorityOutputWith
 	return pulumi.ToOutputWithContext(ctx, i).(ClusterCertificateAuthorityOutput)
 }
 
+func (i ClusterCertificateAuthorityArgs) ToClusterCertificateAuthorityPtrOutput() ClusterCertificateAuthorityPtrOutput {
+	return i.ToClusterCertificateAuthorityPtrOutputWithContext(context.Background())
+}
+
+func (i ClusterCertificateAuthorityArgs) ToClusterCertificateAuthorityPtrOutputWithContext(ctx context.Context) ClusterCertificateAuthorityPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ClusterCertificateAuthorityOutput).ToClusterCertificateAuthorityPtrOutputWithContext(ctx)
+}
+
+// ClusterCertificateAuthorityPtrInput is an input type that accepts ClusterCertificateAuthorityArgs, ClusterCertificateAuthorityPtr and ClusterCertificateAuthorityPtrOutput values.
+// You can construct a concrete instance of `ClusterCertificateAuthorityPtrInput` via:
+//
+//          ClusterCertificateAuthorityArgs{...}
+//
+//  or:
+//
+//          nil
+type ClusterCertificateAuthorityPtrInput interface {
+	pulumi.Input
+
+	ToClusterCertificateAuthorityPtrOutput() ClusterCertificateAuthorityPtrOutput
+	ToClusterCertificateAuthorityPtrOutputWithContext(context.Context) ClusterCertificateAuthorityPtrOutput
+}
+
+type clusterCertificateAuthorityPtrType ClusterCertificateAuthorityArgs
+
+func ClusterCertificateAuthorityPtr(v *ClusterCertificateAuthorityArgs) ClusterCertificateAuthorityPtrInput {
+	return (*clusterCertificateAuthorityPtrType)(v)
+}
+
+func (*clusterCertificateAuthorityPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**ClusterCertificateAuthority)(nil)).Elem()
+}
+
+func (i *clusterCertificateAuthorityPtrType) ToClusterCertificateAuthorityPtrOutput() ClusterCertificateAuthorityPtrOutput {
+	return i.ToClusterCertificateAuthorityPtrOutputWithContext(context.Background())
+}
+
+func (i *clusterCertificateAuthorityPtrType) ToClusterCertificateAuthorityPtrOutputWithContext(ctx context.Context) ClusterCertificateAuthorityPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ClusterCertificateAuthorityPtrOutput)
+}
+
 // ClusterCertificateAuthorityArrayInput is an input type that accepts ClusterCertificateAuthorityArray and ClusterCertificateAuthorityArrayOutput values.
 // You can construct a concrete instance of `ClusterCertificateAuthorityArrayInput` via:
 //
@@ -82,9 +123,53 @@ func (o ClusterCertificateAuthorityOutput) ToClusterCertificateAuthorityOutputWi
 	return o
 }
 
+func (o ClusterCertificateAuthorityOutput) ToClusterCertificateAuthorityPtrOutput() ClusterCertificateAuthorityPtrOutput {
+	return o.ToClusterCertificateAuthorityPtrOutputWithContext(context.Background())
+}
+
+func (o ClusterCertificateAuthorityOutput) ToClusterCertificateAuthorityPtrOutputWithContext(ctx context.Context) ClusterCertificateAuthorityPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v ClusterCertificateAuthority) *ClusterCertificateAuthority {
+		return &v
+	}).(ClusterCertificateAuthorityPtrOutput)
+}
+
 // Base64 encoded certificate data required to communicate with your cluster. Add this to the `certificate-authority-data` section of the `kubeconfig` file for your cluster.
 func (o ClusterCertificateAuthorityOutput) Data() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ClusterCertificateAuthority) *string { return v.Data }).(pulumi.StringPtrOutput)
+}
+
+type ClusterCertificateAuthorityPtrOutput struct{ *pulumi.OutputState }
+
+func (ClusterCertificateAuthorityPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**ClusterCertificateAuthority)(nil)).Elem()
+}
+
+func (o ClusterCertificateAuthorityPtrOutput) ToClusterCertificateAuthorityPtrOutput() ClusterCertificateAuthorityPtrOutput {
+	return o
+}
+
+func (o ClusterCertificateAuthorityPtrOutput) ToClusterCertificateAuthorityPtrOutputWithContext(ctx context.Context) ClusterCertificateAuthorityPtrOutput {
+	return o
+}
+
+func (o ClusterCertificateAuthorityPtrOutput) Elem() ClusterCertificateAuthorityOutput {
+	return o.ApplyT(func(v *ClusterCertificateAuthority) ClusterCertificateAuthority {
+		if v != nil {
+			return *v
+		}
+		var ret ClusterCertificateAuthority
+		return ret
+	}).(ClusterCertificateAuthorityOutput)
+}
+
+// Base64 encoded certificate data required to communicate with your cluster. Add this to the `certificate-authority-data` section of the `kubeconfig` file for your cluster.
+func (o ClusterCertificateAuthorityPtrOutput) Data() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ClusterCertificateAuthority) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Data
+	}).(pulumi.StringPtrOutput)
 }
 
 type ClusterCertificateAuthorityArrayOutput struct{ *pulumi.OutputState }
@@ -3398,6 +3483,7 @@ func (o GetNodeGroupTaintArrayOutput) Index(i pulumi.IntInput) GetNodeGroupTaint
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterCertificateAuthorityInput)(nil)).Elem(), ClusterCertificateAuthorityArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterCertificateAuthorityPtrInput)(nil)).Elem(), ClusterCertificateAuthorityArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterCertificateAuthorityArrayInput)(nil)).Elem(), ClusterCertificateAuthorityArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterEncryptionConfigInput)(nil)).Elem(), ClusterEncryptionConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterEncryptionConfigPtrInput)(nil)).Elem(), ClusterEncryptionConfigArgs{})
@@ -3449,6 +3535,7 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*GetNodeGroupTaintInput)(nil)).Elem(), GetNodeGroupTaintArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetNodeGroupTaintArrayInput)(nil)).Elem(), GetNodeGroupTaintArray{})
 	pulumi.RegisterOutputType(ClusterCertificateAuthorityOutput{})
+	pulumi.RegisterOutputType(ClusterCertificateAuthorityPtrOutput{})
 	pulumi.RegisterOutputType(ClusterCertificateAuthorityArrayOutput{})
 	pulumi.RegisterOutputType(ClusterEncryptionConfigOutput{})
 	pulumi.RegisterOutputType(ClusterEncryptionConfigPtrOutput{})

--- a/sdk/nodejs/eks/cluster.ts
+++ b/sdk/nodejs/eks/cluster.ts
@@ -30,7 +30,7 @@ import * as utilities from "../utilities";
  *     ],
  * });
  * export const endpoint = example.endpoint;
- * export const kubeconfig_certificate_authority_data = example.certificateAuthority;
+ * export const kubeconfig_certificate_authority_data = example.certificateAuthority.apply(certificateAuthority => certificateAuthority.data);
  * ```
  * ### Example IAM Role for EKS Cluster
  *
@@ -132,7 +132,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
      */
-    public /*out*/ readonly certificateAuthority!: pulumi.Output<string>;
+    public /*out*/ readonly certificateAuthority!: pulumi.Output<outputs.eks.ClusterCertificateAuthority>;
     /**
      * Unix epoch timestamp in seconds for when the cluster was created.
      */
@@ -266,7 +266,7 @@ export interface ClusterState {
     /**
      * The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
      */
-    certificateAuthority?: pulumi.Input<string>;
+    certificateAuthority?: pulumi.Input<inputs.eks.ClusterCertificateAuthority>;
     /**
      * Unix epoch timestamp in seconds for when the cluster was created.
      */

--- a/sdk/nodejs/eks/getCluster.ts
+++ b/sdk/nodejs/eks/getCluster.ts
@@ -18,7 +18,7 @@ import * as utilities from "../utilities";
  *     name: "example",
  * });
  * export const endpoint = example.then(example => example.endpoint);
- * export const kubeconfig_certificate_authority_data = example.then(example => example.certificateAuthority);
+ * export const kubeconfig_certificate_authority_data = example.then(example => example.certificateAuthorities?[0]?.data);
  * export const identity_oidc_issuer = example.then(example => example.identities?[0]?.oidcs?[0]?.issuer);
  * ```
  */
@@ -60,10 +60,6 @@ export interface GetClusterResult {
      * Nested attribute containing `certificate-authority-data` for your cluster.
      */
     readonly certificateAuthorities: outputs.eks.GetClusterCertificateAuthority[];
-    /**
-     * The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-     */
-    readonly certificateAuthority: string;
     /**
      * The Unix epoch time stamp in seconds for when the cluster was created.
      */

--- a/sdk/python/pulumi_aws/eks/cluster.py
+++ b/sdk/python/pulumi_aws/eks/cluster.py
@@ -151,7 +151,7 @@ class _ClusterState:
     def __init__(__self__, *,
                  arn: Optional[pulumi.Input[str]] = None,
                  certificate_authorities: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterCertificateAuthorityArgs']]]] = None,
-                 certificate_authority: Optional[pulumi.Input[str]] = None,
+                 certificate_authority: Optional[pulumi.Input['ClusterCertificateAuthorityArgs']] = None,
                  created_at: Optional[pulumi.Input[str]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  encryption_config: Optional[pulumi.Input['ClusterEncryptionConfigArgs']] = None,
@@ -170,7 +170,7 @@ class _ClusterState:
         Input properties used for looking up and filtering Cluster resources.
         :param pulumi.Input[str] arn: ARN of the cluster.
         :param pulumi.Input[Sequence[pulumi.Input['ClusterCertificateAuthorityArgs']]] certificate_authorities: Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
-        :param pulumi.Input[str] certificate_authority: The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        :param pulumi.Input['ClusterCertificateAuthorityArgs'] certificate_authority: The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         :param pulumi.Input[str] created_at: Unix epoch timestamp in seconds for when the cluster was created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
         :param pulumi.Input['ClusterEncryptionConfigArgs'] encryption_config: Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
@@ -247,14 +247,14 @@ class _ClusterState:
 
     @property
     @pulumi.getter(name="certificateAuthority")
-    def certificate_authority(self) -> Optional[pulumi.Input[str]]:
+    def certificate_authority(self) -> Optional[pulumi.Input['ClusterCertificateAuthorityArgs']]:
         """
         The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         """
         return pulumi.get(self, "certificate_authority")
 
     @certificate_authority.setter
-    def certificate_authority(self, value: Optional[pulumi.Input[str]]):
+    def certificate_authority(self, value: Optional[pulumi.Input['ClusterCertificateAuthorityArgs']]):
         pulumi.set(self, "certificate_authority", value)
 
     @property
@@ -463,7 +463,7 @@ class Cluster(pulumi.CustomResource):
                     aws_iam_role_policy_attachment["example-AmazonEKSVPCResourceController"],
                 ]))
         pulumi.export("endpoint", example.endpoint)
-        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
+        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority.data)
         ```
         ### Example IAM Role for EKS Cluster
 
@@ -565,7 +565,7 @@ class Cluster(pulumi.CustomResource):
                     aws_iam_role_policy_attachment["example-AmazonEKSVPCResourceController"],
                 ]))
         pulumi.export("endpoint", example.endpoint)
-        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
+        pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority.data)
         ```
         ### Example IAM Role for EKS Cluster
 
@@ -695,7 +695,7 @@ class Cluster(pulumi.CustomResource):
             opts: Optional[pulumi.ResourceOptions] = None,
             arn: Optional[pulumi.Input[str]] = None,
             certificate_authorities: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCertificateAuthorityArgs']]]]] = None,
-            certificate_authority: Optional[pulumi.Input[str]] = None,
+            certificate_authority: Optional[pulumi.Input[pulumi.InputType['ClusterCertificateAuthorityArgs']]] = None,
             created_at: Optional[pulumi.Input[str]] = None,
             enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
             encryption_config: Optional[pulumi.Input[pulumi.InputType['ClusterEncryptionConfigArgs']]] = None,
@@ -719,7 +719,7 @@ class Cluster(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] arn: ARN of the cluster.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCertificateAuthorityArgs']]]] certificate_authorities: Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
-        :param pulumi.Input[str] certificate_authority: The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
+        :param pulumi.Input[pulumi.InputType['ClusterCertificateAuthorityArgs']] certificate_authority: The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         :param pulumi.Input[str] created_at: Unix epoch timestamp in seconds for when the cluster was created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
         :param pulumi.Input[pulumi.InputType['ClusterEncryptionConfigArgs']] encryption_config: Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
@@ -776,7 +776,7 @@ class Cluster(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="certificateAuthority")
-    def certificate_authority(self) -> pulumi.Output[str]:
+    def certificate_authority(self) -> pulumi.Output['outputs.ClusterCertificateAuthority']:
         """
         The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
         """

--- a/sdk/python/pulumi_aws/eks/get_cluster.py
+++ b/sdk/python/pulumi_aws/eks/get_cluster.py
@@ -21,16 +21,13 @@ class GetClusterResult:
     """
     A collection of values returned by getCluster.
     """
-    def __init__(__self__, arn=None, certificate_authorities=None, certificate_authority=None, created_at=None, enabled_cluster_log_types=None, endpoint=None, id=None, identities=None, kubernetes_network_configs=None, name=None, platform_version=None, role_arn=None, status=None, tags=None, version=None, vpc_config=None):
+    def __init__(__self__, arn=None, certificate_authorities=None, created_at=None, enabled_cluster_log_types=None, endpoint=None, id=None, identities=None, kubernetes_network_configs=None, name=None, platform_version=None, role_arn=None, status=None, tags=None, version=None, vpc_config=None):
         if arn and not isinstance(arn, str):
             raise TypeError("Expected argument 'arn' to be a str")
         pulumi.set(__self__, "arn", arn)
         if certificate_authorities and not isinstance(certificate_authorities, list):
             raise TypeError("Expected argument 'certificate_authorities' to be a list")
         pulumi.set(__self__, "certificate_authorities", certificate_authorities)
-        if certificate_authority and not isinstance(certificate_authority, str):
-            raise TypeError("Expected argument 'certificate_authority' to be a str")
-        pulumi.set(__self__, "certificate_authority", certificate_authority)
         if created_at and not isinstance(created_at, str):
             raise TypeError("Expected argument 'created_at' to be a str")
         pulumi.set(__self__, "created_at", created_at)
@@ -86,14 +83,6 @@ class GetClusterResult:
         Nested attribute containing `certificate-authority-data` for your cluster.
         """
         return pulumi.get(self, "certificate_authorities")
-
-    @property
-    @pulumi.getter(name="certificateAuthority")
-    def certificate_authority(self) -> str:
-        """
-        The first certificate authority. Base64 encoded certificate data required to communicate with your cluster.
-        """
-        return pulumi.get(self, "certificate_authority")
 
     @property
     @pulumi.getter(name="createdAt")
@@ -205,7 +194,6 @@ class AwaitableGetClusterResult(GetClusterResult):
         return GetClusterResult(
             arn=self.arn,
             certificate_authorities=self.certificate_authorities,
-            certificate_authority=self.certificate_authority,
             created_at=self.created_at,
             enabled_cluster_log_types=self.enabled_cluster_log_types,
             endpoint=self.endpoint,
@@ -235,7 +223,7 @@ def get_cluster(name: Optional[str] = None,
 
     example = aws.eks.get_cluster(name="example")
     pulumi.export("endpoint", example.endpoint)
-    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
+    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authorities[0].data)
     pulumi.export("identity-oidc-issuer", example.identities[0].oidcs[0].issuer)
     ```
 
@@ -255,7 +243,6 @@ def get_cluster(name: Optional[str] = None,
     return AwaitableGetClusterResult(
         arn=__ret__.arn,
         certificate_authorities=__ret__.certificate_authorities,
-        certificate_authority=__ret__.certificate_authority,
         created_at=__ret__.created_at,
         enabled_cluster_log_types=__ret__.enabled_cluster_log_types,
         endpoint=__ret__.endpoint,
@@ -286,7 +273,7 @@ def get_cluster_output(name: Optional[pulumi.Input[str]] = None,
 
     example = aws.eks.get_cluster(name="example")
     pulumi.export("endpoint", example.endpoint)
-    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authority)
+    pulumi.export("kubeconfig-certificate-authority-data", example.certificate_authorities[0].data)
     pulumi.export("identity-oidc-issuer", example.identities[0].oidcs[0].issuer)
     ```
 


### PR DESCRIPTION
In #1896, we added a new backward compatible type for certificateAuthority
to ensure that it was available rather than being the new list

Unfortunately, this introduced a string and the old type for certificateauthority
was actually an object with a Data parameter inside it

This rectifies the issue

[![asciicast](https://asciinema.org/a/rdSykSbX5OTv3GD2fvUmEXXZv.svg)](https://asciinema.org/a/rdSykSbX5OTv3GD2fvUmEXXZv)