### PR TITLE
Remove storing AWS_PROFILE in state

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -311,11 +311,6 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"AWS_REGION", "AWS_DEFAULT_REGION"},
 				},
 			},
-			"profile": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"AWS_PROFILE"},
-				},
-			},
 			"skip_get_ec2_platforms": {
 				Default: &tfbridge.DefaultInfo{
 					Value: true,

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -154,7 +154,7 @@ namespace Pulumi.Aws
             set => _maxRetries.Set(value);
         }
 
-        private static readonly __Value<string?> _profile = new __Value<string?>(() => __config.Get("profile") ?? Utilities.GetEnv("AWS_PROFILE"));
+        private static readonly __Value<string?> _profile = new __Value<string?>(() => __config.Get("profile"));
         /// <summary>
         /// The profile for API operations. If not set, the default profile created with `aws configure` will be used.
         /// </summary>

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -323,7 +323,6 @@ namespace Pulumi.Aws
 
         public ProviderArgs()
         {
-            Profile = Utilities.GetEnv("AWS_PROFILE");
             Region = Utilities.GetEnv("AWS_REGION", "AWS_DEFAULT_REGION");
             SkipCredentialsValidation = true;
             SkipGetEc2Platforms = true;

--- a/sdk/go/aws/config/config.go
+++ b/sdk/go/aws/config/config.go
@@ -71,11 +71,7 @@ func GetMaxRetries(ctx *pulumi.Context) int {
 
 // The profile for API operations. If not set, the default profile created with `aws configure` will be used.
 func GetProfile(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "aws:profile")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "AWS_PROFILE").(string)
+	return config.Get(ctx, "aws:profile")
 }
 
 // The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.

--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -54,9 +54,6 @@ func NewProvider(ctx *pulumi.Context,
 		args = &ProviderArgs{}
 	}
 
-	if isZero(args.Profile) {
-		args.Profile = pulumi.StringPtr(getEnvOrDefault("", nil, "AWS_PROFILE").(string))
-	}
 	if isZero(args.Region) {
 		args.Region = pulumi.StringPtr(getEnvOrDefault("", nil, "AWS_REGION", "AWS_DEFAULT_REGION").(string))
 	}

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -151,7 +151,7 @@ Object.defineProperty(exports, "maxRetries", {
 export declare const profile: string | undefined;
 Object.defineProperty(exports, "profile", {
     get() {
-        return __config.get("profile") ?? utilities.getEnv("AWS_PROFILE");
+        return __config.get("profile");
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -103,7 +103,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["ignoreTags"] = pulumi.output(args ? args.ignoreTags : undefined).apply(JSON.stringify);
             resourceInputs["insecure"] = pulumi.output(args ? args.insecure : undefined).apply(JSON.stringify);
             resourceInputs["maxRetries"] = pulumi.output(args ? args.maxRetries : undefined).apply(JSON.stringify);
-            resourceInputs["profile"] = (args ? args.profile : undefined) ?? utilities.getEnv("AWS_PROFILE");
+            resourceInputs["profile"] = args ? args.profile : undefined;
             resourceInputs["region"] = (args ? args.region : undefined) ?? <any>utilities.getEnv("AWS_REGION", "AWS_DEFAULT_REGION");
             resourceInputs["s3ForcePathStyle"] = pulumi.output(args ? args.s3ForcePathStyle : undefined).apply(JSON.stringify);
             resourceInputs["s3UsePathStyle"] = pulumi.output(args ? args.s3UsePathStyle : undefined).apply(JSON.stringify);

--- a/sdk/python/pulumi_aws/config/vars.py
+++ b/sdk/python/pulumi_aws/config/vars.py
@@ -103,7 +103,7 @@ class _ExportableConfig(types.ModuleType):
         """
         The profile for API operations. If not set, the default profile created with `aws configure` will be used.
         """
-        return __config__.get('profile') or _utilities.get_env('AWS_PROFILE')
+        return __config__.get('profile')
 
     @property
     def region(self) -> Optional[str]:

--- a/sdk/python/pulumi_aws/provider.py
+++ b/sdk/python/pulumi_aws/provider.py
@@ -109,8 +109,6 @@ class ProviderArgs:
             pulumi.set(__self__, "insecure", insecure)
         if max_retries is not None:
             pulumi.set(__self__, "max_retries", max_retries)
-        if profile is None:
-            profile = _utilities.get_env('AWS_PROFILE')
         if profile is not None:
             pulumi.set(__self__, "profile", profile)
         if region is None:
@@ -684,8 +682,6 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["ignore_tags"] = pulumi.Output.from_input(ignore_tags).apply(pulumi.runtime.to_json) if ignore_tags is not None else None
             __props__.__dict__["insecure"] = pulumi.Output.from_input(insecure).apply(pulumi.runtime.to_json) if insecure is not None else None
             __props__.__dict__["max_retries"] = pulumi.Output.from_input(max_retries).apply(pulumi.runtime.to_json) if max_retries is not None else None
-            if profile is None:
-                profile = _utilities.get_env('AWS_PROFILE')
             __props__.__dict__["profile"] = profile
             if region is None:
                 region = _utilities.get_env('AWS_REGION', 'AWS_DEFAULT_REGION')


### PR DESCRIPTION
Fixes: #1906

When this is stored in state, a second run of Pulumi with a different
PROFILE name will fail
