### PR TITLE
aws.s3.BucketObject: Remove the Deprecation Warnings

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -13,7 +13,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87
-	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2
+	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220421103944-b09e036781fa
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -757,8 +757,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87 h1:Reqyb/CbcDwThvBRzA62H7cvuCqgTJuGNt+F6mnmXJ4=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20211230170131-3a7c83bfab87/go.mod h1:FjM9DXWfP0w/AeOtJoSKHBZ01LqmaO6uP4bXhv3fekw=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2 h1:o4tgNxegV2prw2DK1pxXttIjVMM64AXfzKYKWlXuFSI=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220421103944-b09e036781fa h1:z6EKrYz7vWC/ZlXE00XiCMR8XGfvc7a2CCEmwJUptkQ=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220421103944-b09e036781fa/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20211105002759-77bad27d9f23
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2
+replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20220421103944-b09e036781fa

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -344,8 +344,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2 h1:o4tgNxegV2prw2DK1pxXttIjVMM64AXfzKYKWlXuFSI=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20220407104105-4ef94827b0b2/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220421103944-b09e036781fa h1:z6EKrYz7vWC/ZlXE00XiCMR8XGfvc7a2CCEmwJUptkQ=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20220421103944-b09e036781fa/go.mod h1:JByArH1mlIVUO+Kjt0okfMRH/KKvbi0Wkyn9zGrQL5Q=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/sdk/dotnet/S3/BucketObject.cs
+++ b/sdk/dotnet/S3/BucketObject.cs
@@ -10,6 +10,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Aws.S3
 {
     /// <summary>
+    /// Provides an S3 object resource.
+    /// 
     /// ## Example Usage
     /// ### Encrypting with KMS Key
     /// 

--- a/sdk/go/aws/s3/bucketObject.go
+++ b/sdk/go/aws/s3/bucketObject.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// Provides an S3 object resource.
+//
 // ## Example Usage
 // ### Encrypting with KMS Key
 //
@@ -200,8 +202,6 @@ type BucketObject struct {
 	// [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 	Acl pulumi.StringPtrOutput `pulumi:"acl"`
 	// Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Bucket pulumi.StringOutput `pulumi:"bucket"`
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled pulumi.BoolOutput `pulumi:"bucketKeyEnabled"`
@@ -224,8 +224,6 @@ type BucketObject struct {
 	// Whether to allow the object to be deleted by removing any legal hold on any object version. Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
 	ForceDestroy pulumi.BoolPtrOutput `pulumi:"forceDestroy"`
 	// Name of the object once it is in the bucket.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Key pulumi.StringOutput `pulumi:"key"`
 	// ARN of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `kms.Key` resource, use the `arn` attribute. If referencing the `kms.Alias` data source or resource, use the `targetKeyArn` attribute. This provider will only perform drift detection if a configuration value is provided.
 	KmsKeyId pulumi.StringOutput `pulumi:"kmsKeyId"`
@@ -290,8 +288,6 @@ type bucketObjectState struct {
 	// [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 	Acl *string `pulumi:"acl"`
 	// Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Bucket interface{} `pulumi:"bucket"`
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled *bool `pulumi:"bucketKeyEnabled"`
@@ -314,8 +310,6 @@ type bucketObjectState struct {
 	// Whether to allow the object to be deleted by removing any legal hold on any object version. Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
 	ForceDestroy *bool `pulumi:"forceDestroy"`
 	// Name of the object once it is in the bucket.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Key *string `pulumi:"key"`
 	// ARN of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `kms.Key` resource, use the `arn` attribute. If referencing the `kms.Alias` data source or resource, use the `targetKeyArn` attribute. This provider will only perform drift detection if a configuration value is provided.
 	KmsKeyId *string `pulumi:"kmsKeyId"`
@@ -349,8 +343,6 @@ type BucketObjectState struct {
 	// [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 	Acl pulumi.StringPtrInput
 	// Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Bucket pulumi.Input
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled pulumi.BoolPtrInput
@@ -373,8 +365,6 @@ type BucketObjectState struct {
 	// Whether to allow the object to be deleted by removing any legal hold on any object version. Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
 	ForceDestroy pulumi.BoolPtrInput
 	// Name of the object once it is in the bucket.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Key pulumi.StringPtrInput
 	// ARN of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `kms.Key` resource, use the `arn` attribute. If referencing the `kms.Alias` data source or resource, use the `targetKeyArn` attribute. This provider will only perform drift detection if a configuration value is provided.
 	KmsKeyId pulumi.StringPtrInput
@@ -412,8 +402,6 @@ type bucketObjectArgs struct {
 	// [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 	Acl *string `pulumi:"acl"`
 	// Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Bucket interface{} `pulumi:"bucket"`
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled *bool `pulumi:"bucketKeyEnabled"`
@@ -436,8 +424,6 @@ type bucketObjectArgs struct {
 	// Whether to allow the object to be deleted by removing any legal hold on any object version. Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
 	ForceDestroy *bool `pulumi:"forceDestroy"`
 	// Name of the object once it is in the bucket.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Key *string `pulumi:"key"`
 	// ARN of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `kms.Key` resource, use the `arn` attribute. If referencing the `kms.Alias` data source or resource, use the `targetKeyArn` attribute. This provider will only perform drift detection if a configuration value is provided.
 	KmsKeyId *string `pulumi:"kmsKeyId"`
@@ -468,8 +454,6 @@ type BucketObjectArgs struct {
 	// [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 	Acl pulumi.StringPtrInput
 	// Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Bucket pulumi.Input
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled pulumi.BoolPtrInput
@@ -492,8 +476,6 @@ type BucketObjectArgs struct {
 	// Whether to allow the object to be deleted by removing any legal hold on any object version. Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
 	ForceDestroy pulumi.BoolPtrInput
 	// Name of the object once it is in the bucket.
-	//
-	// Deprecated: Use the aws_s3_object resource instead
 	Key pulumi.StringPtrInput
 	// ARN of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `kms.Key` resource, use the `arn` attribute. If referencing the `kms.Alias` data source or resource, use the `targetKeyArn` attribute. This provider will only perform drift detection if a configuration value is provided.
 	KmsKeyId pulumi.StringPtrInput

--- a/sdk/nodejs/s3/bucketObject.ts
+++ b/sdk/nodejs/s3/bucketObject.ts
@@ -7,6 +7,8 @@ import * as utilities from "../utilities";
 import {Bucket} from "./index";
 
 /**
+ * Provides an S3 object resource.
+ *
  * ## Example Usage
  * ### Encrypting with KMS Key
  *
@@ -144,8 +146,6 @@ export class BucketObject extends pulumi.CustomResource {
     public readonly acl!: pulumi.Output<string | undefined>;
     /**
      * Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-     *
-     * @deprecated Use the aws_s3_object resource instead
      */
     public readonly bucket!: pulumi.Output<string>;
     /**
@@ -190,8 +190,6 @@ export class BucketObject extends pulumi.CustomResource {
     public readonly forceDestroy!: pulumi.Output<boolean | undefined>;
     /**
      * Name of the object once it is in the bucket.
-     *
-     * @deprecated Use the aws_s3_object resource instead
      */
     public readonly key!: pulumi.Output<string>;
     /**
@@ -333,8 +331,6 @@ export interface BucketObjectState {
     acl?: pulumi.Input<string>;
     /**
      * Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-     *
-     * @deprecated Use the aws_s3_object resource instead
      */
     bucket?: pulumi.Input<string | Bucket>;
     /**
@@ -379,8 +375,6 @@ export interface BucketObjectState {
     forceDestroy?: pulumi.Input<boolean>;
     /**
      * Name of the object once it is in the bucket.
-     *
-     * @deprecated Use the aws_s3_object resource instead
      */
     key?: pulumi.Input<string>;
     /**
@@ -447,8 +441,6 @@ export interface BucketObjectArgs {
     acl?: pulumi.Input<string>;
     /**
      * Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
-     *
-     * @deprecated Use the aws_s3_object resource instead
      */
     bucket: pulumi.Input<string | Bucket>;
     /**
@@ -493,8 +485,6 @@ export interface BucketObjectArgs {
     forceDestroy?: pulumi.Input<boolean>;
     /**
      * Name of the object once it is in the bucket.
-     *
-     * @deprecated Use the aws_s3_object resource instead
      */
     key?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_aws/s3/bucket_object.py
+++ b/sdk/python/pulumi_aws/s3/bucket_object.py
@@ -64,9 +64,6 @@ class BucketObjectArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Map of tags to assign to the object. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param pulumi.Input[str] website_redirect: Target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
         """
-        if bucket is not None:
-            warnings.warn("""Use the aws_s3_object resource instead""", DeprecationWarning)
-            pulumi.log.warn("""bucket is deprecated: Use the aws_s3_object resource instead""")
         pulumi.set(__self__, "bucket", bucket)
         if acl is not None:
             pulumi.set(__self__, "acl", acl)
@@ -90,9 +87,6 @@ class BucketObjectArgs:
             pulumi.set(__self__, "etag", etag)
         if force_destroy is not None:
             pulumi.set(__self__, "force_destroy", force_destroy)
-        if key is not None:
-            warnings.warn("""Use the aws_s3_object resource instead""", DeprecationWarning)
-            pulumi.log.warn("""key is deprecated: Use the aws_s3_object resource instead""")
         if key is not None:
             pulumi.set(__self__, "key", key)
         if kms_key_id is not None:
@@ -468,9 +462,6 @@ class _BucketObjectState:
         if acl is not None:
             pulumi.set(__self__, "acl", acl)
         if bucket is not None:
-            warnings.warn("""Use the aws_s3_object resource instead""", DeprecationWarning)
-            pulumi.log.warn("""bucket is deprecated: Use the aws_s3_object resource instead""")
-        if bucket is not None:
             pulumi.set(__self__, "bucket", bucket)
         if bucket_key_enabled is not None:
             pulumi.set(__self__, "bucket_key_enabled", bucket_key_enabled)
@@ -492,9 +483,6 @@ class _BucketObjectState:
             pulumi.set(__self__, "etag", etag)
         if force_destroy is not None:
             pulumi.set(__self__, "force_destroy", force_destroy)
-        if key is not None:
-            warnings.warn("""Use the aws_s3_object resource instead""", DeprecationWarning)
-            pulumi.log.warn("""key is deprecated: Use the aws_s3_object resource instead""")
         if key is not None:
             pulumi.set(__self__, "key", key)
         if kms_key_id is not None:
@@ -868,6 +856,8 @@ class BucketObject(pulumi.CustomResource):
                  website_redirect: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
+        Provides an S3 object resource.
+
         ## Example Usage
         ### Encrypting with KMS Key
 
@@ -994,6 +984,8 @@ class BucketObject(pulumi.CustomResource):
                  args: BucketObjectArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
+        Provides an S3 object resource.
+
         ## Example Usage
         ### Encrypting with KMS Key
 
@@ -1140,9 +1132,6 @@ class BucketObject(pulumi.CustomResource):
             __props__.__dict__["acl"] = acl
             if bucket is None and not opts.urn:
                 raise TypeError("Missing required property 'bucket'")
-            if bucket is not None and not opts.urn:
-                warnings.warn("""Use the aws_s3_object resource instead""", DeprecationWarning)
-                pulumi.log.warn("""bucket is deprecated: Use the aws_s3_object resource instead""")
             __props__.__dict__["bucket"] = bucket
             __props__.__dict__["bucket_key_enabled"] = bucket_key_enabled
             __props__.__dict__["cache_control"] = cache_control
@@ -1154,9 +1143,6 @@ class BucketObject(pulumi.CustomResource):
             __props__.__dict__["content_type"] = content_type
             __props__.__dict__["etag"] = etag
             __props__.__dict__["force_destroy"] = force_destroy
-            if key is not None and not opts.urn:
-                warnings.warn("""Use the aws_s3_object resource instead""", DeprecationWarning)
-                pulumi.log.warn("""key is deprecated: Use the aws_s3_object resource instead""")
             __props__.__dict__["key"] = key
             __props__.__dict__["kms_key_id"] = kms_key_id
             __props__.__dict__["metadata"] = metadata


### PR DESCRIPTION
Fixes: #1911
FixeS: #1910

These warnings were from upstream and not someething we care about
disclosing to the user
