### PR TITLE
Fix TargetGroup's autoname length

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5025,7 +5025,7 @@ func Provider() tfbridge.ProviderInfo {
 		awsResource(lbMod, "TargetGroup"), legacyElbv2Mod, lbMod, &tfbridge.ResourceInfo{
 			Fields: map[string]*tfbridge.SchemaInfo{
 				// https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
-				"name": tfbridge.AutoName("name", 63, "-"),
+				"name": tfbridge.AutoName("name", 32, "-"),
 				"deregistration_delay": {
 					Type: "integer",
 				},


### PR DESCRIPTION
According to docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
`This name must be unique per region per account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen.`