### PR TITLE
improve error message to contain command to configure AWS credentials

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -345,10 +345,11 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	config.SharedConfigFiles = []string{configPath}
 
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
-		return fmt.Errorf("unable to validate AWS credentials - see https://pulumi.io/install/aws.html for details on configuration\n" +
-			"if using the AWS CLI:\n" +
+		return fmt.Errorf("unable to validate AWS credentials " +
+			"- see https://pulumi.io/install/aws.html for details on configuration\n" +
+			"log in to AWS using the AWS CLI:\n" +
 			"    aws configure\n" +
-			"if using AWS CLI(with SSO):\n" +
+			"log in to AWS using the AWS CLI(with SSO):\n" +
 			"    aws sso login\n")
 	}
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -345,8 +345,11 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	config.SharedConfigFiles = []string{configPath}
 
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
-		return fmt.Errorf("unable to validate AWS credentials " +
-			"- see https://pulumi.io/install/aws.html for details on configuration")
+		return fmt.Errorf("unable to validate AWS credentials - see https://pulumi.io/install/aws.html for details on configuration\n" +
+			"if using the AWS CLI:\n" +
+			"    aws configure\n" +
+			"if using AWS CLI(with SSO):\n" +
+			"    aws sso login\n")
 	}
 
 	return nil

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -347,10 +347,11 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
 
 		return fmt.Errorf("unable to validate AWS credentials. Make sure you have: \n\n" +
-			" \t • Set the AWS_SECRET_ACCESS_KEY \n" +
-			" \t • Set the AWS_ACCESS_KEY_ID \n" +
-			" \t • Set your AWS region using `pulumi config set aws:region <region>`, e.g `us-west-2` \n\n" +
-			"See https://pulumi.io/install/aws.html for details on configuration")
+			" \t • Configured your AWS access key \n" +
+			" \t • Configured your AWS_ access key ID \n" +
+			" \t • Set your AWS region using `pulumi config set aws:region <region>`, e.g `us-west-2` \n" +
+			" \t You can set these via `aws configure`. \n\n" +
+			"See https://pulumi.io/install/aws.html for further details on configuration")
 	}
 
 	return nil

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -347,11 +347,9 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
 
 		return fmt.Errorf("unable to validate AWS credentials. Make sure you have: \n\n" +
-			" \t • Configured your AWS access key \n" +
-			" \t • Configured your AWS_ access key ID \n" +
-			" \t • Set your AWS region using `pulumi config set aws:region <region>`, e.g `us-west-2` \n" +
-			" \t You can set these via `aws configure`. \n\n" +
-			"See https://pulumi.io/install/aws.html for further details on configuration")
+			" \t • Set your AWS region, e.g. `pulumi config set aws:region us-west-2` \n" +
+			" \t • Configured your AWS credentials as per https://pulumi.io/install/aws.html \n" +
+			" \t You can also set these via cli using `aws configure`. \n\n")
 	}
 
 	return nil

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -345,12 +345,12 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	config.SharedConfigFiles = []string{configPath}
 
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
-		return fmt.Errorf("unable to validate AWS credentials " +
-			"- see https://pulumi.io/install/aws.html for details on configuration\n" +
-			"log in to AWS using the AWS CLI:\n" +
-			"    aws configure\n" +
-			"log in to AWS using the AWS CLI(with SSO):\n" +
-			"    aws sso login\n")
+
+		return fmt.Errorf("unable to validate AWS credentials. Make sure you have: \n\n" +
+			" \t • Set the AWS_SECRET_ACCESS_KEY \n" +
+			" \t • Set the AWS_ACCESS_KEY_ID \n" +
+			" \t • Set your AWS region using `pulumi config set aws:region <region>`, e.g `us-west-2` \n\n" +
+			"See https://pulumi.io/install/aws.html for details on configuration")
 	}
 
 	return nil


### PR DESCRIPTION
part of #1968 

redirecting input from the provider to the CLI and back over GRP seems like a lot of work at the moment.

I was trying to optimize for power users double-clicking to pick up the entire command to copy and paste more effortlessly.

the output of the current PR looks as such
```
kdixler@kdixler-20xw004aus ~/Documents/aws-python % pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/dixler/aws-python/dev/previews/6ddacf00-ff5b-4d70-ac17-9f7191c173f6

     Type                 Name            Plan       Info
 +   pulumi:pulumi:Stack  aws-python-dev  create     
     └─ aws:s3:Bucket     my-bucket                  1 error
 
Diagnostics:
  aws:s3:Bucket (my-bucket):
    error: unable to validate AWS credentials - see https://pulumi.io/install/aws.html for details on configuration
    log in to AWS using the AWS CLI:
        aws configure
    log in to AWS using the AWS CLI(with SSO):
        aws sso login
 

255 kdixler@kdixler-20xw004aus ~/Documents/aws-python %         aws configure

AWS Access Key ID [None]: ^C
130 kdixler@kdixler-20xw004aus ~/Documents/aws-python %         aws sso login

Attempting to automatically open the SSO authorization page in your default browser.
If the browser does not open or you wish to use a different device to authorize this request, open the following URL:

https://device.sso.us-west-2.amazonaws.com/

Then enter the code:
```

would definitely appreciate feedback on the language of this command.