### PR TITLE
aws creds validation error - surface more info

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -345,8 +345,9 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	config.SharedConfigFiles = []string{configPath}
 
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
-		return fmt.Errorf("unable to validate AWS credentials " +
-			"- see https://pulumi.io/install/aws.html for details on configuration")
+		return fmt.Errorf("unable to validate AWS credentials "+
+			"- see https://pulumi.io/install/aws.html for details on configuration"+
+			"\n error: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
A few users have run into an issue where they are getting an error that says unable to validate aws credentials when using the static website component and using their profile in the `~/.aws/credentials`. Here is the original [issue](https://github.com/pulumi/pulumi-aws-static-website/issues/8) that was fiiled. 

The only way I was able to repro this was by using an aws profile set in `~/.aws/credentials` and making sure 
- a default region was not set
- AWS_REGION env variable not set
- region missing from stack config

I then was able to get the error the user was seeing: 
```
unable to validate AWS credentials - see https://pulumi.io/install/aws.html for details on configuration
```
So I went and pulled the aws provider and added a log to the error message and then built it locally to print out the exact error that was being thrown and it sort of confirmed my assumption in the repro about the region not being set.

```
unable to validate AWS credentials - see https://pulumi.io/install/aws.html for details on configuration
     error: error validating provider credentials: error calling sts:GetCallerIdentity: operation error 
     STS: GetCallerIdentity, failed to resolve service endpoint, an AWS region is required, but was not found
```

Anyways, was wondering if it would be useful to print out the details of the message so the user can get a more specific error as to what is going on, rather than print that message for all errors. If so, here is a PR to log the error being thrown. I was thinking to see if we could just throw our own custom message based on an error type, but I don't see any error type to check against in the aws hashicorp package that is throwing this error.