### PR TITLE
aws.ec2.SecurityGroupRule: Ensure DeleteBeforeReplace

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1441,7 +1441,8 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"aws_security_group_rule": {
-				Tok: awsResource(ec2Mod, "SecurityGroupRule"),
+				Tok:                 awsResource(ec2Mod, "SecurityGroupRule"),
+				DeleteBeforeReplace: true,
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"protocol": {
 						Type:     "string",


### PR DESCRIPTION
The current implementation of SGRule means that only description
can be changed. Everything else on the resource is ForceNew by
default

Unfortunately, when a SGRule changes, we try and create a new rule
before deleting the old one. We can't create 2 rules of the same
in a SG therefore, we get an error

This ensures we delete the rule first before creating the new one
