### PR TITLE
aws.acm.CertificateValidation: Refactor the API docs to work

### DIFF
--- a/docs/resource/aws_acm_certificate_validation.examples.md
+++ b/docs/resource/aws_acm_certificate_validation.examples.md
@@ -1,0 +1,284 @@
+## Example Usage
+{{% example %}}
+### DNS Validation with Route 53
+
+```typescript
+import * as aws from "@pulumi/aws";
+
+const exampleCertificate = new aws.acm.Certificate("exampleCertificate", {
+    domainName: "example.com",
+    validationMethod: "DNS",
+});
+const exampleZone = aws.route53.getZone({
+    name: "example.com",
+    privateZone: false,
+});
+
+const certValidation = new aws.route53.Record("certValidation", {
+    name: exampleCertificate.domainValidationOptions[0].resourceRecordName,
+    records: [exampleCertificate.domainValidationOptions[0].resourceRecordValue],
+    ttl: 60,
+    type: exampleCertificate.domainValidationOptions[0].resourceRecordType,
+    zoneId: exampleZone.then(x => x.zoneId),
+});
+
+const certCertificateValidation = new aws.acm.CertificateValidation("cert", {
+    certificateArn: exampleCertificate.arn,
+    validationRecordFqdns: [certValidation.fqdn],
+});
+
+export const certificateArn = certCertificateValidation.certificateArn;
+```
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/acm"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/route53"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+        exampleCertificate, err := acm.NewCertificate(ctx, "exampleCertificate", &acm.CertificateArgs{
+            DomainName:       pulumi.String("example.com"),
+            ValidationMethod: pulumi.String("DNS"),
+        })
+        if err != nil {
+            return err
+        }
+        
+        exampleZone, err := route53.LookupZone(ctx, &route53.LookupZoneArgs{
+            Name:        pulumi.StringRef("example.com"),
+            PrivateZone: pulumi.BoolRef(false),
+        }, nil)
+        if err != nil {
+            return err
+        }
+        
+        domainValidationOption := exampleCertificate.DomainValidationOptions.ApplyT(func(options []acm.CertificateDomainValidationOption) interface{} {
+            return options[0]
+        })
+        
+        certValidation, err := route53.NewRecord(ctx, "certValidation", &route53.RecordArgs{
+            Name: domainValidationOption.ApplyT(func(option interface{}) string {
+                return *option.(acm.CertificateDomainValidationOption).ResourceRecordName
+            }).(pulumi.StringOutput),
+            Type: domainValidationOption.ApplyT(func(option interface{}) string {
+                return *option.(acm.CertificateDomainValidationOption).ResourceRecordType
+            }).(pulumi.StringOutput),
+            Records: pulumi.StringArray{
+                domainValidationOption.ApplyT(func(option interface{}) string {
+                    return *option.(acm.CertificateDomainValidationOption).ResourceRecordValue
+                }).(pulumi.StringOutput),
+            },
+            Ttl:    pulumi.Int(10 * 60),
+            ZoneId: pulumi.String(exampleZone.ZoneId),
+        })
+        if err != nil {
+            return err
+        }
+        
+        certCertificateValidation, err := acm.NewCertificateValidation(ctx, "cert", &acm.CertificateValidationArgs{
+            CertificateArn: exampleCertificate.Arn,
+            ValidationRecordFqdns: pulumi.StringArray{
+                certValidation.Fqdn,
+            },
+        })
+        if err != nil {
+            return err
+        }
+        
+        ctx.Export("certificateArn", certCertificateValidation.CertificateArn)
+        
+        return nil
+    })
+}
+```
+```python
+import pulumi_aws as aws
+
+example_certificate = aws.acm.Certificate("exampleCertificate",
+                                          domain_name="example.com",
+                                          validation_method="DNS")
+
+example_zone = aws.route53.getZone(name="example.com",
+                                   private_zone=False)
+
+cert_validation = aws.route53.Record("certValidation",
+                                     name=example_certificate.domain_validation_options[0].resource_record_name,
+                                     records=[example_certificate.domain_validation_options[0].resource_record_value],
+                                     ttl=60,
+                                     type=example_certificate.domain_validation_options[0].resource_record_type,
+                                     zone_id=example_zone.zone_id)
+
+cert_certificate_validation = aws.route53.CertificateValidation("cert",
+                                                              certificate_arn=example_certificate.arn,
+                                                              validation_record_fdqns=[cert_validation.fdqn])
+
+pulumi.export("certificate_arn", cert_certificate_validation.certificate_arn)
+```
+```csharp
+using Pulumi;
+using Pulumi.Aws.Acm;
+using Pulumi.Aws.Route53;
+using System.Collections.Generic;
+
+return await Deployment.RunAsync(() =>
+{
+   var exampleCertificate = new Certificate("exampleCertificate", new CertificateArgs
+   {
+      DomainName = "example.com",
+      ValidationMethod = "DNS"
+   });
+
+   var exampleZone = GetZone.Invoke(new GetZoneInvokeArgs
+   {
+      Name = "example.com",
+      PrivateZone = false,
+   });
+
+   var certValidation = new Record("certValidation", new RecordArgs
+   {
+      Name = exampleCertificate.DomainValidationOptions.Apply(options => options[0].ResourceRecordName!),
+      Records =
+      {
+         exampleCertificate.DomainValidationOptions.Apply(options => options[0].ResourceRecordValue!),
+      },
+      Ttl = 60,
+      Type = exampleCertificate.DomainValidationOptions.Apply(options => options[0].ResourceRecordType!),
+      ZoneId = exampleZone.Apply(zone => zone.Id),
+   });
+
+   var certCertificateValidation = new CertificateValidation("cert", new CertificateValidationArgs
+   {
+      CertificateArn = exampleCertificate.Arn,
+      ValidationRecordFqdns =
+      {
+         certValidation.Fqdn,
+      },
+   });
+   
+   return new Dictionary<string, object?>
+   {
+      ["certificateArn"] = certCertificateValidation.CertificateArn,
+   };
+});
+```
+```yaml
+variables:
+  zoneId:
+    Fn::Invoke:
+      Function: aws.route53.getZone
+      Arguments:
+        name: "example.com"
+        privateZone: false
+      Return: id
+resources:
+  exampleCertificate:
+    type: aws.acm.Certificate
+    properties:
+      domainName: "example.com"
+      validationMethod: "DNS"
+  certValidation:
+    type: aws.route53.Record
+    properties:
+      name: ${exampleCertificate.domainValidationOptions[0].resourceRecordName}
+      records: [${exampleCertificate.domainValidationOptions[0].resourceRecordValue}]
+      ttl: 60
+      type: ${exampleCertificate.domainValidationOptions[0].resourceRecordType}
+      zoneId: ${zoneId}
+  certCertificateValidation:
+    type: aws.acm.CertificateValidation
+    properties:
+      certificateArn: ${exampleCertificate.arn}
+      validationRecordFqdns: [${certValidation.fqdn}]
+outputs:
+  certificateArn: ${certCertificateValidation.certificateArn}
+```
+{{% /example %}}
+{{% example %}}
+### Email Validation
+
+```typescript
+import * as aws from "@pulumi/aws";
+
+const exampleCertificate = new aws.acm.Certificate("exampleCertificate", {
+    domainName: "example.com",
+    validationMethod: "EMAIL",
+});
+
+const exampleCertificateValidation = new aws.acm.CertificateValidation("exampleCertificateValidation", {
+    certificateArn: exampleCertificate.arn,
+});
+```
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/acm"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+        exampleCertificate, err := acm.NewCertificate(ctx, "exampleCertificate", &acm.CertificateArgs{
+            DomainName: pulumi.String("example.com"),
+            ValidationMethod: pulumi.String("EMAIL"),
+        })
+        if err != nil {
+            return err
+        }
+        
+        _, err = acm.NewCertificateValidation(ctx, "exampleCertificateValidation", &acm.CertificateValidationArgs{
+            CertificateArn: exampleCertificate.Arn,
+        })
+        if err != nil {
+            return err
+        }
+		return nil
+	})
+}
+```
+```python
+import pulumi_aws as aws
+
+example_certificate = aws.acm.Certificate("exampleCertificate",
+                                          domain_name="example.com",
+                                          validation_method="EMAIL")
+
+example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation",
+                                                               certificate_arn=example_certificate.arn)
+```
+```csharp
+using Pulumi;
+using Pulumi.Aws.Acm;
+
+return await Deployment.RunAsync(() =>
+{
+   var exampleCertificate = new Certificate("exampleCertificate", new CertificateArgs
+   {
+      DomainName = "example.com",
+      ValidationMethod = "EMAIL"
+   });
+
+   var certCertificateValidation = new CertificateValidation("cert", new CertificateValidationArgs
+   {
+      CertificateArn = exampleCertificate.Arn,
+   });
+});
+
+```
+```yaml
+resources:
+  exampleCertificate:
+    type: aws.acm.Certificate
+    properties:
+      domainName: "example.com"
+      validationMethod: "EMAIL"
+  certCertificateValidation:
+    type: aws.acm.CertificateValidation
+    properties:
+      certificateArn: ${exampleCertificate.arn}
+```
+{{% /example %}}

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.16
 	github.com/hashicorp/terraform-provider-aws/shim v0.0.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.28.1
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.29.2-0.20220831142229-8f701f642638
 	github.com/pulumi/pulumi/pkg/v3 v3.38.0
 	github.com/pulumi/pulumi/sdk/v3 v3.38.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -832,8 +832,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/pulumi/pulumi-java/pkg v0.5.3 h1:wqiP6TnKZm+ocTRLVwjzmd3fApCKQkvwba0qoh7zMV4=
 github.com/pulumi/pulumi-java/pkg v0.5.3/go.mod h1:leMQvQ5IR3APhejwcWSfwZnkHosKHygKRaWkIyhsvtw=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.28.1 h1:eA9UqT9fywdd47eB1rLfEOwx+FE24+DFlFxsm2dIL9k=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.28.1/go.mod h1:vJGI7DS84/eqsOjn1lOml/PpnYqO/f+2PQSf0X/VLyw=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.29.2-0.20220831142229-8f701f642638 h1:r0V0l67WT7aZcfOWGtc/SXqv1rKeUrDPvX1yde1Xvro=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.29.2-0.20220831142229-8f701f642638/go.mod h1:vJGI7DS84/eqsOjn1lOml/PpnYqO/f+2PQSf0X/VLyw=
 github.com/pulumi/pulumi-yaml v0.5.4 h1:O4H0PD0hiJjpci0GJFSkihS+yC8rWACKxuLyjYVt5wo=
 github.com/pulumi/pulumi-yaml v0.5.4/go.mod h1:e8BcP30yunk/u3mLXDykhtEQf8tTItYgQzPHDmRvJcg=
 github.com/pulumi/pulumi/pkg/v3 v3.38.0 h1:JeL4iFCpW+56CPih/FOzdEFE4UyYBmiBt7g2hlu6JyU=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -426,8 +426,13 @@ func Provider() tfbridge.ProviderInfo {
 		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// AWS Certificate Manager
-			"aws_acm_certificate":            {Tok: awsResource(acmMod, "Certificate")},
-			"aws_acm_certificate_validation": {Tok: awsResource(acmMod, "CertificateValidation")},
+			"aws_acm_certificate": {Tok: awsResource(acmMod, "Certificate")},
+			"aws_acm_certificate_validation": {
+				Tok: awsResource(acmMod, "CertificateValidation"),
+				Docs: &tfbridge.DocInfo{
+					ReplaceExamplesSection: true,
+				},
+			},
 			// AWS Private Certificate Authority
 			"aws_acmpca_certificate_authority": {Tok: awsResource(acmpcaMod, "CertificateAuthority")},
 			"aws_acmpca_certificate": {

--- a/sdk/go/aws/acm/certificateValidation.go
+++ b/sdk/go/aws/acm/certificateValidation.go
@@ -21,10 +21,77 @@ import (
 // > **WARNING:** This resource implements a part of the validation workflow. It does not represent a real-world entity in AWS, therefore changing or deleting this resource on its own has no immediate effect.
 //
 // ## Example Usage
+// ### DNS Validation with Route 53
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/acm"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/route53"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//	        exampleCertificate, err := acm.NewCertificate(ctx, "exampleCertificate", &acm.CertificateArgs{
+//	            DomainName:       pulumi.String("example.com"),
+//	            ValidationMethod: pulumi.String("DNS"),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
+//
+//	        exampleZone, err := route53.LookupZone(ctx, &route53.LookupZoneArgs{
+//	            Name:        pulumi.StringRef("example.com"),
+//	            PrivateZone: pulumi.BoolRef(false),
+//	        }, nil)
+//	        if err != nil {
+//	            return err
+//	        }
+//
+//	        domainValidationOption := exampleCertificate.DomainValidationOptions.ApplyT(func(options []acm.CertificateDomainValidationOption) interface{} {
+//	            return options[0]
+//	        })
+//
+//	        certValidation, err := route53.NewRecord(ctx, "certValidation", &route53.RecordArgs{
+//	            Name: domainValidationOption.ApplyT(func(option interface{}) string {
+//	                return *option.(acm.CertificateDomainValidationOption).ResourceRecordName
+//	            }).(pulumi.StringOutput),
+//	            Type: domainValidationOption.ApplyT(func(option interface{}) string {
+//	                return *option.(acm.CertificateDomainValidationOption).ResourceRecordType
+//	            }).(pulumi.StringOutput),
+//	            Records: pulumi.StringArray{
+//	                domainValidationOption.ApplyT(func(option interface{}) string {
+//	                    return *option.(acm.CertificateDomainValidationOption).ResourceRecordValue
+//	                }).(pulumi.StringOutput),
+//	            },
+//	            Ttl:    pulumi.Int(10 * 60),
+//	            ZoneId: pulumi.String(exampleZone.ZoneId),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
+//
+//	        certCertificateValidation, err := acm.NewCertificateValidation(ctx, "cert", &acm.CertificateValidationArgs{
+//	            CertificateArn: exampleCertificate.Arn,
+//	            ValidationRecordFqdns: pulumi.StringArray{
+//	                certValidation.Fqdn,
+//	            },
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
+//
+//	        ctx.Export("certificateArn", certCertificateValidation.CertificateArn)
+//
+//	        return nil
+//	    })
+//	}
+//
+// ```
 // ### Email Validation
-//
-// In this situation, the resource is simply a waiter for manual email approval of ACM certificates.
-//
 // ```go
 // package main
 //
@@ -37,24 +104,27 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			exampleCertificate, err := acm.NewCertificate(ctx, "exampleCertificate", &acm.CertificateArgs{
-//				DomainName:       pulumi.String("example.com"),
-//				ValidationMethod: pulumi.String("EMAIL"),
-//			})
-//			if err != nil {
-//				return err
-//			}
-//			_, err = acm.NewCertificateValidation(ctx, "exampleCertificateValidation", &acm.CertificateValidationArgs{
-//				CertificateArn: exampleCertificate.Arn,
-//			})
-//			if err != nil {
-//				return err
-//			}
+//	        exampleCertificate, err := acm.NewCertificate(ctx, "exampleCertificate", &acm.CertificateArgs{
+//	            DomainName: pulumi.String("example.com"),
+//	            ValidationMethod: pulumi.String("EMAIL"),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
+//
+//	        _, err = acm.NewCertificateValidation(ctx, "exampleCertificateValidation", &acm.CertificateValidationArgs{
+//	            CertificateArn: exampleCertificate.Arn,
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //			return nil
 //		})
 //	}
 //
 // ```
+//
+// {{% //examples %}}
 type CertificateValidation struct {
 	pulumi.CustomResourceState
 

--- a/sdk/java/src/main/java/com/pulumi/aws/acm/CertificateValidation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/acm/CertificateValidation.java
@@ -26,44 +26,8 @@ import javax.annotation.Nullable;
  * &gt; **WARNING:** This resource implements a part of the validation workflow. It does not represent a real-world entity in AWS, therefore changing or deleting this resource on its own has no immediate effect.
  * 
  * ## Example Usage
- * ### Email Validation
  * 
- * In this situation, the resource is simply a waiter for manual email approval of ACM certificates.
- * ```java
- * package generated_program;
- * 
- * import com.pulumi.Context;
- * import com.pulumi.Pulumi;
- * import com.pulumi.core.Output;
- * import com.pulumi.aws.acm.Certificate;
- * import com.pulumi.aws.acm.CertificateArgs;
- * import com.pulumi.aws.acm.CertificateValidation;
- * import com.pulumi.aws.acm.CertificateValidationArgs;
- * import java.util.List;
- * import java.util.ArrayList;
- * import java.util.Map;
- * import java.io.File;
- * import java.nio.file.Files;
- * import java.nio.file.Paths;
- * 
- * public class App {
- *     public static void main(String[] args) {
- *         Pulumi.run(App::stack);
- *     }
- * 
- *     public static void stack(Context ctx) {
- *         var exampleCertificate = new Certificate(&#34;exampleCertificate&#34;, CertificateArgs.builder()        
- *             .domainName(&#34;example.com&#34;)
- *             .validationMethod(&#34;EMAIL&#34;)
- *             .build());
- * 
- *         var exampleCertificateValidation = new CertificateValidation(&#34;exampleCertificateValidation&#34;, CertificateValidationArgs.builder()        
- *             .certificateArn(exampleCertificate.arn())
- *             .build());
- * 
- *     }
- * }
- * ```
+ * {{% //examples %}}
  * 
  */
 @ResourceType(type="aws:acm/certificateValidation:CertificateValidation")

--- a/sdk/python/pulumi_aws/acm/certificate_validation.py
+++ b/sdk/python/pulumi_aws/acm/certificate_validation.py
@@ -110,48 +110,42 @@ class CertificateValidation(pulumi.CustomResource):
 
         ## Example Usage
         ### DNS Validation with Route 53
-
         ```python
-        import pulumi
         import pulumi_aws as aws
 
         example_certificate = aws.acm.Certificate("exampleCertificate",
-            domain_name="example.com",
-            validation_method="DNS")
-        example_zone = aws.route53.get_zone(name="example.com",
-            private_zone=False)
-        example_record = []
-        for range in [{"key": k, "value": v} for [k, v] in enumerate({dvo.domainName: {
-            name: dvo.resourceRecordName,
-            record: dvo.resourceRecordValue,
-            type: dvo.resourceRecordType,
-        } for dvo in example_certificate.domainValidationOptions})]:
-            example_record.append(aws.route53.Record(f"exampleRecord-{range['key']}",
-                allow_overwrite=True,
-                name=range["value"]["name"],
-                records=[range["value"]["record"]],
-                ttl=60,
-                type=aws.route53/recordtype.RecordType(range["value"]["type"]),
-                zone_id=example_zone.zone_id))
-        example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation",
-            certificate_arn=example_certificate.arn,
-            validation_record_fqdns=example_record.apply(lambda example_record: [record.fqdn for record in example_record]))
-        # ... other configuration ...
-        example_listener = aws.lb.Listener("exampleListener", certificate_arn=example_certificate_validation.certificate_arn)
+                                                  domain_name="example.com",
+                                                  validation_method="DNS")
+
+        example_zone = aws.route53.getZone(name="example.com",
+                                           private_zone=False)
+
+        cert_validation = aws.route53.Record("certValidation",
+                                             name=example_certificate.domain_validation_options[0].resource_record_name,
+                                             records=[example_certificate.domain_validation_options[0].resource_record_value],
+                                             ttl=60,
+                                             type=example_certificate.domain_validation_options[0].resource_record_type,
+                                             zone_id=example_zone.zone_id)
+
+        cert_certificate_validation = aws.route53.CertificateValidation("cert",
+                                                                      certificate_arn=example_certificate.arn,
+                                                                      validation_record_fdqns=[cert_validation.fdqn])
+
+        pulumi.export("certificate_arn", cert_certificate_validation.certificate_arn)
         ```
         ### Email Validation
-
-        In this situation, the resource is simply a waiter for manual email approval of ACM certificates.
-
         ```python
-        import pulumi
         import pulumi_aws as aws
 
         example_certificate = aws.acm.Certificate("exampleCertificate",
-            domain_name="example.com",
-            validation_method="EMAIL")
-        example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation", certificate_arn=example_certificate.arn)
+                                                  domain_name="example.com",
+                                                  validation_method="EMAIL")
+
+        example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation",
+                                                                       certificate_arn=example_certificate.arn)
         ```
+
+        {{% //examples %}}
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -176,48 +170,42 @@ class CertificateValidation(pulumi.CustomResource):
 
         ## Example Usage
         ### DNS Validation with Route 53
-
         ```python
-        import pulumi
         import pulumi_aws as aws
 
         example_certificate = aws.acm.Certificate("exampleCertificate",
-            domain_name="example.com",
-            validation_method="DNS")
-        example_zone = aws.route53.get_zone(name="example.com",
-            private_zone=False)
-        example_record = []
-        for range in [{"key": k, "value": v} for [k, v] in enumerate({dvo.domainName: {
-            name: dvo.resourceRecordName,
-            record: dvo.resourceRecordValue,
-            type: dvo.resourceRecordType,
-        } for dvo in example_certificate.domainValidationOptions})]:
-            example_record.append(aws.route53.Record(f"exampleRecord-{range['key']}",
-                allow_overwrite=True,
-                name=range["value"]["name"],
-                records=[range["value"]["record"]],
-                ttl=60,
-                type=aws.route53/recordtype.RecordType(range["value"]["type"]),
-                zone_id=example_zone.zone_id))
-        example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation",
-            certificate_arn=example_certificate.arn,
-            validation_record_fqdns=example_record.apply(lambda example_record: [record.fqdn for record in example_record]))
-        # ... other configuration ...
-        example_listener = aws.lb.Listener("exampleListener", certificate_arn=example_certificate_validation.certificate_arn)
+                                                  domain_name="example.com",
+                                                  validation_method="DNS")
+
+        example_zone = aws.route53.getZone(name="example.com",
+                                           private_zone=False)
+
+        cert_validation = aws.route53.Record("certValidation",
+                                             name=example_certificate.domain_validation_options[0].resource_record_name,
+                                             records=[example_certificate.domain_validation_options[0].resource_record_value],
+                                             ttl=60,
+                                             type=example_certificate.domain_validation_options[0].resource_record_type,
+                                             zone_id=example_zone.zone_id)
+
+        cert_certificate_validation = aws.route53.CertificateValidation("cert",
+                                                                      certificate_arn=example_certificate.arn,
+                                                                      validation_record_fdqns=[cert_validation.fdqn])
+
+        pulumi.export("certificate_arn", cert_certificate_validation.certificate_arn)
         ```
         ### Email Validation
-
-        In this situation, the resource is simply a waiter for manual email approval of ACM certificates.
-
         ```python
-        import pulumi
         import pulumi_aws as aws
 
         example_certificate = aws.acm.Certificate("exampleCertificate",
-            domain_name="example.com",
-            validation_method="EMAIL")
-        example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation", certificate_arn=example_certificate.arn)
+                                                  domain_name="example.com",
+                                                  validation_method="EMAIL")
+
+        example_certificate_validation = aws.acm.CertificateValidation("exampleCertificateValidation",
+                                                                       certificate_arn=example_certificate.arn)
         ```
+
+        {{% //examples %}}
 
         :param str resource_name: The name of the resource.
         :param CertificateValidationArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
Fixes: #2064
Fixes: #2032
Fixes: #2029
Fixes: #https://github.com/pulumi/registry/issues/1224
