### PR TITLE
preconfigureCallback: Allow Env Vars for Credentials Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ The following configuration points are available:
   `sessionName`: Session name to use when assuming the role.
   `tags`: Map of assume role session tags.
 - `aws:insecure` - (Optional) Explicitly allow the provider to perform "insecure" SSL requests. If omitted, the default value is `false`.
-- `aws:skipCredentialsValidation` - (Optional) Skip the credentials validation via the STS API. Useful for AWS API implementations that do not have STS available or implemented. Default value is `false`.
+- `aws:skipCredentialsValidation` - (Optional) Skip the credentials validation via the STS API. Useful for AWS API implementations that do not have STS available or implemented. Default value is `false`. Can be set via the environment variable `AWS_SKIP_CREDENTIALS_VALIDATION`.
 - `aws:skipGetEc2Platforms` - (Optional) Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions. Default value is `true`.
 - `aws:skipRegionValidation` - (Optional) Skip validation of provided region name. Useful for AWS-like implementations that use their own region names or to bypass the validation for regions that aren't publicly available yet. Default value is `true`.
 - `aws:skipRequestionAccountId` - (Optional) Skip requesting the account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API. Default value is `false`. When specified, the use of ARNs is compromised as there is no accountID available to construct the ARN.
-- `aws:skipMetadataApiCheck` - (Optional) Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. This provider from authenticating via the Metadata API by default. You may need to use other authentication methods like static credentials, configuration variables, or environment variables. Default is `true`.
+- `aws:skipMetadataApiCheck` - (Optional) Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. This provider from authenticating via the Metadata API by default. You may need to use other authentication methods like static credentials, configuration variables, or environment variables. Default is `true`. Can be set via the environment variable `AWS_SKIP_METADATA_API_CHECK`.
 - `aws:s3ForcePathStyle` - (Optional) Set this to true to force the request to use path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing, `http://BUCKET.s3.amazonaws.com/KEY`, when possible. Specific to the Amazon S3 service. Default is `false`.
 
 ### Authenticating pulumi-aws via EC2 Instance Metadata?

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -273,6 +274,25 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 	return ""
 }
 
+// boolValue gets a bool value from a property map if present, else false
+func boolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) bool {
+	val, ok := vars[prop]
+	if ok && val.IsBool() {
+		return val.BoolValue()
+	}
+	for _, env := range envs {
+		val, ok := os.LookupEnv(env)
+		if ok {
+			boolValue, err := strconv.ParseBool(val)
+			if err != nil {
+				return false
+			}
+			return boolValue
+		}
+	}
+	return false
+}
+
 func arrayValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) []string {
 	val, ok := vars[prop]
 	var vals []string
@@ -300,12 +320,8 @@ func stringRef(s string) *string {
 // configuration subset of `github.com/terraform-providers/terraform-provider-aws/aws.providerConfigure`.  We do this
 // before passing control to the TF provider to ensure we can report actionable errors.
 func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) error {
-	var skipCredentialsValidation bool
-	if val, ok := vars["skipCredentialsValidation"]; ok {
-		if val.IsBool() {
-			skipCredentialsValidation = val.BoolValue()
-		}
-	}
+	skipCredentialsValidation := boolValue(vars, "skipCredentialsValidation",
+		[]string{"AWS_SKIP_CREDENTIALS_VALIDATION"})
 
 	// if we skipCredentialsValidation then we don't need to do anything in
 	// preConfigureCallback as this is an explicit operation
@@ -337,10 +353,10 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	// will specify that skipMetadataApiCheck: false
 	// therefore, if we have skipMetadataApiCheck false, then we are enabling the imds client
 	config.EC2MetadataServiceEnableState = imds.ClientDisabled
-	if val, ok := vars["skipMetadataApiCheck"]; ok {
-		if val.IsBool() && !val.BoolValue() {
-			config.EC2MetadataServiceEnableState = imds.ClientEnabled
-		}
+	skipMetadataApiCheck := boolValue(vars, "skipMetadataApiCheck",
+		[]string{"AWS_SKIP_METADATA_API_CHECK"})
+	if !skipMetadataApiCheck {
+		config.EC2MetadataServiceEnableState = imds.ClientEnabled
 	}
 
 	// lastly let's set the sharedCreds and sharedConfig file. If these are not found then let's default to the

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -101,11 +101,11 @@ The following configuration points are available:
   `sessionName`: Session name to use when assuming the role.
   `tags`: Map of assume role session tags.
 - `aws:insecure` - (Optional) Explicitly allow the provider to perform "insecure" SSL requests. If omitted, the default value is `false`.
-- `aws:skipCredentialsValidation` - (Optional) Skip the credentials validation via the STS API. Useful for AWS API implementations that do not have STS available or implemented. Default value is `false`.
+- `aws:skipCredentialsValidation` - (Optional) Skip the credentials validation via the STS API. Useful for AWS API implementations that do not have STS available or implemented. Default value is `false`. Can be set via the environment variable `AWS_SKIP_CREDENTIALS_VALIDATION`.
 - `aws:skipGetEc2Platforms` - (Optional) Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions. Default value is `true`.
 - `aws:skipRegionValidation` - (Optional) Skip validation of provided region name. Useful for AWS-like implementations that use their own region names or to bypass the validation for regions that aren't publicly available yet. Default value is `true`.
 - `aws:skipRequestionAccountId` - (Optional) Skip requesting the account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API. Default value is `false`. When specified, the use of ARNs is compromised as there is no accountID available to construct the ARN.
-- `aws:skipMetadataApiCheck` - (Optional) Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. This provider from authenticating via the Metadata API by default. You may need to use other authentication methods like static credentials, configuration variables, or environment variables. Default is `true`.
+- `aws:skipMetadataApiCheck` - (Optional) Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. This provider from authenticating via the Metadata API by default. You may need to use other authentication methods like static credentials, configuration variables, or environment variables. Default is `true`. Can be set via the environment variable `AWS_SKIP_METADATA_API_CHECK`.
 - `aws:s3ForcePathStyle` - (Optional) Set this to true to force the request to use path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing, `http://BUCKET.s3.amazonaws.com/KEY`, when possible. Specific to the Amazon S3 service. Default is `false`.
 
 ### Authenticating pulumi-aws via EC2 Instance Metadata?


### PR DESCRIPTION
In order to ensure that the user doesn't need to add anything to
state to skip a credentials validation or to skip the metadata api
check, we now allow a user to set the value via environment variables.

The order of operations is that we check for provider configuration
first and if we can't find it, we check for the environment variable

Therefore, a person who wants to skip the credentials validation can
now set:

AWS_SKIP_CREDENTIALS_VALIDATION=true when running pulumi up
