### PR TITLE
Read in role ARN in preConfigure validation

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -323,14 +323,15 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	}
 
 	if details, ok := vars["assumeRole"]; ok {
-		assumeRoleDetails := resource.NewPropertyMap(details)
+
 		assumeRole := awsbase.AssumeRole{
-			RoleARN:     stringValue(assumeRoleDetails, "roleArn", []string{}),
-			ExternalID:  stringValue(assumeRoleDetails, "externalId", []string{}),
-			Policy:      stringValue(assumeRoleDetails, "policy", []string{}),
-			SessionName: stringValue(assumeRoleDetails, "sessionName", []string{}),
+			RoleARN:     stringValue(details.ObjectValue(), "roleArn", []string{}),
+			ExternalID:  stringValue(details.ObjectValue(), "externalId", []string{}),
+			Policy:      stringValue(details.ObjectValue(), "policy", []string{}),
+			SessionName: stringValue(details.ObjectValue(), "sessionName", []string{}),
 		}
 		config.AssumeRole = &assumeRole
+
 	}
 
 	// By default `skipMetadataApiCheck` is true for Pulumi to speed operations
@@ -381,11 +382,12 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	config.SharedConfigFiles = []string{configPath}
 
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
-
-		return fmt.Errorf("unable to validate AWS credentials. Make sure you have: \n\n" +
-			" \t • Set your AWS region, e.g. `pulumi config set aws:region us-west-2` \n" +
-			" \t • Configured your AWS credentials as per https://pulumi.io/install/aws.html \n" +
-			" \t You can also set these via cli using `aws configure`. \n\n")
+		return fmt.Errorf("unable to validate AWS credentials. \n"+
+			"Details: %v\n\n"+
+			"Make sure you have: \n\n"+
+			" \t • Set your AWS region, e.g. `pulumi config set aws:region us-west-2` \n"+
+			" \t • Configured your AWS credentials as per https://pulumi.io/install/aws.html \n"+
+			" \t You can also set these via cli using `aws configure`. \n\n", err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #2144.

I followed the pattern we use in pulumi-azure to surface the underlying error.
I am open to other suggestions but I feel at this point it is more helpful to the user to forward the error from TF or AWS.

A screenshot of the new error surfacing when `aws-region is not set:

<img width="1493" alt="Screen Shot 2022-09-20 at 5 20 12 PM" src="https://user-images.githubusercontent.com/13116240/191387439-ea3d05d9-5cb0-4811-9b2d-37c4c89f2b00.png">

Sample terminal output for an invalid role ARN, with identity details removed:
```
Diagnostics:
  aws:ec2:VpcIpam (guin):
    error: unable to validate AWS credentials. Details: IAM Role (xxxxxxxx/xxxx) cannot be assumed.
    
    There are a number of possible causes of this - the most common are:
      * The credentials used in order to assume the role are invalid
      * The credentials do not have appropriate permission to assume the role
      * The role ARN is not valid
    
    Error: operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: yyyyyyyyyyyyyyy, api error AccessDenied: User: xxxxxxxxxxx is not authorized to perform: xxxxxxxxxx
    
    
    Make sure you have:
    
     	 • Set your AWS region, e.g. `pulumi config set aws:region us-west-2`
     	 • Configured your AWS credentials as per https://pulumi.io/install/aws.html
     	 You can also set these via cli using `aws configure`.
 
```
