### PR TITLE
Remove deprecation of RDS Instance name

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9
-	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20221115140012-f835cc91312a
+	github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20221117095546-4f71b6571c4a
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -864,8 +864,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9 h1:JMw+t5I+6E8Lna7JF+ghAoOLOl23UIbshJyRNP+K1HU=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9/go.mod h1:mYPs/uchNcBq7AclQv9QUtSf9iNcfp1Ag21jqTlDf2M=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20221115140012-f835cc91312a h1:rKkiL6H312G+eyCOEXgQST8nZJ8MfYstDcOsGdZu79A=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20221115140012-f835cc91312a/go.mod h1:2v3/UvLrOawJg+Ekk7e6EUX1+5NQ9x1V+ZVoC/omJjo=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20221117095546-4f71b6571c4a h1:fDqJ75cjXTGCv3QBApbaJrMAFuQyDkUeaMo2ECzFjGw=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20221117095546-4f71b6571c4a/go.mod h1:2v3/UvLrOawJg+Ekk7e6EUX1+5NQ9x1V+ZVoC/omJjo=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220923175450-ca71523cdc36
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20221115140012-f835cc91312a
+replace github.com/hashicorp/terraform-provider-aws => github.com/pulumi/terraform-provider-aws v1.38.1-0.20221117095546-4f71b6571c4a
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -269,8 +269,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20221115140012-f835cc91312a h1:rKkiL6H312G+eyCOEXgQST8nZJ8MfYstDcOsGdZu79A=
-github.com/pulumi/terraform-provider-aws v1.38.1-0.20221115140012-f835cc91312a/go.mod h1:2v3/UvLrOawJg+Ekk7e6EUX1+5NQ9x1V+ZVoC/omJjo=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20221117095546-4f71b6571c4a h1:fDqJ75cjXTGCv3QBApbaJrMAFuQyDkUeaMo2ECzFjGw=
+github.com/pulumi/terraform-provider-aws v1.38.1-0.20221117095546-4f71b6571c4a/go.mod h1:2v3/UvLrOawJg+Ekk7e6EUX1+5NQ9x1V+ZVoC/omJjo=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/sdk/go/aws/rds/instance.go
+++ b/sdk/go/aws/rds/instance.go
@@ -235,8 +235,6 @@ type Instance struct {
 	// Specifies if the RDS instance is multi-AZ
 	MultiAz pulumi.BoolOutput `pulumi:"multiAz"`
 	// The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-	//
-	// Deprecated: Use db_name instead
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 	// Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
@@ -489,8 +487,6 @@ type instanceState struct {
 	// Specifies if the RDS instance is multi-AZ
 	MultiAz *bool `pulumi:"multiAz"`
 	// The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-	//
-	// Deprecated: Use db_name instead
 	Name *string `pulumi:"name"`
 	// The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 	// Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
@@ -712,8 +708,6 @@ type InstanceState struct {
 	// Specifies if the RDS instance is multi-AZ
 	MultiAz pulumi.BoolPtrInput
 	// The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-	//
-	// Deprecated: Use db_name instead
 	Name pulumi.StringPtrInput
 	// The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 	// Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
@@ -926,8 +920,6 @@ type instanceArgs struct {
 	// Specifies if the RDS instance is multi-AZ
 	MultiAz *bool `pulumi:"multiAz"`
 	// The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-	//
-	// Deprecated: Use db_name instead
 	Name *string `pulumi:"name"`
 	// The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 	// Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
@@ -1130,8 +1122,6 @@ type InstanceArgs struct {
 	// Specifies if the RDS instance is multi-AZ
 	MultiAz pulumi.BoolPtrInput
 	// The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-	//
-	// Deprecated: Use db_name instead
 	Name pulumi.StringPtrInput
 	// The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 	// Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
@@ -1552,8 +1542,6 @@ func (o InstanceOutput) MultiAz() pulumi.BoolOutput {
 }
 
 // The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-//
-// Deprecated: Use db_name instead
 func (o InstanceOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v *Instance) pulumi.StringOutput { return v.Name }).(pulumi.StringOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/Instance.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/Instance.java
@@ -782,11 +782,7 @@ public class Instance extends com.pulumi.resources.CustomResource {
     /**
      * The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
      * 
-     * @deprecated
-     * Use db_name instead
-     * 
      */
-    @Deprecated /* Use db_name instead */
     @Export(name="name", type=String.class, parameters={})
     private Output<String> name;
 

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/InstanceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/InstanceArgs.java
@@ -631,22 +631,14 @@ public final class InstanceArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
      * 
-     * @deprecated
-     * Use db_name instead
-     * 
      */
-    @Deprecated /* Use db_name instead */
     @Import(name="name")
     private @Nullable Output<String> name;
 
     /**
      * @return The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
      * 
-     * @deprecated
-     * Use db_name instead
-     * 
      */
-    @Deprecated /* Use db_name instead */
     public Optional<Output<String>> name() {
         return Optional.ofNullable(this.name);
     }
@@ -1994,11 +1986,7 @@ public final class InstanceArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use db_name instead
-         * 
          */
-        @Deprecated /* Use db_name instead */
         public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
@@ -2009,11 +1997,7 @@ public final class InstanceArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use db_name instead
-         * 
          */
-        @Deprecated /* Use db_name instead */
         public Builder name(String name) {
             return name(Output.of(name));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/inputs/InstanceState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/inputs/InstanceState.java
@@ -723,22 +723,14 @@ public final class InstanceState extends com.pulumi.resources.ResourceArgs {
     /**
      * The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
      * 
-     * @deprecated
-     * Use db_name instead
-     * 
      */
-    @Deprecated /* Use db_name instead */
     @Import(name="name")
     private @Nullable Output<String> name;
 
     /**
      * @return The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
      * 
-     * @deprecated
-     * Use db_name instead
-     * 
      */
-    @Deprecated /* Use db_name instead */
     public Optional<Output<String>> name() {
         return Optional.ofNullable(this.name);
     }
@@ -2276,11 +2268,7 @@ public final class InstanceState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use db_name instead
-         * 
          */
-        @Deprecated /* Use db_name instead */
         public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
@@ -2291,11 +2279,7 @@ public final class InstanceState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use db_name instead
-         * 
          */
-        @Deprecated /* Use db_name instead */
         public Builder name(String name) {
             return name(Output.of(name));
         }

--- a/sdk/nodejs/rds/instance.ts
+++ b/sdk/nodejs/rds/instance.ts
@@ -307,8 +307,6 @@ export class Instance extends pulumi.CustomResource {
     public readonly multiAz!: pulumi.Output<boolean>;
     /**
      * The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-     *
-     * @deprecated Use db_name instead
      */
     public readonly name!: pulumi.Output<string>;
     /**
@@ -826,8 +824,6 @@ export interface InstanceState {
     multiAz?: pulumi.Input<boolean>;
     /**
      * The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-     *
-     * @deprecated Use db_name instead
      */
     name?: pulumi.Input<string>;
     /**
@@ -1161,8 +1157,6 @@ export interface InstanceArgs {
     multiAz?: pulumi.Input<boolean>;
     /**
      * The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-     *
-     * @deprecated Use db_name instead
      */
     name?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_aws/rds/instance.py
+++ b/sdk/python/pulumi_aws/rds/instance.py
@@ -284,9 +284,6 @@ class InstanceArgs:
         if multi_az is not None:
             pulumi.set(__self__, "multi_az", multi_az)
         if name is not None:
-            warnings.warn("""Use db_name instead""", DeprecationWarning)
-            pulumi.log.warn("""name is deprecated: Use db_name instead""")
-        if name is not None:
             pulumi.set(__self__, "name", name)
         if nchar_character_set_name is not None:
             pulumi.set(__self__, "nchar_character_set_name", nchar_character_set_name)
@@ -1417,9 +1414,6 @@ class _InstanceState:
             pulumi.set(__self__, "monitoring_role_arn", monitoring_role_arn)
         if multi_az is not None:
             pulumi.set(__self__, "multi_az", multi_az)
-        if name is not None:
-            warnings.warn("""Use db_name instead""", DeprecationWarning)
-            pulumi.log.warn("""name is deprecated: Use db_name instead""")
         if name is not None:
             pulumi.set(__self__, "name", name)
         if nchar_character_set_name is not None:
@@ -2824,9 +2818,6 @@ class Instance(pulumi.CustomResource):
             __props__.__dict__["monitoring_interval"] = monitoring_interval
             __props__.__dict__["monitoring_role_arn"] = monitoring_role_arn
             __props__.__dict__["multi_az"] = multi_az
-            if name is not None and not opts.urn:
-                warnings.warn("""Use db_name instead""", DeprecationWarning)
-                pulumi.log.warn("""name is deprecated: Use db_name instead""")
             __props__.__dict__["name"] = name
             __props__.__dict__["nchar_character_set_name"] = nchar_character_set_name
             __props__.__dict__["network_type"] = network_type


### PR DESCRIPTION
Fixes #2203 

This just turns off the warning for now as either approach works for the time being. 

This patch is maintained in the upstream fork. This should be reverted once https://github.com/pulumi/pulumi/issues/9115 is fixed and we have a way of migrating existing resources to the new property without causing replacements.