### PR TITLE
Add support for gp3 storage in RDS

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -4643,6 +4643,7 @@ func Provider() tfbridge.ProviderInfo {
 				Enum: []schema.EnumValueSpec{
 					{Name: "Standard", Value: "standard"},
 					{Name: "GP2", Value: "gp2"},
+					{Name: "GP3", Value: "gp3"},
 					{Name: "IO1", Value: "io1"},
 				},
 			},

--- a/sdk/dotnet/Rds/Enums.cs
+++ b/sdk/dotnet/Rds/Enums.cs
@@ -183,6 +183,7 @@ namespace Pulumi.Aws.Rds
 
         public static StorageType Standard { get; } = new StorageType("standard");
         public static StorageType GP2 { get; } = new StorageType("gp2");
+        public static StorageType GP3 { get; } = new StorageType("gp3");
         public static StorageType IO1 { get; } = new StorageType("io1");
 
         public static bool operator ==(StorageType left, StorageType right) => left.Equals(right);

--- a/sdk/go/aws/rds/pulumiEnums.go
+++ b/sdk/go/aws/rds/pulumiEnums.go
@@ -587,6 +587,7 @@ type StorageType string
 const (
 	StorageTypeStandard = StorageType("standard")
 	StorageTypeGP2      = StorageType("gp2")
+	StorageTypeGP3      = StorageType("gp3")
 	StorageTypeIO1      = StorageType("io1")
 )
 

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/enums/StorageType.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/enums/StorageType.java
@@ -12,6 +12,7 @@ import java.util.StringJoiner;
     public enum StorageType {
         Standard("standard"),
         GP2("gp2"),
+        GP3("gp3"),
         IO1("io1");
 
         private final String value;

--- a/sdk/nodejs/types/enums/rds/index.ts
+++ b/sdk/nodejs/types/enums/rds/index.ts
@@ -106,6 +106,7 @@ export type InstanceType = (typeof InstanceType)[keyof typeof InstanceType];
 export const StorageType = {
     Standard: "standard",
     GP2: "gp2",
+    GP3: "gp3",
     IO1: "io1",
 } as const;
 

--- a/sdk/python/pulumi_aws/rds/_enums.py
+++ b/sdk/python/pulumi_aws/rds/_enums.py
@@ -110,4 +110,5 @@ class InstanceType(str, Enum):
 class StorageType(str, Enum):
     STANDARD = "standard"
     GP2 = "gp2"
+    GP3 = "gp3"
     IO1 = "io1"


### PR DESCRIPTION
RDS supports gp3 storage types for multiple RDS configurations. Allow the selection of gp3 storage type.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage.GeneralSSD