### PR TITLE
Use larger runner for Java release steps

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -253,7 +253,7 @@ jobs:
     continue-on-error: true
     name: publish_java_sdk
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
     continue-on-error: true
     name: publish_java_sdk
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3


### PR DESCRIPTION
- Avoid out-of-memory issues when running gradle.
- This causes some drift from ci-mgmt. Follow-up work is to adapt the ci-mgmt automation to be able to customise runners.