### PR TITLE
Fix eventBus support in EventRule#onEvent

### DIFF
--- a/examples/eventbus/Pulumi.yaml
+++ b/examples/eventbus/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: eventbus
+runtime: nodejs
+description: A simple example of using the `EventBus` APIs.

--- a/examples/eventbus/index.ts
+++ b/examples/eventbus/index.ts
@@ -1,0 +1,38 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const eventBusHealth = new aws.cloudwatch.EventBus("health", {}, providerOpts);
+const ec2IssueEventRule = new aws.cloudwatch.EventRule("ec2-issue", {
+  description: "Trigger Lambda to respond to EC2 issue events",
+  eventPattern: JSON.stringify({
+    source: ["aws.health"],
+    "detail-type": ["AWS Health Event"],
+    detail: {
+      service: ["EC2"],
+      eventTypeCategory: ["issue"],
+    },
+  }),
+  eventBusName: eventBusHealth.name,
+}, providerOpts);
+
+ec2IssueEventRule.onEvent("ec2-issue", (event) => {
+  console.log(event);
+}, providerOpts);
+

--- a/examples/eventbus/package.json
+++ b/examples/eventbus/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "eventbus",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^5.0.0"
+    },
+    "devDependencies": {
+        "@types/aws-sdk": "^2.7.0",
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/eventbus/tsconfig.json
+++ b/examples/eventbus/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1,4 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build nodejs || all
+// +build nodejs all
 
 package examples
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1,6 +1,4 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
-//go:build nodejs || all
-// +build nodejs all
 
 package examples
 
@@ -99,6 +97,16 @@ func TestAccQueue(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           filepath.Join(getCwd(t), "queue"),
+			RunUpdateTest: true,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestAccEventBus(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:           filepath.Join(getCwd(t), "eventbus"),
 			RunUpdateTest: true,
 		})
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -108,8 +108,7 @@ func TestAccQueue(t *testing.T) {
 func TestAccEventBus(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "eventbus"),
-			RunUpdateTest: true,
+			Dir: filepath.Join(getCwd(t), "eventbus"),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/sdk/nodejs/cloudwatch/eventRuleMixins.ts
+++ b/sdk/nodejs/cloudwatch/eventRuleMixins.ts
@@ -107,6 +107,7 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
             rule: this.eventRule.name,
             arn: this.func.arn,
             targetId: name,
+            eventBusName: this.eventRule.eventBusName.apply(x => x!),
         }, parentOpts);
 
         this.registerOutputs();


### PR DESCRIPTION
In cases where the EventRule specified an eventBus other than `default`, this was not being used correctly in the EventTarget.  We can just pass along the eventBusName from the rule to the target.

Fixes #1323.