### PR TITLE
Remove deprecated skip_get_ec2_platforms config

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -440,6 +440,10 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"AWS_REGION", "AWS_DEFAULT_REGION"},
 				},
 			},
+			"skip_get_ec2_platforms": {
+				// We don't want a default here because this setting is deprecated upstream,
+				// so setting it triggers a warning on all provider operations. #2292
+			},
 			"skip_region_validation": {
 				Default: &tfbridge.DefaultInfo{
 					Value: true,

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/ryboe/q"
 )
 
 // all of the AWS token components used below.
@@ -5729,8 +5728,6 @@ func Provider() tfbridge.ProviderInfo {
 
 	// Add a CSharp-specific override for aws_s3_bucket.bucket.
 	prov.Resources["aws_s3_bucket_legacy"].Fields["bucket"].CSharpName = "BucketName"
-
-	q.Q(prov.Config)
 
 	return prov
 }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/ryboe/q"
 )
 
 // all of the AWS token components used below.
@@ -438,11 +439,6 @@ func Provider() tfbridge.ProviderInfo {
 				Type: awsTypeDefaultFile(awsMod, "Region"),
 				Default: &tfbridge.DefaultInfo{
 					EnvVars: []string{"AWS_REGION", "AWS_DEFAULT_REGION"},
-				},
-			},
-			"skip_get_ec2_platforms": {
-				Default: &tfbridge.DefaultInfo{
-					Value: true,
 				},
 			},
 			"skip_region_validation": {
@@ -5733,6 +5729,8 @@ func Provider() tfbridge.ProviderInfo {
 
 	// Add a CSharp-specific override for aws_s3_bucket.bucket.
 	prov.Resources["aws_s3_bucket_legacy"].Fields["bucket"].CSharpName = "BucketName"
+
+	q.Q(prov.Config)
 
 	return prov
 }

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -256,7 +256,7 @@ namespace Pulumi.Aws
             set => _skipCredentialsValidation.Set(value);
         }
 
-        private static readonly __Value<bool?> _skipGetEc2Platforms = new __Value<bool?>(() => __config.GetBoolean("skipGetEc2Platforms") ?? true);
+        private static readonly __Value<bool?> _skipGetEc2Platforms = new __Value<bool?>(() => __config.GetBoolean("skipGetEc2Platforms"));
         /// <summary>
         /// Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
         /// </summary>

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -328,7 +328,6 @@ namespace Pulumi.Aws
         {
             Region = Utilities.GetEnv("AWS_REGION", "AWS_DEFAULT_REGION");
             SkipCredentialsValidation = false;
-            SkipGetEc2Platforms = true;
             SkipMetadataApiCheck = true;
             SkipRegionValidation = true;
         }

--- a/sdk/go/aws/config/config.go
+++ b/sdk/go/aws/config/config.go
@@ -138,11 +138,7 @@ func GetSkipCredentialsValidation(ctx *pulumi.Context) bool {
 //
 // Deprecated: With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has been deprecated and will be removed in a future version.
 func GetSkipGetEc2Platforms(ctx *pulumi.Context) bool {
-	v, err := config.TryBool(ctx, "aws:skipGetEc2Platforms")
-	if err == nil {
-		return v
-	}
-	return true
+	return config.GetBool(ctx, "aws:skipGetEc2Platforms")
 }
 
 // Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.

--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -60,9 +60,6 @@ func NewProvider(ctx *pulumi.Context,
 	if isZero(args.SkipCredentialsValidation) {
 		args.SkipCredentialsValidation = pulumi.BoolPtr(false)
 	}
-	if isZero(args.SkipGetEc2Platforms) {
-		args.SkipGetEc2Platforms = pulumi.BoolPtr(true)
-	}
 	if isZero(args.SkipMetadataApiCheck) {
 		args.SkipMetadataApiCheck = pulumi.BoolPtr(true)
 	}

--- a/sdk/java/src/main/java/com/pulumi/aws/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/Config.java
@@ -174,7 +174,7 @@ public final class Config {
  * 
  */
     public Optional<Boolean> skipGetEc2Platforms() {
-        return Codegen.booleanProp("skipGetEc2Platforms").config(config).def(true).get();
+        return Codegen.booleanProp("skipGetEc2Platforms").config(config).get();
     }
 /**
  * Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.

--- a/sdk/java/src/main/java/com/pulumi/aws/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ProviderArgs.java
@@ -1217,7 +1217,6 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         public ProviderArgs build() {
             $.region = Codegen.stringProp("region").output().arg($.region).env("AWS_REGION", "AWS_DEFAULT_REGION").getNullable();
             $.skipCredentialsValidation = Codegen.booleanProp("skipCredentialsValidation").output().arg($.skipCredentialsValidation).def(false).getNullable();
-            $.skipGetEc2Platforms = Codegen.booleanProp("skipGetEc2Platforms").output().arg($.skipGetEc2Platforms).def(true).getNullable();
             $.skipMetadataApiCheck = Codegen.booleanProp("skipMetadataApiCheck").output().arg($.skipMetadataApiCheck).def(true).getNullable();
             $.skipRegionValidation = Codegen.booleanProp("skipRegionValidation").output().arg($.skipRegionValidation).def(true).getNullable();
             return $;

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -262,10 +262,10 @@ Object.defineProperty(exports, "skipCredentialsValidation", {
 /**
  * Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
  */
-export declare const skipGetEc2Platforms: boolean;
+export declare const skipGetEc2Platforms: boolean | undefined;
 Object.defineProperty(exports, "skipGetEc2Platforms", {
     get() {
-        return __config.getObject<boolean>("skipGetEc2Platforms") ?? true;
+        return __config.getObject<boolean>("skipGetEc2Platforms");
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -115,7 +115,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["sharedCredentialsFile"] = args ? args.sharedCredentialsFile : undefined;
             resourceInputs["sharedCredentialsFiles"] = pulumi.output(args ? args.sharedCredentialsFiles : undefined).apply(JSON.stringify);
             resourceInputs["skipCredentialsValidation"] = pulumi.output((args ? args.skipCredentialsValidation : undefined) ?? false).apply(JSON.stringify);
-            resourceInputs["skipGetEc2Platforms"] = pulumi.output((args ? args.skipGetEc2Platforms : undefined) ?? true).apply(JSON.stringify);
+            resourceInputs["skipGetEc2Platforms"] = pulumi.output(args ? args.skipGetEc2Platforms : undefined).apply(JSON.stringify);
             resourceInputs["skipMetadataApiCheck"] = pulumi.output((args ? args.skipMetadataApiCheck : undefined) ?? true).apply(JSON.stringify);
             resourceInputs["skipRegionValidation"] = pulumi.output((args ? args.skipRegionValidation : undefined) ?? true).apply(JSON.stringify);
             resourceInputs["skipRequestingAccountId"] = pulumi.output(args ? args.skipRequestingAccountId : undefined).apply(JSON.stringify);

--- a/sdk/python/pulumi_aws/config/__init__.pyi
+++ b/sdk/python/pulumi_aws/config/__init__.pyi
@@ -119,7 +119,7 @@ Skip the credentials validation via STS API. Used for AWS API implementations th
 available/implemented.
 """
 
-skipGetEc2Platforms: bool
+skipGetEc2Platforms: Optional[bool]
 """
 Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
 """

--- a/sdk/python/pulumi_aws/config/vars.py
+++ b/sdk/python/pulumi_aws/config/vars.py
@@ -172,11 +172,11 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get_bool('skipCredentialsValidation') or False
 
     @property
-    def skip_get_ec2_platforms(self) -> bool:
+    def skip_get_ec2_platforms(self) -> Optional[bool]:
         """
         Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
         """
-        return __config__.get_bool('skipGetEc2Platforms') or True
+        return __config__.get_bool('skipGetEc2Platforms')
 
     @property
     def skip_metadata_api_check(self) -> bool:

--- a/sdk/python/pulumi_aws/provider.py
+++ b/sdk/python/pulumi_aws/provider.py
@@ -141,8 +141,6 @@ class ProviderArgs:
             skip_credentials_validation = False
         if skip_credentials_validation is not None:
             pulumi.set(__self__, "skip_credentials_validation", skip_credentials_validation)
-        if skip_get_ec2_platforms is None:
-            skip_get_ec2_platforms = True
         if skip_get_ec2_platforms is not None:
             warnings.warn("""With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has been deprecated and will be removed in a future version.""", DeprecationWarning)
             pulumi.log.warn("""skip_get_ec2_platforms is deprecated: With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has been deprecated and will be removed in a future version.""")
@@ -717,8 +715,6 @@ class Provider(pulumi.ProviderResource):
             if skip_credentials_validation is None:
                 skip_credentials_validation = False
             __props__.__dict__["skip_credentials_validation"] = pulumi.Output.from_input(skip_credentials_validation).apply(pulumi.runtime.to_json) if skip_credentials_validation is not None else None
-            if skip_get_ec2_platforms is None:
-                skip_get_ec2_platforms = True
             if skip_get_ec2_platforms is not None and not opts.urn:
                 warnings.warn("""With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has been deprecated and will be removed in a future version.""", DeprecationWarning)
                 pulumi.log.warn("""skip_get_ec2_platforms is deprecated: With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has been deprecated and will be removed in a future version.""")


### PR DESCRIPTION
Since the upstream provider deprecated this setting, all uses of this provider emit this warning on all operations:

```warning: provider config warning: With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has been deprecated and will be removed in a future version.```

This PR removes the setting from provider configuration.

Tested locally via `replace github.com/pulumi/pulumi-aws/sdk/v5 => $HOME/pulumi/pulumi-aws/sdk` and observing the before/after change.

Fixes #2292 