### PR TITLE
Configure pulumi/terraform-provider-aws submodule to use HTTPS like elsewhere

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "terraform-provider-aws"]
 	path = upstream
-	url = git@github.com:pulumi/terraform-provider-aws.git
+	url = https://github.com/pulumi/terraform-provider-aws.git
 	ignore = dirty


### PR DESCRIPTION
HTTPS is the standard at Pulumi and avoids setting up SSH keys in workflows.