### PR TITLE
Updates timeout on goreleaser to 150m

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -285,7 +285,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         args: -p 1 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          120m0s
+          150m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -297,7 +297,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         args: -p 1 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          120m0s
+          150m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -240,7 +240,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         args: -p 1 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          120m0s
+          150m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 1 release --rm-dist --timeout 120m0s
+        args: -p 1 release --rm-dist --timeout 150m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack


### PR DESCRIPTION
Our release job uses goreleaser which was previously configured to timeout at 120m.  The build itself often takes 110m, which can easily slip over the 120m timeout threshold.  This bumps to 150m to cover the +-10% band and prevent the job from artificially failing.