### PR TITLE
Improve auth error message

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -343,6 +343,9 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 		Profile:   stringValue(vars, "profile", []string{"AWS_PROFILE"}),
 		Token:     stringValue(vars, "token", []string{"AWS_SESSION_TOKEN"}),
 		Region:    stringValue(vars, "region", []string{"AWS_REGION", "AWS_DEFAULT_REGION"}),
+
+		CallerName:             "Pulumi AWS Classic",
+		CallerDocumentationURL: "https://www.pulumi.com/registry/packages/aws/installation-configuration/",
 	}
 
 	if details, ok := vars["assumeRole"]; ok {
@@ -406,11 +409,8 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 
 	if _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
 		return fmt.Errorf("unable to validate AWS credentials. \n"+
-			"Details: %v\n\n"+
-			"Make sure you have: \n\n"+
-			" \t • Set your AWS region, e.g. `pulumi config set aws:region us-west-2` \n"+
-			" \t • Configured your AWS credentials as per https://pulumi.io/install/aws.html \n"+
-			" \t You can also set these via cli using `aws configure`. \n\n", err)
+			"Details: %v\n"+
+			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n", err)
 	}
 
 	return nil


### PR DESCRIPTION
- Fix missing values in auth error messages coming from upstream
- Update link to Pulumi docs
- Shorten a bit

Before (note second line "for ..." and third line "see ..."):
```
    error: unable to validate AWS credentials.
    Details: no valid credential sources for  found.

    Please see
    for more information about providing credentials.

    Error: <actual error>


    Make sure you have:

     	 • Set your AWS region, e.g. `pulumi config set aws:region us-west-2`
     	 • Configured your AWS credentials as per https://pulumi.io/install/aws.html
     	 You can also set these via cli using `aws configure`.
```

After:
```
    error: unable to validate AWS credentials.
    Details: no valid credential sources for Pulumi AWS Classic found.

    Please see https://www.pulumi.com/registry/packages/aws/installation-configuration/
    for more information about providing credentials.

    Error: <actual error>

    Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`.
```