### PR TITLE
Use larger GitHub Actions runner for publish step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,7 @@ jobs:
   publish:
     name: publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -268,7 +268,7 @@ jobs:
   publish:
     name: publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -210,7 +210,7 @@ jobs:
   publish:
     name: publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
   publish:
     name: publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3


### PR DESCRIPTION
The `publish` step has started failing with the error "no space left on device":

    https://github.com/pulumi/pulumi-aws/actions/runs/4308251155/jobs/7528823156

The default runner has 7GB of disk space, and I hypothesise that space is taken up by the Go build cache -- including the AWS SDK, six times (arch x OS), ends up being a lot of object files. As a mitigation, we can use a larger runner instance, which will come with signficantly more disk space.

Fixes #2400 