### PR TITLE
Export patches to local repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,10 @@ patch_upstream: init_upstream
 	cd upstream-tools && yarn --silent run apply
 	@# Check for any pending replacements
 	cd upstream-tools && yarn --silent run check
+	rm upstream-patches/*
+	cd upstream && \
+		LAST_TAG=$$(git describe --abbrev=0 --tags) && \
+		git format-patch  -o ../upstream-patches --minimal --no-signature HEAD...$${LAST_TAG}
 
 update_upstream: init_upstream
 	@echo "\033[1;33mupdate_upstream is still under construction and will likely fail.\033[0m"

--- a/upstream-patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
+++ b/upstream-patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
@@ -1,0 +1,25 @@
+From 36641e77219060d66bc0f7f2f120b808a7b68c4f Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 16:49:08 +0000
+Subject: [PATCH 01/25] Add TagsSchemaTrulyComputed definition
+
+---
+ internal/tags/tags.go | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/internal/tags/tags.go b/internal/tags/tags.go
+index 30b491fc7a..ea00250a50 100644
+--- a/internal/tags/tags.go
++++ b/internal/tags/tags.go
+@@ -39,3 +39,11 @@ func TagsSchemaForceNew() *schema.Schema {
+ 		Elem:     &schema.Schema{Type: schema.TypeString},
+ 	}
+ }
++
++func TagsSchemaTrulyComputed() *schema.Schema {
++	return &schema.Schema{
++		Type:     schema.TypeMap,
++		Computed: true,
++		Elem:     &schema.Schema{Type: schema.TypeString},
++	}
++}

--- a/upstream-patches/0002-Conns-user-agent.patch
+++ b/upstream-patches/0002-Conns-user-agent.patch
@@ -1,0 +1,35 @@
+From b8d96bfd7405adf21427cd7666ed77e70fc259d5 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:03:31 +0000
+Subject: [PATCH 02/25] Conns user agent
+
+---
+ internal/conns/conns.go | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/internal/conns/conns.go b/internal/conns/conns.go
+index 5aceaf55d4..5c923349f6 100644
+--- a/internal/conns/conns.go
++++ b/internal/conns/conns.go
+@@ -11,7 +11,6 @@ import (
+ 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+ 	"github.com/hashicorp/terraform-plugin-framework/resource"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+-	"github.com/hashicorp/terraform-provider-aws/version"
+ )
+ 
+ // ServicePackage is the minimal interface exported from each AWS service package.
+@@ -40,10 +39,10 @@ func NewSessionForRegion(cfg *aws.Config, region, terraformVersion string) (*ses
+ 
+ func StdUserAgentProducts(terraformVersion string) *awsbase.APNInfo {
+ 	return &awsbase.APNInfo{
+-		PartnerName: "HashiCorp",
++		PartnerName: "Pulumi",
+ 		Products: []awsbase.UserAgentProduct{
+-			{Name: "Terraform", Version: terraformVersion, Comment: "+https://www.terraform.io"},
+-			{Name: "terraform-provider-aws", Version: version.ProviderVersion, Comment: "+https://registry.terraform.io/providers/hashicorp/aws"},
++			{Name: "Pulumi", Version: "1.0"},
++			{Name: "Pulumi-Aws", Version: terraformVersion, Comment: "+https://www.pulumi.com"},
+ 		},
+ 	}
+ }

--- a/upstream-patches/0003-Add-S3-legacy-bucket.patch
+++ b/upstream-patches/0003-Add-S3-legacy-bucket.patch
@@ -1,0 +1,4310 @@
+From b9c2bd9ca7e5394df3ce3021d7c1d789fb7009fc Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:05:11 +0000
+Subject: [PATCH 03/25] Add S3 legacy bucket
+
+---
+ go.mod                                        |    1 +
+ go.sum                                        |    6 +
+ internal/provider/provider.go                 |    6 +-
+ internal/service/s3legacy/bucket_legacy.go    | 3029 +++++++++++++++++
+ internal/service/s3legacy/enum.go             |   32 +
+ internal/service/s3legacy/errors.go           |    8 +
+ internal/service/s3legacy/generate.go         |    4 +
+ internal/service/s3legacy/hosted_zones.go     |   45 +
+ internal/service/s3legacy/object.go           |  177 +
+ internal/service/s3legacy/retry.go            |   30 +
+ internal/service/s3legacy/tags.go             |  174 +
+ internal/service/s3legacy/tags_gen.go         |   38 +
+ internal/service/s3legacy/wait.go             |   18 +
+ website/docs/r/s3_bucket_legacy.html.markdown |  575 ++++
+ 14 files changed, 4142 insertions(+), 1 deletion(-)
+ create mode 100644 internal/service/s3legacy/bucket_legacy.go
+ create mode 100644 internal/service/s3legacy/enum.go
+ create mode 100644 internal/service/s3legacy/errors.go
+ create mode 100644 internal/service/s3legacy/generate.go
+ create mode 100644 internal/service/s3legacy/hosted_zones.go
+ create mode 100644 internal/service/s3legacy/object.go
+ create mode 100644 internal/service/s3legacy/retry.go
+ create mode 100644 internal/service/s3legacy/tags.go
+ create mode 100644 internal/service/s3legacy/tags_gen.go
+ create mode 100644 internal/service/s3legacy/wait.go
+ create mode 100644 website/docs/r/s3_bucket_legacy.html.markdown
+
+diff --git a/go.mod b/go.mod
+index be2fc360af..cb095c332c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -38,6 +38,7 @@ require (
+ 	github.com/beevik/etree v1.1.0
+ 	github.com/google/go-cmp v0.5.9
+ 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.20.0
++	github.com/hashicorp/aws-sdk-go-base v1.1.0
+ 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.24
+ 	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.25
+ 	github.com/hashicorp/awspolicyequivalence v1.6.0
+diff --git a/go.sum b/go.sum
+index 6a7282d0c0..056ce1a68a 100644
+--- a/go.sum
++++ b/go.sum
+@@ -23,6 +23,7 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
+ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
+ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
++github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+ github.com/aws/aws-sdk-go v1.44.212 h1:IRstlErdeKeQ8qBsCwWt4MG2RihUOcUJVqYwbvqpE28=
+ github.com/aws/aws-sdk-go v1.44.212/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+ github.com/aws/aws-sdk-go-v2 v1.17.4/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+@@ -147,6 +148,7 @@ github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
+ github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
+ github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
+ github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
++github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+ github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
+ github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+@@ -167,6 +169,8 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+ github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.20.0 h1:xc1OYpWvNo6dhnzemfjwtbNxeu3Ag4Wr6yT8BOo0/q0=
+ github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.20.0/go.mod h1:cdTE6F2pCKQobug+RqRaQp7Kz9hIEqiSvpPmb6E5G1w=
++github.com/hashicorp/aws-sdk-go-base v1.1.0 h1:27urM3JAp6v+Oj/Ea5ULZwuFPK9cO1RUdEpV+rNdSAc=
++github.com/hashicorp/aws-sdk-go-base v1.1.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
+ github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.24 h1:syXF0qM0fnGTDqCfrh4gaPeFKlxKxOjKmoI8E+DJMRY=
+ github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.24/go.mod h1:VYfmMo8LdxeZg4sH/4/cbgxx9BOEm/U48RHCs2SlmhM=
+ github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.25 h1:H9SxZgt7pRcMabtsfe/+3M3rOETawbWVyOFSHGCbl3E=
+@@ -239,6 +243,7 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
+ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+ github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+ github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
++github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+@@ -371,6 +376,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
++golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+diff --git a/internal/provider/provider.go b/internal/provider/provider.go
+index 45923390d4..251ded1058 100644
+--- a/internal/provider/provider.go
++++ b/internal/provider/provider.go
+@@ -8,6 +8,8 @@ import (
+ 	"regexp"
+ 	"time"
+ 
++	"github.com/hashicorp/terraform-provider-aws/internal/service/s3legacy"
++
+ 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+ 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+ 	multierror "github.com/hashicorp/go-multierror"
+@@ -245,7 +247,9 @@ func New(ctx context.Context) (*schema.Provider, error) {
+ 		// should use the @SDKDataSource and @SDKResource function-level annotations
+ 		// rather than adding directly to these maps.
+ 		DataSourcesMap: make(map[string]*schema.Resource),
+-		ResourcesMap:   make(map[string]*schema.Resource),
++		ResourcesMap: map[string]*schema.Resource{
++			"aws_s3_bucket_legacy": s3legacy.ResourceBucketLegacy(),
++		},
+ 	}
+ 
+ 	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go
+new file mode 100644
+index 0000000000..27fe651a83
+--- /dev/null
++++ b/internal/service/s3legacy/bucket_legacy.go
+@@ -0,0 +1,3029 @@
++package s3legacy
++
++import (
++	"bytes"
++	"context"
++	"encoding/json"
++	"fmt"
++	"log"
++	"net/http"
++	"net/url"
++	"regexp"
++	"strings"
++	"time"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/aws/arn"
++	"github.com/aws/aws-sdk-go/aws/awserr"
++	"github.com/aws/aws-sdk-go/aws/endpoints"
++	"github.com/aws/aws-sdk-go/aws/request"
++	"github.com/aws/aws-sdk-go/service/s3"
++	"github.com/aws/aws-sdk-go/service/s3/s3manager"
++	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	"github.com/hashicorp/terraform-provider-aws/internal/create"
++	"github.com/hashicorp/terraform-provider-aws/internal/flex"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
++	"github.com/hashicorp/terraform-provider-aws/internal/verify"
++)
++
++func ResourceBucketLegacy() *schema.Resource {
++	return &schema.Resource{
++		Create: resourceBucketLegacyCreate,
++		Read:   resourceBucketLegacyRead,
++		Update: resourceBucketLegacyUpdate,
++		Delete: resourceBucketLegacyDelete,
++		Importer: &schema.ResourceImporter{
++			State: schema.ImportStatePassthrough,
++		},
++
++		Schema: map[string]*schema.Schema{
++			"bucket": {
++				Type:          schema.TypeString,
++				Optional:      true,
++				Computed:      true,
++				ForceNew:      true,
++				ConflictsWith: []string{"bucket_prefix"},
++				ValidateFunc:  validation.StringLenBetween(0, 63),
++			},
++			"bucket_prefix": {
++				Type:          schema.TypeString,
++				Optional:      true,
++				ForceNew:      true,
++				ConflictsWith: []string{"bucket"},
++				ValidateFunc:  validation.StringLenBetween(0, 63-resource.UniqueIDSuffixLength),
++			},
++
++			"bucket_domain_name": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"bucket_regional_domain_name": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"arn": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"acl": {
++				Type:          schema.TypeString,
++				Default:       "private",
++				Optional:      true,
++				ConflictsWith: []string{"grant"},
++				ValidateFunc:  validation.StringInSlice(BucketCannedACL_Values(), false),
++			},
++
++			"grant": {
++				Type:          schema.TypeSet,
++				Optional:      true,
++				Set:           grantHashLegacy,
++				ConflictsWith: []string{"acl"},
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"id": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++						"type": {
++							Type:     schema.TypeString,
++							Required: true,
++							// TypeAmazonCustomerByEmail is not currently supported
++							ValidateFunc: validation.StringInSlice([]string{
++								s3.TypeCanonicalUser,
++								s3.TypeGroup,
++							}, false),
++						},
++						"uri": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++
++						"permissions": {
++							Type:     schema.TypeSet,
++							Required: true,
++							Set:      schema.HashString,
++							Elem: &schema.Schema{
++								Type:         schema.TypeString,
++								ValidateFunc: validation.StringInSlice(s3.Permission_Values(), false),
++							},
++						},
++					},
++				},
++			},
++
++			"policy": {
++				Type:             schema.TypeString,
++				Optional:         true,
++				ValidateFunc:     validation.StringIsJSON,
++				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
++			},
++
++			"cors_rule": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"allowed_headers": {
++							Type:     schema.TypeList,
++							Optional: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"allowed_methods": {
++							Type:     schema.TypeList,
++							Required: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"allowed_origins": {
++							Type:     schema.TypeList,
++							Required: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"expose_headers": {
++							Type:     schema.TypeList,
++							Optional: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"max_age_seconds": {
++							Type:     schema.TypeInt,
++							Optional: true,
++						},
++					},
++				},
++			},
++
++			"website": {
++				Type:     schema.TypeList,
++				Optional: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"index_document": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++
++						"error_document": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++
++						"redirect_all_requests_to": {
++							Type: schema.TypeString,
++							ConflictsWith: []string{
++								"website.0.index_document",
++								"website.0.error_document",
++								"website.0.routing_rules",
++							},
++							Optional: true,
++						},
++
++						"routing_rules": {
++							Type:         schema.TypeString,
++							Optional:     true,
++							ValidateFunc: validation.StringIsJSON,
++							StateFunc: func(v interface{}) string {
++								json, _ := structure.NormalizeJsonString(v)
++								return json
++							},
++						},
++					},
++				},
++			},
++
++			"hosted_zone_id": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"region": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"website_endpoint": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++			"website_domain": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"versioning": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Computed: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"enabled": {
++							Type:     schema.TypeBool,
++							Optional: true,
++							Default:  false,
++						},
++						"mfa_delete": {
++							Type:     schema.TypeBool,
++							Optional: true,
++							Default:  false,
++						},
++					},
++				},
++			},
++
++			"logging": {
++				Type:     schema.TypeSet,
++				Optional: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"target_bucket": {
++							Type:     schema.TypeString,
++							Required: true,
++						},
++						"target_prefix": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++					},
++				},
++				Set: func(v interface{}) int {
++					var buf bytes.Buffer
++					m := v.(map[string]interface{})
++					buf.WriteString(fmt.Sprintf("%s-", m["target_bucket"]))
++					buf.WriteString(fmt.Sprintf("%s-", m["target_prefix"]))
++					return create.StringHashcode(buf.String())
++				},
++			},
++
++			"lifecycle_rule": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"id": {
++							Type:         schema.TypeString,
++							Optional:     true,
++							Computed:     true,
++							ValidateFunc: validation.StringLenBetween(0, 255),
++						},
++						"prefix": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++						"tags": tftags.TagsSchema(),
++						"enabled": {
++							Type:     schema.TypeBool,
++							Required: true,
++						},
++						"abort_incomplete_multipart_upload_days": {
++							Type:     schema.TypeInt,
++							Optional: true,
++						},
++						"expiration": {
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"date": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validBucketLifecycleTimestampLegacy,
++									},
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(0),
++									},
++									"expired_object_delete_marker": {
++										Type:     schema.TypeBool,
++										Optional: true,
++									},
++								},
++							},
++						},
++						"noncurrent_version_expiration": {
++							Type:     schema.TypeList,
++							MaxItems: 1,
++							Optional: true,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(1),
++									},
++								},
++							},
++						},
++						"transition": {
++							Type:     schema.TypeSet,
++							Optional: true,
++							Set:      transitionHashLegacy,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"date": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validBucketLifecycleTimestampLegacy,
++									},
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(0),
++									},
++									"storage_class": {
++										Type:         schema.TypeString,
++										Required:     true,
++										ValidateFunc: validation.StringInSlice(s3.TransitionStorageClass_Values(), false),
++									},
++								},
++							},
++						},
++						"noncurrent_version_transition": {
++							Type:     schema.TypeSet,
++							Optional: true,
++							Set:      transitionHashLegacy,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(0),
++									},
++									"storage_class": {
++										Type:         schema.TypeString,
++										Required:     true,
++										ValidateFunc: validation.StringInSlice(s3.TransitionStorageClass_Values(), false),
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"force_destroy": {
++				Type:     schema.TypeBool,
++				Optional: true,
++				Default:  false,
++			},
++
++			"acceleration_status": {
++				Type:         schema.TypeString,
++				Optional:     true,
++				Computed:     true,
++				ValidateFunc: validation.StringInSlice(s3.BucketAccelerateStatus_Values(), false),
++			},
++
++			"request_payer": {
++				Type:         schema.TypeString,
++				Optional:     true,
++				Computed:     true,
++				ValidateFunc: validation.StringInSlice(s3.Payer_Values(), false),
++			},
++
++			"replication_configuration": {
++				Type:     schema.TypeList,
++				Optional: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"role": {
++							Type:     schema.TypeString,
++							Required: true,
++						},
++						"rules": {
++							Type:     schema.TypeSet,
++							Required: true,
++							Set:      rulesHashLegacy,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"id": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validation.StringLenBetween(0, 255),
++									},
++									"destination": {
++										Type:     schema.TypeList,
++										MaxItems: 1,
++										MinItems: 1,
++										Required: true,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"account_id": {
++													Type:         schema.TypeString,
++													Optional:     true,
++													ValidateFunc: verify.ValidAccountID,
++												},
++												"bucket": {
++													Type:         schema.TypeString,
++													Required:     true,
++													ValidateFunc: verify.ValidARN,
++												},
++												"storage_class": {
++													Type:         schema.TypeString,
++													Optional:     true,
++													ValidateFunc: validation.StringInSlice(s3.StorageClass_Values(), false),
++												},
++												"replica_kms_key_id": {
++													Type:     schema.TypeString,
++													Optional: true,
++												},
++												"access_control_translation": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MinItems: 1,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"owner": {
++																Type:         schema.TypeString,
++																Required:     true,
++																ValidateFunc: validation.StringInSlice(s3.OwnerOverride_Values(), false),
++															},
++														},
++													},
++												},
++												"replication_time": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"minutes": {
++																Type:         schema.TypeInt,
++																Optional:     true,
++																Default:      15,
++																ValidateFunc: validation.IntBetween(15, 15),
++															},
++															"status": {
++																Type:         schema.TypeString,
++																Optional:     true,
++																Default:      s3.ReplicationTimeStatusEnabled,
++																ValidateFunc: validation.StringInSlice(s3.ReplicationTimeStatus_Values(), false),
++															},
++														},
++													},
++												},
++												"metrics": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"minutes": {
++																Type:         schema.TypeInt,
++																Optional:     true,
++																Default:      15,
++																ValidateFunc: validation.IntBetween(10, 15),
++															},
++															"status": {
++																Type:         schema.TypeString,
++																Optional:     true,
++																Default:      s3.MetricsStatusEnabled,
++																ValidateFunc: validation.StringInSlice(s3.MetricsStatus_Values(), false),
++															},
++														},
++													},
++												},
++											},
++										},
++									},
++									"source_selection_criteria": {
++										Type:     schema.TypeList,
++										Optional: true,
++										MinItems: 1,
++										MaxItems: 1,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"sse_kms_encrypted_objects": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MinItems: 1,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"enabled": {
++																Type:     schema.TypeBool,
++																Required: true,
++															},
++														},
++													},
++												},
++											},
++										},
++									},
++									"prefix": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validation.StringLenBetween(0, 1024),
++									},
++									"status": {
++										Type:         schema.TypeString,
++										Required:     true,
++										ValidateFunc: validation.StringInSlice(s3.ReplicationRuleStatus_Values(), false),
++									},
++									"priority": {
++										Type:     schema.TypeInt,
++										Optional: true,
++									},
++									"filter": {
++										Type:     schema.TypeList,
++										Optional: true,
++										MinItems: 1,
++										MaxItems: 1,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"prefix": {
++													Type:         schema.TypeString,
++													Optional:     true,
++													ValidateFunc: validation.StringLenBetween(0, 1024),
++												},
++												"tags": tftags.TagsSchema(),
++											},
++										},
++									},
++									"delete_marker_replication_status": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validation.StringInSlice([]string{s3.DeleteMarkerReplicationStatusEnabled}, false),
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"server_side_encryption_configuration": {
++				Type:     schema.TypeList,
++				MaxItems: 1,
++				Optional: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"rule": {
++							Type:     schema.TypeList,
++							MaxItems: 1,
++							Required: true,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"apply_server_side_encryption_by_default": {
++										Type:     schema.TypeList,
++										MaxItems: 1,
++										Required: true,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"kms_master_key_id": {
++													Type:     schema.TypeString,
++													Optional: true,
++												},
++												"sse_algorithm": {
++													Type:         schema.TypeString,
++													Required:     true,
++													ValidateFunc: validation.StringInSlice(s3.ServerSideEncryption_Values(), false),
++												},
++											},
++										},
++									},
++									"bucket_key_enabled": {
++										Type:     schema.TypeBool,
++										Optional: true,
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"object_lock_configuration": {
++				Type:     schema.TypeList,
++				Optional: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"object_lock_enabled": {
++							Type:         schema.TypeString,
++							Required:     true,
++							ForceNew:     true,
++							ValidateFunc: validation.StringInSlice(s3.ObjectLockEnabled_Values(), false),
++						},
++
++						"rule": {
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"default_retention": {
++										Type:     schema.TypeList,
++										Required: true,
++										MinItems: 1,
++										MaxItems: 1,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"mode": {
++													Type:         schema.TypeString,
++													Required:     true,
++													ValidateFunc: validation.StringInSlice(s3.ObjectLockRetentionMode_Values(), false),
++												},
++
++												"days": {
++													Type:         schema.TypeInt,
++													Optional:     true,
++													ValidateFunc: validation.IntAtLeast(1),
++												},
++
++												"years": {
++													Type:         schema.TypeInt,
++													Optional:     true,
++													ValidateFunc: validation.IntAtLeast(1),
++												},
++											},
++										},
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"tags":     tftags.TagsSchema(),
++			"tags_all": tftags.TagsSchemaTrulyComputed(),
++		},
++
++		CustomizeDiff: verify.SetTagsDiff,
++	}
++}
++
++func resourceBucketLegacyCreate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).S3Conn()
++
++	// Get the bucket and acl
++	var bucket string
++	if v, ok := d.GetOk("bucket"); ok {
++		bucket = v.(string)
++	} else if v, ok := d.GetOk("bucket_prefix"); ok {
++		bucket = resource.PrefixedUniqueId(v.(string))
++	} else {
++		bucket = resource.UniqueId()
++	}
++	d.Set("bucket", bucket)
++
++	log.Printf("[DEBUG] S3 bucket create: %s", bucket)
++
++	req := &s3.CreateBucketInput{
++		Bucket: aws.String(bucket),
++	}
++
++	if acl, ok := d.GetOk("acl"); ok {
++		acl := acl.(string)
++		req.ACL = aws.String(acl)
++		log.Printf("[DEBUG] S3 bucket %s has canned ACL %s", bucket, acl)
++	}
++
++	awsRegion := meta.(*conns.AWSClient).Region
++	log.Printf("[DEBUG] S3 bucket create: %s, using region: %s", bucket, awsRegion)
++
++	// Special case us-east-1 region and do not set the LocationConstraint.
++	// See "Request Elements: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
++	if awsRegion != endpoints.UsEast1RegionID {
++		req.CreateBucketConfiguration = &s3.CreateBucketConfiguration{
++			LocationConstraint: aws.String(awsRegion),
++		}
++	}
++
++	if err := ValidBucketNameLegacy(bucket, awsRegion); err != nil {
++		return fmt.Errorf("Error validating S3 bucket name: %s", err)
++	}
++
++	// S3 Object Lock can only be enabled on bucket creation.
++	objectLockConfiguration := expandS3ObjectLockConfigurationLegacy(d.Get("object_lock_configuration").([]interface{}))
++	if objectLockConfiguration != nil && aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled {
++		req.ObjectLockEnabledForBucket = aws.Bool(true)
++	}
++
++	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
++		_, err := conn.CreateBucket(req)
++		if awsErr, ok := err.(awserr.Error); ok {
++			if awsErr.Code() == "OperationAborted" {
++				return resource.RetryableError(
++					fmt.Errorf("Error creating S3 bucket %s, retrying: %s", bucket, err))
++			}
++		}
++		if err != nil {
++			return resource.NonRetryableError(err)
++		}
++
++		return nil
++	})
++	if tfresource.TimedOut(err) {
++		_, err = conn.CreateBucket(req)
++	}
++	if err != nil {
++		return fmt.Errorf("Error creating S3 bucket: %s", err)
++	}
++
++	// Assign the bucket name as the resource ID
++	d.SetId(bucket)
++	return resourceBucketLegacyUpdate(d, meta)
++}
++
++func resourceBucketLegacyUpdate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).S3Conn()
++
++	if d.HasChange("tags_all") {
++		o, n := d.GetChange("tags_all")
++
++		// Retry due to S3 eventual consistency
++		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++			terr := BucketUpdateTags(conn, d.Id(), o, n)
++			return nil, terr
++		})
++		if err != nil {
++			return fmt.Errorf("error updating S3 Bucket (%s) tags: %s", d.Id(), err)
++		}
++	}
++
++	if d.HasChange("policy") {
++		if err := resourceBucketLegacyPolicyUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("cors_rule") {
++		if err := resourceBucketLegacyCorsUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("website") {
++		if err := resourceBucketLegacyWebsiteUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("versioning") {
++		v := d.Get("versioning").([]interface{})
++
++		if d.IsNewResource() {
++			if versioning := expandVersioningWhenIsNewResourceLegacy(v); versioning != nil {
++				err := resourceBucketLegacyVersioningUpdate(conn, d.Id(), versioning)
++				if err != nil {
++					return err
++				}
++			}
++		} else {
++			if err := resourceBucketLegacyVersioningUpdate(conn, d.Id(), expandVersioningLegacy(v)); err != nil {
++				return err
++			}
++		}
++	}
++
++	if d.HasChange("acl") && !d.IsNewResource() {
++		if err := resourceBucketLegacyACLUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("grant") {
++		if err := resourceBucketLegacyGrantsUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("logging") {
++		if err := resourceBucketLegacyLoggingUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("lifecycle_rule") {
++		if err := resourceBucketLegacyLifecycleUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("acceleration_status") {
++		if err := resourceBucketLegacyAccelerationUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("request_payer") {
++		if err := resourceBucketLegacyRequestPayerUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("replication_configuration") {
++		if err := resourceBucketLegacyInternalReplicationConfigurationUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("server_side_encryption_configuration") {
++		if err := resourceBucketLegacyServerSideEncryptionConfigurationUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	if d.HasChange("object_lock_configuration") {
++		if err := resourceBucketLegacyObjectLockConfigurationUpdate(conn, d); err != nil {
++			return err
++		}
++	}
++
++	return resourceBucketLegacyRead(d, meta)
++}
++
++func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).S3Conn()
++	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
++	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
++
++	input := &s3.HeadBucketInput{
++		Bucket: aws.String(d.Id()),
++	}
++
++	err := resource.Retry(bucketCreatedTimeout, func() *resource.RetryError {
++		_, err := conn.HeadBucket(input)
++
++		if d.IsNewResource() && tfawserr.ErrStatusCodeEquals(err, http.StatusNotFound) {
++			return resource.RetryableError(err)
++		}
++
++		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
++			return resource.RetryableError(err)
++		}
++
++		if err != nil {
++			return resource.NonRetryableError(err)
++		}
++
++		return nil
++	})
++
++	if tfresource.TimedOut(err) {
++		_, err = conn.HeadBucket(input)
++	}
++
++	if !d.IsNewResource() && tfawserr.ErrStatusCodeEquals(err, http.StatusNotFound) {
++		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
++		d.SetId("")
++		return nil
++	}
++
++	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
++		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
++		d.SetId("")
++		return nil
++	}
++
++	if err != nil {
++		return fmt.Errorf("error reading S3 Bucket (%s): %w", d.Id(), err)
++	}
++
++	// In the import case, we won't have this
++	if _, ok := d.GetOk("bucket"); !ok {
++		d.Set("bucket", d.Id())
++	}
++
++	d.Set("bucket_domain_name", meta.(*conns.AWSClient).PartitionHostname(fmt.Sprintf("%s.s3", d.Get("bucket").(string))))
++
++	// Read the policy
++	if _, ok := d.GetOk("policy"); ok {
++
++		pol, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++			return conn.GetBucketPolicy(&s3.GetBucketPolicyInput{
++				Bucket: aws.String(d.Id()),
++			})
++		})
++		log.Printf("[DEBUG] S3 bucket: %s, read policy: %v", d.Id(), pol)
++		if err != nil {
++			if err := d.Set("policy", ""); err != nil {
++				return err
++			}
++		} else {
++			if v := pol.(*s3.GetBucketPolicyOutput).Policy; v == nil {
++				if err := d.Set("policy", ""); err != nil {
++					return err
++				}
++			} else {
++				policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.StringValue(v))
++
++				if err != nil {
++					return fmt.Errorf("while setting policy (%s), encountered: %w", aws.StringValue(v), err)
++				}
++
++				policyToSet, err = structure.NormalizeJsonString(policyToSet)
++
++				if err != nil {
++					return fmt.Errorf("policy (%s) contains invalid JSON: %w", d.Get("policy").(string), err)
++				}
++
++				d.Set("policy", policyToSet)
++			}
++		}
++	}
++
++	//Read the Grant ACL. Reset if `acl` (canned ACL) is set.
++	if acl, ok := d.GetOk("acl"); ok && acl.(string) != "private" {
++		if err := d.Set("grant", nil); err != nil {
++			return fmt.Errorf("error resetting grant %s", err)
++		}
++	} else {
++		apResponse, err := retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
++			return conn.GetBucketAcl(&s3.GetBucketAclInput{
++				Bucket: aws.String(d.Id()),
++			})
++		})
++		if err != nil {
++			return fmt.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
++		}
++		log.Printf("[DEBUG] S3 bucket: %s, read ACL grants policy: %+v", d.Id(), apResponse)
++		grants := flattenGrantsLegacy(apResponse.(*s3.GetBucketAclOutput))
++		if err := d.Set("grant", schema.NewSet(grantHashLegacy, grants)); err != nil {
++			return fmt.Errorf("error setting grant %s", err)
++		}
++	}
++
++	// Read the CORS
++	corsResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketCors(&s3.GetBucketCorsInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++	if err != nil && !tfawserr.ErrMessageContains(err, "NoSuchCORSConfiguration", "") {
++		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
++	}
++
++	corsRules := make([]map[string]interface{}, 0)
++	if cors, ok := corsResponse.(*s3.GetBucketCorsOutput); ok && len(cors.CORSRules) > 0 {
++		corsRules = make([]map[string]interface{}, 0, len(cors.CORSRules))
++		for _, ruleObject := range cors.CORSRules {
++			rule := make(map[string]interface{})
++			rule["allowed_headers"] = flex.FlattenStringList(ruleObject.AllowedHeaders)
++			rule["allowed_methods"] = flex.FlattenStringList(ruleObject.AllowedMethods)
++			rule["allowed_origins"] = flex.FlattenStringList(ruleObject.AllowedOrigins)
++			// Both the "ExposeHeaders" and "MaxAgeSeconds" might not be set.
++			if ruleObject.AllowedOrigins != nil {
++				rule["expose_headers"] = flex.FlattenStringList(ruleObject.ExposeHeaders)
++			}
++			if ruleObject.MaxAgeSeconds != nil {
++				rule["max_age_seconds"] = int(aws.Int64Value(ruleObject.MaxAgeSeconds))
++			}
++			corsRules = append(corsRules, rule)
++		}
++	}
++	if err := d.Set("cors_rule", corsRules); err != nil {
++		return fmt.Errorf("error setting cors_rule: %s", err)
++	}
++
++	// Read the website configuration
++	wsResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketWebsite(&s3.GetBucketWebsiteInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++	if err != nil && !tfawserr.ErrMessageContains(err, "NotImplemented", "") && !tfawserr.ErrMessageContains(err, "NoSuchWebsiteConfiguration", "") {
++		return fmt.Errorf("error getting S3 Bucket website configuration: %s", err)
++	}
++
++	websites := make([]map[string]interface{}, 0, 1)
++	if ws, ok := wsResponse.(*s3.GetBucketWebsiteOutput); ok {
++		w := make(map[string]interface{})
++
++		if v := ws.IndexDocument; v != nil {
++			w["index_document"] = aws.StringValue(v.Suffix)
++		}
++
++		if v := ws.ErrorDocument; v != nil {
++			w["error_document"] = aws.StringValue(v.Key)
++		}
++
++		if v := ws.RedirectAllRequestsTo; v != nil {
++			if v.Protocol == nil {
++				w["redirect_all_requests_to"] = aws.StringValue(v.HostName)
++			} else {
++				var host string
++				var path string
++				var query string
++				parsedHostName, err := url.Parse(aws.StringValue(v.HostName))
++				if err == nil {
++					host = parsedHostName.Host
++					path = parsedHostName.Path
++					query = parsedHostName.RawQuery
++				} else {
++					host = aws.StringValue(v.HostName)
++					path = ""
++				}
++
++				w["redirect_all_requests_to"] = (&url.URL{
++					Host:     host,
++					Path:     path,
++					Scheme:   aws.StringValue(v.Protocol),
++					RawQuery: query,
++				}).String()
++			}
++		}
++
++		if v := ws.RoutingRules; v != nil {
++			rr, err := normalizeRoutingRulesLegacy(v)
++			if err != nil {
++				return fmt.Errorf("Error while marshaling routing rules: %s", err)
++			}
++			w["routing_rules"] = rr
++		}
++
++		// We have special handling for the website configuration,
++		// so only add the configuration if there is any
++		if len(w) > 0 {
++			websites = append(websites, w)
++		}
++	}
++	if err := d.Set("website", websites); err != nil {
++		return fmt.Errorf("error setting website: %s", err)
++	}
++
++	// Read the versioning configuration
++
++	versioningResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketVersioning(&s3.GetBucketVersioningInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++
++	if err != nil {
++		return fmt.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
++	}
++
++	if versioning, ok := versioningResponse.(*s3.GetBucketVersioningOutput); ok {
++		if err := d.Set("versioning", flattenVersioningLegacy(versioning)); err != nil {
++			return fmt.Errorf("error setting versioning: %w", err)
++		}
++	}
++
++	// Read the acceleration status
++
++	accelerateResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketAccelerateConfiguration(&s3.GetBucketAccelerateConfigurationInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++
++	// Amazon S3 Transfer Acceleration might not be supported in the region
++	if err != nil && !tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") && !tfawserr.ErrMessageContains(err, "UnsupportedArgument", "") {
++		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
++	}
++	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {
++		d.Set("acceleration_status", accelerate.Status)
++	}
++
++	// Read the request payer configuration.
++
++	payerResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketRequestPayment(&s3.GetBucketRequestPaymentInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++
++	if err != nil {
++		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
++	}
++
++	if payer, ok := payerResponse.(*s3.GetBucketRequestPaymentOutput); ok {
++		d.Set("request_payer", payer.Payer)
++	}
++
++	// Read the logging configuration
++	loggingResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketLogging(&s3.GetBucketLoggingInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++
++	if err != nil {
++		return fmt.Errorf("error getting S3 Bucket logging: %s", err)
++	}
++
++	lcl := make([]map[string]interface{}, 0, 1)
++	if logging, ok := loggingResponse.(*s3.GetBucketLoggingOutput); ok && logging.LoggingEnabled != nil {
++		v := logging.LoggingEnabled
++		lc := make(map[string]interface{})
++		if aws.StringValue(v.TargetBucket) != "" {
++			lc["target_bucket"] = aws.StringValue(v.TargetBucket)
++		}
++		if aws.StringValue(v.TargetPrefix) != "" {
++			lc["target_prefix"] = aws.StringValue(v.TargetPrefix)
++		}
++		lcl = append(lcl, lc)
++	}
++	if err := d.Set("logging", lcl); err != nil {
++		return fmt.Errorf("error setting logging: %s", err)
++	}
++
++	// Read the lifecycle configuration
++
++	lifecycleResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++	if err != nil && !tfawserr.ErrMessageContains(err, "NoSuchLifecycleConfiguration", "") {
++		return err
++	}
++
++	lifecycleRules := make([]map[string]interface{}, 0)
++	if lifecycle, ok := lifecycleResponse.(*s3.GetBucketLifecycleConfigurationOutput); ok && len(lifecycle.Rules) > 0 {
++		lifecycleRules = make([]map[string]interface{}, 0, len(lifecycle.Rules))
++
++		for _, lifecycleRule := range lifecycle.Rules {
++			log.Printf("[DEBUG] S3 bucket: %s, read lifecycle rule: %v", d.Id(), lifecycleRule)
++			rule := make(map[string]interface{})
++
++			// ID
++			if lifecycleRule.ID != nil && aws.StringValue(lifecycleRule.ID) != "" {
++				rule["id"] = aws.StringValue(lifecycleRule.ID)
++			}
++			filter := lifecycleRule.Filter
++			if filter != nil {
++				if filter.And != nil {
++					// Prefix
++					if filter.And.Prefix != nil && aws.StringValue(filter.And.Prefix) != "" {
++						rule["prefix"] = aws.StringValue(filter.And.Prefix)
++					}
++					// Tag
++					if len(filter.And.Tags) > 0 {
++						rule["tags"] = KeyValueTags(filter.And.Tags).IgnoreAWS().Map()
++					}
++				} else {
++					// Prefix
++					if filter.Prefix != nil && aws.StringValue(filter.Prefix) != "" {
++						rule["prefix"] = aws.StringValue(filter.Prefix)
++					}
++					// Tag
++					if filter.Tag != nil {
++						rule["tags"] = KeyValueTags([]*s3.Tag{filter.Tag}).IgnoreAWS().Map()
++					}
++				}
++			} else {
++				if lifecycleRule.Prefix != nil {
++					rule["prefix"] = aws.StringValue(lifecycleRule.Prefix)
++				}
++			}
++
++			// Enabled
++			if lifecycleRule.Status != nil {
++				if aws.StringValue(lifecycleRule.Status) == s3.ExpirationStatusEnabled {
++					rule["enabled"] = true
++				} else {
++					rule["enabled"] = false
++				}
++			}
++
++			// AbortIncompleteMultipartUploadDays
++			if lifecycleRule.AbortIncompleteMultipartUpload != nil {
++				if lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
++					rule["abort_incomplete_multipart_upload_days"] = int(aws.Int64Value(lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation))
++				}
++			}
++
++			// expiration
++			if lifecycleRule.Expiration != nil {
++				e := make(map[string]interface{})
++				if lifecycleRule.Expiration.Date != nil {
++					e["date"] = (aws.TimeValue(lifecycleRule.Expiration.Date)).Format("2006-01-02")
++				}
++				if lifecycleRule.Expiration.Days != nil {
++					e["days"] = int(aws.Int64Value(lifecycleRule.Expiration.Days))
++				}
++				if lifecycleRule.Expiration.ExpiredObjectDeleteMarker != nil {
++					e["expired_object_delete_marker"] = aws.BoolValue(lifecycleRule.Expiration.ExpiredObjectDeleteMarker)
++				}
++				rule["expiration"] = []interface{}{e}
++			}
++			// noncurrent_version_expiration
++			if lifecycleRule.NoncurrentVersionExpiration != nil {
++				e := make(map[string]interface{})
++				if lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays != nil {
++					e["days"] = int(aws.Int64Value(lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays))
++				}
++				rule["noncurrent_version_expiration"] = []interface{}{e}
++			}
++			//// transition
++			if len(lifecycleRule.Transitions) > 0 {
++				transitions := make([]interface{}, 0, len(lifecycleRule.Transitions))
++				for _, v := range lifecycleRule.Transitions {
++					t := make(map[string]interface{})
++					if v.Date != nil {
++						t["date"] = (aws.TimeValue(v.Date)).Format("2006-01-02")
++					}
++					if v.Days != nil {
++						t["days"] = int(aws.Int64Value(v.Days))
++					}
++					if v.StorageClass != nil {
++						t["storage_class"] = aws.StringValue(v.StorageClass)
++					}
++					transitions = append(transitions, t)
++				}
++				rule["transition"] = schema.NewSet(transitionHashLegacy, transitions)
++			}
++			// noncurrent_version_transition
++			if len(lifecycleRule.NoncurrentVersionTransitions) > 0 {
++				transitions := make([]interface{}, 0, len(lifecycleRule.NoncurrentVersionTransitions))
++				for _, v := range lifecycleRule.NoncurrentVersionTransitions {
++					t := make(map[string]interface{})
++					if v.NoncurrentDays != nil {
++						t["days"] = int(aws.Int64Value(v.NoncurrentDays))
++					}
++					if v.StorageClass != nil {
++						t["storage_class"] = aws.StringValue(v.StorageClass)
++					}
++					transitions = append(transitions, t)
++				}
++				rule["noncurrent_version_transition"] = schema.NewSet(transitionHashLegacy, transitions)
++			}
++
++			lifecycleRules = append(lifecycleRules, rule)
++		}
++	}
++	if err := d.Set("lifecycle_rule", lifecycleRules); err != nil {
++		return fmt.Errorf("error setting lifecycle_rule: %s", err)
++	}
++
++	// Read the bucket replication configuration
++
++	replicationResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketReplication(&s3.GetBucketReplicationInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++	if err != nil && !tfawserr.ErrMessageContains(err, "ReplicationConfigurationNotFoundError", "") {
++		return fmt.Errorf("error getting S3 Bucket replication: %s", err)
++	}
++
++	replicationConfiguration := make([]map[string]interface{}, 0)
++	if replication, ok := replicationResponse.(*s3.GetBucketReplicationOutput); ok {
++		replicationConfiguration = flattenBucketReplicationConfigurationLegacy(replication.ReplicationConfiguration)
++	}
++	if err := d.Set("replication_configuration", replicationConfiguration); err != nil {
++		return fmt.Errorf("error setting replication_configuration: %s", err)
++	}
++
++	// Read the bucket server side encryption configuration
++
++	encryptionResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetBucketEncryption(&s3.GetBucketEncryptionInput{
++			Bucket: aws.String(d.Id()),
++		})
++	})
++	if err != nil && !tfawserr.ErrMessageContains(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
++		return fmt.Errorf("error getting S3 Bucket encryption: %s", err)
++	}
++
++	serverSideEncryptionConfiguration := make([]map[string]interface{}, 0)
++	if encryption, ok := encryptionResponse.(*s3.GetBucketEncryptionOutput); ok && encryption.ServerSideEncryptionConfiguration != nil {
++		serverSideEncryptionConfiguration = flattenServerSideEncryptionConfigurationLegacy(encryption.ServerSideEncryptionConfiguration)
++	}
++	if err := d.Set("server_side_encryption_configuration", serverSideEncryptionConfiguration); err != nil {
++		return fmt.Errorf("error setting server_side_encryption_configuration: %s", err)
++	}
++
++	// Object Lock configuration.
++	conf, err := readS3ObjectLockConfigurationLegacy(conn, d.Id())
++
++	// Object lock not supported in all partitions (extra guard, also guards in read func)
++	if err != nil && (meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID) {
++		return fmt.Errorf("error getting S3 Bucket Object Lock configuration: %s", err)
++	}
++
++	if err != nil {
++		log.Printf("[WARN] Unable to read S3 bucket (%s) object lock configuration: %s", d.Id(), err)
++	}
++
++	if err == nil {
++		if err := d.Set("object_lock_configuration", conf); err != nil {
++			return fmt.Errorf("error setting object_lock_configuration: %s", err)
++		}
++	}
++
++	// Add the region as an attribute
++	discoveredRegion, err := retryOnAWSCode("NotFound", func() (interface{}, error) {
++		return s3manager.GetBucketRegionWithClient(context.Background(), conn, d.Id(), func(r *request.Request) {
++			// By default, GetBucketRegion forces virtual host addressing, which
++			// is not compatible with many non-AWS implementations. Instead, pass
++			// the provider s3_force_path_style configuration, which defaults to
++			// false, but allows override.
++			r.Config.S3ForcePathStyle = conn.Config.S3ForcePathStyle
++
++			// By default, GetBucketRegion uses anonymous credentials when doing
++			// a HEAD request to get the bucket region. This breaks in aws-cn regions
++			// when the account doesn't have an ICP license to host public content.
++			// Use the current credentials when getting the bucket region.
++			r.Config.Credentials = conn.Config.Credentials
++		})
++	})
++	if err != nil {
++		return fmt.Errorf("error getting S3 Bucket location: %s", err)
++	}
++
++	region := discoveredRegion.(string)
++	if err := d.Set("region", region); err != nil {
++		return err
++	}
++
++	// Add the bucket_regional_domain_name as an attribute
++	regionalEndpoint, err := bucketLegacyRegionalDomainName(d.Get("bucket").(string), region)
++	if err != nil {
++		return err
++	}
++	d.Set("bucket_regional_domain_name", regionalEndpoint)
++
++	// Add the hosted zone ID for this bucket's region as an attribute
++	hostedZoneID, err := HostedZoneIDForRegion(region)
++	if err != nil {
++		log.Printf("[WARN] %s", err)
++	} else {
++		d.Set("hosted_zone_id", hostedZoneID)
++	}
++
++	// Add website_endpoint as an attribute
++	websiteEndpoint, err := websiteLegacyEndpoint(meta.(*conns.AWSClient), d)
++	if err != nil {
++		return err
++	}
++	if websiteEndpoint != nil {
++		if err := d.Set("website_endpoint", websiteEndpoint.Endpoint); err != nil {
++			return err
++		}
++		if err := d.Set("website_domain", websiteEndpoint.Domain); err != nil {
++			return err
++		}
++	}
++
++	// Retry due to S3 eventual consistency
++	tagsRaw, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return BucketListTags(conn, d.Id())
++	})
++
++	if err != nil {
++		return fmt.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)
++	}
++
++	tags, ok := tagsRaw.(tftags.KeyValueTags)
++
++	if !ok {
++		return fmt.Errorf("error listing tags for S3 Bucket (%s): unable to convert tags", d.Id())
++	}
++
++	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
++
++	//lintignore:AWSR002
++	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
++		return fmt.Errorf("error setting tags: %w", err)
++	}
++
++	if err := d.Set("tags_all", tags.Map()); err != nil {
++		return fmt.Errorf("error setting tags_all: %w", err)
++	}
++
++	arn := arn.ARN{
++		Partition: meta.(*conns.AWSClient).Partition,
++		Service:   "s3",
++		Resource:  d.Id(),
++	}.String()
++	d.Set("arn", arn)
++
++	return nil
++}
++
++func resourceBucketLegacyDelete(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).S3Conn()
++
++	log.Printf("[DEBUG] S3 Delete Bucket: %s", d.Id())
++	_, err := conn.DeleteBucket(&s3.DeleteBucketInput{
++		Bucket: aws.String(d.Id()),
++	})
++
++	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
++		return nil
++	}
++
++	if tfawserr.ErrMessageContains(err, "BucketNotEmpty", "") {
++		if d.Get("force_destroy").(bool) {
++			// Use a S3 service client that can handle multiple slashes in URIs.
++			// While aws_s3_bucket_object resources cannot create these object
++			// keys, other AWS services and applications using the S3 Bucket can.
++			conn = meta.(*conns.AWSClient).S3ConnURICleaningDisabled()
++
++			// bucket may have things delete them
++			log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
++
++			// Delete everything including locked objects.
++			// Don't ignore any object errors or we could recurse infinitely.
++			var objectLockEnabled bool
++			objectLockConfiguration := expandS3ObjectLockConfigurationLegacy(d.Get("object_lock_configuration").([]interface{}))
++			if objectLockConfiguration != nil {
++				objectLockEnabled = aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled
++			}
++			err = DeleteAllObjectVersions(conn, d.Id(), "", objectLockEnabled, false)
++
++			if err != nil {
++				return fmt.Errorf("error S3 Bucket force_destroy: %s", err)
++			}
++
++			// this line recurses until all objects are deleted or an error is returned
++			return resourceBucketLegacyDelete(d, meta)
++		}
++	}
++
++	if err != nil {
++		return fmt.Errorf("error deleting S3 Bucket (%s): %s", d.Id(), err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyPolicyUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++
++	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
++
++	if err != nil {
++		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policy, err)
++	}
++
++	if policy != "" {
++		log.Printf("[DEBUG] S3 bucket: %s, put policy: %s", bucket, policy)
++
++		params := &s3.PutBucketPolicyInput{
++			Bucket: aws.String(bucket),
++			Policy: aws.String(policy),
++		}
++
++		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
++			_, err := conn.PutBucketPolicy(params)
++			if tfawserr.ErrMessageContains(err, "MalformedPolicy", "") || tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
++				return resource.RetryableError(err)
++			}
++			if err != nil {
++				return resource.NonRetryableError(err)
++			}
++			return nil
++		})
++		if tfresource.TimedOut(err) {
++			_, err = conn.PutBucketPolicy(params)
++		}
++		if err != nil {
++			return fmt.Errorf("Error putting S3 policy: %s", err)
++		}
++	} else {
++		log.Printf("[DEBUG] S3 bucket: %s, delete policy: %s", bucket, policy)
++		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++			return conn.DeleteBucketPolicy(&s3.DeleteBucketPolicyInput{
++				Bucket: aws.String(bucket),
++			})
++		})
++
++		if err != nil {
++			return fmt.Errorf("Error deleting S3 policy: %s", err)
++		}
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyGrantsUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	rawGrants := d.Get("grant").(*schema.Set).List()
++
++	if len(rawGrants) == 0 {
++		log.Printf("[DEBUG] S3 bucket: %s, Grants fallback to canned ACL", bucket)
++		if err := resourceBucketLegacyACLUpdate(conn, d); err != nil {
++			return fmt.Errorf("Error fallback to canned ACL, %s", err)
++		}
++	} else {
++		apResponse, err := retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
++			return conn.GetBucketAcl(&s3.GetBucketAclInput{
++				Bucket: aws.String(d.Id()),
++			})
++		})
++
++		if err != nil {
++			return fmt.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
++		}
++
++		ap := apResponse.(*s3.GetBucketAclOutput)
++		log.Printf("[DEBUG] S3 bucket: %s, read ACL grants policy: %+v", d.Id(), ap)
++
++		grants := make([]*s3.Grant, 0, len(rawGrants))
++		for _, rawGrant := range rawGrants {
++			log.Printf("[DEBUG] S3 bucket: %s, put grant: %#v", bucket, rawGrant)
++			grantMap := rawGrant.(map[string]interface{})
++			for _, rawPermission := range grantMap["permissions"].(*schema.Set).List() {
++				ge := &s3.Grantee{}
++				if i, ok := grantMap["id"].(string); ok && i != "" {
++					ge.SetID(i)
++				}
++				if t, ok := grantMap["type"].(string); ok && t != "" {
++					ge.SetType(t)
++				}
++				if u, ok := grantMap["uri"].(string); ok && u != "" {
++					ge.SetURI(u)
++				}
++
++				g := &s3.Grant{
++					Grantee:    ge,
++					Permission: aws.String(rawPermission.(string)),
++				}
++				grants = append(grants, g)
++			}
++		}
++
++		grantsInput := &s3.PutBucketAclInput{
++			Bucket: aws.String(bucket),
++			AccessControlPolicy: &s3.AccessControlPolicy{
++				Grants: grants,
++				Owner:  ap.Owner,
++			},
++		}
++
++		log.Printf("[DEBUG] S3 bucket: %s, put Grants: %#v", bucket, grantsInput)
++
++		_, err = retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
++			return conn.PutBucketAcl(grantsInput)
++		})
++
++		if err != nil {
++			return fmt.Errorf("Error putting S3 Grants: %s", err)
++		}
++	}
++	return nil
++}
++
++func resourceBucketLegacyCorsUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	rawCors := d.Get("cors_rule").([]interface{})
++
++	if len(rawCors) == 0 {
++		// Delete CORS
++		log.Printf("[DEBUG] S3 bucket: %s, delete CORS", bucket)
++
++		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++			return conn.DeleteBucketCors(&s3.DeleteBucketCorsInput{
++				Bucket: aws.String(bucket),
++			})
++		})
++		if err != nil {
++			return fmt.Errorf("Error deleting S3 CORS: %s", err)
++		}
++	} else {
++		// Put CORS
++		rules := make([]*s3.CORSRule, 0, len(rawCors))
++		for _, cors := range rawCors {
++			corsMap := cors.(map[string]interface{})
++			r := &s3.CORSRule{}
++			for k, v := range corsMap {
++				log.Printf("[DEBUG] S3 bucket: %s, put CORS: %#v, %#v", bucket, k, v)
++				if k == "max_age_seconds" {
++					r.MaxAgeSeconds = aws.Int64(int64(v.(int)))
++				} else {
++					vMap := make([]*string, len(v.([]interface{})))
++					for i, vv := range v.([]interface{}) {
++						if str, ok := vv.(string); ok {
++							vMap[i] = aws.String(str)
++						}
++					}
++					switch k {
++					case "allowed_headers":
++						r.AllowedHeaders = vMap
++					case "allowed_methods":
++						r.AllowedMethods = vMap
++					case "allowed_origins":
++						r.AllowedOrigins = vMap
++					case "expose_headers":
++						r.ExposeHeaders = vMap
++					}
++				}
++			}
++			rules = append(rules, r)
++		}
++		corsInput := &s3.PutBucketCorsInput{
++			Bucket: aws.String(bucket),
++			CORSConfiguration: &s3.CORSConfiguration{
++				CORSRules: rules,
++			},
++		}
++		log.Printf("[DEBUG] S3 bucket: %s, put CORS: %#v", bucket, corsInput)
++
++		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++			return conn.PutBucketCors(corsInput)
++		})
++		if err != nil {
++			return fmt.Errorf("Error putting S3 CORS: %s", err)
++		}
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyWebsiteUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	ws := d.Get("website").([]interface{})
++
++	if len(ws) == 0 {
++		return resourceBucketLegacyWebsiteDelete(conn, d)
++	}
++
++	var w map[string]interface{}
++	if ws[0] != nil {
++		w = ws[0].(map[string]interface{})
++	} else {
++		w = make(map[string]interface{})
++	}
++	return resourceBucketLegacyWebsitePut(conn, d, w)
++}
++
++func resourceBucketLegacyWebsitePut(conn *s3.S3, d *schema.ResourceData, website map[string]interface{}) error {
++	bucket := d.Get("bucket").(string)
++
++	var indexDocument, errorDocument, redirectAllRequestsTo, routingRules string
++	if v, ok := website["index_document"]; ok {
++		indexDocument = v.(string)
++	}
++	if v, ok := website["error_document"]; ok {
++		errorDocument = v.(string)
++	}
++	if v, ok := website["redirect_all_requests_to"]; ok {
++		redirectAllRequestsTo = v.(string)
++	}
++	if v, ok := website["routing_rules"]; ok {
++		routingRules = v.(string)
++	}
++
++	if indexDocument == "" && redirectAllRequestsTo == "" {
++		return fmt.Errorf("Must specify either index_document or redirect_all_requests_to.")
++	}
++
++	websiteConfiguration := &s3.WebsiteConfiguration{}
++
++	if indexDocument != "" {
++		websiteConfiguration.IndexDocument = &s3.IndexDocument{Suffix: aws.String(indexDocument)}
++	}
++
++	if errorDocument != "" {
++		websiteConfiguration.ErrorDocument = &s3.ErrorDocument{Key: aws.String(errorDocument)}
++	}
++
++	if redirectAllRequestsTo != "" {
++		redirect, err := url.Parse(redirectAllRequestsTo)
++		if err == nil && redirect.Scheme != "" {
++			var redirectHostBuf bytes.Buffer
++			redirectHostBuf.WriteString(redirect.Host)
++			if redirect.Path != "" {
++				redirectHostBuf.WriteString(redirect.Path)
++			}
++			if redirect.RawQuery != "" {
++				redirectHostBuf.WriteString("?")
++				redirectHostBuf.WriteString(redirect.RawQuery)
++			}
++			websiteConfiguration.RedirectAllRequestsTo = &s3.RedirectAllRequestsTo{HostName: aws.String(redirectHostBuf.String()), Protocol: aws.String(redirect.Scheme)}
++		} else {
++			websiteConfiguration.RedirectAllRequestsTo = &s3.RedirectAllRequestsTo{HostName: aws.String(redirectAllRequestsTo)}
++		}
++	}
++
++	if routingRules != "" {
++		var unmarshaledRules []*s3.RoutingRule
++		if err := json.Unmarshal([]byte(routingRules), &unmarshaledRules); err != nil {
++			return err
++		}
++		websiteConfiguration.RoutingRules = unmarshaledRules
++	}
++
++	putInput := &s3.PutBucketWebsiteInput{
++		Bucket:               aws.String(bucket),
++		WebsiteConfiguration: websiteConfiguration,
++	}
++
++	log.Printf("[DEBUG] S3 put bucket website: %#v", putInput)
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketWebsite(putInput)
++	})
++	if err != nil {
++		return fmt.Errorf("Error putting S3 website: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyWebsiteDelete(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	deleteInput := &s3.DeleteBucketWebsiteInput{Bucket: aws.String(bucket)}
++
++	log.Printf("[DEBUG] S3 delete bucket website: %#v", deleteInput)
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.DeleteBucketWebsite(deleteInput)
++	})
++	if err != nil {
++		return fmt.Errorf("Error deleting S3 website: %s", err)
++	}
++
++	d.Set("website_endpoint", "")
++	d.Set("website_domain", "")
++
++	return nil
++}
++
++func websiteLegacyEndpoint(client *conns.AWSClient, d *schema.ResourceData) (*S3WebsiteLegacy, error) {
++	// If the bucket doesn't have a website configuration, return an empty
++	// endpoint
++	if _, ok := d.GetOk("website"); !ok {
++		return nil, nil
++	}
++
++	bucket := d.Get("bucket").(string)
++
++	// Lookup the region for this bucket
++
++	locationResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return client.S3Conn().GetBucketLocation(
++			&s3.GetBucketLocationInput{
++				Bucket: aws.String(bucket),
++			},
++		)
++	})
++	if err != nil {
++		return nil, err
++	}
++	location := locationResponse.(*s3.GetBucketLocationOutput)
++	var region string
++	if location.LocationConstraint != nil {
++		region = aws.StringValue(location.LocationConstraint)
++	}
++
++	return WebsiteLegacyEndpoint(client, bucket, region), nil
++}
++
++// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
++func bucketLegacyRegionalDomainName(bucket string, region string) (string, error) {
++	// Return a default AWS Commercial domain name if no region is provided
++	// Otherwise EndpointFor() will return BUCKET.s3..amazonaws.com
++	if region == "" {
++		return fmt.Sprintf("%s.s3.amazonaws.com", bucket), nil //lintignore:AWSR001
++	}
++	endpoint, err := endpoints.DefaultResolver().EndpointFor(endpoints.S3ServiceID, region)
++	if err != nil {
++		return "", err
++	}
++	return fmt.Sprintf("%s.%s", bucket, strings.TrimPrefix(endpoint.URL, "https://")), nil
++}
++
++func WebsiteLegacyEndpoint(client *conns.AWSClient, bucket string, region string) *S3WebsiteLegacy {
++	domain := websiteLegacyDomainUrl(client, region)
++	return &S3WebsiteLegacy{Endpoint: fmt.Sprintf("%s.%s", bucket, domain), Domain: domain}
++}
++
++func websiteLegacyDomainUrl(client *conns.AWSClient, region string) string {
++	region = normalizeRegionLegacy(region)
++
++	// Different regions have different syntax for website endpoints
++	// https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
++	// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
++	if isOldRegionLegacy(region) {
++		return fmt.Sprintf("s3-website-%s.amazonaws.com", region) //lintignore:AWSR001
++	}
++	return client.RegionalHostname("s3-website")
++}
++
++func isOldRegionLegacy(region string) bool {
++	oldRegions := []string{
++		endpoints.ApNortheast1RegionID,
++		endpoints.ApSoutheast1RegionID,
++		endpoints.ApSoutheast2RegionID,
++		endpoints.EuWest1RegionID,
++		endpoints.SaEast1RegionID,
++		endpoints.UsEast1RegionID,
++		endpoints.UsGovWest1RegionID,
++		endpoints.UsWest1RegionID,
++		endpoints.UsWest2RegionID,
++	}
++	for _, r := range oldRegions {
++		if region == r {
++			return true
++		}
++	}
++	return false
++}
++
++func resourceBucketLegacyACLUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	acl := d.Get("acl").(string)
++	bucket := d.Get("bucket").(string)
++
++	i := &s3.PutBucketAclInput{
++		Bucket: aws.String(bucket),
++		ACL:    aws.String(acl),
++	}
++	log.Printf("[DEBUG] S3 put bucket ACL: %#v", i)
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketAcl(i)
++	})
++	if err != nil {
++		return fmt.Errorf("Error putting S3 ACL: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyVersioningUpdate(conn *s3.S3, bucket string, versioningConfig *s3.VersioningConfiguration) error {
++	input := &s3.PutBucketVersioningInput{
++		Bucket:                  aws.String(bucket),
++		VersioningConfiguration: versioningConfig,
++	}
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketVersioning(input)
++	})
++
++	if err != nil {
++		return fmt.Errorf("error putting S3 versioning for bucket (%s): %w", bucket, err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyLoggingUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	logging := d.Get("logging").(*schema.Set).List()
++	bucket := d.Get("bucket").(string)
++	loggingStatus := &s3.BucketLoggingStatus{}
++
++	if len(logging) > 0 {
++		c := logging[0].(map[string]interface{})
++
++		loggingEnabled := &s3.LoggingEnabled{}
++		if val, ok := c["target_bucket"]; ok {
++			loggingEnabled.TargetBucket = aws.String(val.(string))
++		}
++		if val, ok := c["target_prefix"]; ok {
++			loggingEnabled.TargetPrefix = aws.String(val.(string))
++		}
++
++		loggingStatus.LoggingEnabled = loggingEnabled
++	}
++
++	i := &s3.PutBucketLoggingInput{
++		Bucket:              aws.String(bucket),
++		BucketLoggingStatus: loggingStatus,
++	}
++	log.Printf("[DEBUG] S3 put bucket logging: %#v", i)
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketLogging(i)
++	})
++	if err != nil {
++		return fmt.Errorf("Error putting S3 logging: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyAccelerationUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	enableAcceleration := d.Get("acceleration_status").(string)
++
++	i := &s3.PutBucketAccelerateConfigurationInput{
++		Bucket: aws.String(bucket),
++		AccelerateConfiguration: &s3.AccelerateConfiguration{
++			Status: aws.String(enableAcceleration),
++		},
++	}
++	log.Printf("[DEBUG] S3 put bucket acceleration: %#v", i)
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketAccelerateConfiguration(i)
++	})
++	if err != nil {
++		return fmt.Errorf("Error putting S3 acceleration: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyRequestPayerUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	payer := d.Get("request_payer").(string)
++
++	i := &s3.PutBucketRequestPaymentInput{
++		Bucket: aws.String(bucket),
++		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
++			Payer: aws.String(payer),
++		},
++	}
++	log.Printf("[DEBUG] S3 put bucket request payer: %#v", i)
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketRequestPayment(i)
++	})
++	if err != nil {
++		return fmt.Errorf("Error putting S3 request payer: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyServerSideEncryptionConfigurationUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	serverSideEncryptionConfiguration := d.Get("server_side_encryption_configuration").([]interface{})
++	if len(serverSideEncryptionConfiguration) == 0 {
++		log.Printf("[DEBUG] Delete server side encryption configuration: %#v", serverSideEncryptionConfiguration)
++		i := &s3.DeleteBucketEncryptionInput{
++			Bucket: aws.String(bucket),
++		}
++
++		_, err := conn.DeleteBucketEncryption(i)
++		if err != nil {
++			return fmt.Errorf("error removing S3 bucket server side encryption: %s", err)
++		}
++		return nil
++	}
++
++	c := serverSideEncryptionConfiguration[0].(map[string]interface{})
++
++	rc := &s3.ServerSideEncryptionConfiguration{}
++
++	rcRules := c["rule"].([]interface{})
++	var rules []*s3.ServerSideEncryptionRule
++	for _, v := range rcRules {
++		rr := v.(map[string]interface{})
++		rrDefault := rr["apply_server_side_encryption_by_default"].([]interface{})
++		sseAlgorithm := rrDefault[0].(map[string]interface{})["sse_algorithm"].(string)
++		kmsMasterKeyId := rrDefault[0].(map[string]interface{})["kms_master_key_id"].(string)
++		rcDefaultRule := &s3.ServerSideEncryptionByDefault{
++			SSEAlgorithm: aws.String(sseAlgorithm),
++		}
++		if kmsMasterKeyId != "" {
++			rcDefaultRule.KMSMasterKeyID = aws.String(kmsMasterKeyId)
++		}
++		rcRule := &s3.ServerSideEncryptionRule{
++			ApplyServerSideEncryptionByDefault: rcDefaultRule,
++		}
++
++		if val, ok := rr["bucket_key_enabled"].(bool); ok {
++			rcRule.BucketKeyEnabled = aws.Bool(val)
++		}
++
++		rules = append(rules, rcRule)
++	}
++
++	rc.Rules = rules
++	i := &s3.PutBucketEncryptionInput{
++		Bucket:                            aws.String(bucket),
++		ServerSideEncryptionConfiguration: rc,
++	}
++	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
++
++	_, err := tfresource.RetryWhenAWSErrCodeEquals(
++		context.Background(),
++		propagationTimeout,
++		func() (interface{}, error) {
++			return conn.PutBucketEncryption(i)
++		},
++		s3.ErrCodeNoSuchBucket,
++		ErrCodeOperationAborted,
++	)
++
++	if err != nil {
++		return fmt.Errorf("error putting S3 server side encryption configuration: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyObjectLockConfigurationUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	// S3 Object Lock configuration cannot be deleted, only updated.
++	req := &s3.PutObjectLockConfigurationInput{
++		Bucket:                  aws.String(d.Get("bucket").(string)),
++		ObjectLockConfiguration: expandS3ObjectLockConfigurationLegacy(d.Get("object_lock_configuration").([]interface{})),
++	}
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutObjectLockConfiguration(req)
++	})
++	if err != nil {
++		return fmt.Errorf("error putting S3 object lock configuration: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyInternalReplicationConfigurationUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++	replicationConfiguration := d.Get("replication_configuration").([]interface{})
++
++	if len(replicationConfiguration) == 0 {
++		i := &s3.DeleteBucketReplicationInput{
++			Bucket: aws.String(bucket),
++		}
++
++		_, err := conn.DeleteBucketReplication(i)
++		if err != nil {
++			return fmt.Errorf("Error removing S3 bucket replication: %s", err)
++		}
++		return nil
++	}
++
++	hasVersioning := false
++	// Validate that bucket versioning is enabled
++	if versioning, ok := d.GetOk("versioning"); ok {
++		v := versioning.([]interface{})
++
++		if v[0].(map[string]interface{})["enabled"].(bool) {
++			hasVersioning = true
++		}
++	}
++
++	if !hasVersioning {
++		return fmt.Errorf("versioning must be enabled to allow S3 bucket replication")
++	}
++
++	c := replicationConfiguration[0].(map[string]interface{})
++
++	rc := &s3.ReplicationConfiguration{}
++	if val, ok := c["role"]; ok {
++		rc.Role = aws.String(val.(string))
++	}
++
++	rcRules := c["rules"].(*schema.Set).List()
++	rules := []*s3.ReplicationRule{}
++	for _, v := range rcRules {
++		rr := v.(map[string]interface{})
++		rcRule := &s3.ReplicationRule{}
++		if status, ok := rr["status"]; ok && status != "" {
++			rcRule.Status = aws.String(status.(string))
++		} else {
++			continue
++		}
++
++		if rrid, ok := rr["id"]; ok && rrid != "" {
++			rcRule.ID = aws.String(rrid.(string))
++		}
++
++		ruleDestination := &s3.Destination{}
++		if dest, ok := rr["destination"].([]interface{}); ok && len(dest) > 0 {
++			if dest[0] != nil {
++				bd := dest[0].(map[string]interface{})
++				ruleDestination.Bucket = aws.String(bd["bucket"].(string))
++
++				if storageClass, ok := bd["storage_class"]; ok && storageClass != "" {
++					ruleDestination.StorageClass = aws.String(storageClass.(string))
++				}
++
++				if replicaKmsKeyId, ok := bd["replica_kms_key_id"]; ok && replicaKmsKeyId != "" {
++					ruleDestination.EncryptionConfiguration = &s3.EncryptionConfiguration{
++						ReplicaKmsKeyID: aws.String(replicaKmsKeyId.(string)),
++					}
++				}
++
++				if account, ok := bd["account_id"]; ok && account != "" {
++					ruleDestination.Account = aws.String(account.(string))
++				}
++
++				if aclTranslation, ok := bd["access_control_translation"].([]interface{}); ok && len(aclTranslation) > 0 {
++					aclTranslationValues := aclTranslation[0].(map[string]interface{})
++					ruleAclTranslation := &s3.AccessControlTranslation{}
++					ruleAclTranslation.Owner = aws.String(aclTranslationValues["owner"].(string))
++					ruleDestination.AccessControlTranslation = ruleAclTranslation
++				}
++
++				// replication metrics (required for RTC)
++				if metrics, ok := bd["metrics"].([]interface{}); ok && len(metrics) > 0 {
++					metricsConfig := &s3.Metrics{}
++					metricsValues := metrics[0].(map[string]interface{})
++					metricsConfig.EventThreshold = &s3.ReplicationTimeValue{}
++					metricsConfig.Status = aws.String(metricsValues["status"].(string))
++					metricsConfig.EventThreshold.Minutes = aws.Int64(int64(metricsValues["minutes"].(int)))
++					ruleDestination.Metrics = metricsConfig
++				}
++
++				// replication time control (RTC)
++				if rtc, ok := bd["replication_time"].([]interface{}); ok && len(rtc) > 0 {
++					rtcValues := rtc[0].(map[string]interface{})
++					rtcConfig := &s3.ReplicationTime{}
++					rtcConfig.Status = aws.String(rtcValues["status"].(string))
++					rtcConfig.Time = &s3.ReplicationTimeValue{}
++					rtcConfig.Time.Minutes = aws.Int64(int64(rtcValues["minutes"].(int)))
++					ruleDestination.ReplicationTime = rtcConfig
++				}
++			}
++		}
++		rcRule.Destination = ruleDestination
++
++		if ssc, ok := rr["source_selection_criteria"].([]interface{}); ok && len(ssc) > 0 {
++			if ssc[0] != nil {
++				sscValues := ssc[0].(map[string]interface{})
++				ruleSsc := &s3.SourceSelectionCriteria{}
++				if sseKms, ok := sscValues["sse_kms_encrypted_objects"].([]interface{}); ok && len(sseKms) > 0 {
++					if sseKms[0] != nil {
++						sseKmsValues := sseKms[0].(map[string]interface{})
++						sseKmsEncryptedObjects := &s3.SseKmsEncryptedObjects{}
++						if sseKmsValues["enabled"].(bool) {
++							sseKmsEncryptedObjects.Status = aws.String(s3.SseKmsEncryptedObjectsStatusEnabled)
++						} else {
++							sseKmsEncryptedObjects.Status = aws.String(s3.SseKmsEncryptedObjectsStatusDisabled)
++						}
++						ruleSsc.SseKmsEncryptedObjects = sseKmsEncryptedObjects
++					}
++				}
++				rcRule.SourceSelectionCriteria = ruleSsc
++			}
++		}
++
++		if f, ok := rr["filter"].([]interface{}); ok && len(f) > 0 && f[0] != nil {
++			// XML schema V2.
++			rcRule.Priority = aws.Int64(int64(rr["priority"].(int)))
++			rcRule.Filter = &s3.ReplicationRuleFilter{}
++			filter := f[0].(map[string]interface{})
++			tags := Tags(tftags.New(context.Background(), filter["tags"]).IgnoreAWS())
++			if len(tags) > 0 {
++				rcRule.Filter.And = &s3.ReplicationRuleAndOperator{
++					Prefix: aws.String(filter["prefix"].(string)),
++					Tags:   tags,
++				}
++			} else {
++				rcRule.Filter.Prefix = aws.String(filter["prefix"].(string))
++			}
++
++			if dmr, ok := rr["delete_marker_replication_status"].(string); ok && dmr != "" {
++				rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
++					Status: aws.String(dmr),
++				}
++			} else {
++				rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
++					Status: aws.String(s3.DeleteMarkerReplicationStatusDisabled),
++				}
++			}
++		} else {
++			// XML schema V1.
++			rcRule.Prefix = aws.String(rr["prefix"].(string))
++		}
++
++		rules = append(rules, rcRule)
++	}
++
++	rc.Rules = rules
++	i := &s3.PutBucketReplicationInput{
++		Bucket:                   aws.String(bucket),
++		ReplicationConfiguration: rc,
++	}
++	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
++
++	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
++		_, err := conn.PutBucketReplication(i)
++		if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") || tfawserr.ErrMessageContains(err, "InvalidRequest", "Versioning must be 'Enabled' on the bucket") {
++			return resource.RetryableError(err)
++		}
++		if err != nil {
++			return resource.NonRetryableError(err)
++		}
++		return nil
++	})
++	if tfresource.TimedOut(err) {
++		_, err = conn.PutBucketReplication(i)
++	}
++	if err != nil {
++		return fmt.Errorf("Error putting S3 replication configuration: %s", err)
++	}
++
++	return nil
++}
++
++func resourceBucketLegacyLifecycleUpdate(conn *s3.S3, d *schema.ResourceData) error {
++	bucket := d.Get("bucket").(string)
++
++	lifecycleRules := d.Get("lifecycle_rule").([]interface{})
++
++	if len(lifecycleRules) == 0 || lifecycleRules[0] == nil {
++		i := &s3.DeleteBucketLifecycleInput{
++			Bucket: aws.String(bucket),
++		}
++
++		_, err := conn.DeleteBucketLifecycle(i)
++		if err != nil {
++			return fmt.Errorf("Error removing S3 lifecycle: %s", err)
++		}
++		return nil
++	}
++
++	rules := make([]*s3.LifecycleRule, 0, len(lifecycleRules))
++
++	for i, lifecycleRule := range lifecycleRules {
++		r := lifecycleRule.(map[string]interface{})
++
++		rule := &s3.LifecycleRule{}
++
++		// Filter
++		tags := Tags(tftags.New(context.Background(), r["tags"]).IgnoreAWS())
++		filter := &s3.LifecycleRuleFilter{}
++		if len(tags) > 0 {
++			lifecycleRuleAndOp := &s3.LifecycleRuleAndOperator{}
++			lifecycleRuleAndOp.SetPrefix(r["prefix"].(string))
++			lifecycleRuleAndOp.SetTags(tags)
++			filter.SetAnd(lifecycleRuleAndOp)
++		} else {
++			filter.SetPrefix(r["prefix"].(string))
++		}
++		rule.SetFilter(filter)
++
++		// ID
++		if val, ok := r["id"].(string); ok && val != "" {
++			rule.ID = aws.String(val)
++		} else {
++			rule.ID = aws.String(resource.PrefixedUniqueId("tf-s3-lifecycle-"))
++		}
++
++		// Enabled
++		if val, ok := r["enabled"].(bool); ok && val {
++			rule.Status = aws.String(s3.ExpirationStatusEnabled)
++		} else {
++			rule.Status = aws.String(s3.ExpirationStatusDisabled)
++		}
++
++		// AbortIncompleteMultipartUpload
++		if val, ok := r["abort_incomplete_multipart_upload_days"].(int); ok && val > 0 {
++			rule.AbortIncompleteMultipartUpload = &s3.AbortIncompleteMultipartUpload{
++				DaysAfterInitiation: aws.Int64(int64(val)),
++			}
++		}
++
++		// Expiration
++		expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.expiration", i)).([]interface{})
++		if len(expiration) > 0 && expiration[0] != nil {
++			e := expiration[0].(map[string]interface{})
++			i := &s3.LifecycleExpiration{}
++			if val, ok := e["date"].(string); ok && val != "" {
++				t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", val))
++				if err != nil {
++					return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
++				}
++				i.Date = aws.Time(t)
++			} else if val, ok := e["days"].(int); ok && val > 0 {
++				i.Days = aws.Int64(int64(val))
++			} else if val, ok := e["expired_object_delete_marker"].(bool); ok {
++				i.ExpiredObjectDeleteMarker = aws.Bool(val)
++			}
++			rule.Expiration = i
++		}
++
++		// NoncurrentVersionExpiration
++		nc_expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_expiration", i)).([]interface{})
++		if len(nc_expiration) > 0 && nc_expiration[0] != nil {
++			e := nc_expiration[0].(map[string]interface{})
++
++			if val, ok := e["days"].(int); ok && val > 0 {
++				rule.NoncurrentVersionExpiration = &s3.NoncurrentVersionExpiration{
++					NoncurrentDays: aws.Int64(int64(val)),
++				}
++			}
++		}
++
++		// Transitions
++		transitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.transition", i)).(*schema.Set).List()
++		if len(transitions) > 0 {
++			rule.Transitions = make([]*s3.Transition, 0, len(transitions))
++			for _, transition := range transitions {
++				transition := transition.(map[string]interface{})
++				i := &s3.Transition{}
++				if val, ok := transition["date"].(string); ok && val != "" {
++					t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", val))
++					if err != nil {
++						return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
++					}
++					i.Date = aws.Time(t)
++				} else if val, ok := transition["days"].(int); ok && val >= 0 {
++					i.Days = aws.Int64(int64(val))
++				}
++				if val, ok := transition["storage_class"].(string); ok && val != "" {
++					i.StorageClass = aws.String(val)
++				}
++
++				rule.Transitions = append(rule.Transitions, i)
++			}
++		}
++		// NoncurrentVersionTransitions
++		nc_transitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_transition", i)).(*schema.Set).List()
++		if len(nc_transitions) > 0 {
++			rule.NoncurrentVersionTransitions = make([]*s3.NoncurrentVersionTransition, 0, len(nc_transitions))
++			for _, transition := range nc_transitions {
++				transition := transition.(map[string]interface{})
++				i := &s3.NoncurrentVersionTransition{}
++				if val, ok := transition["days"].(int); ok && val >= 0 {
++					i.NoncurrentDays = aws.Int64(int64(val))
++				}
++				if val, ok := transition["storage_class"].(string); ok && val != "" {
++					i.StorageClass = aws.String(val)
++				}
++
++				rule.NoncurrentVersionTransitions = append(rule.NoncurrentVersionTransitions, i)
++			}
++		}
++
++		// As a lifecycle rule requires 1 or more transition/expiration actions,
++		// we explicitly pass a default ExpiredObjectDeleteMarker value to be able to create
++		// the rule while keeping the policy unaffected if the conditions are not met.
++		if rule.Expiration == nil && rule.NoncurrentVersionExpiration == nil &&
++			rule.Transitions == nil && rule.NoncurrentVersionTransitions == nil &&
++			rule.AbortIncompleteMultipartUpload == nil {
++			rule.Expiration = &s3.LifecycleExpiration{ExpiredObjectDeleteMarker: aws.Bool(false)}
++		}
++
++		rules = append(rules, rule)
++	}
++
++	i := &s3.PutBucketLifecycleConfigurationInput{
++		Bucket: aws.String(bucket),
++		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
++			Rules: rules,
++		},
++	}
++
++	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.PutBucketLifecycleConfiguration(i)
++	})
++	if err != nil {
++		return fmt.Errorf("Error putting S3 lifecycle: %s", err)
++	}
++
++	return nil
++}
++
++func flattenServerSideEncryptionConfigurationLegacy(c *s3.ServerSideEncryptionConfiguration) []map[string]interface{} {
++	var encryptionConfiguration []map[string]interface{}
++	rules := make([]interface{}, 0, len(c.Rules))
++	for _, v := range c.Rules {
++		if v.ApplyServerSideEncryptionByDefault != nil {
++			r := make(map[string]interface{})
++			d := make(map[string]interface{})
++			d["kms_master_key_id"] = aws.StringValue(v.ApplyServerSideEncryptionByDefault.KMSMasterKeyID)
++			d["sse_algorithm"] = aws.StringValue(v.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
++			r["apply_server_side_encryption_by_default"] = []map[string]interface{}{d}
++			r["bucket_key_enabled"] = aws.BoolValue(v.BucketKeyEnabled)
++			rules = append(rules, r)
++		}
++	}
++	encryptionConfiguration = append(encryptionConfiguration, map[string]interface{}{
++		"rule": rules,
++	})
++	return encryptionConfiguration
++}
++
++func flattenBucketReplicationConfigurationLegacy(r *s3.ReplicationConfiguration) []map[string]interface{} {
++	replication_configuration := make([]map[string]interface{}, 0, 1)
++
++	if r == nil {
++		return replication_configuration
++	}
++
++	m := make(map[string]interface{})
++
++	if r.Role != nil && aws.StringValue(r.Role) != "" {
++		m["role"] = aws.StringValue(r.Role)
++	}
++
++	rules := make([]interface{}, 0, len(r.Rules))
++	for _, v := range r.Rules {
++		t := make(map[string]interface{})
++		if v.Destination != nil {
++			rd := make(map[string]interface{})
++			if v.Destination.Bucket != nil {
++				rd["bucket"] = aws.StringValue(v.Destination.Bucket)
++			}
++			if v.Destination.StorageClass != nil {
++				rd["storage_class"] = aws.StringValue(v.Destination.StorageClass)
++			}
++			if v.Destination.ReplicationTime != nil {
++				rtc := map[string]interface{}{
++					"minutes": int(aws.Int64Value(v.Destination.ReplicationTime.Time.Minutes)),
++					"status":  aws.StringValue(v.Destination.ReplicationTime.Status),
++				}
++				rd["replication_time"] = []interface{}{rtc}
++			}
++			if v.Destination.Metrics != nil {
++				metrics := map[string]interface{}{
++					"status": aws.StringValue(v.Destination.Metrics.Status),
++				}
++				if v.Destination.Metrics.EventThreshold != nil {
++					metrics["minutes"] = int(aws.Int64Value(v.Destination.Metrics.EventThreshold.Minutes))
++				}
++				rd["metrics"] = []interface{}{metrics}
++			}
++			if v.Destination.EncryptionConfiguration != nil {
++				if v.Destination.EncryptionConfiguration.ReplicaKmsKeyID != nil {
++					rd["replica_kms_key_id"] = aws.StringValue(v.Destination.EncryptionConfiguration.ReplicaKmsKeyID)
++				}
++			}
++			if v.Destination.Account != nil {
++				rd["account_id"] = aws.StringValue(v.Destination.Account)
++			}
++			if v.Destination.AccessControlTranslation != nil {
++				rdt := map[string]interface{}{
++					"owner": aws.StringValue(v.Destination.AccessControlTranslation.Owner),
++				}
++				rd["access_control_translation"] = []interface{}{rdt}
++			}
++			t["destination"] = []interface{}{rd}
++		}
++
++		if v.ID != nil {
++			t["id"] = aws.StringValue(v.ID)
++		}
++		if v.Prefix != nil {
++			t["prefix"] = aws.StringValue(v.Prefix)
++		}
++		if v.Status != nil {
++			t["status"] = aws.StringValue(v.Status)
++		}
++		if vssc := v.SourceSelectionCriteria; vssc != nil {
++			tssc := make(map[string]interface{})
++			if vssc.SseKmsEncryptedObjects != nil {
++				tSseKms := make(map[string]interface{})
++				if aws.StringValue(vssc.SseKmsEncryptedObjects.Status) == s3.SseKmsEncryptedObjectsStatusEnabled {
++					tSseKms["enabled"] = true
++				} else if aws.StringValue(vssc.SseKmsEncryptedObjects.Status) == s3.SseKmsEncryptedObjectsStatusDisabled {
++					tSseKms["enabled"] = false
++				}
++				tssc["sse_kms_encrypted_objects"] = []interface{}{tSseKms}
++			}
++			t["source_selection_criteria"] = []interface{}{tssc}
++		}
++
++		if v.Priority != nil {
++			t["priority"] = int(aws.Int64Value(v.Priority))
++		}
++
++		if f := v.Filter; f != nil {
++			m := map[string]interface{}{}
++			if f.Prefix != nil {
++				m["prefix"] = aws.StringValue(f.Prefix)
++			}
++			if t := f.Tag; t != nil {
++				m["tags"] = KeyValueTags([]*s3.Tag{t}).IgnoreAWS().Map()
++			}
++			if a := f.And; a != nil {
++				m["prefix"] = aws.StringValue(a.Prefix)
++				m["tags"] = KeyValueTags(a.Tags).IgnoreAWS().Map()
++			}
++			t["filter"] = []interface{}{m}
++
++			if v.DeleteMarkerReplication != nil && v.DeleteMarkerReplication.Status != nil && aws.StringValue(v.DeleteMarkerReplication.Status) == s3.DeleteMarkerReplicationStatusEnabled {
++				t["delete_marker_replication_status"] = aws.StringValue(v.DeleteMarkerReplication.Status)
++			}
++		}
++
++		rules = append(rules, t)
++	}
++	m["rules"] = schema.NewSet(rulesHashLegacy, rules)
++
++	replication_configuration = append(replication_configuration, m)
++
++	return replication_configuration
++}
++
++func normalizeRoutingRulesLegacy(w []*s3.RoutingRule) (string, error) {
++	withNulls, err := json.Marshal(w)
++	if err != nil {
++		return "", err
++	}
++
++	var rules []map[string]interface{}
++	if err := json.Unmarshal(withNulls, &rules); err != nil {
++		return "", err
++	}
++
++	var cleanRules []map[string]interface{}
++	for _, rule := range rules {
++		cleanRules = append(cleanRules, removeNilLegacy(rule))
++	}
++
++	withoutNulls, err := json.Marshal(cleanRules)
++	if err != nil {
++		return "", err
++	}
++
++	return string(withoutNulls), nil
++}
++
++func removeNilLegacy(data map[string]interface{}) map[string]interface{} {
++	withoutNil := make(map[string]interface{})
++
++	for k, v := range data {
++		if v == nil {
++			continue
++		}
++
++		switch v := v.(type) {
++		case map[string]interface{}:
++			withoutNil[k] = removeNilLegacy(v)
++		default:
++			withoutNil[k] = v
++		}
++	}
++
++	return withoutNil
++}
++
++func normalizeRegionLegacy(region string) string {
++	// Default to us-east-1 if the bucket doesn't have a region:
++	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
++	if region == "" {
++		region = endpoints.UsEast1RegionID
++	}
++
++	return region
++}
++
++// ValidBucketName validates any S3 bucket name that is not inside the us-east-1 region.
++// Buckets outside of this region have to be DNS-compliant. After the same restrictions are
++// applied to buckets in the us-east-1 region, this function can be refactored as a SchemaValidateFunc
++func ValidBucketNameLegacy(value string, region string) error {
++	if region != endpoints.UsEast1RegionID {
++		if (len(value) < 3) || (len(value) > 63) {
++			return fmt.Errorf("%q must contain from 3 to 63 characters", value)
++		}
++		if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
++			return fmt.Errorf("only lowercase alphanumeric characters and hyphens allowed in %q", value)
++		}
++		if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
++			return fmt.Errorf("%q must not be formatted as an IP address", value)
++		}
++		if strings.HasPrefix(value, `.`) {
++			return fmt.Errorf("%q cannot start with a period", value)
++		}
++		if strings.HasSuffix(value, `.`) {
++			return fmt.Errorf("%q cannot end with a period", value)
++		}
++		if strings.Contains(value, `..`) {
++			return fmt.Errorf("%q can be only one period between labels", value)
++		}
++	} else {
++		if len(value) > 255 {
++			return fmt.Errorf("%q must contain less than 256 characters", value)
++		}
++		if !regexp.MustCompile(`^[0-9a-zA-Z-._]+$`).MatchString(value) {
++			return fmt.Errorf("only alphanumeric characters, hyphens, periods, and underscores allowed in %q", value)
++		}
++	}
++	return nil
++}
++
++func grantHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["id"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["type"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["uri"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if p, ok := m["permissions"]; ok {
++		buf.WriteString(fmt.Sprintf("%v-", p.(*schema.Set).List()))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func transitionHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["date"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["days"]; ok {
++		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
++	}
++	if v, ok := m["storage_class"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func rulesHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["id"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["prefix"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["status"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["destination"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", destinationHashLegacy(v[0])))
++	}
++	if v, ok := m["source_selection_criteria"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", sourceSelectionCriteriaHashLegacy(v[0])))
++	}
++	if v, ok := m["priority"]; ok {
++		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
++	}
++	if v, ok := m["filter"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", replicationRuleFilterHashLegacy(v[0])))
++
++		if v, ok := m["delete_marker_replication_status"]; ok && v.(string) == s3.DeleteMarkerReplicationStatusEnabled {
++			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++		}
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func replicationRuleFilterHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["prefix"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["tags"]; ok {
++		buf.WriteString(fmt.Sprintf("%d-", tftags.New(context.Background(), v).Hash()))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func destinationHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["bucket"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["storage_class"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["replica_kms_key_id"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["account"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	if v, ok := m["access_control_translation"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", accessControlTranslationHashLegacy(v[0])))
++	}
++	if v, ok := m["replication_time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", replicationTimeHashLegacy(v[0])))
++	}
++	if v, ok := m["metrics"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", metricsHashLegacy(v[0])))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func accessControlTranslationHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["owner"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func metricsHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["minutes"]; ok {
++		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
++	}
++	if v, ok := m["status"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func replicationTimeHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["minutes"]; ok {
++		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
++	}
++	if v, ok := m["status"]; ok {
++		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func sourceSelectionCriteriaHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["sse_kms_encrypted_objects"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
++		buf.WriteString(fmt.Sprintf("%d-", sourceSseKmsObjectsHashLegacy(v[0])))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++func sourceSseKmsObjectsHashLegacy(v interface{}) int {
++	var buf bytes.Buffer
++	m, ok := v.(map[string]interface{})
++
++	if !ok {
++		return 0
++	}
++
++	if v, ok := m["enabled"]; ok {
++		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
++	}
++	return create.StringHashcode(buf.String())
++}
++
++type S3WebsiteLegacy struct {
++	Endpoint, Domain string
++}
++
++//
++// S3 Object Lock functions.
++//
++
++func readS3ObjectLockConfigurationLegacy(conn *s3.S3, bucket string) ([]interface{}, error) {
++	resp, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
++		return conn.GetObjectLockConfiguration(&s3.GetObjectLockConfigurationInput{
++			Bucket: aws.String(bucket),
++		})
++	})
++	if err != nil {
++		// Certain S3 implementations do not include this API
++		if tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") {
++			return nil, nil
++		}
++
++		if tfawserr.ErrMessageContains(err, "ObjectLockConfigurationNotFoundError", "") {
++			return nil, nil
++		}
++		return nil, err
++	}
++
++	return flattenS3ObjectLockConfigurationLegacy(resp.(*s3.GetObjectLockConfigurationOutput).ObjectLockConfiguration), nil
++}
++
++func expandS3ObjectLockConfigurationLegacy(vConf []interface{}) *s3.ObjectLockConfiguration {
++	if len(vConf) == 0 || vConf[0] == nil {
++		return nil
++	}
++
++	mConf := vConf[0].(map[string]interface{})
++
++	conf := &s3.ObjectLockConfiguration{}
++
++	if vObjectLockEnabled, ok := mConf["object_lock_enabled"].(string); ok && vObjectLockEnabled != "" {
++		conf.ObjectLockEnabled = aws.String(vObjectLockEnabled)
++	}
++
++	if vRule, ok := mConf["rule"].([]interface{}); ok && len(vRule) > 0 {
++		mRule := vRule[0].(map[string]interface{})
++
++		if vDefaultRetention, ok := mRule["default_retention"].([]interface{}); ok && len(vDefaultRetention) > 0 && vDefaultRetention[0] != nil {
++			mDefaultRetention := vDefaultRetention[0].(map[string]interface{})
++
++			conf.Rule = &s3.ObjectLockRule{
++				DefaultRetention: &s3.DefaultRetention{},
++			}
++
++			if vMode, ok := mDefaultRetention["mode"].(string); ok && vMode != "" {
++				conf.Rule.DefaultRetention.Mode = aws.String(vMode)
++			}
++			if vDays, ok := mDefaultRetention["days"].(int); ok && vDays > 0 {
++				conf.Rule.DefaultRetention.Days = aws.Int64(int64(vDays))
++			}
++			if vYears, ok := mDefaultRetention["years"].(int); ok && vYears > 0 {
++				conf.Rule.DefaultRetention.Years = aws.Int64(int64(vYears))
++			}
++		}
++	}
++
++	return conf
++}
++
++// Versioning functions
++
++func expandVersioningLegacy(l []interface{}) *s3.VersioningConfiguration {
++	if len(l) == 0 || l[0] == nil {
++		return nil
++	}
++
++	tfMap, ok := l[0].(map[string]interface{})
++
++	if !ok {
++		return nil
++	}
++
++	output := &s3.VersioningConfiguration{}
++
++	if v, ok := tfMap["enabled"].(bool); ok {
++		if v {
++			output.Status = aws.String(s3.BucketVersioningStatusEnabled)
++		} else {
++			output.Status = aws.String(s3.BucketVersioningStatusSuspended)
++		}
++	}
++
++	if v, ok := tfMap["mfa_delete"].(bool); ok {
++		if v {
++			output.MFADelete = aws.String(s3.MFADeleteEnabled)
++		} else {
++			output.MFADelete = aws.String(s3.MFADeleteDisabled)
++		}
++	}
++
++	return output
++}
++
++func expandVersioningWhenIsNewResourceLegacy(l []interface{}) *s3.VersioningConfiguration {
++	if len(l) == 0 || l[0] == nil {
++		return nil
++	}
++
++	tfMap, ok := l[0].(map[string]interface{})
++
++	if !ok {
++		return nil
++	}
++
++	output := &s3.VersioningConfiguration{}
++
++	// Only set and return a non-nil VersioningConfiguration with at least one of
++	// MFADelete or Status enabled as the PutBucketVersioning API request
++	// does not need to be made for new buckets that don't require versioning.
++	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4494
++
++	if v, ok := tfMap["enabled"].(bool); ok && v {
++		output.Status = aws.String(s3.BucketVersioningStatusEnabled)
++	}
++
++	if v, ok := tfMap["mfa_delete"].(bool); ok && v {
++		output.MFADelete = aws.String(s3.MFADeleteEnabled)
++	}
++
++	if output.MFADelete == nil && output.Status == nil {
++		return nil
++	}
++
++	return output
++}
++
++func flattenVersioningLegacy(versioning *s3.GetBucketVersioningOutput) []interface{} {
++	if versioning == nil {
++		return []interface{}{}
++	}
++
++	vc := make(map[string]interface{})
++
++	if aws.StringValue(versioning.Status) == s3.BucketVersioningStatusEnabled {
++		vc["enabled"] = true
++	} else {
++		vc["enabled"] = false
++	}
++
++	if aws.StringValue(versioning.MFADelete) == s3.MFADeleteEnabled {
++		vc["mfa_delete"] = true
++	} else {
++		vc["mfa_delete"] = false
++	}
++
++	return []interface{}{vc}
++}
++
++func flattenS3ObjectLockConfigurationLegacy(conf *s3.ObjectLockConfiguration) []interface{} {
++	if conf == nil {
++		return []interface{}{}
++	}
++
++	mConf := map[string]interface{}{
++		"object_lock_enabled": aws.StringValue(conf.ObjectLockEnabled),
++	}
++
++	if conf.Rule != nil && conf.Rule.DefaultRetention != nil {
++		mRule := map[string]interface{}{
++			"default_retention": []interface{}{
++				map[string]interface{}{
++					"mode":  aws.StringValue(conf.Rule.DefaultRetention.Mode),
++					"days":  int(aws.Int64Value(conf.Rule.DefaultRetention.Days)),
++					"years": int(aws.Int64Value(conf.Rule.DefaultRetention.Years)),
++				},
++			},
++		}
++
++		mConf["rule"] = []interface{}{mRule}
++	}
++
++	return []interface{}{mConf}
++}
++
++func flattenGrantsLegacy(ap *s3.GetBucketAclOutput) []interface{} {
++	//if ACL grants contains bucket owner FULL_CONTROL only - it is default "private" acl
++	if len(ap.Grants) == 1 && aws.StringValue(ap.Grants[0].Grantee.ID) == aws.StringValue(ap.Owner.ID) &&
++		aws.StringValue(ap.Grants[0].Permission) == s3.PermissionFullControl {
++		return nil
++	}
++
++	getGrant := func(grants []interface{}, grantee map[string]interface{}) (interface{}, bool) {
++		for _, pg := range grants {
++			pgt := pg.(map[string]interface{})
++			if pgt["type"] == grantee["type"] && pgt["id"] == grantee["id"] && pgt["uri"] == grantee["uri"] &&
++				pgt["permissions"].(*schema.Set).Len() > 0 {
++				return pg, true
++			}
++		}
++		return nil, false
++	}
++
++	grants := make([]interface{}, 0, len(ap.Grants))
++	for _, granteeObject := range ap.Grants {
++		grantee := make(map[string]interface{})
++		grantee["type"] = aws.StringValue(granteeObject.Grantee.Type)
++
++		if granteeObject.Grantee.ID != nil {
++			grantee["id"] = aws.StringValue(granteeObject.Grantee.ID)
++		}
++		if granteeObject.Grantee.URI != nil {
++			grantee["uri"] = aws.StringValue(granteeObject.Grantee.URI)
++		}
++		if pg, ok := getGrant(grants, grantee); ok {
++			pg.(map[string]interface{})["permissions"].(*schema.Set).Add(aws.StringValue(granteeObject.Permission))
++		} else {
++			grantee["permissions"] = schema.NewSet(schema.HashString, []interface{}{aws.StringValue(granteeObject.Permission)})
++			grants = append(grants, grantee)
++		}
++	}
++
++	return grants
++}
++
++func validBucketLifecycleTimestampLegacy(v interface{}, k string) (ws []string, errors []error) {
++	value := v.(string)
++	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
++	if err != nil {
++		errors = append(errors, fmt.Errorf(
++			"%q cannot be parsed as RFC3339 Timestamp Format", value))
++	}
++
++	return
++}
+diff --git a/internal/service/s3legacy/enum.go b/internal/service/s3legacy/enum.go
+new file mode 100644
+index 0000000000..2e9caaae18
+--- /dev/null
++++ b/internal/service/s3legacy/enum.go
+@@ -0,0 +1,32 @@
++package s3legacy
++
++import (
++	"github.com/aws/aws-sdk-go/service/s3"
++)
++
++const DefaultKmsKeyAlias = "alias/aws/s3"
++
++// These should be defined in the AWS SDK for Go. There is an open issue https://github.com/aws/aws-sdk-go/issues/2683
++const (
++	BucketCannedACLExecRead         = "aws-exec-read"
++	BucketCannedACLLogDeliveryWrite = "log-delivery-write"
++
++	LifecycleRuleStatusEnabled  = "Enabled"
++	LifecycleRuleStatusDisabled = "Disabled"
++)
++
++func BucketCannedACL_Values() []string {
++	result := s3.BucketCannedACL_Values()
++	result = appendUniqueString(result, BucketCannedACLExecRead)
++	result = appendUniqueString(result, BucketCannedACLLogDeliveryWrite)
++	return result
++}
++
++func appendUniqueString(slice []string, elem string) []string {
++	for _, e := range slice {
++		if e == elem {
++			return slice
++		}
++	}
++	return append(slice, elem)
++}
+diff --git a/internal/service/s3legacy/errors.go b/internal/service/s3legacy/errors.go
+new file mode 100644
+index 0000000000..af03bdf5aa
+--- /dev/null
++++ b/internal/service/s3legacy/errors.go
+@@ -0,0 +1,8 @@
++package s3legacy
++
++// Error code constants missing from AWS Go SDK:
++// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#pkg-constants
++
++const (
++	ErrCodeOperationAborted = "OperationAborted"
++)
+diff --git a/internal/service/s3legacy/generate.go b/internal/service/s3legacy/generate.go
+new file mode 100644
+index 0000000000..8e0b62b3da
+--- /dev/null
++++ b/internal/service/s3legacy/generate.go
+@@ -0,0 +1,4 @@
++//go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
++// ONLY generate directives and package declaration! Do not add anything else to this file.
++
++package s3legacy
+diff --git a/internal/service/s3legacy/hosted_zones.go b/internal/service/s3legacy/hosted_zones.go
+new file mode 100644
+index 0000000000..a94403b066
+--- /dev/null
++++ b/internal/service/s3legacy/hosted_zones.go
+@@ -0,0 +1,45 @@
++package s3legacy
++
++import (
++	"fmt"
++
++	"github.com/aws/aws-sdk-go/aws/endpoints"
++)
++
++// See https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints.
++var hostedZoneIDsMap = map[string]string{
++	endpoints.AfSouth1RegionID:     "Z83WF9RJE8B12",
++	endpoints.ApEast1RegionID:      "ZNB98KWMFR0R6",
++	endpoints.ApNortheast1RegionID: "Z2M4EHUR26P7ZW",
++	endpoints.ApNortheast2RegionID: "Z3W03O7B5YMIYP",
++	endpoints.ApNortheast3RegionID: "Z2YQB5RD63NC85",
++	endpoints.ApSouth1RegionID:     "Z11RGJOFQNVJUP",
++	endpoints.ApSoutheast1RegionID: "Z3O0J2DXBE1FTB",
++	endpoints.ApSoutheast2RegionID: "Z1WCIGYICN2BYD",
++	endpoints.ApSoutheast3RegionID: "Z01613992JD795ZI93075",
++	endpoints.CaCentral1RegionID:   "Z1QDHH18159H29",
++	endpoints.CnNorthwest1RegionID: "Z282HJ1KT0DH03",
++	endpoints.EuCentral1RegionID:   "Z21DNDUVLTQW6Q",
++	endpoints.EuNorth1RegionID:     "Z3BAZG2TWCNX0D",
++	endpoints.EuSouth1RegionID:     "Z30OZKI7KPW7MI",
++	endpoints.EuWest1RegionID:      "Z1BKCTXD74EZPE",
++	endpoints.EuWest2RegionID:      "Z3GKZC51ZF0DB4",
++	endpoints.EuWest3RegionID:      "Z3R1K369G5AVDG",
++	endpoints.MeSouth1RegionID:     "Z1MPMWCPA7YB62",
++	endpoints.SaEast1RegionID:      "Z7KQH4QJS55SO",
++	endpoints.UsEast1RegionID:      "Z3AQBSTGFYJSTF",
++	endpoints.UsEast2RegionID:      "Z2O1EMRO9K5GLX",
++	endpoints.UsGovEast1RegionID:   "Z2NIFVYYW2VKV1",
++	endpoints.UsGovWest1RegionID:   "Z31GFT0UA1I2HV",
++	endpoints.UsWest1RegionID:      "Z2F56UZL2M1ACD",
++	endpoints.UsWest2RegionID:      "Z3BJ6K6RIION7M",
++}
++
++// Returns the hosted zone ID for an S3 website endpoint region. This can be
++// used as input to the aws_route53_record resource's zone_id argument.
++func HostedZoneIDForRegion(region string) (string, error) {
++	if v, ok := hostedZoneIDsMap[region]; ok {
++		return v, nil
++	}
++	return "", fmt.Errorf("S3 hosted zone ID not found for region: %s", region)
++}
+diff --git a/internal/service/s3legacy/object.go b/internal/service/s3legacy/object.go
+new file mode 100644
+index 0000000000..f44b435af6
+--- /dev/null
++++ b/internal/service/s3legacy/object.go
+@@ -0,0 +1,177 @@
++package s3legacy
++
++import (
++	"fmt"
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/s3"
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"log"
++)
++
++// DeleteAllObjectVersions deletes all versions of a specified key from an S3 bucket.
++// If key is empty then all versions of all objects are deleted.
++// Set force to true to override any S3 object lock protections on object lock enabled buckets.
++func DeleteAllObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreObjectErrors bool) error {
++	input := &s3.ListObjectVersionsInput{
++		Bucket: aws.String(bucketName),
++	}
++	if key != "" {
++		input.Prefix = aws.String(key)
++	}
++
++	var lastErr error
++	err := conn.ListObjectVersionsPages(input, func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
++		if page == nil {
++			return !lastPage
++		}
++
++		for _, objectVersion := range page.Versions {
++			objectKey := aws.StringValue(objectVersion.Key)
++			objectVersionID := aws.StringValue(objectVersion.VersionId)
++
++			if key != "" && key != objectKey {
++				continue
++			}
++
++			err := deleteS3ObjectVersion(conn, bucketName, objectKey, objectVersionID, force)
++			if tfawserr.ErrMessageContains(err, "AccessDenied", "") && force {
++				// Remove any legal hold.
++				resp, err := conn.HeadObject(&s3.HeadObjectInput{
++					Bucket:    aws.String(bucketName),
++					Key:       objectVersion.Key,
++					VersionId: objectVersion.VersionId,
++				})
++
++				if err != nil {
++					log.Printf("[ERROR] Error getting S3 Bucket (%s) Object (%s) Version (%s) metadata: %s", bucketName, objectKey, objectVersionID, err)
++					lastErr = err
++					continue
++				}
++
++				if aws.StringValue(resp.ObjectLockLegalHoldStatus) == s3.ObjectLockLegalHoldStatusOn {
++					_, err := conn.PutObjectLegalHold(&s3.PutObjectLegalHoldInput{
++						Bucket:    aws.String(bucketName),
++						Key:       objectVersion.Key,
++						VersionId: objectVersion.VersionId,
++						LegalHold: &s3.ObjectLockLegalHold{
++							Status: aws.String(s3.ObjectLockLegalHoldStatusOff),
++						},
++					})
++
++					if err != nil {
++						log.Printf("[ERROR] Error putting S3 Bucket (%s) Object (%s) Version(%s) legal hold: %s", bucketName, objectKey, objectVersionID, err)
++						lastErr = err
++						continue
++					}
++
++					// Attempt to delete again.
++					err = deleteS3ObjectVersion(conn, bucketName, objectKey, objectVersionID, force)
++
++					if err != nil {
++						lastErr = err
++					}
++
++					continue
++				}
++
++				// AccessDenied for another reason.
++				lastErr = fmt.Errorf("AccessDenied deleting S3 Bucket (%s) Object (%s) Version: %s", bucketName, objectKey, objectVersionID)
++				continue
++			}
++
++			if err != nil {
++				lastErr = err
++			}
++		}
++
++		return !lastPage
++	})
++
++	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
++		err = nil
++	}
++
++	if err != nil {
++		return err
++	}
++
++	if lastErr != nil {
++		if !ignoreObjectErrors {
++			return fmt.Errorf("error deleting at least one object version, last error: %s", lastErr)
++		}
++
++		lastErr = nil
++	}
++
++	err = conn.ListObjectVersionsPages(input, func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
++		if page == nil {
++			return !lastPage
++		}
++
++		for _, deleteMarker := range page.DeleteMarkers {
++			deleteMarkerKey := aws.StringValue(deleteMarker.Key)
++			deleteMarkerVersionID := aws.StringValue(deleteMarker.VersionId)
++
++			if key != "" && key != deleteMarkerKey {
++				continue
++			}
++
++			// Delete markers have no object lock protections.
++			err := deleteS3ObjectVersion(conn, bucketName, deleteMarkerKey, deleteMarkerVersionID, false)
++
++			if err != nil {
++				lastErr = err
++			}
++		}
++
++		return !lastPage
++	})
++
++	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
++		err = nil
++	}
++
++	if err != nil {
++		return err
++	}
++
++	if lastErr != nil {
++		if !ignoreObjectErrors {
++			return fmt.Errorf("error deleting at least one object delete marker, last error: %s", lastErr)
++		}
++
++		lastErr = nil
++	}
++
++	return nil
++}
++
++// deleteS3ObjectVersion deletes a specific object version.
++// Set force to true to override any S3 object lock protections.
++func deleteS3ObjectVersion(conn *s3.S3, b, k, v string, force bool) error {
++	input := &s3.DeleteObjectInput{
++		Bucket: aws.String(b),
++		Key:    aws.String(k),
++	}
++
++	if v != "" {
++		input.VersionId = aws.String(v)
++	}
++
++	if force {
++		input.BypassGovernanceRetention = aws.Bool(true)
++	}
++
++	log.Printf("[INFO] Deleting S3 Bucket (%s) Object (%s) Version: %s", b, k, v)
++	_, err := conn.DeleteObject(input)
++
++	if err != nil {
++		log.Printf("[WARN] Error deleting S3 Bucket (%s) Object (%s) Version (%s): %s", b, k, v, err)
++	}
++
++	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") || tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchKey, "") {
++		return nil
++	}
++
++	return err
++}
+diff --git a/internal/service/s3legacy/retry.go b/internal/service/s3legacy/retry.go
+new file mode 100644
+index 0000000000..0dab58b0a3
+--- /dev/null
++++ b/internal/service/s3legacy/retry.go
+@@ -0,0 +1,30 @@
++package s3legacy
++
++import (
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
++	"time"
++)
++
++// FORK: Adding the retryOnAWSCode to the fork for the old AWS S3 Logic
++func retryOnAWSCode(code string, f func() (interface{}, error)) (interface{}, error) {
++	var resp interface{}
++	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
++		var err error
++		resp, err = f()
++		if err != nil {
++			if tfawserr.ErrCodeEquals(err, code) {
++				return resource.RetryableError(err)
++			}
++			return resource.NonRetryableError(err)
++		}
++		return nil
++	})
++
++	if tfresource.TimedOut(err) {
++		resp, err = f()
++	}
++
++	return resp, err
++}
+diff --git a/internal/service/s3legacy/tags.go b/internal/service/s3legacy/tags.go
+new file mode 100644
+index 0000000000..543d41715a
+--- /dev/null
++++ b/internal/service/s3legacy/tags.go
+@@ -0,0 +1,174 @@
++//go:build !generate
++// +build !generate
++
++package s3legacy
++
++import (
++	"context"
++	"fmt"
++	"time"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/aws/awserr"
++	"github.com/aws/aws-sdk-go/service/s3"
++	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
++)
++
++const (
++	ErrCodeNoSuchTagSet = "NoSuchTagSet"
++)
++
++// Custom S3 tag service update functions using the same format as generated code.
++
++// BucketListTags lists S3 bucket tags.
++// The identifier is the bucket name.
++func BucketListTags(conn *s3.S3, identifier string) (tftags.KeyValueTags, error) {
++	input := &s3.GetBucketTaggingInput{
++		Bucket: aws.String(identifier),
++	}
++
++	output, err := conn.GetBucketTagging(input)
++
++	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
++	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
++	// and the AWS Go SDK has neither as a constant.
++	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet) {
++		return tftags.New(context.Background(), nil), nil
++	}
++
++	if err != nil {
++		return tftags.New(context.Background(), nil), err
++	}
++
++	return KeyValueTags(output.TagSet), nil
++}
++
++// BucketUpdateTags updates S3 bucket tags.
++// The identifier is the bucket name.
++func BucketUpdateTags(conn *s3.S3, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
++	oldTags := tftags.New(context.Background(), oldTagsMap)
++	newTags := tftags.New(context.Background(), newTagsMap)
++
++	// We need to also consider any existing ignored tags.
++	allTags, err := BucketListTags(conn, identifier)
++
++	if err != nil {
++		return fmt.Errorf("error listing resource tags (%s): %w", identifier, err)
++	}
++
++	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
++
++	if len(newTags)+len(ignoredTags) > 0 {
++		input := &s3.PutBucketTaggingInput{
++			Bucket: aws.String(identifier),
++			Tagging: &s3.Tagging{
++				TagSet: Tags(newTags.Merge(ignoredTags)),
++			},
++		}
++
++		_, err := conn.PutBucketTagging(input)
++
++		if err != nil {
++			return fmt.Errorf("error setting resource tags (%s): %w", identifier, err)
++		}
++	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
++		input := &s3.DeleteBucketTaggingInput{
++			Bucket: aws.String(identifier),
++		}
++
++		_, err := conn.DeleteBucketTagging(input)
++
++		if err != nil {
++			return fmt.Errorf("error deleting resource tags (%s): %w", identifier, err)
++		}
++	}
++
++	return nil
++}
++
++// ObjectListTags lists S3 object tags.
++func ObjectListTags(conn *s3.S3, bucket, key string) (tftags.KeyValueTags, error) {
++	input := &s3.GetObjectTaggingInput{
++		Bucket: aws.String(bucket),
++		Key:    aws.String(key),
++	}
++
++	var output *s3.GetObjectTaggingOutput
++
++	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
++		var err error
++		output, err = conn.GetObjectTagging(input)
++		if awsErr, ok := err.(awserr.Error); ok {
++			if awsErr.Code() == "NoSuchKey" {
++				return resource.RetryableError(
++					fmt.Errorf("getting object tagging %s, retrying: %w", bucket, err),
++				)
++			}
++		}
++		if err != nil {
++			return resource.NonRetryableError(err)
++		}
++
++		return nil
++	})
++	if tfresource.TimedOut(err) {
++		output, err = conn.GetObjectTagging(input)
++	}
++
++	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet) {
++		return tftags.New(context.Background(), nil), nil
++	}
++
++	if err != nil {
++		return tftags.New(context.Background(), nil), err
++	}
++
++	return KeyValueTags(output.TagSet), nil
++}
++
++// ObjectUpdateTags updates S3 object tags.
++func ObjectUpdateTags(conn *s3.S3, bucket, key string, oldTagsMap interface{}, newTagsMap interface{}) error {
++	oldTags := tftags.New(context.Background(), oldTagsMap)
++	newTags := tftags.New(context.Background(), newTagsMap)
++
++	// We need to also consider any existing ignored tags.
++	allTags, err := ObjectListTags(conn, bucket, key)
++
++	if err != nil {
++		return fmt.Errorf("error listing resource tags (%s/%s): %w", bucket, key, err)
++	}
++
++	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
++
++	if len(newTags)+len(ignoredTags) > 0 {
++		input := &s3.PutObjectTaggingInput{
++			Bucket: aws.String(bucket),
++			Key:    aws.String(key),
++			Tagging: &s3.Tagging{
++				TagSet: Tags(newTags.Merge(ignoredTags).IgnoreAWS()),
++			},
++		}
++
++		_, err := conn.PutObjectTagging(input)
++
++		if err != nil {
++			return fmt.Errorf("error setting resource tags (%s/%s): %w", bucket, key, err)
++		}
++	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
++		input := &s3.DeleteObjectTaggingInput{
++			Bucket: aws.String(bucket),
++			Key:    aws.String(key),
++		}
++
++		_, err := conn.DeleteObjectTagging(input)
++
++		if err != nil {
++			return fmt.Errorf("error deleting resource tags (%s/%s): %w", bucket, key, err)
++		}
++	}
++
++	return nil
++}
+diff --git a/internal/service/s3legacy/tags_gen.go b/internal/service/s3legacy/tags_gen.go
+new file mode 100644
+index 0000000000..c65bacf65d
+--- /dev/null
++++ b/internal/service/s3legacy/tags_gen.go
+@@ -0,0 +1,38 @@
++// Code generated by internal/generate/tags/main.go; DO NOT EDIT.
++package s3legacy
++
++import (
++	"context"
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/s3"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++)
++
++// []*SERVICE.Tag handling
++
++// Tags returns s3 service tags.
++func Tags(tags tftags.KeyValueTags) []*s3.Tag {
++	result := make([]*s3.Tag, 0, len(tags))
++
++	for k, v := range tags.Map() {
++		tag := &s3.Tag{
++			Key:   aws.String(k),
++			Value: aws.String(v),
++		}
++
++		result = append(result, tag)
++	}
++
++	return result
++}
++
++// KeyValueTags creates tftags.KeyValueTags from s3 service tags.
++func KeyValueTags(tags []*s3.Tag) tftags.KeyValueTags {
++	m := make(map[string]*string, len(tags))
++
++	for _, tag := range tags {
++		m[aws.StringValue(tag.Key)] = tag.Value
++	}
++
++	return tftags.New(context.Background(), m)
++}
+diff --git a/internal/service/s3legacy/wait.go b/internal/service/s3legacy/wait.go
+new file mode 100644
+index 0000000000..7a548d8d6d
+--- /dev/null
++++ b/internal/service/s3legacy/wait.go
+@@ -0,0 +1,18 @@
++package s3legacy
++
++import (
++	"context"
++	"time"
++
++	"github.com/aws/aws-sdk-go/service/s3"
++	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
++)
++
++const (
++	bucketCreatedTimeout = 2 * time.Minute
++	propagationTimeout   = 1 * time.Minute
++)
++
++func retryWhenBucketNotFound(f func() (interface{}, error)) (interface{}, error) {
++	return tfresource.RetryWhenAWSErrCodeEquals(context.Background(), propagationTimeout, f, s3.ErrCodeNoSuchBucket)
++}
+diff --git a/website/docs/r/s3_bucket_legacy.html.markdown b/website/docs/r/s3_bucket_legacy.html.markdown
+new file mode 100644
+index 0000000000..529368067d
+--- /dev/null
++++ b/website/docs/r/s3_bucket_legacy.html.markdown
+@@ -0,0 +1,575 @@
++---
++subcategory: "S3"
++layout: "aws"
++page_title: "AWS: aws_s3_bucket"
++description: |-
++Provides a S3 bucket resource.
++---
++
++# Resource: aws_s3_bucket
++
++Provides a S3 bucket resource.
++
++-> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the `aws_s3control_bucket` resource.
++
++## Example Usage
++
++### Private Bucket w/ Tags
++
++```terraform
++resource "aws_s3_bucket_legacy" "b" {
++  bucket = "my-tf-test-bucket"
++  acl    = "private"
++
++  tags = {
++    Name        = "My bucket"
++    Environment = "Dev"
++  }
++}
++```
++
++### Static Website Hosting
++
++```terraform
++resource "aws_s3_bucket_legacy" "b" {
++  bucket = "s3-website-test.mydomain.com"
++  acl    = "public-read"
++  policy = file("policy.json")
++
++  website {
++    index_document = "index.html"
++    error_document = "error.html"
++
++    routing_rules = <<EOF
++[{
++    "Condition": {
++        "KeyPrefixEquals": "docs/"
++    },
++    "Redirect": {
++        "ReplaceKeyPrefixWith": "documents/"
++    }
++}]
++EOF
++  }
++}
++```
++
++### Using CORS
++
++```terraform
++resource "aws_s3_bucket_legacy" "b" {
++  bucket = "s3-website-test.mydomain.com"
++  acl    = "public-read"
++
++  cors_rule {
++    allowed_headers = ["*"]
++    allowed_methods = ["PUT", "POST"]
++    allowed_origins = ["https://s3-website-test.mydomain.com"]
++    expose_headers  = ["ETag"]
++    max_age_seconds = 3000
++  }
++}
++```
++
++### Using versioning
++
++```terraform
++resource "aws_s3_bucket_legacy" "b" {
++  bucket = "my-tf-test-bucket"
++  acl    = "private"
++
++  versioning {
++    enabled = true
++  }
++}
++```
++
++### Enable Logging
++
++```terraform
++resource "aws_s3_bucket_legacy" "log_bucket" {
++  bucket = "my-tf-log-bucket"
++  acl    = "log-delivery-write"
++}
++
++resource "aws_s3_bucket_legacy" "b" {
++  bucket = "my-tf-test-bucket"
++  acl    = "private"
++
++  logging {
++    target_bucket = aws_s3_bucket_legacy.log_bucket.id
++    target_prefix = "log/"
++  }
++}
++```
++
++### Using object lifecycle
++
++```terraform
++resource "aws_s3_bucket_legacy" "bucket" {
++  bucket = "my-bucket"
++  acl    = "private"
++
++  lifecycle_rule {
++    id      = "log"
++    enabled = true
++
++    prefix = "log/"
++
++    tags = {
++      rule      = "log"
++      autoclean = "true"
++    }
++
++    transition {
++      days          = 30
++      storage_class = "STANDARD_IA" # or "ONEZONE_IA"
++    }
++
++    transition {
++      days          = 60
++      storage_class = "GLACIER"
++    }
++
++    expiration {
++      days = 90
++    }
++  }
++
++  lifecycle_rule {
++    id      = "tmp"
++    prefix  = "tmp/"
++    enabled = true
++
++    expiration {
++      date = "2016-01-12"
++    }
++  }
++}
++
++resource "aws_s3_bucket_legacy" "versioning_bucket" {
++  bucket = "my-versioning-bucket"
++  acl    = "private"
++
++  versioning {
++    enabled = true
++  }
++
++  lifecycle_rule {
++    prefix  = "config/"
++    enabled = true
++
++    noncurrent_version_transition {
++      days          = 30
++      storage_class = "STANDARD_IA"
++    }
++
++    noncurrent_version_transition {
++      days          = 60
++      storage_class = "GLACIER"
++    }
++
++    noncurrent_version_expiration {
++      days = 90
++    }
++  }
++}
++```
++
++### Using replication configuration
++
++~> **NOTE:** See the `aws_s3_bucket_replication_configuration` resource to support bi-directional replication configuration and additional features.
++
++```terraform
++provider "aws" {
++  region = "eu-west-1"
++}
++
++provider "aws" {
++  alias  = "central"
++  region = "eu-central-1"
++}
++
++resource "aws_iam_role" "replication" {
++  name = "tf-iam-role-replication-12345"
++
++  assume_role_policy = <<POLICY
++{
++  "Version": "2012-10-17",
++  "Statement": [
++    {
++      "Action": "sts:AssumeRole",
++      "Principal": {
++        "Service": "s3.amazonaws.com"
++      },
++      "Effect": "Allow",
++      "Sid": ""
++    }
++  ]
++}
++POLICY
++}
++
++resource "aws_iam_policy" "replication" {
++  name = "tf-iam-role-policy-replication-12345"
++
++  policy = <<POLICY
++{
++  "Version": "2012-10-17",
++  "Statement": [
++    {
++      "Action": [
++        "s3:GetReplicationConfiguration",
++        "s3:ListBucket"
++      ],
++      "Effect": "Allow",
++      "Resource": [
++        "${aws_s3_bucket_legacy.source.arn}"
++      ]
++    },
++    {
++      "Action": [
++        "s3:GetObjectVersionForReplication",
++        "s3:GetObjectVersionAcl",
++         "s3:GetObjectVersionTagging"
++      ],
++      "Effect": "Allow",
++      "Resource": [
++        "${aws_s3_bucket_legacy.source.arn}/*"
++      ]
++    },
++    {
++      "Action": [
++        "s3:ReplicateObject",
++        "s3:ReplicateDelete",
++        "s3:ReplicateTags"
++      ],
++      "Effect": "Allow",
++      "Resource": "${aws_s3_bucket_legacy.destination.arn}/*"
++    }
++  ]
++}
++POLICY
++}
++
++resource "aws_iam_role_policy_attachment" "replication" {
++  role       = aws_iam_role.replication.name
++  policy_arn = aws_iam_policy.replication.arn
++}
++
++resource "aws_s3_bucket_legacy" "destination" {
++  bucket = "tf-test-bucket-destination-12345"
++
++  versioning {
++    enabled = true
++  }
++}
++
++resource "aws_s3_bucket_legacy" "source" {
++  provider = aws.central
++  bucket   = "tf-test-bucket-source-12345"
++  acl      = "private"
++
++  versioning {
++    enabled = true
++  }
++
++  replication_configuration {
++    role = aws_iam_role.replication.arn
++
++    rules {
++      id     = "foobar"
++      status = "Enabled"
++
++      filter {
++        tags = {}
++      }
++      destination {
++        bucket        = aws_s3_bucket_legacy.destination.arn
++        storage_class = "STANDARD"
++
++        replication_time {
++          status  = "Enabled"
++          minutes = 15
++        }
++
++        metrics {
++          status  = "Enabled"
++          minutes = 15
++        }
++      }
++    }
++  }
++}
++```
++
++### Enable Default Server Side Encryption
++
++```terraform
++resource "aws_kms_key" "mykey" {
++  description             = "This key is used to encrypt bucket objects"
++  deletion_window_in_days = 10
++}
++
++resource "aws_s3_bucket_legacy" "mybucket" {
++  bucket = "mybucket"
++
++  server_side_encryption_configuration {
++    rule {
++      apply_server_side_encryption_by_default {
++        kms_master_key_id = aws_kms_key.mykey.arn
++        sse_algorithm     = "aws:kms"
++      }
++    }
++  }
++}
++```
++
++### Using ACL policy grants
++
++```terraform
++data "aws_canonical_user_id" "current_user" {}
++
++resource "aws_s3_bucket_legacy" "bucket" {
++  bucket = "mybucket"
++
++  grant {
++    id          = data.aws_canonical_user_id.current_user.id
++    type        = "CanonicalUser"
++    permissions = ["FULL_CONTROL"]
++  }
++
++  grant {
++    type        = "Group"
++    permissions = ["READ_ACP", "WRITE"]
++    uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
++  }
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
++* `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
++* `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
++* `grant` - (Optional) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
++* `policy` - (Optional) A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
++
++* `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
++* `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
++* `website` - (Optional) A website object (documented below).
++* `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
++* `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
++* `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
++* `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
++* `acceleration_status` - (Optional) Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
++* `request_payer` - (Optional) Specifies who should bear the cost of Amazon S3 data transfer.
++  Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
++  the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
++  developer guide for more information.
++* `replication_configuration` - (Optional) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
++* `server_side_encryption_configuration` - (Optional) A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
++* `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
++
++~> **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
++
++The `website` object supports the following:
++
++* `index_document` - (Required, unless using `redirect_all_requests_to`) Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
++* `error_document` - (Optional) An absolute path to the document to return in case of a 4XX error.
++* `redirect_all_requests_to` - (Optional) A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
++* `routing_rules` - (Optional) A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
++  describing redirect behavior and when redirects are applied.
++
++The `CORS` object supports the following:
++
++* `allowed_headers` (Optional) Specifies which headers are allowed.
++* `allowed_methods` (Required) Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
++* `allowed_origins` (Required) Specifies which origins are allowed.
++* `expose_headers` (Optional) Specifies expose header in the response.
++* `max_age_seconds` (Optional) Specifies time in seconds that browser can cache the response for a preflight request.
++
++The `versioning` object supports the following:
++
++* `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
++* `mfa_delete` - (Optional) Enable MFA delete for either `Change the versioning state of your bucket` or `Permanently delete an object version`. Default is `false`. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS
++
++The `logging` object supports the following:
++
++* `target_bucket` - (Required) The name of the bucket that will receive the log objects.
++* `target_prefix` - (Optional) To specify a key prefix for log objects.
++
++The `lifecycle_rule` object supports the following:
++
++* `id` - (Optional) Unique identifier for the rule. Must be less than or equal to 255 characters in length.
++* `prefix` - (Optional) Object key prefix identifying one or more objects to which the rule applies.
++* `tags` - (Optional) Specifies object tags key and value.
++* `enabled` - (Required) Specifies lifecycle rule status.
++* `abort_incomplete_multipart_upload_days` (Optional) Specifies the number of days after initiating a multipart upload when the multipart upload must be completed.
++* `expiration` - (Optional) Specifies a period in the object's expire (documented below).
++* `transition` - (Optional) Specifies a period in the object's transitions (documented below).
++* `noncurrent_version_expiration` - (Optional) Specifies when noncurrent object versions expire (documented below).
++* `noncurrent_version_transition` - (Optional) Specifies when noncurrent object versions transitions (documented below).
++
++At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
++
++The `expiration` object supports the following
++
++* `date` (Optional) Specifies the date after which you want the corresponding action to take effect.
++* `days` (Optional) Specifies the number of days after object creation when the specific rule action takes effect.
++* `expired_object_delete_marker` (Optional) On a versioned bucket (versioning-enabled or versioning-suspended bucket), you can add this element in the lifecycle configuration to direct Amazon S3 to delete expired object delete markers. This cannot be specified with Days or Date in a Lifecycle Expiration Policy.
++
++The `transition` object supports the following
++
++* `date` (Optional) Specifies the date after which you want the corresponding action to take effect.
++* `days` (Optional) Specifies the number of days after object creation when the specific rule action takes effect.
++* `storage_class` (Required) Specifies the Amazon S3 [storage class](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Transition.html#AmazonS3-Type-Transition-StorageClass) to which you want the object to transition.
++
++The `noncurrent_version_expiration` object supports the following
++
++* `days` (Required) Specifies the number of days noncurrent object versions expire.
++
++The `noncurrent_version_transition` object supports the following
++
++* `days` (Required) Specifies the number of days noncurrent object versions transition.
++* `storage_class` (Required) Specifies the Amazon S3 [storage class](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Transition.html#AmazonS3-Type-Transition-StorageClass) to which you want the object to transition.
++
++The `replication_configuration` object supports the following:
++
++~> **NOTE:** See the `aws_s3_bucket_replication_configuration` resource documentation to avoid conflicts. Replication configuration can only be defined in one resource not both.  When using the independent replication configuration resource the following lifecycle rule is needed on the `aws_s3_bucket_legacy` resource.
++
++```
++lifecycle {
++  ignore_changes = [
++    replication_configuration
++  ]
++}
++```
++
++* `role` - (Required) The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
++* `rules` - (Required) Specifies the rules managing the replication (documented below).
++
++The `rules` object supports the following:
++
++~> **NOTE:** Amazon S3's latest version of the replication configuration is V2, which includes the `filter` attribute for replication rules.
++With the `filter` attribute, you can specify object filters based on the object key prefix, tags, or both to scope the objects that the rule applies to.
++Replication configuration V1 supports filtering based on only the `prefix` attribute. For backwards compatibility, Amazon S3 continues to support the V1 configuration.
++
++* `delete_marker_replication_status` - (Optional) Whether delete markers are replicated. The only valid value is `Enabled`. To disable, omit this argument. This argument is only valid with V2 replication configurations (i.e., when `filter` is used).
++* `destination` - (Required) Specifies the destination for the rule (documented below).
++* `filter` - (Optional, Conflicts with `prefix`) Filter that identifies subset of objects to which the replication rule applies (documented below).
++* `id` - (Optional) Unique identifier for the rule. Must be less than or equal to 255 characters in length.
++* `prefix` - (Optional, Conflicts with `filter`) Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
++* `priority` - (Optional) The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
++* `source_selection_criteria` - (Optional) Specifies special object selection criteria (documented below).
++* `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
++
++~> **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
++
++The `destination` object supports the following:
++
++* `bucket` - (Required) The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
++* `storage_class` - (Optional) The [storage class](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Destination.html#AmazonS3-Type-Destination-StorageClass) used to store the object. By default, Amazon S3 uses the storage class of the source object to create the object replica.
++* `replica_kms_key_id` - (Optional) Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
++  `sse_kms_encrypted_objects` source selection criteria.
++* `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
++* `account_id` - (Optional) The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
++* `replication_time` - (Optional) Enables S3 Replication Time Control (S3 RTC) (documented below).
++* `metrics` - (Optional) Enables replication metrics (required for S3 RTC) (documented below).
++
++The `replication_time` object supports the following:
++
++* `status` - (Optional) The status of RTC. Either `Enabled` or `Disabled`.
++* `minutes` - (Optional) Threshold within which objects are to be replicated. The only valid value is `15`.
++
++The `metrics` object supports the following:
++
++* `status` - (Optional) The status of replication metrics. Either `Enabled` or `Disabled`.
++* `minutes` - (Optional) Threshold within which objects are to be replicated. The only valid value is `15`.
++
++The `source_selection_criteria` object supports the following:
++
++* `sse_kms_encrypted_objects` - (Optional) Match SSE-KMS encrypted objects (documented below). If specified, `replica_kms_key_id`
++  in `destination` must be specified as well.
++
++The `sse_kms_encrypted_objects` object supports the following:
++
++* `enabled` - (Required) Boolean which indicates if this criteria is enabled.
++
++The `filter` object supports the following:
++
++* `prefix` - (Optional) Object keyname prefix that identifies subset of objects to which the rule applies. Must be less than or equal to 1024 characters in length.
++* `tags` - (Optional)  A map of tags that identifies subset of objects to which the rule applies.
++  The rule applies only to objects having all the tags in its tagset.
++
++The `server_side_encryption_configuration` object supports the following:
++
++* `rule` - (required) A single object for server-side encryption by default configuration. (documented below)
++
++The `rule` object supports the following:
++
++* `apply_server_side_encryption_by_default` - (required) A single object for setting server-side encryption by default. (documented below)
++* `bucket_key_enabled` - (Optional) Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
++
++The `apply_server_side_encryption_by_default` object supports the following:
++
++* `sse_algorithm` - (required) The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
++* `kms_master_key_id` - (optional) The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
++
++The `grant` object supports the following:
++
++* `id` - (optional) Canonical user id to grant for. Used only when `type` is `CanonicalUser`.
++* `type` - (required) - Type of grantee to apply for. Valid values are `CanonicalUser` and `Group`. `AmazonCustomerByEmail` is not supported.
++* `permissions` - (required) List of permissions to apply for grantee. Valid values are `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_CONTROL`.
++* `uri` - (optional) Uri address to grant for. Used only when `type` is `Group`.
++
++The `access_control_translation` object supports the following:
++
++* `owner` - (Required) The override value for the owner on replicated objects. Currently only `Destination` is supported.
++
++The `object_lock_configuration` object supports the following:
++
++* `object_lock_enabled` - (Required) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
++* `rule` - (Optional) The Object Lock rule in place for this bucket.
++
++The `rule` object supports the following:
++
++* `default_retention` - (Required) The default retention period that you want to apply to new objects placed in this bucket.
++
++The `default_retention` object supports the following:
++
++* `mode` - (Required) The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
++* `days` - (Optional) The number of days that you want to specify for the default retention period.
++* `years` - (Optional) The number of years that you want to specify for the default retention period.
++
++Either `days` or `years` must be specified, but not both.
++
++~> **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
++When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
++Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
++
++## Attributes Reference
++
++In addition to all arguments above, the following attributes are exported:
++
++* `id` - The name of the bucket.
++* `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
++* `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
++* `bucket_regional_domain_name` - The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
++* `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
++* `region` - The AWS region this bucket resides in.
++* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
++* `website_endpoint` - The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
++* `website_domain` - The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
++
++## Import
++
++S3 bucket can be imported using the `bucket`, e.g.,
++
++```
++$ terraform import aws_s3_bucket_legacy.bucket bucket-name
++```
++
++The `policy` argument is not imported and will be deprecated in a future version of the provider. Use the `aws_s3_bucket_policy` resource to manage the S3 Bucket Policy instead.

--- a/upstream-patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
+++ b/upstream-patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
@@ -1,0 +1,27 @@
+From 3a0c5490b2cb0bf2f84f74e0b14132390a800abf Mon Sep 17 00:00:00 2001
+From: Kyle Pitzen <kpitzen@pulumi.com>
+Date: Thu, 9 Mar 2023 09:47:49 -0600
+Subject: [PATCH 04/25] Marks SSE Configuration as Computed for Legacy S3
+ Bucket
+
+In January, AWS enabled SSE by default for all new S3 buckets.
+Since we maintain a forked version of the legacy S3 bucket resource,
+this change was not properly propagated to the legacy S3 bucket, which
+appears in pulumi as `aws.s3.Bucket` and is likely the default version of
+the Bucket resource that users will use.
+---
+ internal/service/s3legacy/bucket_legacy.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go
+index 27fe651a83..8879116578 100644
+--- a/internal/service/s3legacy/bucket_legacy.go
++++ b/internal/service/s3legacy/bucket_legacy.go
+@@ -571,6 +571,7 @@ func ResourceBucketLegacy() *schema.Resource {
+ 				Type:     schema.TypeList,
+ 				MaxItems: 1,
+ 				Optional: true,
++				Computed: true,
+ 				Elem: &schema.Resource{
+ 					Schema: map[string]*schema.Schema{
+ 						"rule": {

--- a/upstream-patches/0005-De-deprecate-bucket_object.patch
+++ b/upstream-patches/0005-De-deprecate-bucket_object.patch
@@ -1,0 +1,31 @@
+From b781e3a5e05333c7ebb3fb123b9b1edaa206eead Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:06:11 +0000
+Subject: [PATCH 05/25] De-deprecate bucket_object
+
+---
+ internal/service/s3/bucket_object.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/internal/service/s3/bucket_object.go b/internal/service/s3/bucket_object.go
+index f090923769..24aaf50f17 100644
+--- a/internal/service/s3/bucket_object.go
++++ b/internal/service/s3/bucket_object.go
+@@ -61,7 +61,7 @@ func ResourceBucketObject() *schema.Resource {
+ 				ValidateFunc: validation.StringInSlice(s3.ObjectCannedACL_Values(), false),
+ 			},
+ 			"bucket": {
+-				Deprecated:   "Use the aws_s3_object resource instead",
++				// FORK: Stack72 removed the deprecation warning as it was misleading for Pulumi users
+ 				Type:         schema.TypeString,
+ 				Required:     true,
+ 				ForceNew:     true,
+@@ -118,7 +118,7 @@ func ResourceBucketObject() *schema.Resource {
+ 				Default:  false,
+ 			},
+ 			"key": {
+-				Deprecated:   "Use the aws_s3_object resource instead",
++				// FORK: Stack72 removed the deprecation warning as it was misleading for Pulumi users
+ 				Type:         schema.TypeString,
+ 				Required:     true,
+ 				ForceNew:     true,

--- a/upstream-patches/0006-Remove-lakeformation-catalog_resource-default.patch
+++ b/upstream-patches/0006-Remove-lakeformation-catalog_resource-default.patch
@@ -1,0 +1,24 @@
+From e92fb6cefbe322ddea8f3db53b772bdb40e649d8 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:08:23 +0000
+Subject: [PATCH 06/25] Remove lakeformation catalog_resource default
+
+---
+ internal/service/lakeformation/permissions.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/internal/service/lakeformation/permissions.go b/internal/service/lakeformation/permissions.go
+index 9a2a3ab063..f518aa840c 100644
+--- a/internal/service/lakeformation/permissions.go
++++ b/internal/service/lakeformation/permissions.go
+@@ -37,8 +37,8 @@ func ResourcePermissions() *schema.Resource {
+ 				ValidateFunc: verify.ValidAccountID,
+ 			},
+ 			"catalog_resource": {
+-				Type:     schema.TypeBool,
+-				Default:  false,
++				Type: schema.TypeBool,
++				//Default:  false,
+ 				ForceNew: true,
+ 				Optional: true,
+ 				ExactlyOneOf: []string{

--- a/upstream-patches/0007-Check-for-changes-in-ACM-certificate-private_key.patch
+++ b/upstream-patches/0007-Check-for-changes-in-ACM-certificate-private_key.patch
@@ -1,0 +1,25 @@
+From 6998a8199b36f41736f6c635db9caa45bede70a9 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:21:30 +0000
+Subject: [PATCH 07/25] Check for changes in ACM certificate private_key
+
+---
+ internal/service/acm/certificate.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/internal/service/acm/certificate.go b/internal/service/acm/certificate.go
+index c793abb685..3b6d167f46 100644
+--- a/internal/service/acm/certificate.go
++++ b/internal/service/acm/certificate.go
+@@ -152,7 +152,10 @@ func ResourceCertificate() *schema.Resource {
+ 					},
+ 				},
+ 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+-					if _, ok := d.GetOk("private_key"); ok {
++					// getOk is not sufficient alone if the private key has changed - we need to check
++					// whether there is a change in addition, else we do not suppress the diff for imported
++					// certificates.
++					if _, ok := d.GetOk("private_key"); ok || d.HasChange("private_key") {
+ 						// ignore diffs for imported certs; they have a different logging preference
+ 						// default to requested certs which can't be changed by the ImportCertificate API
+ 						return true

--- a/upstream-patches/0008-Workaround-SSM-Parameter-tier-bug.patch
+++ b/upstream-patches/0008-Workaround-SSM-Parameter-tier-bug.patch
@@ -1,0 +1,58 @@
+From 5c37a409d1e54bfdf09026b50e8d74366262325a Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:24:42 +0000
+Subject: [PATCH 08/25] Workaround SSM Parameter tier bug
+
+- Disable "computed".
+- Disable diff suppression & counteractions
+---
+ internal/service/ssm/parameter.go | 26 +++++++++++++++-----------
+ 1 file changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/internal/service/ssm/parameter.go b/internal/service/ssm/parameter.go
+index 6fdc42cfe5..2c57756e4a 100644
+--- a/internal/service/ssm/parameter.go
++++ b/internal/service/ssm/parameter.go
+@@ -87,15 +87,17 @@ func ResourceParameter() *schema.Resource {
+ 			"tags":     tftags.TagsSchema(),
+ 			"tags_all": tftags.TagsSchemaComputed(),
+ 			"tier": {
+-				Type:         schema.TypeString,
+-				Optional:     true,
+-				Computed:     true,
++				Type:     schema.TypeString,
++				Optional: true,
++				//Computed:     true,
++				Default:      ssm.ParameterTierStandard,
+ 				ValidateFunc: validation.StringInSlice(ssm.ParameterTier_Values(), false),
+ 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+-					if old != "" {
+-						return new == ssm.ParameterTierIntelligentTiering
+-					}
+-					return false
++					return d.Get("tier").(string) == ssm.ParameterTierIntelligentTiering
++					//if old != "" {
++					//	return new == ssm.ParameterTierIntelligentTiering
++					//}
++					//return false
+ 				},
+ 			},
+ 			"type": {
+@@ -335,11 +337,13 @@ func resourceParameterUpdate(ctx context.Context, d *schema.ResourceData, meta i
+ 			AllowedPattern: aws.String(d.Get("allowed_pattern").(string)),
+ 		}
+ 
++		// FORK: Stack72 to undo this Tier comment out below when associated bridge issue is solved
++
+ 		// Retrieve the value set in the config directly to counteract the DiffSuppressFunc above
+-		tier := d.GetRawConfig().GetAttr("tier")
+-		if tier.IsKnown() && !tier.IsNull() {
+-			paramInput.Tier = aws.String(tier.AsString())
+-		}
++		//tier := d.GetRawConfig().GetAttr("tier")
++		//if tier.IsKnown() && !tier.IsNull() {
++		//	paramInput.Tier = aws.String(tier.AsString())
++		//}
+ 
+ 		if d.HasChange("data_type") {
+ 			paramInput.DataType = aws.String(d.Get("data_type").(string))

--- a/upstream-patches/0009-Add-EKS-cluster-default_addons_to_remove.patch
+++ b/upstream-patches/0009-Add-EKS-cluster-default_addons_to_remove.patch
@@ -1,0 +1,269 @@
+From a115bd2c8a4f0c809ced918dd81fc8261c881283 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:31:27 +0000
+Subject: [PATCH 09/25] Add EKS cluster default_addons_to_remove
+
+---
+ internal/service/eks/cluster.go               |   7 +
+ internal/service/eks/cluster_addon_removal.go | 128 ++++++++++++++++++
+ .../service/eks/cluster_addon_removal_test.go |  83 ++++++++++++
+ internal/service/eks/wait.go                  |   3 +
+ 4 files changed, 221 insertions(+)
+ create mode 100644 internal/service/eks/cluster_addon_removal.go
+ create mode 100644 internal/service/eks/cluster_addon_removal_test.go
+
+diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go
+index 658f3e4cae..9eb3f74d7c 100644
+--- a/internal/service/eks/cluster.go
++++ b/internal/service/eks/cluster.go
+@@ -72,6 +72,13 @@ func ResourceCluster() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Computed: true,
+ 			},
++			"default_addons_to_remove": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Elem: &schema.Schema{
++					Type: schema.TypeString,
++				},
++			},
+ 			"enabled_cluster_log_types": {
+ 				Type:     schema.TypeSet,
+ 				Optional: true,
+diff --git a/internal/service/eks/cluster_addon_removal.go b/internal/service/eks/cluster_addon_removal.go
+new file mode 100644
+index 0000000000..faa4fb9c6a
+--- /dev/null
++++ b/internal/service/eks/cluster_addon_removal.go
+@@ -0,0 +1,128 @@
++package eks
++
++import (
++	"context"
++	"fmt"
++	"log"
++	"sync"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/eks"
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/hashicorp/go-multierror"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++
++	"github.com/hashicorp/terraform-provider-aws/internal/flex"
++	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
++)
++
++func removeAddons(d *schema.ResourceData, conn *eks.EKS) error {
++	if v, ok := d.GetOk("default_addons_to_remove"); ok && len(v.([]interface{})) > 0 {
++		ctx := context.Background()
++		var wg sync.WaitGroup
++		var removalErrors *multierror.Error
++
++		for _, addon := range flex.ExpandStringList(v.([]interface{})) {
++			if addon == nil {
++				return fmt.Errorf("addonName cannot be dereferenced")
++			}
++			addonName := *addon
++			wg.Add(1)
++
++			go func() {
++				defer wg.Done()
++				removalErrors = multierror.Append(removalErrors, removeAddon(d, conn, addonName, ctx))
++			}()
++		}
++		wg.Wait()
++		return removalErrors.ErrorOrNil()
++	}
++	return nil
++}
++
++func removeAddon(d *schema.ResourceData, conn *eks.EKS, addonName string, ctx context.Context) error {
++	log.Printf("[DEBUG] Creating EKS Add-On: %s", addonName)
++	createAddonInput := &eks.CreateAddonInput{
++		AddonName:          aws.String(addonName),
++		ClientRequestToken: aws.String(resource.UniqueId()),
++		ClusterName:        aws.String(d.Id()),
++		ResolveConflicts:   aws.String(eks.ResolveConflictsOverwrite),
++	}
++
++	err := resource.RetryContext(ctx, propagationTimeout, func() *resource.RetryError {
++		_, err := conn.CreateAddonWithContext(ctx, createAddonInput)
++
++		if tfawserr.ErrMessageContains(err, eks.ErrCodeInvalidParameterException, "CREATE_FAILED") {
++			return resource.RetryableError(err)
++		}
++
++		if tfawserr.ErrMessageContains(err, eks.ErrCodeInvalidParameterException, "does not exist") {
++			return resource.RetryableError(err)
++		}
++
++		if err != nil {
++			return resource.NonRetryableError(err)
++		}
++
++		return nil
++	})
++
++	if tfresource.TimedOut(err) {
++		_, err = conn.CreateAddonWithContext(ctx, createAddonInput)
++	}
++
++	if err != nil {
++		return fmt.Errorf("error creating EKS Add-On (%s): %w", addonName, err)
++	}
++
++	_, err = waitAddonCreatedAllowDegraded(ctx, conn, d.Id(), addonName)
++
++	if err != nil {
++		return fmt.Errorf("unexpected EKS Add-On (%s) state returned during creation: %w", addonName, err)
++	}
++	log.Printf("[DEBUG] Created EKS Add-On: %s", addonName)
++
++	deleteAddonInput := &eks.DeleteAddonInput{
++		AddonName:   aws.String(addonName),
++		ClusterName: aws.String(d.Id()),
++	}
++
++	log.Printf("[DEBUG] Deleting EKS Add-On: %s", addonName)
++	_, err = conn.DeleteAddonWithContext(ctx, deleteAddonInput)
++
++	if err != nil {
++		return fmt.Errorf("error deleting EKS Add-On (%s): %w", addonName, err)
++	}
++
++	_, err = waitAddonDeleted(ctx, conn, d.Id(), addonName, addonDeletedTimeout)
++
++	if err != nil {
++		return fmt.Errorf("error waiting for EKS Add-On (%s) to delete: %w", addonName, err)
++	}
++	log.Printf("[DEBUG] Deleted EKS Add-On: %s", addonName)
++	return nil
++}
++
++func waitAddonCreatedAllowDegraded(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
++	// We do not care about the addons actually being created successfully here. We only want them to be adopted by
++	// Terraform to be able to fully remove them afterwards again.
++	stateConf := resource.StateChangeConf{
++		Pending: []string{eks.AddonStatusCreating},
++		Target:  []string{eks.AddonStatusActive, eks.AddonStatusDegraded},
++		Refresh: statusAddon(ctx, conn, clusterName, addonName),
++		Timeout: addonCreatedTimeout,
++	}
++
++	outputRaw, err := stateConf.WaitForStateContext(ctx)
++
++	if output, ok := outputRaw.(*eks.Addon); ok {
++		if status, health := aws.StringValue(output.Status), output.Health; status == eks.AddonStatusCreateFailed && health != nil {
++			tfresource.SetLastError(err, AddonIssuesError(health.Issues))
++		}
++
++		return output, err
++	}
++
++	return nil, err
++}
+diff --git a/internal/service/eks/cluster_addon_removal_test.go b/internal/service/eks/cluster_addon_removal_test.go
+new file mode 100644
+index 0000000000..7ec8d0303e
+--- /dev/null
++++ b/internal/service/eks/cluster_addon_removal_test.go
+@@ -0,0 +1,83 @@
++package eks_test
++
++import (
++	"context"
++	"fmt"
++	"testing"
++
++	"github.com/aws/aws-sdk-go/service/eks"
++	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
++
++	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tfeks "github.com/hashicorp/terraform-provider-aws/internal/service/eks"
++)
++
++func TestAccEKSCluster_Addons_remove(t *testing.T) {
++	var cluster eks.Cluster
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_eks_cluster.test"
++
++	resource.ParallelTest(t, resource.TestCase{
++		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
++		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
++		ProviderFactories: acctest.ProviderFactories,
++		CheckDestroy:      testAccCheckClusterDestroy,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccClusterConfig_addons(rName),
++				Check: resource.ComposeTestCheckFunc(
++					testAccCheckClusterExists(resourceName, &cluster),
++					testAccCheckAddonNotExists(resourceName, "kube-proxy"),
++					testAccCheckAddonNotExists(resourceName, "coredns"),
++					testAccCheckAddonNotExists(resourceName, "vpc-cni"),
++				),
++			},
++		},
++	})
++}
++
++func testAccClusterConfig_addons(rName string) string {
++	return acctest.ConfigCompose(testAccClusterConfig_Base(rName), fmt.Sprintf(`
++
++resource "aws_eks_cluster" "test" {
++  name     = %[1]q
++  role_arn = aws_iam_role.test.arn
++
++  vpc_config {
++    subnet_ids = aws_subnet.test[*].id
++  }
++
++  default_addons_to_remove = ["kube-proxy", "coredns", "vpc-cni"]
++
++}
++`, rName))
++}
++
++func testAccCheckAddonNotExists(resourceName, addonName string) resource.TestCheckFunc {
++	return func(s *terraform.State) error {
++		rs, ok := s.RootModule().Resources[resourceName]
++		if !ok {
++			return fmt.Errorf("Not found: %s", resourceName)
++		}
++
++		if rs.Primary.ID == "" {
++			return fmt.Errorf("No EKS Cluster ID is set")
++		}
++
++		conn := acctest.Provider.Meta().(*conns.AWSClient).EKSConn
++
++		_, err := tfeks.FindAddonByClusterNameAndAddonName(context.Background(), conn, rs.Primary.ID, addonName)
++
++		if err != nil {
++			_, ok := err.(*resource.NotFoundError)
++			if ok {
++				return nil
++			}
++		}
++
++		return fmt.Errorf("EKS Addon with ID %q found", addonName)
++	}
++}
+diff --git a/internal/service/eks/wait.go b/internal/service/eks/wait.go
+index 13b50ef76b..9027567ec8 100644
+--- a/internal/service/eks/wait.go
++++ b/internal/service/eks/wait.go
+@@ -11,6 +11,9 @@ import (
+ )
+ 
+ const (
++	addonCreatedTimeout = 20 * time.Minute
++	addonUpdatedTimeout = 20 * time.Minute
++	addonDeletedTimeout = 40 * time.Minute
+ 	clusterDeleteRetryTimeout = 60 * time.Minute
+ )
+ 

--- a/upstream-patches/0010-Add-EKS-cluster-certificate_authorities-plural.patch
+++ b/upstream-patches/0010-Add-EKS-cluster-certificate_authorities-plural.patch
@@ -1,0 +1,52 @@
+From 518ef0c89511d2159b9a8bb9e019632fba96078b Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:32:49 +0000
+Subject: [PATCH 10/25] Add EKS cluster certificate_authorities (plural)
+
+---
+ internal/service/eks/cluster.go | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go
+index 9eb3f74d7c..d3f84ba86a 100644
+--- a/internal/service/eks/cluster.go
++++ b/internal/service/eks/cluster.go
+@@ -52,9 +52,24 @@ func ResourceCluster() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Computed: true,
+ 			},
++			// FORK: Stack72: Renamed certificate_authority list to be certificate_authorities and map in the Pulumi provider
++			"certificate_authorities": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"data": {
++							Type:     schema.TypeString,
++							Computed: true,
++						},
++					},
++				},
++			},
++			// FORK: Stack72: Added a singular backward compatible value for certificate authorities
+ 			"certificate_authority": {
+ 				Type:     schema.TypeList,
+ 				Computed: true,
++				//MaxItems: 1,
+ 				Elem: &schema.Resource{
+ 					Schema: map[string]*schema.Schema{
+ 						"data": {
+@@ -387,6 +402,13 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
+ 	}
+ 
+ 	d.Set("arn", cluster.Arn)
++
++	// FORK: Stack72: Renamed certificate_authority list to be certificate_authorities and map in the Pulumi provider
++	if err := d.Set("certificate_authorities", flattenCertificate(cluster.CertificateAuthority)); err != nil {
++		return diag.Errorf("error setting certificate_authorities: %w", err)
++	}
++
++	// FORK: Stack72: Adding a single certificate authority to ensure backwards compatibility
+ 	if err := d.Set("certificate_authority", flattenCertificate(cluster.CertificateAuthority)); err != nil {
+ 		return diag.Errorf("setting certificate_authority: %s", err)
+ 	}

--- a/upstream-patches/0011-Workaround-Autoscaling-launch_configuration-associat.patch
+++ b/upstream-patches/0011-Workaround-Autoscaling-launch_configuration-associat.patch
@@ -1,0 +1,53 @@
+From b28496c27c94dcb86c23705d94487fe5d65cc382 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:34:56 +0000
+Subject: [PATCH 11/25] Workaround Autoscaling launch_configuration
+ associate_public_ip_address
+
+- Disable computation of property until fixed.
+---
+ .../autoscaling/launch_configuration.go       | 22 +++++++++++--------
+ 1 file changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/internal/service/autoscaling/launch_configuration.go b/internal/service/autoscaling/launch_configuration.go
+index 73601d36ea..34477997fe 100644
+--- a/internal/service/autoscaling/launch_configuration.go
++++ b/internal/service/autoscaling/launch_configuration.go
+@@ -44,7 +44,8 @@ func ResourceLaunchConfiguration() *schema.Resource {
+ 			"associate_public_ip_address": {
+ 				Type:     schema.TypeBool,
+ 				Optional: true,
+-				Computed: true,
++				//Computed: true,
++				Default:  false,
+ 				ForceNew: true,
+ 			},
+ 			"ebs_block_device": {
+@@ -340,16 +341,19 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
+ 
+ 	lcName := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
+ 	input := autoscaling.CreateLaunchConfigurationInput{
+-		EbsOptimized:            aws.Bool(d.Get("ebs_optimized").(bool)),
+-		ImageId:                 aws.String(d.Get("image_id").(string)),
+-		InstanceType:            aws.String(d.Get("instance_type").(string)),
+-		LaunchConfigurationName: aws.String(lcName),
++		EbsOptimized:             aws.Bool(d.Get("ebs_optimized").(bool)),
++		ImageId:                  aws.String(d.Get("image_id").(string)),
++		InstanceType:             aws.String(d.Get("instance_type").(string)),
++		LaunchConfigurationName:  aws.String(lcName),
++		AssociatePublicIpAddress: aws.Bool(d.Get("associate_public_ip_address").(bool)),
+ 	}
+ 
+-	associatePublicIPAddress := d.GetRawConfig().GetAttr("associate_public_ip_address")
+-	if associatePublicIPAddress.IsKnown() && !associatePublicIPAddress.IsNull() {
+-		input.AssociatePublicIpAddress = aws.Bool(associatePublicIPAddress.True())
+-	}
++	// FORK: Stack72 to remove this AssociatePublicIpAddress below when associated bridge issue is solved
++
++	//associatePublicIPAddress := d.GetRawConfig().GetAttr("associate_public_ip_address")
++	//if associatePublicIPAddress.IsKnown() && !associatePublicIPAddress.IsNull() {
++	//	input.AssociatePublicIpAddress = aws.Bool(associatePublicIPAddress.True())
++	//}
+ 
+ 	if v, ok := d.GetOk("iam_instance_profile"); ok {
+ 		input.IamInstanceProfile = aws.String(v.(string))

--- a/upstream-patches/0012-Add-ECR-credentials_data_source.patch
+++ b/upstream-patches/0012-Add-ECR-credentials_data_source.patch
@@ -1,0 +1,155 @@
+From a583cb83f8048b8b243f3214faca3e83f6b354ca Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:36:34 +0000
+Subject: [PATCH 12/25] Add ECR credentials_data_source
+
+---
+ internal/provider/provider.go                 |  6 +-
+ .../service/ecr/credentials_data_source.go    | 69 +++++++++++++++++++
+ .../ecr/credentials_data_source_test.go       | 37 ++++++++++
+ 3 files changed, 111 insertions(+), 1 deletion(-)
+ create mode 100644 internal/service/ecr/credentials_data_source.go
+ create mode 100644 internal/service/ecr/credentials_data_source_test.go
+
+diff --git a/internal/provider/provider.go b/internal/provider/provider.go
+index 251ded1058..98502bfabb 100644
+--- a/internal/provider/provider.go
++++ b/internal/provider/provider.go
+@@ -8,6 +8,7 @@ import (
+ 	"regexp"
+ 	"time"
+ 
++	"github.com/hashicorp/terraform-provider-aws/internal/service/ecr"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/s3legacy"
+ 
+ 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+@@ -246,7 +247,10 @@ func New(ctx context.Context) (*schema.Provider, error) {
+ 		// Data sources and resources implemented using Terraform Plugin SDK
+ 		// should use the @SDKDataSource and @SDKResource function-level annotations
+ 		// rather than adding directly to these maps.
+-		DataSourcesMap: make(map[string]*schema.Resource),
++		DataSourcesMap: map[string]*schema.Resource{
++			"aws_ecr_credentials": ecr.DataSourceCredentials(),
++		},
++
+ 		ResourcesMap: map[string]*schema.Resource{
+ 			"aws_s3_bucket_legacy": s3legacy.ResourceBucketLegacy(),
+ 		},
+diff --git a/internal/service/ecr/credentials_data_source.go b/internal/service/ecr/credentials_data_source.go
+new file mode 100644
+index 0000000000..572754846f
+--- /dev/null
++++ b/internal/service/ecr/credentials_data_source.go
+@@ -0,0 +1,69 @@
++package ecr
++
++import (
++	"log"
++	"time"
++
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/aws/awserr"
++	"github.com/aws/aws-sdk-go/service/ecr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++)
++
++func DataSourceCredentials() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceAwsEcrCredentialsRead,
++
++		Schema: map[string]*schema.Schema{
++			"registry_id": {
++				Type:     schema.TypeString,
++				Required: true,
++				ForceNew: true,
++			},
++			"authorization_token": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"expires_at": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"proxy_endpoint": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceAwsEcrCredentialsRead(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).ECRConn()
++
++	registryID := d.Get("registry_id").(string)
++	log.Printf("[DEBUG] Reading ECR repository credentials %s", registryID)
++
++	out, err := conn.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{
++		RegistryIds: []*string{aws.String(registryID)},
++	})
++
++	if err != nil {
++		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "ErrCodeInvalidParameterException" {
++			log.Printf("[WARN] ECR Repository %s not found", d.Id())
++			d.SetId("")
++			return nil
++		}
++		return err
++	}
++
++	auth := out.AuthorizationData[0]
++	log.Printf("[DEBUG] Received ECR repository credentials for %s", auth.ProxyEndpoint)
++
++	d.SetId(registryID)
++	d.Set("authorization_token", auth.AuthorizationToken)
++	d.Set("expires_at", auth.ExpiresAt.Format(time.RFC3339))
++	d.Set("proxy_endpoint", auth.ProxyEndpoint)
++
++	return nil
++}
+diff --git a/internal/service/ecr/credentials_data_source_test.go b/internal/service/ecr/credentials_data_source_test.go
+new file mode 100644
+index 0000000000..28bc53646f
+--- /dev/null
++++ b/internal/service/ecr/credentials_data_source_test.go
+@@ -0,0 +1,37 @@
++package ecr_test
++
++import (
++	"fmt"
++	"regexp"
++	"testing"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++)
++
++func TestAccAWSEcrDataSource_ecrCredentials(t *testing.T) {
++	resource.Test(t, resource.TestCase{
++		PreCheck:  func() { testAccPreCheck(t) },
++		Providers: testAccProviders,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccCheckAwsEcrCredentialsDataSourceConfig,
++				Check: resource.ComposeTestCheckFunc(
++					resource.TestCheckResourceAttrSet("data.aws_ecr_credentials.default", "authorization_token"),
++					resource.TestCheckResourceAttrSet("data.aws_ecr_credentials.default", "expires_at"),
++					resource.TestMatchResourceAttr("data.aws_ecr_credentials.default", "proxy_endpoint", regexp.MustCompile("^https://\\d+\\.dkr\\.ecr\\.[a-zA-Z]+-[a-zA-Z]+-\\d+\\.amazonaws\\.com$")),
++				),
++			},
++		},
++	})
++}
++
++var testAccCheckAwsEcrCredentialsDataSourceConfig = fmt.Sprintf(`
++resource "aws_ecr_repository" "default" {
++  name = "foo-repository-terraform-%d"
++}
++
++data "aws_ecr_credentials" "default" {
++  registry_id = "${aws_ecr_repository.default.registry_id}"
++}
++`, acctest.RandInt())

--- a/upstream-patches/0013-Revert-framework-conversions.patch
+++ b/upstream-patches/0013-Revert-framework-conversions.patch
@@ -1,0 +1,1509 @@
+From 2f551b413640f0e699eceab3611f9abf1adf6310 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Fri, 4 Nov 2022 17:42:19 +0000
+Subject: [PATCH 13/25] Revert framework conversions
+
+---
+ internal/framework/types/arn.go               |   2 +
+ internal/framework/types/arn_reverted.go      |  61 ++++++
+ internal/provider/provider.go                 |  23 +++
+ internal/provider/service_packages_gen.go     |  16 +-
+ .../accelerator_data_source.go                |   2 +
+ .../accelerator_data_source_reverted.go       | 154 +++++++++++++++
+ .../globalaccelerator/service_package_gen.go  |   2 +
+ internal/service/meta/arn.go                  |  71 +++++++
+ internal/service/meta/arn_data_source.go      |   2 +
+ .../service/meta/arn_data_source_reverted.go  |  60 ++++++
+ .../billing_service_account_data_source.go    |   2 +
+ ...ng_service_account_data_source_reverted.go |  36 ++++
+ .../service/meta/default_tags_data_source.go  |   2 +
+ .../meta/default_tags_data_source_reverted.go |  38 ++++
+ .../service/meta/ip_ranges_data_source.go     |   2 +
+ .../meta/ip_ranges_data_source_reverted.go    | 177 ++++++++++++++++++
+ .../service/meta/partition_data_source.go     |   2 +
+ .../meta/partition_data_source_reverted.go    |  49 +++++
+ internal/service/meta/region_data_source.go   |   2 +
+ .../meta/region_data_source_reverted.go       | 111 +++++++++++
+ internal/service/meta/regions_data_source.go  |   2 +
+ .../meta/regions_data_source_reverted.go      |  63 +++++++
+ internal/service/meta/service_data_source.go  |   2 +
+ .../meta/service_data_source_reverted.go      | 121 ++++++++++++
+ internal/service/meta/service_package_gen.go  |   2 +
+ internal/service/simpledb/domain.go           |   2 +
+ internal/service/simpledb/domain_reverted.go  |  83 ++++++++
+ internal/service/simpledb/domain_test.go      |   2 +
+ internal/service/simpledb/exports_test.go     |   3 +-
+ .../service/simpledb/service_package_gen.go   |   2 +
+ .../sts/caller_identity_data_source.go        |   2 +
+ .../caller_identity_data_source_reverted.go   |  54 ++++++
+ internal/service/sts/service_package_gen.go   |   2 +
+ 33 files changed, 1145 insertions(+), 9 deletions(-)
+ create mode 100644 internal/framework/types/arn_reverted.go
+ create mode 100644 internal/service/globalaccelerator/accelerator_data_source_reverted.go
+ create mode 100644 internal/service/meta/arn.go
+ create mode 100644 internal/service/meta/arn_data_source_reverted.go
+ create mode 100644 internal/service/meta/billing_service_account_data_source_reverted.go
+ create mode 100644 internal/service/meta/default_tags_data_source_reverted.go
+ create mode 100644 internal/service/meta/ip_ranges_data_source_reverted.go
+ create mode 100644 internal/service/meta/partition_data_source_reverted.go
+ create mode 100644 internal/service/meta/region_data_source_reverted.go
+ create mode 100644 internal/service/meta/regions_data_source_reverted.go
+ create mode 100644 internal/service/meta/service_data_source_reverted.go
+ create mode 100644 internal/service/simpledb/domain_reverted.go
+ create mode 100644 internal/service/sts/caller_identity_data_source_reverted.go
+
+diff --git a/internal/framework/types/arn.go b/internal/framework/types/arn.go
+index bae74fc7c1..fa0c107fba 100644
+--- a/internal/framework/types/arn.go
++++ b/internal/framework/types/arn.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package types
+ 
+ import (
+diff --git a/internal/framework/types/arn_reverted.go b/internal/framework/types/arn_reverted.go
+new file mode 100644
+index 0000000000..9f1b58046f
+--- /dev/null
++++ b/internal/framework/types/arn_reverted.go
+@@ -0,0 +1,61 @@
++package types
++
++import (
++	"context"
++	"fmt"
++
++	"github.com/aws/aws-sdk-go-v2/aws/arn"
++	"github.com/hashicorp/terraform-plugin-go/tftypes"
++)
++
++type arnType uint8
++
++const (
++	ARNType arnType = iota
++)
++
++func (t arnType) TerraformType(_ context.Context) tftypes.Type {
++	return tftypes.String
++}
++
++// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
++// type.
++func (t arnType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
++	return nil, fmt.Errorf("cannot apply AttributePathStep %T to %s", step, t.String())
++}
++
++// String returns a human-friendly description of the ARNType.
++func (t arnType) String() string {
++	return "types.ARNType"
++}
++
++func (t arnType) Description() string {
++	return `An Amazon Resource Name.`
++}
++
++type ARN struct {
++	Unknown bool
++	Null    bool
++	Value   arn.ARN
++}
++
++func (a ARN) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
++	t := ARNType.TerraformType(ctx)
++	if a.Null {
++		return tftypes.NewValue(t, nil), nil
++	}
++	if a.Unknown {
++		return tftypes.NewValue(t, tftypes.UnknownValue), nil
++	}
++	return tftypes.NewValue(t, a.Value.String()), nil
++}
++
++// IsNull returns true if the Value is not set, or is explicitly set to null.
++func (a ARN) IsNull() bool {
++	return a.Null
++}
++
++// IsUnknown returns true if the Value is not yet known.
++func (a ARN) IsUnknown() bool {
++	return a.Unknown
++}
+diff --git a/internal/provider/provider.go b/internal/provider/provider.go
+index 98502bfabb..7772ba7aa6 100644
+--- a/internal/provider/provider.go
++++ b/internal/provider/provider.go
+@@ -9,7 +9,11 @@ import (
+ 	"time"
+ 
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/ecr"
++	"github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator"
++	"github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/s3legacy"
++	"github.com/hashicorp/terraform-provider-aws/internal/service/simpledb"
++	"github.com/hashicorp/terraform-provider-aws/internal/service/sts"
+ 
+ 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+ 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+@@ -249,10 +253,29 @@ func New(ctx context.Context) (*schema.Provider, error) {
+ 		// rather than adding directly to these maps.
+ 		DataSourcesMap: map[string]*schema.Resource{
+ 			"aws_ecr_credentials": ecr.DataSourceCredentials(),
++
++			"aws_globalaccelerator_accelerator": globalaccelerator.DataSourceAccelerator(),
++
++			"aws_arn":                     meta.DataSourceARN(),
++			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),
++			"aws_default_tags":            meta.DataSourceDefaultTags(),
++			"aws_ip_ranges":               meta.DataSourceIPRanges(),
++			"aws_partition":               meta.DataSourcePartition(),
++			"aws_region":                  meta.DataSourceRegion(),
++			"aws_regions":                 meta.DataSourceRegions(),
++			"aws_service":                 meta.DataSourceService(),
++
++			"aws_caller_identity": sts.DataSourceCallerIdentity(),
+ 		},
+ 
+ 		ResourcesMap: map[string]*schema.Resource{
+ 			"aws_s3_bucket_legacy": s3legacy.ResourceBucketLegacy(),
++
++			"aws_simpledb_domain": simpledb.ResourceDomain(),
++
++			"aws_globalaccelerator_accelerator":    globalaccelerator.ResourceAccelerator(),
++			"aws_globalaccelerator_endpoint_group": globalaccelerator.ResourceEndpointGroup(),
++			"aws_globalaccelerator_listener":       globalaccelerator.ResourceListener(),
+ 		},
+ 	}
+ 
+diff --git a/internal/provider/service_packages_gen.go b/internal/provider/service_packages_gen.go
+index 0e1df01cb7..ba499f109f 100644
+--- a/internal/provider/service_packages_gen.go
++++ b/internal/provider/service_packages_gen.go
+@@ -90,7 +90,7 @@ import (
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/fsx"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/gamelift"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/glacier"
+-	"github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator"
++
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/glue"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/grafana"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/greengrass"
+@@ -130,7 +130,7 @@ import (
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/mediastore"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/memorydb"
+-	"github.com/hashicorp/terraform-provider-aws/internal/service/meta"
++
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/mq"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/mwaa"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/neptune"
+@@ -179,13 +179,13 @@ import (
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/sfn"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/shield"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/signer"
+-	"github.com/hashicorp/terraform-provider-aws/internal/service/simpledb"
++
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/sns"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/sqs"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
+-	"github.com/hashicorp/terraform-provider-aws/internal/service/sts"
++
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/swf"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/synthetics"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite"
+@@ -286,7 +286,7 @@ func servicePackages(context.Context) []conns.ServicePackage {
+ 		fsx.ServicePackage,
+ 		gamelift.ServicePackage,
+ 		glacier.ServicePackage,
+-		globalaccelerator.ServicePackage,
++		// globalaccelerator.ServicePackage,
+ 		glue.ServicePackage,
+ 		grafana.ServicePackage,
+ 		greengrass.ServicePackage,
+@@ -326,7 +326,7 @@ func servicePackages(context.Context) []conns.ServicePackage {
+ 		mediapackage.ServicePackage,
+ 		mediastore.ServicePackage,
+ 		memorydb.ServicePackage,
+-		meta.ServicePackage,
++		// meta.ServicePackage,
+ 		mq.ServicePackage,
+ 		mwaa.ServicePackage,
+ 		neptune.ServicePackage,
+@@ -375,13 +375,13 @@ func servicePackages(context.Context) []conns.ServicePackage {
+ 		sfn.ServicePackage,
+ 		shield.ServicePackage,
+ 		signer.ServicePackage,
+-		simpledb.ServicePackage,
++		// simpledb.ServicePackage,
+ 		sns.ServicePackage,
+ 		sqs.ServicePackage,
+ 		ssm.ServicePackage,
+ 		ssoadmin.ServicePackage,
+ 		storagegateway.ServicePackage,
+-		sts.ServicePackage,
++		// sts.ServicePackage,
+ 		swf.ServicePackage,
+ 		synthetics.ServicePackage,
+ 		timestreamwrite.ServicePackage,
+diff --git a/internal/service/globalaccelerator/accelerator_data_source.go b/internal/service/globalaccelerator/accelerator_data_source.go
+index f480a79be3..c95148aa26 100644
+--- a/internal/service/globalaccelerator/accelerator_data_source.go
++++ b/internal/service/globalaccelerator/accelerator_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package globalaccelerator
+ 
+ import (
+diff --git a/internal/service/globalaccelerator/accelerator_data_source_reverted.go b/internal/service/globalaccelerator/accelerator_data_source_reverted.go
+new file mode 100644
+index 0000000000..3bd69472c8
+--- /dev/null
++++ b/internal/service/globalaccelerator/accelerator_data_source_reverted.go
+@@ -0,0 +1,154 @@
++package globalaccelerator
++
++import (
++	"context"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/globalaccelerator"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++)
++
++func DataSourceAccelerator() *schema.Resource {
++	return &schema.Resource{
++		ReadWithoutTimeout: dataSourceAcceleratorRead,
++
++		Schema: map[string]*schema.Schema{
++			"arn": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++			"name": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++			"ip_address_type": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"enabled": {
++				Type:     schema.TypeBool,
++				Computed: true,
++			},
++			"dns_name": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"hosted_zone_id": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"ip_sets": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"ip_addresses": {
++							Type:     schema.TypeList,
++							Computed: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"ip_family": {
++							Type:     schema.TypeString,
++							Computed: true,
++						},
++					},
++				},
++			},
++			"attributes": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"flow_logs_enabled": {
++							Type:     schema.TypeBool,
++							Computed: true,
++						},
++						"flow_logs_s3_bucket": {
++							Type:     schema.TypeString,
++							Computed: true,
++						},
++						"flow_logs_s3_prefix": {
++							Type:     schema.TypeString,
++							Computed: true,
++						},
++					},
++				},
++			},
++
++			"tags": tftags.TagsSchemaComputed(),
++		},
++	}
++}
++
++func dataSourceAcceleratorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
++	conn := meta.(*conns.AWSClient).GlobalAcceleratorConn()
++	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
++
++	var results []*globalaccelerator.Accelerator
++
++	err := conn.ListAcceleratorsPages(&globalaccelerator.ListAcceleratorsInput{}, func(page *globalaccelerator.ListAcceleratorsOutput, lastPage bool) bool {
++		if page == nil {
++			return !lastPage
++		}
++
++		for _, l := range page.Accelerators {
++			if l == nil {
++				continue
++			}
++
++			if v, ok := d.GetOk("arn"); ok && v.(string) != aws.StringValue(l.AcceleratorArn) {
++				continue
++			}
++
++			if v, ok := d.GetOk("name"); ok && v.(string) != aws.StringValue(l.Name) {
++				continue
++			}
++
++			results = append(results, l)
++		}
++
++		return !lastPage
++	})
++
++	if err != nil {
++		return diag.Errorf("error reading AWS Global Accelerator: %w", err)
++	}
++
++	if len(results) != 1 {
++		return diag.Errorf("Search returned %d results, please revise so only one is returned", len(results))
++	}
++
++	accelerator := results[0]
++	d.SetId(aws.StringValue(accelerator.AcceleratorArn))
++	d.Set("arn", accelerator.AcceleratorArn)
++	d.Set("enabled", accelerator.Enabled)
++	d.Set("dns_name", accelerator.DnsName)
++	d.Set("hosted_zone_id", route53ZoneID)
++	d.Set("name", accelerator.Name)
++	d.Set("ip_address_type", accelerator.IpAddressType)
++	d.Set("ip_sets", flattenIPSets(accelerator.IpSets))
++
++	acceleratorAttributes, err := FindAcceleratorAttributesByARN(ctx, conn, d.Id())
++	if err != nil {
++		return diag.Errorf("error reading Global Accelerator Accelerator (%s) attributes: %w", d.Id(), err)
++	}
++
++	if err := d.Set("attributes", []interface{}{flattenAcceleratorAttributes(acceleratorAttributes)}); err != nil {
++		return diag.Errorf("error setting attributes: %w", err)
++	}
++
++	tags, err := ListTags(context.Background(), conn, d.Id())
++	if err != nil {
++		return diag.Errorf("error listing tags for Global Accelerator Accelerator (%s): %w", d.Id(), err)
++	}
++
++	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
++		return diag.Errorf("error setting tags: %w", err)
++	}
++	return nil
++}
+diff --git a/internal/service/globalaccelerator/service_package_gen.go b/internal/service/globalaccelerator/service_package_gen.go
+index e1095259c3..d2e250cdb4 100644
+--- a/internal/service/globalaccelerator/service_package_gen.go
++++ b/internal/service/globalaccelerator/service_package_gen.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ // Code generated by internal/generate/servicepackages/main.go; DO NOT EDIT.
+ 
+ package globalaccelerator
+diff --git a/internal/service/meta/arn.go b/internal/service/meta/arn.go
+new file mode 100644
+index 0000000000..6cb4854667
+--- /dev/null
++++ b/internal/service/meta/arn.go
+@@ -0,0 +1,71 @@
++package meta
++
++import (
++	"context"
++	"fmt"
++	"github.com/aws/aws-sdk-go-v2/aws/arn"
++	"github.com/hashicorp/terraform-plugin-go/tftypes"
++)
++
++type arnType uint8
++
++const (
++	ARNType arnType = iota
++)
++
++func (t arnType) TerraformType(_ context.Context) tftypes.Type {
++	return tftypes.String
++}
++
++// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
++// type.
++func (t arnType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
++	return nil, fmt.Errorf("cannot apply AttributePathStep %T to %s", step, t.String())
++}
++
++// String returns a human-friendly description of the ARNType.
++func (t arnType) String() string {
++	return "types.ARNType"
++}
++
++func (t arnType) Description() string {
++	return `An Amazon Resource Name.`
++}
++
++type ARN struct {
++	Unknown bool
++	Null    bool
++	Value   arn.ARN
++}
++
++func (a ARN) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
++	t := ARNType.TerraformType(ctx)
++	if a.Null {
++		return tftypes.NewValue(t, nil), nil
++	}
++	if a.Unknown {
++		return tftypes.NewValue(t, tftypes.UnknownValue), nil
++	}
++	return tftypes.NewValue(t, a.Value.String()), nil
++}
++
++// IsNull returns true if the Value is not set, or is explicitly set to null.
++func (a ARN) IsNull() bool {
++	return a.Null
++}
++
++// IsUnknown returns true if the Value is not yet known.
++func (a ARN) IsUnknown() bool {
++	return a.Unknown
++}
++
++// String returns a summary representation of either the underlying Value,
++// or UnknownValueString (`<unknown>`) when IsUnknown() returns true,
++// or NullValueString (`<null>`) when IsNull() return true.
++//
++// This is an intentionally lossy representation, that are best suited for
++// logging and error reporting, as they are not protected by
++// compatibility guarantees within the framework.
++func (a ARN) String() string {
++	return a.Value.String()
++}
+diff --git a/internal/service/meta/arn_data_source.go b/internal/service/meta/arn_data_source.go
+index ea1e1a53a4..6dec3a541c 100644
+--- a/internal/service/meta/arn_data_source.go
++++ b/internal/service/meta/arn_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ // Code generated by tools/tfsdk2fw/main.go. Manual editing is required.
+ 
+ package meta
+diff --git a/internal/service/meta/arn_data_source_reverted.go b/internal/service/meta/arn_data_source_reverted.go
+new file mode 100644
+index 0000000000..6a75cd3975
+--- /dev/null
++++ b/internal/service/meta/arn_data_source_reverted.go
+@@ -0,0 +1,60 @@
++package meta
++
++import (
++	"fmt"
++
++	"github.com/aws/aws-sdk-go/aws/arn"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/verify"
++)
++
++func DataSourceARN() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceARNRead,
++
++		Schema: map[string]*schema.Schema{
++			"arn": {
++				Type:         schema.TypeString,
++				Required:     true,
++				ValidateFunc: verify.ValidARN,
++			},
++			"partition": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"service": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"region": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"account": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"resource": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceARNRead(d *schema.ResourceData, meta interface{}) error {
++	v := d.Get("arn").(string)
++	arn, err := arn.Parse(v)
++	if err != nil {
++		return fmt.Errorf("Error parsing '%s': %w", v, err)
++	}
++
++	d.SetId(arn.String())
++	d.Set("partition", arn.Partition)
++	d.Set("service", arn.Service)
++	d.Set("region", arn.Region)
++	d.Set("account", arn.AccountID)
++	d.Set("resource", arn.Resource)
++
++	return nil
++}
+diff --git a/internal/service/meta/billing_service_account_data_source.go b/internal/service/meta/billing_service_account_data_source.go
+index 319502dfd5..7a7df6f5ca 100644
+--- a/internal/service/meta/billing_service_account_data_source.go
++++ b/internal/service/meta/billing_service_account_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package meta
+ 
+ import (
+diff --git a/internal/service/meta/billing_service_account_data_source_reverted.go b/internal/service/meta/billing_service_account_data_source_reverted.go
+new file mode 100644
+index 0000000000..5205e6bc84
+--- /dev/null
++++ b/internal/service/meta/billing_service_account_data_source_reverted.go
+@@ -0,0 +1,36 @@
++package meta
++
++import (
++	"github.com/aws/aws-sdk-go/aws/arn"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++// See http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2
++var billingAccountId = "386209384616"
++
++func DataSourceBillingServiceAccount() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceBillingServiceAccountRead,
++
++		Schema: map[string]*schema.Schema{
++			"arn": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceBillingServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
++	d.SetId(billingAccountId)
++	arn := arn.ARN{
++		Partition: meta.(*conns.AWSClient).Partition,
++		Service:   "iam",
++		AccountID: billingAccountId,
++		Resource:  "root",
++	}.String()
++	d.Set("arn", arn)
++
++	return nil
++}
+diff --git a/internal/service/meta/default_tags_data_source.go b/internal/service/meta/default_tags_data_source.go
+index 0d0516f1c4..b4eaeacba5 100644
+--- a/internal/service/meta/default_tags_data_source.go
++++ b/internal/service/meta/default_tags_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ // Code generated by tools/tfsdk2fw/main.go. Manual editing is required.
+ 
+ package meta
+diff --git a/internal/service/meta/default_tags_data_source_reverted.go b/internal/service/meta/default_tags_data_source_reverted.go
+new file mode 100644
+index 0000000000..e775cffb09
+--- /dev/null
++++ b/internal/service/meta/default_tags_data_source_reverted.go
+@@ -0,0 +1,38 @@
++package meta
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++)
++
++func DataSourceDefaultTags() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceDefaultTagsRead,
++
++		Schema: map[string]*schema.Schema{
++			"tags": tftags.TagsSchemaComputed(),
++		},
++	}
++}
++
++func dataSourceDefaultTagsRead(d *schema.ResourceData, meta interface{}) error {
++	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
++	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
++
++	d.SetId(meta.(*conns.AWSClient).Partition)
++
++	tags := defaultTagsConfig.GetTags()
++
++	if tags != nil {
++		if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
++			return fmt.Errorf("error setting tags: %w", err)
++		}
++	} else {
++		d.Set("tags", nil)
++	}
++
++	return nil
++}
+diff --git a/internal/service/meta/ip_ranges_data_source.go b/internal/service/meta/ip_ranges_data_source.go
+index 8537a89e89..fc6061a860 100644
+--- a/internal/service/meta/ip_ranges_data_source.go
++++ b/internal/service/meta/ip_ranges_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package meta
+ 
+ import (
+diff --git a/internal/service/meta/ip_ranges_data_source_reverted.go b/internal/service/meta/ip_ranges_data_source_reverted.go
+new file mode 100644
+index 0000000000..2ad149767f
+--- /dev/null
++++ b/internal/service/meta/ip_ranges_data_source_reverted.go
+@@ -0,0 +1,177 @@
++package meta
++
++import (
++	"encoding/json"
++	"fmt"
++	"io"
++	"log"
++	"sort"
++	"strconv"
++	"strings"
++
++	"github.com/hashicorp/go-cleanhttp"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++)
++
++type dataSourceAwsIPRangesResult struct {
++	CreateDate   string
++	Prefixes     []dataSourceAwsIPRangesPrefix
++	Ipv6Prefixes []dataSourceAwsIPRangesIpv6Prefix `json:"ipv6_prefixes"`
++	SyncToken    string
++}
++
++type dataSourceAwsIPRangesPrefix struct {
++	IpPrefix string `json:"ip_prefix"`
++	Region   string
++	Service  string
++}
++
++type dataSourceAwsIPRangesIpv6Prefix struct {
++	Ipv6Prefix string `json:"ipv6_prefix"`
++	Region     string
++	Service    string
++}
++
++func DataSourceIPRanges() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceIPRangesRead,
++
++		Schema: map[string]*schema.Schema{
++			"cidr_blocks": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem:     &schema.Schema{Type: schema.TypeString},
++			},
++			"create_date": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"ipv6_cidr_blocks": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem:     &schema.Schema{Type: schema.TypeString},
++			},
++			"regions": {
++				Type:     schema.TypeSet,
++				Elem:     &schema.Schema{Type: schema.TypeString},
++				Optional: true,
++			},
++			"services": {
++				Type:     schema.TypeSet,
++				Required: true,
++				Elem:     &schema.Schema{Type: schema.TypeString},
++			},
++			"sync_token": {
++				Type:     schema.TypeInt,
++				Computed: true,
++			},
++			"url": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Default:  "https://ip-ranges.amazonaws.com/ip-ranges.json",
++			},
++		},
++	}
++}
++
++func dataSourceIPRangesRead(d *schema.ResourceData, meta interface{}) error {
++
++	conn := cleanhttp.DefaultClient()
++	url := d.Get("url").(string)
++
++	log.Printf("[DEBUG] Reading IP ranges from %s", url)
++
++	res, err := conn.Get(url)
++
++	if err != nil {
++		return fmt.Errorf("Error listing IP ranges from (%s): %w", url, err)
++	}
++
++	defer res.Body.Close()
++
++	data, err := io.ReadAll(res.Body)
++
++	if err != nil {
++		return fmt.Errorf("Error reading response body from (%s): %w", url, err)
++	}
++
++	result := new(dataSourceAwsIPRangesResult)
++
++	if err := json.Unmarshal(data, result); err != nil {
++		return fmt.Errorf("Error parsing result from (%s): %w", url, err)
++	}
++
++	if err := d.Set("create_date", result.CreateDate); err != nil {
++		return fmt.Errorf("Error setting create date: %w", err)
++	}
++
++	syncToken, err := strconv.Atoi(result.SyncToken)
++
++	if err != nil {
++		return fmt.Errorf("Error while converting sync token: %w", err)
++	}
++
++	d.SetId(result.SyncToken)
++
++	if err := d.Set("sync_token", syncToken); err != nil {
++		return fmt.Errorf("Error setting sync token: %w", err)
++	}
++
++	get := func(key string) *schema.Set {
++
++		set := d.Get(key).(*schema.Set)
++
++		for _, e := range set.List() {
++
++			s := e.(string)
++
++			set.Remove(s)
++			set.Add(strings.ToLower(s))
++
++		}
++
++		return set
++
++	}
++
++	var (
++		regions        = get("regions")
++		services       = get("services")
++		noRegionFilter = regions.Len() == 0
++		ipPrefixes     []string
++		ipv6Prefixes   []string
++	)
++
++	matchFilter := func(region, service string) bool {
++		matchRegion := noRegionFilter || regions.Contains(strings.ToLower(region))
++		matchService := services.Contains(strings.ToLower(service))
++		return matchRegion && matchService
++	}
++
++	for _, e := range result.Prefixes {
++		if matchFilter(e.Region, e.Service) {
++			ipPrefixes = append(ipPrefixes, e.IpPrefix)
++		}
++	}
++
++	for _, e := range result.Ipv6Prefixes {
++		if matchFilter(e.Region, e.Service) {
++			ipv6Prefixes = append(ipv6Prefixes, e.Ipv6Prefix)
++		}
++	}
++
++	sort.Strings(ipPrefixes)
++
++	if err := d.Set("cidr_blocks", ipPrefixes); err != nil {
++		return fmt.Errorf("Error setting cidr_blocks: %w", err)
++	}
++
++	sort.Strings(ipv6Prefixes)
++
++	if err := d.Set("ipv6_cidr_blocks", ipv6Prefixes); err != nil {
++		return fmt.Errorf("Error setting ipv6_cidr_blocks: %w", err)
++	}
++
++	return nil
++
++}
+diff --git a/internal/service/meta/partition_data_source.go b/internal/service/meta/partition_data_source.go
+index 368737def3..2e172da24d 100644
+--- a/internal/service/meta/partition_data_source.go
++++ b/internal/service/meta/partition_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package meta
+ 
+ import (
+diff --git a/internal/service/meta/partition_data_source_reverted.go b/internal/service/meta/partition_data_source_reverted.go
+new file mode 100644
+index 0000000000..0a66f5331f
+--- /dev/null
++++ b/internal/service/meta/partition_data_source_reverted.go
+@@ -0,0 +1,49 @@
++package meta
++
++import (
++	"log"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++func DataSourcePartition() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourcePartitionRead,
++
++		Schema: map[string]*schema.Schema{
++			"partition": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"dns_suffix": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"reverse_dns_prefix": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourcePartitionRead(d *schema.ResourceData, meta interface{}) error {
++	client := meta.(*conns.AWSClient)
++
++	log.Printf("[DEBUG] Reading Partition.")
++	d.SetId(meta.(*conns.AWSClient).Partition)
++
++	log.Printf("[DEBUG] Setting AWS Partition to %s.", client.Partition)
++	d.Set("partition", meta.(*conns.AWSClient).Partition)
++
++	log.Printf("[DEBUG] Setting AWS URL Suffix to %s.", client.DNSSuffix)
++	d.Set("dns_suffix", meta.(*conns.AWSClient).DNSSuffix)
++
++	d.Set("reverse_dns_prefix", meta.(*conns.AWSClient).ReverseDNSPrefix)
++	log.Printf("[DEBUG] Setting service prefix to %s.", meta.(*conns.AWSClient).ReverseDNSPrefix)
++
++	return nil
++}
+diff --git a/internal/service/meta/region_data_source.go b/internal/service/meta/region_data_source.go
+index bfed7c2b88..8e750c4c13 100644
+--- a/internal/service/meta/region_data_source.go
++++ b/internal/service/meta/region_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package meta
+ 
+ import (
+diff --git a/internal/service/meta/region_data_source_reverted.go b/internal/service/meta/region_data_source_reverted.go
+new file mode 100644
+index 0000000000..253da23125
+--- /dev/null
++++ b/internal/service/meta/region_data_source_reverted.go
+@@ -0,0 +1,111 @@
++package meta
++
++import (
++	"fmt"
++	"strings"
++
++	"github.com/aws/aws-sdk-go/aws/endpoints"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++func DataSourceRegion() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceRegionRead,
++
++		Schema: map[string]*schema.Schema{
++			"name": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"endpoint": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"description": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceRegionRead(d *schema.ResourceData, meta interface{}) error {
++	providerRegion := meta.(*conns.AWSClient).Region
++
++	var region *endpoints.Region
++
++	if v, ok := d.GetOk("endpoint"); ok {
++		endpoint := v.(string)
++		matchingRegion, err := FindRegionByEndpoint(endpoint)
++		if err != nil {
++			return err
++		}
++		region = matchingRegion
++	}
++
++	if v, ok := d.GetOk("name"); ok {
++		name := v.(string)
++		matchingRegion, err := FindRegionByName(name)
++		if err != nil {
++			return err
++		}
++		if region != nil && region.ID() != matchingRegion.ID() {
++			return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
++		}
++		region = matchingRegion
++	}
++
++	// Default to provider current region if no other filters matched
++	if region == nil {
++		matchingRegion, err := FindRegionByName(providerRegion)
++		if err != nil {
++			return err
++		}
++		region = matchingRegion
++	}
++
++	d.SetId(region.ID())
++
++	regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
++	if err != nil {
++		return err
++	}
++	d.Set("endpoint", strings.TrimPrefix(regionEndpointEc2.URL, "https://"))
++
++	d.Set("name", region.ID())
++
++	d.Set("description", region.Description())
++
++	return nil
++}
++
++func FindRegionByEndpoint(endpoint string) (*endpoints.Region, error) {
++	for _, partition := range endpoints.DefaultPartitions() {
++		for _, region := range partition.Regions() {
++			regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
++			if err != nil {
++				return nil, err
++			}
++			if strings.TrimPrefix(regionEndpointEc2.URL, "https://") == endpoint {
++				return &region, nil
++			}
++		}
++	}
++	return nil, fmt.Errorf("region not found for endpoint %q", endpoint)
++}
++
++func FindRegionByName(name string) (*endpoints.Region, error) {
++	for _, partition := range endpoints.DefaultPartitions() {
++		for _, region := range partition.Regions() {
++			if region.ID() == name {
++				return &region, nil
++			}
++		}
++	}
++	return nil, fmt.Errorf("region not found for name %q", name)
++}
+diff --git a/internal/service/meta/regions_data_source.go b/internal/service/meta/regions_data_source.go
+index 031b9dae90..97c0abab6c 100644
+--- a/internal/service/meta/regions_data_source.go
++++ b/internal/service/meta/regions_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package meta
+ 
+ import (
+diff --git a/internal/service/meta/regions_data_source_reverted.go b/internal/service/meta/regions_data_source_reverted.go
+new file mode 100644
+index 0000000000..efe02e777f
+--- /dev/null
++++ b/internal/service/meta/regions_data_source_reverted.go
+@@ -0,0 +1,63 @@
++package meta
++
++import (
++	"fmt"
++	"log"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/ec2"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
++)
++
++func DataSourceRegions() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceRegionsRead,
++
++		Schema: map[string]*schema.Schema{
++			"filter": tfec2.DataSourceFiltersSchema(),
++			"names": {
++				Type:     schema.TypeSet,
++				Computed: true,
++				Elem:     &schema.Schema{Type: schema.TypeString},
++			},
++
++			"all_regions": {
++				Type:     schema.TypeBool,
++				Optional: true,
++			},
++		},
++	}
++}
++
++func dataSourceRegionsRead(d *schema.ResourceData, meta interface{}) error {
++	connection := meta.(*conns.AWSClient).EC2Conn()
++
++	log.Printf("[DEBUG] Reading regions.")
++	request := &ec2.DescribeRegionsInput{}
++	if v, ok := d.GetOk("filter"); ok {
++		request.Filters = tfec2.BuildFiltersDataSource(v.(*schema.Set))
++	}
++	if v, ok := d.GetOk("all_regions"); ok {
++		request.AllRegions = aws.Bool(v.(bool))
++	}
++
++	log.Printf("[DEBUG] Reading regions for request: %s", request)
++	response, err := connection.DescribeRegions(request)
++	if err != nil {
++		return fmt.Errorf("Error fetching Regions: %w", err)
++	}
++
++	names := []string{}
++	for _, v := range response.Regions {
++		names = append(names, aws.StringValue(v.RegionName))
++	}
++
++	d.SetId(meta.(*conns.AWSClient).Partition)
++	if err := d.Set("names", names); err != nil {
++		return fmt.Errorf("error setting names: %w", err)
++	}
++
++	return nil
++}
+diff --git a/internal/service/meta/service_data_source.go b/internal/service/meta/service_data_source.go
+index adb00eb94f..8b43277832 100644
+--- a/internal/service/meta/service_data_source.go
++++ b/internal/service/meta/service_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package meta
+ 
+ import (
+diff --git a/internal/service/meta/service_data_source_reverted.go b/internal/service/meta/service_data_source_reverted.go
+new file mode 100644
+index 0000000000..1ca781bef7
+--- /dev/null
++++ b/internal/service/meta/service_data_source_reverted.go
+@@ -0,0 +1,121 @@
++package meta
++
++import (
++	"fmt"
++	"strings"
++
++	"github.com/aws/aws-sdk-go/aws/endpoints"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++func DataSourceService() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceServiceRead,
++
++		Schema: map[string]*schema.Schema{
++			"dns_name": {
++				Type:         schema.TypeString,
++				Computed:     true,
++				Optional:     true,
++				ExactlyOneOf: []string{"dns_name", "reverse_dns_name", "service_id"},
++			},
++			"partition": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"region": {
++				Type:          schema.TypeString,
++				Computed:      true,
++				Optional:      true,
++				ConflictsWith: []string{"dns_name", "reverse_dns_name"},
++			},
++			"reverse_dns_name": {
++				Type:         schema.TypeString,
++				Computed:     true,
++				Optional:     true,
++				ExactlyOneOf: []string{"dns_name", "reverse_dns_name", "service_id"},
++			},
++			"reverse_dns_prefix": {
++				Type:          schema.TypeString,
++				Computed:      true,
++				Optional:      true,
++				ConflictsWith: []string{"dns_name", "reverse_dns_name"},
++			},
++			"service_id": {
++				Type:         schema.TypeString,
++				Computed:     true,
++				Optional:     true,
++				ExactlyOneOf: []string{"dns_name", "reverse_dns_name", "service_id"},
++			},
++			"supported": {
++				Type:     schema.TypeBool,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceServiceRead(d *schema.ResourceData, meta interface{}) error {
++	client := meta.(*conns.AWSClient)
++
++	if v, ok := d.GetOk("reverse_dns_name"); ok {
++		serviceParts := strings.Split(v.(string), ".")
++		if len(serviceParts) < 4 {
++			return fmt.Errorf("reverse service DNS names must have at least 4 parts (%s has %d)", v.(string), len(serviceParts))
++		}
++
++		d.Set("service_id", serviceParts[len(serviceParts)-1])
++		d.Set("region", serviceParts[len(serviceParts)-2])
++		d.Set("reverse_dns_prefix", strings.Join(serviceParts[0:len(serviceParts)-2], "."))
++	}
++
++	if v, ok := d.GetOk("dns_name"); ok {
++		serviceParts := InvertStringSlice(strings.Split(v.(string), "."))
++		if len(serviceParts) < 4 {
++			return fmt.Errorf("service DNS names must have at least 4 parts (%s has %d)", v.(string), len(serviceParts))
++		}
++
++		d.Set("service_id", serviceParts[len(serviceParts)-1])
++		d.Set("region", serviceParts[len(serviceParts)-2])
++		d.Set("reverse_dns_prefix", strings.Join(serviceParts[0:len(serviceParts)-2], "."))
++	}
++
++	if _, ok := d.GetOk("region"); !ok {
++		d.Set("region", client.Region)
++	}
++
++	if _, ok := d.GetOk("service_id"); !ok {
++		return fmt.Errorf("service ID not provided directly or through a DNS name")
++	}
++
++	if _, ok := d.GetOk("reverse_dns_prefix"); !ok {
++		dnsParts := strings.Split(meta.(*conns.AWSClient).DNSSuffix, ".")
++		d.Set("reverse_dns_prefix", strings.Join(InvertStringSlice(dnsParts), "."))
++	}
++
++	reverseDNS := fmt.Sprintf("%s.%s.%s", d.Get("reverse_dns_prefix").(string), d.Get("region").(string), d.Get("service_id").(string))
++	d.Set("reverse_dns_name", reverseDNS)
++	d.Set("dns_name", strings.ToLower(strings.Join(InvertStringSlice(strings.Split(reverseDNS, ".")), ".")))
++
++	d.Set("supported", true)
++	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), d.Get("region").(string)); ok {
++		d.Set("partition", partition.ID())
++		if _, ok := partition.Services()[d.Get("service_id").(string)]; !ok {
++			d.Set("supported", false)
++		}
++	}
++
++	d.SetId(reverseDNS)
++
++	return nil
++}
++
++// invertStringSlice returns inverted string slice without sorting slice like sort.Reverse()
++func InvertStringSlice(slice []string) []string {
++	inverse := make([]string, 0)
++	for i := 0; i < len(slice); i++ {
++		inverse = append(inverse, slice[len(slice)-i-1])
++	}
++	return inverse
++}
+diff --git a/internal/service/meta/service_package_gen.go b/internal/service/meta/service_package_gen.go
+index 7eb5d21f03..9ae463b337 100644
+--- a/internal/service/meta/service_package_gen.go
++++ b/internal/service/meta/service_package_gen.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ // Code generated by internal/generate/servicepackages/main.go; DO NOT EDIT.
+ 
+ package meta
+diff --git a/internal/service/simpledb/domain.go b/internal/service/simpledb/domain.go
+index c101bdc6b5..849abde753 100644
+--- a/internal/service/simpledb/domain.go
++++ b/internal/service/simpledb/domain.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package simpledb
+ 
+ import (
+diff --git a/internal/service/simpledb/domain_reverted.go b/internal/service/simpledb/domain_reverted.go
+new file mode 100644
+index 0000000000..fc0f83feab
+--- /dev/null
++++ b/internal/service/simpledb/domain_reverted.go
+@@ -0,0 +1,83 @@
++package simpledb
++
++import (
++	"fmt"
++	"log"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/aws/awserr"
++	"github.com/aws/aws-sdk-go/service/simpledb"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++func ResourceDomain() *schema.Resource {
++	return &schema.Resource{
++		Create: resourceDomainCreate,
++		Read:   resourceDomainRead,
++		Delete: resourceDomainDelete,
++		Importer: &schema.ResourceImporter{
++			State: schema.ImportStatePassthrough,
++		},
++
++		Schema: map[string]*schema.Schema{
++			"name": {
++				Type:     schema.TypeString,
++				Required: true,
++				ForceNew: true,
++			},
++		},
++	}
++}
++
++func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).SimpleDBConn()
++
++	name := d.Get("name").(string)
++	input := &simpledb.CreateDomainInput{
++		DomainName: aws.String(name),
++	}
++	_, err := conn.CreateDomain(input)
++	if err != nil {
++		return fmt.Errorf("Create SimpleDB Domain failed: %s", err)
++	}
++
++	d.SetId(name)
++	return nil
++}
++
++func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).SimpleDBConn()
++
++	input := &simpledb.DomainMetadataInput{
++		DomainName: aws.String(d.Id()),
++	}
++	_, err := conn.DomainMetadata(input)
++	if awsErr, ok := err.(awserr.Error); ok {
++		if awsErr.Code() == "NoSuchDomain" {
++			log.Printf("[WARN] Removing SimpleDB domain %q because it's gone.", d.Id())
++			d.SetId("")
++			return nil
++		}
++	}
++	if err != nil {
++		return err
++	}
++
++	d.Set("name", d.Id())
++	return nil
++}
++
++func resourceDomainDelete(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).SimpleDBConn()
++
++	input := &simpledb.DeleteDomainInput{
++		DomainName: aws.String(d.Id()),
++	}
++	_, err := conn.DeleteDomain(input)
++	if err != nil {
++		return fmt.Errorf("Delete SimpleDB Domain failed: %s", err)
++	}
++
++	return nil
++}
+diff --git a/internal/service/simpledb/domain_test.go b/internal/service/simpledb/domain_test.go
+index bc8a17b7a7..742a97a402 100644
+--- a/internal/service/simpledb/domain_test.go
++++ b/internal/service/simpledb/domain_test.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package simpledb_test
+ 
+ import (
+diff --git a/internal/service/simpledb/exports_test.go b/internal/service/simpledb/exports_test.go
+index 8c66737d1c..624e68ffcb 100644
+--- a/internal/service/simpledb/exports_test.go
++++ b/internal/service/simpledb/exports_test.go
+@@ -1,4 +1,5 @@
+ package simpledb
+ 
+ // Exports for use in tests only.
+-var ResourceDomain = newResourceDomain
++// Removed because the reverted code already exports this name
++// var ResourceDomain = newResourceDomain
+diff --git a/internal/service/simpledb/service_package_gen.go b/internal/service/simpledb/service_package_gen.go
+index 38eaf55e1e..8e16d77004 100644
+--- a/internal/service/simpledb/service_package_gen.go
++++ b/internal/service/simpledb/service_package_gen.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ // Code generated by internal/generate/servicepackages/main.go; DO NOT EDIT.
+ 
+ package simpledb
+diff --git a/internal/service/sts/caller_identity_data_source.go b/internal/service/sts/caller_identity_data_source.go
+index 09c82fcfe4..b75ece7473 100644
+--- a/internal/service/sts/caller_identity_data_source.go
++++ b/internal/service/sts/caller_identity_data_source.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ package sts
+ 
+ import (
+diff --git a/internal/service/sts/caller_identity_data_source_reverted.go b/internal/service/sts/caller_identity_data_source_reverted.go
+new file mode 100644
+index 0000000000..a885bdfc8e
+--- /dev/null
++++ b/internal/service/sts/caller_identity_data_source_reverted.go
+@@ -0,0 +1,54 @@
++package sts
++
++import (
++	"fmt"
++	"log"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/sts"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++func DataSourceCallerIdentity() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceCallerIdentityRead,
++
++		Schema: map[string]*schema.Schema{
++			"account_id": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"arn": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"user_id": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceCallerIdentityRead(d *schema.ResourceData, meta interface{}) error {
++	client := meta.(*conns.AWSClient).STSConn()
++
++	log.Printf("[DEBUG] Reading Caller Identity")
++	res, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
++
++	if err != nil {
++		return fmt.Errorf("getting Caller Identity: %w", err)
++	}
++
++	log.Printf("[DEBUG] Received Caller Identity: %s", res)
++
++	d.SetId(aws.StringValue(res.Account))
++	d.Set("account_id", res.Account)
++	d.Set("arn", res.Arn)
++	d.Set("user_id", res.UserId)
++
++	return nil
++}
+diff --git a/internal/service/sts/service_package_gen.go b/internal/service/sts/service_package_gen.go
+index 42614de816..07d34f8086 100644
+--- a/internal/service/sts/service_package_gen.go
++++ b/internal/service/sts/service_package_gen.go
+@@ -1,3 +1,5 @@
++//go:build ignores
++
+ // Code generated by internal/generate/servicepackages/main.go; DO NOT EDIT.
+ 
+ package sts

--- a/upstream-patches/0014-Add-custom-appautoscaling-examples.patch
+++ b/upstream-patches/0014-Add-custom-appautoscaling-examples.patch
@@ -1,0 +1,72 @@
+From eea9db6a20b1456213fe3eb935ed8af88f2a2192 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Wed, 9 Nov 2022 17:37:35 +0000
+Subject: [PATCH 14/25] Add custom appautoscaling examples
+
+---
+ .../r/appautoscaling_policy.html.markdown     | 28 +++++++++++++++++++
+ .../r/appautoscaling_target.html.markdown     | 12 ++++++++
+ 2 files changed, 40 insertions(+)
+
+diff --git a/website/docs/r/appautoscaling_policy.html.markdown b/website/docs/r/appautoscaling_policy.html.markdown
+index b281e542ae..9b1a7483d2 100644
+--- a/website/docs/r/appautoscaling_policy.html.markdown
++++ b/website/docs/r/appautoscaling_policy.html.markdown
+@@ -116,6 +116,34 @@ resource "aws_appautoscaling_policy" "replicas" {
+ }
+ ```
+ 
++### MSK / Kafka Autoscaling
++
++```hcl
++resource "aws_appautoscaling_target" "msk_target" {
++  service_namespace  = "kafka"
++  scalable_dimension = "kafka:broker-storage:VolumeSize"
++  resource_id        = "${aws_msk_cluster.example.arn}"
++  min_capacity       = 1
++  max_capacity       = 8
++}
++
++resource "aws_appautoscaling_policy" "targets" {
++  name               = "storage-size-auto-scaling"
++  service_namespace  = aws_appautoscaling_target.msk_target.service_namespace
++  scalable_dimension = aws_appautoscaling_target.msk_target.scalable_dimension
++  resource_id        = aws_appautoscaling_target.msk_target.resource_id
++  policy_type        = "TargetTrackingScaling"
++
++  target_tracking_scaling_policy_configuration {
++    predefined_metric_specification {
++      predefined_metric_type = "KafkaBrokerStorageUtilization"
++    }
++
++    target_value = 55
++  }
++}
++```
++
+ ## Argument Reference
+ 
+ The following arguments are supported:
+diff --git a/website/docs/r/appautoscaling_target.html.markdown b/website/docs/r/appautoscaling_target.html.markdown
+index 7060afc3b7..8cc3132712 100644
+--- a/website/docs/r/appautoscaling_target.html.markdown
++++ b/website/docs/r/appautoscaling_target.html.markdown
+@@ -62,6 +62,18 @@ resource "aws_appautoscaling_target" "replicas" {
+ }
+ ```
+ 
++### MSK / Kafka Autoscaling
++
++```hcl
++resource "aws_appautoscaling_target" "msk_target" {
++  service_namespace  = "kafka"
++  scalable_dimension = "kafka:broker-storage:VolumeSize"
++  resource_id        = "${aws_msk_cluster.example.arn}"
++  min_capacity       = 1
++  max_capacity       = 8
++}
++```
++
+ ## Argument Reference
+ 
+ The following arguments are supported:

--- a/upstream-patches/0015-Add-dedicated_host-docs.patch
+++ b/upstream-patches/0015-Add-dedicated_host-docs.patch
@@ -1,0 +1,170 @@
+From 8efe1362d95b1432199781f74b2ee8cb007749a6 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Tue, 15 Nov 2022 10:08:05 +0000
+Subject: [PATCH 15/25] Add dedicated_host docs
+
+---
+ website/docs/d/dedicated_host.html.markdown | 75 +++++++++++++++++++++
+ website/docs/r/dedicated_host.html.markdown | 71 +++++++++++++++++++
+ 2 files changed, 146 insertions(+)
+ create mode 100644 website/docs/d/dedicated_host.html.markdown
+ create mode 100644 website/docs/r/dedicated_host.html.markdown
+
+diff --git a/website/docs/d/dedicated_host.html.markdown b/website/docs/d/dedicated_host.html.markdown
+new file mode 100644
+index 0000000000..9473a00c59
+--- /dev/null
++++ b/website/docs/d/dedicated_host.html.markdown
+@@ -0,0 +1,75 @@
++---
++subcategory: "EC2"
++layout: "aws"
++page_title: "AWS: aws_dedicated_host"
++description: |-
++  Get information on a EC2 host.
++---
++
++# Data Source: aws_dedicated_host
++
++Use this data source to get information about the host when allocating an EC2 Dedicated Host.
++
++## Example Usage
++
++```hcl
++# Create a new host with instance type of c5.18xlarge with Auto Placement 
++# and Host Recovery enabled. 
++provider "aws" {
++  region = "us-west-2"
++}
++
++resource "aws_dedicated_host" "test" {
++  instance_type     = "c5.18xlarge"
++  availability_zone = "us-west-1a"
++  host_recovery     = "on"
++  auto_placement    = "on"
++}
++
++data "aws_dedicated_host" "test_data" {
++  host_id = "${aws_dedicated_host.test.id}"
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `auto_placement` - (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID.
++* `availability_zone` - (Optional) The AZ to start the host in.
++* `host_recovery` - (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default.
++* `instance_type` - (Optional) Specifies the instance type for which to configure your Dedicated Hosts. When you specify the instance type, that is the only instance type that you can launch onto that host. 
++
++
++
++
++
++### Timeouts
++
++The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
++
++* `create` - (Defaults to 10 mins) Used when launching the host (until it reaches the initial `running` state)
++* `update` - (Defaults to 10 mins) Used when stopping and starting the host when necessary during update - e.g. when changing host type
++* `delete` - (Defaults to 20 mins) Used when terminating the host
++
++
++## Attributes Reference
++
++In addition to all arguments above, the following attributes are exported:
++
++* `host_id` - The host ID. 
++* `cores` - The number of cores on the Dedicated Host.
++* `instance_family` - The instance family supported by the Dedicated Host. For example, m5.
++* `instance_type` -The instance type supported by the Dedicated Host. For example, m5.large. If the host supports multiple instance types, no instanceType is returned.
++* `sockets` - The instance family supported by the Dedicated Host. For example, m5.
++* `total_vcpus` - The total number of vCPUs on the Dedicated Host.
++
++
++
++## Import
++
++hosts can be imported using the `host_id`, e.g.
++
++```
++$ terraform import aws_dedicated_host.host_id h-0385a99d0e4b20cbb
++```
+diff --git a/website/docs/r/dedicated_host.html.markdown b/website/docs/r/dedicated_host.html.markdown
+new file mode 100644
+index 0000000000..01845aa221
+--- /dev/null
++++ b/website/docs/r/dedicated_host.html.markdown
+@@ -0,0 +1,71 @@
++---
++subcategory: "EC2"
++layout: "aws"
++page_title: "AWS: aws_dedicated_host"
++description: |-
++  Provides an EC2 host resource. This allows hosts to be created, updated, and deleted.
++---
++
++# Resource: aws_dedicated_host
++
++Provides an EC2 host resource. This allows hosts to be created, updated,
++and deleted.
++
++## Example Usage
++
++```hcl
++# Create a new host with instance type of c5.18xlarge with Auto Placement 
++# and Host Recovery enabled. 
++provider "aws" {
++  region = "us-west-2"
++}
++
++resource "aws_dedicated_host" "test" {
++  instance_type     = "c5.18xlarge"
++  availability_zone = "us-west-1a"
++  host_recovery     = "on"
++  auto_placement    = "on"
++}
++
++data "aws_dedicated_host" "test_data" {
++  host_id = "${aws_dedicated_host.test.id}"
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `auto_placement` - (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID.
++* `availability_zone` - (Optional) The AZ to start the host in.
++* `host_recovery` - (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default.
++* `instance_type` - (Optional) Specifies the instance type for which to configure your Dedicated Host. When you specify the instance type, that is the only instance type that you can launch onto that host. Mutually exclusive with `instance_family`.
++* `instance_family` - (Optional) Specifies the instance family for which to configure your Dedicated Host. Mutually exclusive with `instance_type`.
++
++
++
++
++
++### Timeouts
++
++The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
++
++* `create` - (Defaults to 10 mins) Used when launching the host (until it reaches the initial `running` state)
++* `update` - (Defaults to 10 mins) Used when stopping and starting the host when necessary during update - e.g. when changing host type
++* `delete` - (Defaults to 20 mins) Used when terminating the host
++
++
++## Attributes Reference
++
++In addition to all arguments above, the following attributes are exported:
++
++* `host_id` - The host ID.
++
++
++## Import
++
++hosts can be imported using the `host_id`, e.g.
++
++```
++$ terraform import aws_dedicated_host.host_id h-0385a99d0e4b20cbb
++```

--- a/upstream-patches/0016-Revert-WAF-schema-changes.patch
+++ b/upstream-patches/0016-Revert-WAF-schema-changes.patch
@@ -1,0 +1,33 @@
+From c3058571a20162cec9ba204cad5a9ce2ab95b66e Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Tue, 15 Nov 2022 13:59:57 +0000
+Subject: [PATCH 16/25] Revert WAF schema changes
+
+- This causes far too many types to be generated downstream.
+---
+ internal/service/wafv2/schemas.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/internal/service/wafv2/schemas.go b/internal/service/wafv2/schemas.go
+index eee20e44f4..b1eb45ea63 100644
+--- a/internal/service/wafv2/schemas.go
++++ b/internal/service/wafv2/schemas.go
+@@ -59,14 +59,14 @@ func ruleGroupRootStatementSchema(level int) *schema.Schema {
+ 		MaxItems: 1,
+ 		Elem: &schema.Resource{
+ 			Schema: map[string]*schema.Schema{
+-				"and_statement":                         statementSchema(level),
++				"and_statement":                         statementSchema(level - 1),
+ 				"byte_match_statement":                  byteMatchStatementSchema(),
+ 				"geo_match_statement":                   geoMatchStatementSchema(),
+ 				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+ 				"label_match_statement":                 labelMatchStatementSchema(),
+-				"not_statement":                         statementSchema(level),
+-				"or_statement":                          statementSchema(level),
+-				"rate_based_statement":                  rateBasedStatementSchema(level),
++				"not_statement":                         statementSchema(level - 1),
++				"or_statement":                          statementSchema(level - 1),
++				"rate_based_statement":                  rateBasedStatementSchema(level - 1),
+ 				"regex_match_statement":                 regexMatchStatementSchema(),
+ 				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+ 				"size_constraint_statement":             sizeConstraintSchema(),

--- a/upstream-patches/0017-Un-deprecate-RDS-instance-name.patch
+++ b/upstream-patches/0017-Un-deprecate-RDS-instance-name.patch
@@ -1,0 +1,32 @@
+From 939cac6cd3e0758ca63bd3b56dce04e99bddd6b2 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Thu, 17 Nov 2022 09:55:46 +0000
+Subject: [PATCH 17/25] Un-deprecate RDS instance name
+
+We don't have a good migration story yet so this just adds noise for users.
+
+Reference: https://github.com/pulumi/pulumi-aws/issues/2203
+---
+ internal/service/rds/instance.go | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/internal/service/rds/instance.go b/internal/service/rds/instance.go
+index dff77c99a6..0b16fc283e 100644
+--- a/internal/service/rds/instance.go
++++ b/internal/service/rds/instance.go
+@@ -333,11 +333,10 @@ func ResourceInstance() *schema.Resource {
+ 				Computed: true,
+ 			},
+ 			"name": {
+-				Type:       schema.TypeString,
+-				Optional:   true,
+-				Computed:   true,
+-				Deprecated: "Use db_name instead",
+-				ForceNew:   true,
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++				ForceNew: true,
+ 				ConflictsWith: []string{
+ 					"db_name",
+ 					"replicate_source_db",

--- a/upstream-patches/0018-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
+++ b/upstream-patches/0018-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
@@ -1,0 +1,28 @@
+From ad861f11ef67621582b929c97b019d6311b99a68 Mon Sep 17 00:00:00 2001
+From: Thomas Kappler <tkappler@gmail.com>
+Date: Thu, 1 Dec 2022 10:56:32 -0800
+Subject: [PATCH 18/25] Catch cty panic in new
+ resourceTopicSubscriptionCustomizeDiff.
+
+The root cause is not fully understood yet but this might unblock us.
+---
+ internal/service/sns/topic_subscription.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/internal/service/sns/topic_subscription.go b/internal/service/sns/topic_subscription.go
+index c3acba5efe..3665ba1e74 100644
+--- a/internal/service/sns/topic_subscription.go
++++ b/internal/service/sns/topic_subscription.go
+@@ -514,9 +514,11 @@ func normalizeTopicSubscriptionDeliveryPolicy(policy string) ([]byte, error) {
+ 
+ func resourceTopicSubscriptionCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+ 	hasPolicy := diff.Get("filter_policy").(string) != ""
+-	hasScope := !diff.GetRawConfig().GetAttr("filter_policy_scope").IsNull()
+ 	hadScope := diff.Get("filter_policy_scope").(string) != ""
+ 
++	rawConfig := diff.GetRawConfig()
++	hasScope := rawConfig.Type().IsObjectType() && !rawConfig.GetAttr("filter_policy_scope").IsNull()
++
+ 	if hasPolicy && !hasScope {
+ 		if !hadScope {
+ 			// When the filter_policy_scope hasn't been read back from the API,

--- a/upstream-patches/0019-add-matchmaking-configuration-72.patch
+++ b/upstream-patches/0019-add-matchmaking-configuration-72.patch
@@ -1,0 +1,1196 @@
+From b21cdee348e100923ac47bba5377c93155732ca6 Mon Sep 17 00:00:00 2001
+From: Lee Briggs <jaxxstorm@users.noreply.github.com>
+Date: Wed, 21 Dec 2022 12:23:59 -0800
+Subject: [PATCH 19/25] add matchmaking configuration (#72)
+
+* add matchmaking configuration
+* add matchmaking rule set
+* implement flex_match_mode
+  * Also fixes error codes for read operations
+* add resource docs
+---
+ internal/provider/provider.go                 |   4 +
+ .../gamelift/matchmaking_configuration.go     | 386 ++++++++++++++++++
+ .../matchmaking_configuration_test.go         | 267 ++++++++++++
+ .../service/gamelift/matchmaking_rule_set.go  | 163 ++++++++
+ .../gamelift/matchmaking_rule_set_test.go     | 138 +++++++
+ ...ft_matchmaking_configuration.html.markdown | 106 +++++
+ ...amelift_matchmaking_rule_set.html.markdown |  52 +++
+ 7 files changed, 1116 insertions(+)
+ create mode 100644 internal/service/gamelift/matchmaking_configuration.go
+ create mode 100644 internal/service/gamelift/matchmaking_configuration_test.go
+ create mode 100644 internal/service/gamelift/matchmaking_rule_set.go
+ create mode 100644 internal/service/gamelift/matchmaking_rule_set_test.go
+ create mode 100644 website/docs/r/gamelift_matchmaking_configuration.html.markdown
+ create mode 100644 website/docs/r/gamelift_matchmaking_rule_set.html.markdown
+
+diff --git a/internal/provider/provider.go b/internal/provider/provider.go
+index 7772ba7aa6..2af880e3da 100644
+--- a/internal/provider/provider.go
++++ b/internal/provider/provider.go
+@@ -9,6 +9,7 @@ import (
+ 	"time"
+ 
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/ecr"
++	"github.com/hashicorp/terraform-provider-aws/internal/service/gamelift"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/service/s3legacy"
+@@ -276,6 +277,9 @@ func New(ctx context.Context) (*schema.Provider, error) {
+ 			"aws_globalaccelerator_accelerator":    globalaccelerator.ResourceAccelerator(),
+ 			"aws_globalaccelerator_endpoint_group": globalaccelerator.ResourceEndpointGroup(),
+ 			"aws_globalaccelerator_listener":       globalaccelerator.ResourceListener(),
++
++			"aws_gamelift_matchmaking_configuration": gamelift.ResourceMatchMakingConfiguration(),
++			"aws_gamelift_matchmaking_rule_set":      gamelift.ResourceMatchmakingRuleSet(),
+ 		},
+ 	}
+ 
+diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go
+new file mode 100644
+index 0000000000..0a7c8ea635
+--- /dev/null
++++ b/internal/service/gamelift/matchmaking_configuration.go
+@@ -0,0 +1,386 @@
++package gamelift
++
++import (
++	"context"
++	"fmt"
++	"log"
++	"regexp"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/gamelift"
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	"github.com/hashicorp/terraform-provider-aws/internal/flex"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++)
++
++func ResourceMatchMakingConfiguration() *schema.Resource {
++	return &schema.Resource{
++		Create: resourceMatchmakingConfigurationCreate,
++		Read:   resourceMatchmakingConfigurationRead,
++		Update: resourceMatchmakingConfigurationUpdate,
++		Delete: resourceMatchmakingConfigurationDelete,
++		Importer: &schema.ResourceImporter{
++			StateContext: schema.ImportStatePassthroughContext,
++		},
++
++		Schema: map[string]*schema.Schema{
++			"acceptance_required": {
++				Type:     schema.TypeBool,
++				Required: true,
++			},
++			"acceptance_timeout_seconds": {
++				Type:         schema.TypeInt,
++				Optional:     true,
++				ValidateFunc: validation.IntBetween(1, 600),
++			},
++			"additional_player_count": {
++				Type:         schema.TypeInt,
++				Optional:     true,
++				ValidateFunc: validation.IntAtLeast(0),
++			},
++			"arn": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"backfill_mode": {
++				Type:         schema.TypeString,
++				Optional:     true,
++				ValidateFunc: validation.StringInSlice([]string{gamelift.BackfillModeAutomatic, gamelift.BackfillModeManual}, false),
++			},
++			"creation_time": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"custom_event_data": {
++				Type:         schema.TypeString,
++				Optional:     true,
++				ValidateFunc: validation.StringLenBetween(0, 256),
++			},
++			"description": {
++				Type:         schema.TypeString,
++				Optional:     true,
++				ValidateFunc: validation.StringLenBetween(1, 1024),
++			},
++			"flex_match_mode": {
++				Type:         schema.TypeString,
++				Optional:     true,
++				Computed:     true,
++				ValidateFunc: validation.StringInSlice([]string{gamelift.FlexMatchModeStandalone, gamelift.FlexMatchModeWithQueue}, false),
++			},
++			"game_property": {
++				Type:     schema.TypeSet,
++				Optional: true,
++				MaxItems: 16,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"key": {
++							Type:         schema.TypeString,
++							Required:     true,
++							ValidateFunc: validation.StringLenBetween(0, 32),
++						},
++						"value": {
++							Type:         schema.TypeString,
++							Required:     true,
++							ValidateFunc: validation.StringLenBetween(0, 96),
++						},
++					},
++				},
++			},
++			"game_session_data": {
++				Type:         schema.TypeString,
++				Required:     true,
++				ValidateFunc: validation.StringLenBetween(0, 4096),
++			},
++			"game_session_queue_arns": {
++				Type:     schema.TypeSet,
++				Optional: true,
++				Elem: &schema.Schema{
++					Type: schema.TypeString,
++					ValidateFunc: validation.All(
++						validation.StringLenBetween(1, 256),
++						validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9:/-]+$`), "must contain only alphanumeric characters, colon, slash and hyphens"),
++					),
++				},
++			},
++			"name": {
++				Type:     schema.TypeString,
++				Required: true,
++				ForceNew: true,
++				ValidateFunc: validation.All(
++					validation.StringLenBetween(0, 128),
++					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-\.]*$`), "must contain only alphanumeric characters, hyphens and periods"),
++				),
++			},
++			"notification_target": {
++				Type:     schema.TypeString,
++				Optional: true,
++				ValidateFunc: validation.All(
++					validation.StringLenBetween(0, 300),
++					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9:_/-]*$`), "must contain only alphanumeric characters, colons, underscores, slashes and hyphens"),
++				),
++			},
++			"request_timeout_seconds": {
++				Type:         schema.TypeInt,
++				Required:     true,
++				ValidateFunc: validation.IntBetween(1, 43200),
++			},
++			"rule_set_arn": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"rule_set_name": {
++				Type:     schema.TypeString,
++				Required: true,
++				ValidateFunc: validation.All(
++					validation.StringLenBetween(0, 128),
++					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-\.]*$`), "must contain only alphanumeric characters, hyphens and periods"),
++				),
++			},
++			"tags":     tftags.TagsSchema(),
++			"tags_all": tftags.TagsSchemaTrulyComputed(),
++		},
++	}
++}
++
++func resourceMatchmakingConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
++	tags := defaultTagsConfig.MergeTags(tftags.New(context.Background(), d.Get("tags").(map[string]interface{})))
++
++	input := gamelift.CreateMatchmakingConfigurationInput{
++		AcceptanceRequired:    aws.Bool(d.Get("acceptance_required").(bool)),
++		Name:                  aws.String(d.Get("name").(string)),
++		RequestTimeoutSeconds: aws.Int64(int64(d.Get("request_timeout_seconds").(int))),
++		RuleSetName:           aws.String(d.Get("rule_set_name").(string)),
++		Tags:                  Tags(tags.IgnoreAWS()),
++	}
++
++	if v, ok := d.GetOk("acceptance_timeout_seconds"); ok {
++		input.AcceptanceTimeoutSeconds = aws.Int64(int64(v.(int)))
++	}
++	if v, ok := d.GetOk("additional_player_count"); ok {
++		input.AdditionalPlayerCount = aws.Int64(int64(v.(int)))
++	}
++	if v, ok := d.GetOk("backfill_mode"); ok {
++		input.BackfillMode = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("custom_event_data"); ok {
++		input.CustomEventData = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("description"); ok {
++		input.Description = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("flex_match_mode"); ok {
++		input.FlexMatchMode = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("game_property"); ok {
++		set := v.(*schema.Set)
++		input.GameProperties = expandGameliftGameProperties(set.List())
++	}
++	if v, ok := d.GetOk("game_session_data"); ok {
++		input.GameSessionData = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("game_session_queue_arns"); ok {
++		input.GameSessionQueueArns = flex.ExpandStringSet(v.(*schema.Set))
++	}
++	if v, ok := d.GetOk("notification_target"); ok {
++		input.NotificationTarget = aws.String(v.(string))
++	}
++
++	log.Printf("[INFO] Creating GameLift Matchmaking Configuration: %s", input)
++	out, err := conn.CreateMatchmakingConfiguration(&input)
++	if err != nil {
++		return fmt.Errorf("error creating GameLift Matchmaking Configuration: %s", err)
++	}
++
++	d.SetId(aws.StringValue(out.Configuration.ConfigurationArn))
++	return resourceMatchmakingConfigurationRead(d, meta)
++}
++
++func resourceMatchmakingConfigurationRead(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
++	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
++
++	log.Printf("[INFO] Describing GameLift Matchmaking Configuration: %s", d.Id())
++	out, err := conn.DescribeMatchmakingConfigurations(&gamelift.DescribeMatchmakingConfigurationsInput{
++		Names: aws.StringSlice([]string{d.Id()}),
++	})
++	if err != nil {
++		if tfawserr.ErrStatusCodeEquals(err, 400) || tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++			log.Printf("[WARN] GameLift Matchmaking Configuration (%s) not found, removing from state", d.Id())
++			d.SetId("")
++			return nil
++		}
++		return fmt.Errorf("error reading GameLift Matchmaking Configuration (%s): %s", d.Id(), err)
++	}
++	configurations := out.Configurations
++
++	if len(configurations) < 1 {
++		log.Printf("[WARN] GameLift Matchmaking Configuration (%s) not found, removing from state", d.Id())
++		d.SetId("")
++		return nil
++	}
++	if len(configurations) != 1 {
++		return fmt.Errorf("expected exactly 1 GameLift Matchmaking Configuration, found %d under %q",
++			len(configurations), d.Id())
++	}
++	configuration := configurations[0]
++
++	arn := aws.StringValue(configuration.ConfigurationArn)
++	d.Set("acceptance_required", configuration.AcceptanceRequired)
++	d.Set("acceptance_timeout_seconds", configuration.AcceptanceTimeoutSeconds)
++	d.Set("additional_player_count", configuration.AdditionalPlayerCount)
++	d.Set("arn", arn)
++	d.Set("backfill_mode", configuration.BackfillMode)
++	d.Set("creation_time", configuration.CreationTime.Format("2006-01-02 15:04:05"))
++	d.Set("custom_event_data", configuration.CustomEventData)
++	d.Set("description", configuration.Description)
++	d.Set("flex_match_mode", configuration.FlexMatchMode)
++	d.Set("game_property", flattenGameliftGameProperties(configuration.GameProperties))
++	d.Set("game_session_data", configuration.GameSessionData)
++	d.Set("game_session_queue_arns", configuration.GameSessionQueueArns)
++	d.Set("name", configuration.Name)
++	d.Set("notification_target", configuration.NotificationTarget)
++	d.Set("request_timeout_seconds", configuration.RequestTimeoutSeconds)
++	d.Set("rule_set_arn", configuration.RuleSetArn)
++	d.Set("rule_set_name", configuration.RuleSetName)
++
++	tags, err := ListTags(context.Background(), conn, arn)
++
++	if err != nil {
++		return fmt.Errorf("error listing tags for GameLift Matchmaking Configuration (%s): %s", arn, err)
++	}
++
++	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
++
++	//lintignore:AWSR002
++	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
++		return fmt.Errorf("error setting tags: %w", err)
++	}
++
++	if err := d.Set("tags_all", tags.Map()); err != nil {
++		return fmt.Errorf("error setting tags_all: %w", err)
++	}
++
++	return nil
++}
++
++func resourceMatchmakingConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++
++	log.Printf("[INFO] Updating GameLift Matchmaking Configuration: %s", d.Id())
++
++	input := gamelift.UpdateMatchmakingConfigurationInput{
++		Name:                  aws.String(d.Id()),
++		AcceptanceRequired:    aws.Bool(d.Get("acceptance_required").(bool)),
++		RequestTimeoutSeconds: aws.Int64(int64(d.Get("request_timeout_seconds").(int))),
++		RuleSetName:           aws.String(d.Get("rule_set_name").(string)),
++	}
++
++	if v, ok := d.GetOk("acceptance_timeout_seconds"); ok {
++		input.AcceptanceTimeoutSeconds = aws.Int64(int64(v.(int)))
++	}
++	if v, ok := d.GetOk("additional_player_count"); ok {
++		input.AdditionalPlayerCount = aws.Int64(int64(v.(int)))
++	}
++	if v, ok := d.GetOk("backfill_mode"); ok {
++		input.BackfillMode = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("custom_event_data"); ok {
++		input.CustomEventData = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("description"); ok {
++		input.Description = aws.String(v.(string))
++	}
++	if d.HasChange("flex_match_mode") {
++		if v, ok := d.GetOk("flex_match_mode"); ok {
++			input.FlexMatchMode = aws.String(v.(string))
++		}
++	}
++	if v, ok := d.GetOk("game_property"); ok {
++		set := v.(*schema.Set)
++		input.GameProperties = expandGameliftGameProperties(set.List())
++	}
++	if v, ok := d.GetOk("game_session_data"); ok {
++		input.GameSessionData = aws.String(v.(string))
++	}
++	if v, ok := d.GetOk("game_session_queue_arns"); ok {
++		input.GameSessionQueueArns = expandStringList(v.([]interface{}))
++	}
++	if v, ok := d.GetOk("notification_target"); ok {
++		input.NotificationTarget = aws.String(v.(string))
++	}
++
++	_, err := conn.UpdateMatchmakingConfiguration(&input)
++	if err != nil {
++		return fmt.Errorf("error updating Gamelift Matchmaking Configuration (%s): %s", d.Id(), err)
++	}
++
++	arn := d.Id()
++
++	if d.HasChange("tags_all") {
++		o, n := d.GetChange("tags_all")
++
++		if err := UpdateTags(context.Background(), conn, arn, o, n); err != nil {
++			return fmt.Errorf("error updating GameLift Matchmaking Configuration (%s) tags: %s", arn, err)
++		}
++	}
++
++	return resourceMatchmakingConfigurationRead(d, meta)
++}
++
++func resourceMatchmakingConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++	log.Printf("[INFO] Deleting GameLift Matchmaking Configuration: %s", d.Id())
++	_, err := conn.DeleteMatchmakingConfiguration(&gamelift.DeleteMatchmakingConfigurationInput{
++		Name: aws.String(d.Id()),
++	})
++	if tfawserr.ErrStatusCodeEquals(err, 400) || tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++		return nil
++	}
++	if err != nil {
++		return fmt.Errorf("error deleting GameLift Matchmaking Configuration (%s): %s", d.Id(), err)
++	}
++
++	return nil
++}
++
++func expandGameliftGameProperties(cfg []interface{}) []*gamelift.GameProperty {
++	properties := make([]*gamelift.GameProperty, len(cfg))
++	for i, property := range cfg {
++		prop := property.(map[string]interface{})
++		properties[i] = &gamelift.GameProperty{
++			Key:   aws.String(prop["key"].(string)),
++			Value: aws.String(prop["value"].(string)),
++		}
++	}
++	return properties
++}
++
++func flattenGameliftGameProperties(awsProperties []*gamelift.GameProperty) []interface{} {
++	properties := []interface{}{}
++	for _, awsProperty := range awsProperties {
++		property := map[string]string{
++			"key":   *awsProperty.Key,
++			"value": *awsProperty.Value,
++		}
++		properties = append(properties, property)
++	}
++	return properties
++}
++
++func expandStringList(tfList []interface{}) []*string {
++	var result []*string
++
++	for _, rawVal := range tfList {
++		if v, ok := rawVal.(string); ok && v != "" {
++			result = append(result, &v)
++		}
++	}
++
++	return result
++}
+diff --git a/internal/service/gamelift/matchmaking_configuration_test.go b/internal/service/gamelift/matchmaking_configuration_test.go
+new file mode 100644
+index 0000000000..7bd8451404
+--- /dev/null
++++ b/internal/service/gamelift/matchmaking_configuration_test.go
+@@ -0,0 +1,267 @@
++package gamelift_test
++
++import (
++	"fmt"
++	"regexp"
++	"testing"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/gamelift"
++
++	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
++	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tfgamelift "github.com/hashicorp/terraform-provider-aws/internal/service/gamelift"
++)
++
++func TestAccMatchmakingConfiguration_basic(t *testing.T) {
++
++	var conf gamelift.MatchmakingConfiguration
++
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_gamelift_matchmaking_configuration.test"
++	queueName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++
++	additionalParameters := ""
++
++	resource.ParallelTest(t, resource.TestCase{
++		PreCheck: func() {
++			acctest.PreCheck(t)
++			acctest.PreCheckPartitionHasService(gamelift.EndpointsID, t)
++			testAccPreCheck(t)
++		},
++		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckGameServerGroupDestroy,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccGameServerMatchmakingConfiguration_basic(rName, queueName, ruleSetName, additionalParameters, 10),
++				Check: resource.ComposeTestCheckFunc(
++					testAccCheckMatchmakingConfigurationExists(resourceName, &conf),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`matchmakingconfiguration/.+`)),
++					resource.TestCheckResourceAttr(resourceName, "name", rName),
++					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
++					resource.TestCheckResourceAttr(resourceName, "custom_event_data", "pvp"),
++					resource.TestCheckResourceAttr(resourceName, "game_session_data", "game_session_data"),
++					resource.TestCheckResourceAttr(resourceName, "acceptance_required", "false"),
++					resource.TestCheckResourceAttr(resourceName, "request_timeout_seconds", "10"),
++					resource.TestCheckResourceAttr(resourceName, "backfill_mode", gamelift.BackfillModeManual),
++				),
++			},
++			{
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
++			},
++		},
++	})
++}
++
++func TestAccMatchmakingConfiguration_tags(t *testing.T) {
++
++	var conf gamelift.MatchmakingConfiguration
++
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_gamelift_matchmaking_configuration.test"
++	queueName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++
++	additionalParameters := ""
++
++	resource.ParallelTest(t, resource.TestCase{
++		PreCheck: func() {
++			acctest.PreCheck(t)
++			acctest.PreCheckPartitionHasService(gamelift.EndpointsID, t)
++			testAccPreCheck(t)
++		},
++		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckGameServerGroupDestroy,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccGameServerMatchmakingConfiguration_tags(rName, queueName, ruleSetName, additionalParameters, 10),
++				Check: resource.ComposeTestCheckFunc(
++					testAccCheckMatchmakingConfigurationExists(resourceName, &conf),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`matchmakingconfiguration/.+`)),
++					resource.TestCheckResourceAttr(resourceName, "name", rName),
++					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
++					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
++					resource.TestCheckResourceAttr(resourceName, "custom_event_data", "pvp"),
++					resource.TestCheckResourceAttr(resourceName, "game_session_data", "game_session_data"),
++					resource.TestCheckResourceAttr(resourceName, "acceptance_required", "false"),
++					resource.TestCheckResourceAttr(resourceName, "request_timeout_seconds", "10"),
++					resource.TestCheckResourceAttr(resourceName, "backfill_mode", gamelift.BackfillModeManual),
++				),
++			},
++			{
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
++			},
++		},
++	})
++}
++
++func TestAccMatchmakingConfiguration_disappears(t *testing.T) {
++	var conf gamelift.MatchmakingConfiguration
++
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_gamelift_matchmaking_configuration.test"
++	queueName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++
++	additionalParameters := ""
++
++	resource.ParallelTest(t, resource.TestCase{
++		PreCheck: func() {
++			acctest.PreCheck(t)
++			acctest.PreCheckPartitionHasService(gamelift.EndpointsID, t)
++			testAccPreCheck(t)
++		},
++		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckGameServerGroupDestroy,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccGameServerMatchmakingConfiguration_basic(rName, queueName, ruleSetName, additionalParameters, 10),
++				Check: resource.ComposeTestCheckFunc(
++					testAccCheckMatchmakingConfigurationExists(resourceName, &conf),
++					acctest.CheckResourceDisappears(acctest.Provider, tfgamelift.ResourceMatchMakingConfiguration(), resourceName),
++				),
++				ExpectNonEmptyPlan: true,
++			},
++		},
++	})
++}
++
++func testAccCheckMatchmakingConfigurationExists(n string, res *gamelift.MatchmakingConfiguration) resource.TestCheckFunc {
++	return func(s *terraform.State) error {
++
++		rs, ok := s.RootModule().Resources[n]
++		if !ok {
++			return fmt.Errorf("not found: %s", n)
++		}
++
++		if rs.Primary.ID == "" {
++			return fmt.Errorf("no Gamelift Matchmaking Configuration Name is set")
++		}
++
++		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
++
++		name := rs.Primary.Attributes["name"]
++		out, err := conn.DescribeMatchmakingConfigurations(&gamelift.DescribeMatchmakingConfigurationsInput{
++			Names: aws.StringSlice([]string{name}),
++		})
++
++		if err != nil {
++			return err
++		}
++		configurations := out.Configurations
++		if len(configurations) == 0 {
++			return fmt.Errorf("GameLift Matchmaking Configuration %q not found", name)
++		}
++		*res = *configurations[0]
++
++		return nil
++	}
++}
++
++func testAccAWSGameliftMatchMakingConfigurationRuleSetBody() string {
++	maxPlayers := int64(1)
++	return fmt.Sprintf(`{
++		"name": "test",
++		"ruleLanguageVersion": "1.0",
++		"teams": [{
++			"name": "alpha",
++			"minPlayers": 1,
++			"maxPlayers": %[1]d
++		}]
++	}`, maxPlayers)
++}
++
++func testAccGameServerMatchmakingConfiguration_basic(rName string, queueName string, ruleSetName string, additionalParameters string, requestTimeoutSeconds int) string {
++	backfillMode := gamelift.BackfillModeManual
++	return fmt.Sprintf(`
++resource "aws_gamelift_game_session_queue" "test" {
++	name         = %[2]q
++	destinations = []
++	
++	player_latency_policy {
++		maximum_individual_player_latency_milliseconds = 3
++		policy_duration_seconds                        = 7
++	}
++	
++	player_latency_policy {
++		maximum_individual_player_latency_milliseconds = 10
++	}
++	
++	timeout_in_seconds = 25
++}
++
++resource "aws_gamelift_matchmaking_rule_set" "test" {
++	name          = %[3]q
++	rule_set_body = <<RULE_SET_BODY
++	%[4]s
++	RULE_SET_BODY	
++}
++
++resource "aws_gamelift_matchmaking_configuration" "test" {
++	name          = %[1]q
++	acceptance_required = false
++	custom_event_data = "pvp"
++	game_session_data = "game_session_data"
++	backfill_mode = %[7]q
++	request_timeout_seconds = %[6]d
++	rule_set_name = aws_gamelift_matchmaking_rule_set.test.name
++	game_session_queue_arns = [aws_gamelift_game_session_queue.test.arn]
++	%[5]s
++}
++
++`, rName, queueName, ruleSetName, testAccAWSGameliftMatchMakingConfigurationRuleSetBody(), additionalParameters, requestTimeoutSeconds, backfillMode)
++}
++
++func testAccGameServerMatchmakingConfiguration_tags(rName string, queueName string, ruleSetName string, additionalParameters string, requestTimeoutSeconds int) string {
++	backfillMode := gamelift.BackfillModeManual
++	return fmt.Sprintf(`
++resource "aws_gamelift_game_session_queue" "test" {
++	name         = %[2]q
++	destinations = []
++	
++	player_latency_policy {
++		maximum_individual_player_latency_milliseconds = 3
++		policy_duration_seconds                        = 7
++	}
++	
++	player_latency_policy {
++		maximum_individual_player_latency_milliseconds = 10
++	}
++	
++	timeout_in_seconds = 25
++}
++
++resource "aws_gamelift_matchmaking_rule_set" "test" {
++	name          = %[3]q
++	rule_set_body = <<RULE_SET_BODY
++	%[4]s
++	RULE_SET_BODY	
++}
++
++resource "aws_gamelift_matchmaking_configuration" "test" {
++	name          = %[1]q
++	acceptance_required = false
++	custom_event_data = "pvp"
++	game_session_data = "game_session_data"
++	backfill_mode = %[7]q
++	request_timeout_seconds = %[6]d
++	rule_set_name = aws_gamelift_matchmaking_rule_set.test.name
++	game_session_queue_arns = [aws_gamelift_game_session_queue.test.arn]
++	tags = {
++		"key1" = "value1"
++	}
++	%[5]s
++}
++`, rName, queueName, ruleSetName, testAccAWSGameliftMatchMakingConfigurationRuleSetBody(), additionalParameters, requestTimeoutSeconds, backfillMode)
++}
+diff --git a/internal/service/gamelift/matchmaking_rule_set.go b/internal/service/gamelift/matchmaking_rule_set.go
+new file mode 100644
+index 0000000000..28d15ecf5e
+--- /dev/null
++++ b/internal/service/gamelift/matchmaking_rule_set.go
+@@ -0,0 +1,163 @@
++package gamelift
++
++import (
++	"context"
++	"fmt"
++	"log"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/gamelift"
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++	"github.com/hashicorp/terraform-provider-aws/internal/verify"
++)
++
++func ResourceMatchmakingRuleSet() *schema.Resource {
++	return &schema.Resource{
++		Create: resourceMatchmakingRuleSetCreate,
++		Read:   resourceMatchmakingRuleSetRead,
++		Update: resourceMatchmakingRuleSetUpdate,
++		Delete: resourceMatchmakingRuleSetDelete,
++		Importer: &schema.ResourceImporter{
++			StateContext: schema.ImportStatePassthroughContext,
++		},
++
++		Schema: map[string]*schema.Schema{
++			"name": {
++				Type:         schema.TypeString,
++				Required:     true,
++				ForceNew:     true,
++				ValidateFunc: validation.StringLenBetween(1, 128),
++			},
++			"rule_set_body": {
++				Type:     schema.TypeString,
++				Required: true,
++				ForceNew: true,
++				ValidateFunc: validation.All(
++					validation.StringLenBetween(1, 65535),
++					validation.StringIsJSON,
++				),
++				StateFunc: func(v interface{}) string {
++					json, _ := structure.NormalizeJsonString(v)
++					return json
++				},
++				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
++			},
++			"arn": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"tags":     tftags.TagsSchema(),
++			"tags_all": tftags.TagsSchemaTrulyComputed(),
++		},
++	}
++}
++
++func resourceMatchmakingRuleSetCreate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
++	tags := defaultTagsConfig.MergeTags(tftags.New(context.Background(), d.Get("tags").(map[string]interface{})))
++
++	input := gamelift.CreateMatchmakingRuleSetInput{
++		Name:        aws.String(d.Get("name").(string)),
++		RuleSetBody: aws.String(d.Get("rule_set_body").(string)),
++		Tags:        Tags(tags.IgnoreAWS()),
++	}
++	log.Printf("[INFO] Creating GameLift Matchmaking Rule Set: %s", input)
++	out, err := conn.CreateMatchmakingRuleSet(&input)
++	if err != nil {
++		return fmt.Errorf("error creating GameLift Matchmaking Rule Set: %s", err)
++	}
++
++	d.SetId(aws.StringValue(out.RuleSet.RuleSetName))
++
++	return resourceMatchmakingRuleSetRead(d, meta)
++}
++
++func resourceMatchmakingRuleSetRead(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
++
++	log.Printf("[INFO] Describing GameLift Matchmaking Rule Set: %s", d.Id())
++	out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{
++		Names: aws.StringSlice([]string{d.Id()}),
++	})
++	if err != nil {
++		if tfawserr.ErrStatusCodeEquals(err, 400) || tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++			log.Printf("[WARN] GameLift Matchmaking Rule Set (%s) not found, removing from state", d.Id())
++			d.SetId("")
++			return nil
++		}
++		return fmt.Errorf("error reading GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
++	}
++	ruleSets := out.RuleSets
++
++	if len(ruleSets) < 1 {
++		log.Printf("[WARN] GameLift Matchmaking Rule Set (%s) not found, removing from state", d.Id())
++		d.SetId("")
++		return nil
++	}
++	if len(ruleSets) != 1 {
++		return fmt.Errorf("expected exactly 1 GameLift Matchmaking Rule Set, found %d under %q",
++			len(ruleSets), d.Id())
++	}
++	ruleSet := ruleSets[0]
++
++	arn := aws.StringValue(ruleSet.RuleSetArn)
++	d.Set("arn", arn)
++	d.Set("name", ruleSet.RuleSetName)
++	d.Set("rule_set_body", ruleSet.RuleSetBody)
++
++	tags, err := ListTags(context.Background(), conn, arn)
++
++	if err != nil {
++		return fmt.Errorf("error listing tags for GameLift Matchmaking Rule Set (%s): %s", arn, err)
++	}
++
++	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
++		return fmt.Errorf("error setting tags: %w", err)
++	}
++
++	if err := d.Set("tags_all", tags.Map()); err != nil {
++		return fmt.Errorf("error setting tags_all: %w", err)
++	}
++
++	return nil
++}
++
++func resourceMatchmakingRuleSetUpdate(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++
++	log.Printf("[INFO] Updating GameLift Matchmaking Rule Set: %s", d.Id())
++
++	arn := d.Id()
++	if d.HasChange("tags_all") {
++		o, n := d.GetChange("tags_all")
++
++		if err := UpdateTags(context.Background(), conn, arn, o, n); err != nil {
++			return fmt.Errorf("error updating GameLift Matchmaking Rule Set (%s) tags: %s", arn, err)
++		}
++	}
++
++	return resourceMatchmakingRuleSetRead(d, meta)
++}
++
++func resourceMatchmakingRuleSetDelete(d *schema.ResourceData, meta interface{}) error {
++	conn := meta.(*conns.AWSClient).GameLiftConn()
++	log.Printf("[INFO] Deleting GameLift Matchmaking Rule Set: %s", d.Id())
++	_, err := conn.DeleteMatchmakingRuleSet(&gamelift.DeleteMatchmakingRuleSetInput{
++		Name: aws.String(d.Id()),
++	})
++	if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++		return nil
++	}
++	if err != nil {
++		return fmt.Errorf("error deleting GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
++	}
++
++	return nil
++}
+diff --git a/internal/service/gamelift/matchmaking_rule_set_test.go b/internal/service/gamelift/matchmaking_rule_set_test.go
+new file mode 100644
+index 0000000000..8788ef5b45
+--- /dev/null
++++ b/internal/service/gamelift/matchmaking_rule_set_test.go
+@@ -0,0 +1,138 @@
++package gamelift_test
++
++import (
++	"fmt"
++	"regexp"
++	"testing"
++
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/gamelift"
++	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
++	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	tfgamelift "github.com/hashicorp/terraform-provider-aws/internal/service/gamelift"
++)
++
++func TestAccMatchmakingRuleSet_basic(t *testing.T) {
++
++	var conf gamelift.MatchmakingRuleSet
++
++	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_gamelift_matchmaking_rule_set.test"
++	maxPlayers := 5
++
++	resource.Test(t, resource.TestCase{
++		PreCheck: func() {
++			acctest.PreCheck(t)
++			acctest.PreCheckPartitionHasService(gamelift.EndpointsID, t)
++			testAccPreCheck(t)
++		},
++		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckGameServerGroupDestroy,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccMatchmakingRuleSetBasicConfig(ruleSetName, maxPlayers),
++				Check: resource.ComposeTestCheckFunc(
++					testAccCheckMatchmakingRuleSetExists(resourceName, &conf),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`matchmakingruleset/.+`)),
++					resource.TestCheckResourceAttr(resourceName, "name", ruleSetName),
++					resource.TestCheckResourceAttr(resourceName, "rule_set_body", testAccMatchmakingRuleSetBody(maxPlayers)+"\n"),
++					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
++				),
++			},
++			{
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
++			},
++		},
++	})
++}
++
++func TestAccMatchmakingRuleSet_disappears(t *testing.T) {
++
++	var conf gamelift.MatchmakingRuleSet
++
++	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_gamelift_matchmaking_rule_set.test"
++	maxPlayers := 5
++
++	resource.ParallelTest(t, resource.TestCase{
++		PreCheck: func() {
++			acctest.PreCheck(t)
++			acctest.PreCheckPartitionHasService(gamelift.EndpointsID, t)
++			testAccPreCheck(t)
++		},
++		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckGameServerGroupDestroy,
++		Steps: []resource.TestStep{
++			{
++				Config: testAccMatchmakingRuleSetBasicConfig(ruleSetName, maxPlayers),
++				Check: resource.ComposeTestCheckFunc(
++					testAccCheckMatchmakingRuleSetExists(resourceName, &conf),
++					acctest.CheckResourceDisappears(acctest.Provider, tfgamelift.ResourceMatchmakingRuleSet(), resourceName),
++				),
++				ExpectNonEmptyPlan: true,
++			},
++		},
++	})
++}
++
++func testAccCheckMatchmakingRuleSetExists(n string, res *gamelift.MatchmakingRuleSet) resource.TestCheckFunc {
++	return func(s *terraform.State) error {
++		rs, ok := s.RootModule().Resources[n]
++
++		if !ok {
++			return fmt.Errorf("not found: %s", n)
++		}
++
++		if rs.Primary.ID == "" {
++			return fmt.Errorf("no Gamelift Matchmaking Rule Set Name is set")
++		}
++
++		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
++
++		name := rs.Primary.Attributes["name"]
++		out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{
++			Names: aws.StringSlice([]string{name}),
++		})
++		if err != nil {
++			return err
++		}
++		ruleSets := out.RuleSets
++		if len(ruleSets) == 0 {
++			return fmt.Errorf("GameLift Matchmaking Rule Set %q not found", name)
++		}
++
++		*res = *ruleSets[0]
++
++		return nil
++	}
++}
++
++func testAccMatchmakingRuleSetBody(maxPlayers int) string {
++	return fmt.Sprintf(`{
++	"name": "test",
++	"ruleLanguageVersion": "1.0",
++	"teams": [{
++		"name": "alpha",
++		"minPlayers": 1,
++		"maxPlayers": %[1]d
++	}]
++}`, maxPlayers)
++}
++
++func testAccMatchmakingRuleSetBasicConfig(rName string, maxPlayers int) string {
++	return fmt.Sprintf(`
++resource "aws_gamelift_matchmaking_rule_set" "test" {
++  name          = %[1]q
++  rule_set_body = <<RULE_SET_BODY
++%[2]s
++RULE_SET_BODY
++}
++`, rName, testAccMatchmakingRuleSetBody(maxPlayers))
++}
+diff --git a/website/docs/r/gamelift_matchmaking_configuration.html.markdown b/website/docs/r/gamelift_matchmaking_configuration.html.markdown
+new file mode 100644
+index 0000000000..2d411ad301
+--- /dev/null
++++ b/website/docs/r/gamelift_matchmaking_configuration.html.markdown
+@@ -0,0 +1,106 @@
++---
++subcategory: "GameLift"
++layout: "aws"
++page_title: "AWS: aws_gamelift_matchmaking_configuration"
++description: |-
++  Provides a GameLift Matchmaking Configuration resource.
++---
++
++# Resource: aws_gamelift_matchmaking_configuration
++
++Provides a GameLift Alias resource.
++
++## Example Usage
++
++```terraform
++
++resource "aws_gamelift_game_session_queue" "example" {
++	name         = example
++	destinations = []
++	
++	player_latency_policy {
++		maximum_individual_player_latency_milliseconds = 3
++		policy_duration_seconds                        = 7
++	}
++	
++	player_latency_policy {
++		maximum_individual_player_latency_milliseconds = 10
++	}
++	
++	timeout_in_seconds = 25
++}
++
++resource "aws_gamelift_matchmaking_rule_set" "example" {
++	name          = example
++	rule_set_body = jsonencode({
++		"name": "test",
++		"ruleLanguageVersion": "1.0",
++		"teams": [{
++			"name": "alpha",
++			"minPlayers": 1,
++			"maxPlayers": 5
++		}]
++	})
++}
++
++resource "aws_gamelift_matchmaking_configuration" "example" {
++	name          = example
++	acceptance_required = false
++	custom_event_data = "pvp"
++	game_session_data = "game_session_data"
++	backfill_mode = "MANUAL"
++	request_timeout_seconds = 30
++	rule_set_name = aws_gamelift_matchmaking_rule_set.test.name
++	game_session_queue_arns = [aws_gamelift_game_session_queue.test.arn]
++	tags = {
++		"key1" = "value1"
++	}
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `name` - (Required) Name of the matchmaking configuration
++* `acceptance_required` - (Required) Specifies if the match that was created with this configuration must be accepted by matched players.
++* `additional_player_count` - (Required) The number of player slots in a match to keep open for future players.
++* `game_session_data` - (Required) A set of custom game session properties.
++* `rule_set_name` - (Required) A rule set names for the matchmaking rule set to use with this configuration.
++* `acceptance_timeout_seconds` - (Optional) The length of time (in seconds) to wait for players to accept a proposed match, if acceptance is required.
++* `backfill_mode` - (Optional) The method used to backfill game sessions that are created with this matchmaking configuration.
++* `custom_event_data` - (Optional) Information to be added to all events related to this matchmaking configuration.
++* `description` - (Optional) A human-readable description of the matchmaking configuration.
++* `flex_match_mode` - (Optional) Indicates whether this matchmaking configuration is being used with GameLift hosting or as a standalone matchmaking solution.
++* `game_property` - (Optional) One or more custom game properties. See below.
++* `game_session_queue_arns` - (Optional) The ARNs of the GameLift game session queue resources.
++* `notification_target` - (Optional) An SNS topic ARN that is set up to receive matchmaking notifications.
++* `request_timeout_seconds` - (Optional) The maximum duration, in seconds, that a matchmaking ticket can remain in process before timing out.
++* `tags` - (Optional) Key-value map of resource tags. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
++
++
++
++
++### Nested Fields
++
++#### `game_property`
++
++* `key` - (Optional) A game property key
++* `value` - (Optional) A game property value.
++
++## Attributes Reference
++
++In addition to all arguments above, the following attributes are exported:
++
++* `id` - Matchmaking Configuration ID.
++* `arn` - Matchmaking Configuration ARN.
++* `creation_time` - The time when the Matchmaking Configuration was created.
++* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
++
++## Import
++
++GameLift Matchmaking Configurations can be imported using the ID, e.g.,
++
++```
++$ terraform import aws_gamelift_matchmaking_configuration.example <matchmakingconfiguration-id>
++```
+diff --git a/website/docs/r/gamelift_matchmaking_rule_set.html.markdown b/website/docs/r/gamelift_matchmaking_rule_set.html.markdown
+new file mode 100644
+index 0000000000..28013532bf
+--- /dev/null
++++ b/website/docs/r/gamelift_matchmaking_rule_set.html.markdown
+@@ -0,0 +1,52 @@
++---
++subcategory: "GameLift"
++layout: "aws"
++page_title: "AWS: aws_gamelift_matchmaking_rule_set"
++description: |-
++  Provides a GameLift Matchmaking Rule Set .
++---
++
++# Resource: aws_gamelift_matchmaking_rule_set
++
++Provides a GameLift Matchmaking Rule Set resources.
++
++## Example Usage
++
++```terraform
++resource "aws_gamelift_matchmaking_rule_set" "example" {
++  name          = %[1]q
++  rule_set_body = jsonencodes({
++	"name": "test",
++	"ruleLanguageVersion": "1.0",
++	"teams": [{
++		"name": "alpha",
++		"minPlayers": 1,
++		"maxPlayers": 5
++	}]
++})
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `name` - (Required) Name of the matchmaking rule set.
++* `rule_set_body` - (Required) JSON encoded string containing rule set data.
++
++
++## Attributes Reference
++
++In addition to all arguments above, the following attributes are exported:
++
++* `id` - Rule Set ID.
++* `arn` - Rule Set ARN.
++* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
++
++## Import
++
++GameLift Matchmaking Rule Sets  can be imported using the ID, e.g.,
++
++```
++$ terraform import aws_gamelift_matchmaking_rule_set.example <ruleset-id>
++```

--- a/upstream-patches/0020-fix-Adding-back-in-removeAddons.patch
+++ b/upstream-patches/0020-fix-Adding-back-in-removeAddons.patch
@@ -1,0 +1,24 @@
+From ca3af1a60ed600bd9adf515d280a91bfa5c9f1f6 Mon Sep 17 00:00:00 2001
+From: Richard Shade <richard@pulumi.com>
+Date: Fri, 6 Jan 2023 15:31:22 -0600
+Subject: [PATCH 20/25] fix: Adding back in removeAddons
+
+---
+ internal/service/eks/cluster.go | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go
+index d3f84ba86a..ecd3664459 100644
+--- a/internal/service/eks/cluster.go
++++ b/internal/service/eks/cluster.go
+@@ -381,6 +381,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
+ 		return diag.Errorf("waiting for EKS Cluster (%s) create: %s", d.Id(), err)
+ 	}
+ 
++	if err = removeAddons(d, conn); err != nil {
++		return diag.Errorf("removing addons (%s): %s", d.Id(), err)
++	}
++
+ 	return resourceClusterRead(ctx, d, meta)
+ }
+ 

--- a/upstream-patches/0021-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
+++ b/upstream-patches/0021-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
@@ -1,0 +1,929 @@
+From cc452b0a10444968aaaa16159ed4c69f8bb44b41 Mon Sep 17 00:00:00 2001
+From: Kyle Pitzen <kpitzen@pulumi.com>
+Date: Fri, 27 Jan 2023 09:37:43 -0600
+Subject: [PATCH 21/25] Reverts patches to S3BucketLegacy and GameLift
+
+Previously, we were pulling along patches which removed a few simplifications
+to waiters in AWS GameLift, and a newer patch which plumbed through context.Context
+in various places for CRUD operations in S3 Buckets (which are now ported to Legacy)
+and in GameLift - specifically matchmaking configurations and rulesets.
+
+This PR reverts our patches which will prevent future merge conflicts, and updates
+call sites to plumb through the proper Context objects.
+---
+ .../gamelift/matchmaking_configuration.go     |  44 ++---
+ .../service/gamelift/matchmaking_rule_set.go  |  42 ++---
+ .../accelerator_data_source_reverted.go       |   2 +-
+ internal/service/s3legacy/bucket_legacy.go    | 157 +++++++++---------
+ internal/service/s3legacy/wait.go             |   4 +-
+ 5 files changed, 125 insertions(+), 124 deletions(-)
+
+diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go
+index 0a7c8ea635..d8ee20dc65 100644
+--- a/internal/service/gamelift/matchmaking_configuration.go
++++ b/internal/service/gamelift/matchmaking_configuration.go
+@@ -2,13 +2,13 @@ package gamelift
+ 
+ import (
+ 	"context"
+-	"fmt"
+ 	"log"
+ 	"regexp"
+ 
+ 	"github.com/aws/aws-sdk-go/aws"
+ 	"github.com/aws/aws-sdk-go/service/gamelift"
+ 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+@@ -18,10 +18,10 @@ import (
+ 
+ func ResourceMatchMakingConfiguration() *schema.Resource {
+ 	return &schema.Resource{
+-		Create: resourceMatchmakingConfigurationCreate,
+-		Read:   resourceMatchmakingConfigurationRead,
+-		Update: resourceMatchmakingConfigurationUpdate,
+-		Delete: resourceMatchmakingConfigurationDelete,
++		CreateWithoutTimeout: resourceMatchmakingConfigurationCreate,
++		ReadWithoutTimeout:   resourceMatchmakingConfigurationRead,
++		UpdateWithoutTimeout: resourceMatchmakingConfigurationUpdate,
++		DeleteWithoutTimeout: resourceMatchmakingConfigurationDelete,
+ 		Importer: &schema.ResourceImporter{
+ 			StateContext: schema.ImportStatePassthroughContext,
+ 		},
+@@ -145,7 +145,7 @@ func ResourceMatchMakingConfiguration() *schema.Resource {
+ 	}
+ }
+ 
+-func resourceMatchmakingConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 	tags := defaultTagsConfig.MergeTags(tftags.New(context.Background(), d.Get("tags").(map[string]interface{})))
+@@ -193,14 +193,14 @@ func resourceMatchmakingConfigurationCreate(d *schema.ResourceData, meta interfa
+ 	log.Printf("[INFO] Creating GameLift Matchmaking Configuration: %s", input)
+ 	out, err := conn.CreateMatchmakingConfiguration(&input)
+ 	if err != nil {
+-		return fmt.Errorf("error creating GameLift Matchmaking Configuration: %s", err)
++		return diag.Errorf("error creating GameLift Matchmaking Configuration: %s", err)
+ 	}
+ 
+ 	d.SetId(aws.StringValue(out.Configuration.ConfigurationArn))
+-	return resourceMatchmakingConfigurationRead(d, meta)
++	return resourceMatchmakingConfigurationRead(ctx, d, meta)
+ }
+ 
+-func resourceMatchmakingConfigurationRead(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+@@ -215,7 +215,7 @@ func resourceMatchmakingConfigurationRead(d *schema.ResourceData, meta interface
+ 			d.SetId("")
+ 			return nil
+ 		}
+-		return fmt.Errorf("error reading GameLift Matchmaking Configuration (%s): %s", d.Id(), err)
++		return diag.Errorf("error reading GameLift Matchmaking Configuration (%s): %s", d.Id(), err)
+ 	}
+ 	configurations := out.Configurations
+ 
+@@ -225,7 +225,7 @@ func resourceMatchmakingConfigurationRead(d *schema.ResourceData, meta interface
+ 		return nil
+ 	}
+ 	if len(configurations) != 1 {
+-		return fmt.Errorf("expected exactly 1 GameLift Matchmaking Configuration, found %d under %q",
++		return diag.Errorf("expected exactly 1 GameLift Matchmaking Configuration, found %d under %q",
+ 			len(configurations), d.Id())
+ 	}
+ 	configuration := configurations[0]
+@@ -249,27 +249,27 @@ func resourceMatchmakingConfigurationRead(d *schema.ResourceData, meta interface
+ 	d.Set("rule_set_arn", configuration.RuleSetArn)
+ 	d.Set("rule_set_name", configuration.RuleSetName)
+ 
+-	tags, err := ListTags(context.Background(), conn, arn)
++	tags, err := ListTags(ctx, conn, arn)
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error listing tags for GameLift Matchmaking Configuration (%s): %s", arn, err)
++		return diag.Errorf("error listing tags for GameLift Matchmaking Configuration (%s): %s", arn, err)
+ 	}
+ 
+ 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+ 
+ 	//lintignore:AWSR002
+ 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+-		return fmt.Errorf("error setting tags: %w", err)
++		return diag.Errorf("error setting tags: %w", err)
+ 	}
+ 
+ 	if err := d.Set("tags_all", tags.Map()); err != nil {
+-		return fmt.Errorf("error setting tags_all: %w", err)
++		return diag.Errorf("error setting tags_all: %w", err)
+ 	}
+ 
+ 	return nil
+ }
+ 
+-func resourceMatchmakingConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 
+ 	log.Printf("[INFO] Updating GameLift Matchmaking Configuration: %s", d.Id())
+@@ -317,7 +317,7 @@ func resourceMatchmakingConfigurationUpdate(d *schema.ResourceData, meta interfa
+ 
+ 	_, err := conn.UpdateMatchmakingConfiguration(&input)
+ 	if err != nil {
+-		return fmt.Errorf("error updating Gamelift Matchmaking Configuration (%s): %s", d.Id(), err)
++		return diag.Errorf("error updating Gamelift Matchmaking Configuration (%s): %s", d.Id(), err)
+ 	}
+ 
+ 	arn := d.Id()
+@@ -325,15 +325,15 @@ func resourceMatchmakingConfigurationUpdate(d *schema.ResourceData, meta interfa
+ 	if d.HasChange("tags_all") {
+ 		o, n := d.GetChange("tags_all")
+ 
+-		if err := UpdateTags(context.Background(), conn, arn, o, n); err != nil {
+-			return fmt.Errorf("error updating GameLift Matchmaking Configuration (%s) tags: %s", arn, err)
++		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
++			return diag.Errorf("error updating GameLift Matchmaking Configuration (%s) tags: %s", arn, err)
+ 		}
+ 	}
+ 
+-	return resourceMatchmakingConfigurationRead(d, meta)
++	return resourceMatchmakingConfigurationRead(ctx, d, meta)
+ }
+ 
+-func resourceMatchmakingConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	log.Printf("[INFO] Deleting GameLift Matchmaking Configuration: %s", d.Id())
+ 	_, err := conn.DeleteMatchmakingConfiguration(&gamelift.DeleteMatchmakingConfigurationInput{
+@@ -343,7 +343,7 @@ func resourceMatchmakingConfigurationDelete(d *schema.ResourceData, meta interfa
+ 		return nil
+ 	}
+ 	if err != nil {
+-		return fmt.Errorf("error deleting GameLift Matchmaking Configuration (%s): %s", d.Id(), err)
++		return diag.Errorf("error deleting GameLift Matchmaking Configuration (%s): %s", d.Id(), err)
+ 	}
+ 
+ 	return nil
+diff --git a/internal/service/gamelift/matchmaking_rule_set.go b/internal/service/gamelift/matchmaking_rule_set.go
+index 28d15ecf5e..8c1189199f 100644
+--- a/internal/service/gamelift/matchmaking_rule_set.go
++++ b/internal/service/gamelift/matchmaking_rule_set.go
+@@ -2,12 +2,12 @@ package gamelift
+ 
+ import (
+ 	"context"
+-	"fmt"
+ 	"log"
+ 
+ 	"github.com/aws/aws-sdk-go/aws"
+ 	"github.com/aws/aws-sdk-go/service/gamelift"
+ 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+@@ -18,10 +18,10 @@ import (
+ 
+ func ResourceMatchmakingRuleSet() *schema.Resource {
+ 	return &schema.Resource{
+-		Create: resourceMatchmakingRuleSetCreate,
+-		Read:   resourceMatchmakingRuleSetRead,
+-		Update: resourceMatchmakingRuleSetUpdate,
+-		Delete: resourceMatchmakingRuleSetDelete,
++		CreateWithoutTimeout: resourceMatchmakingRuleSetCreate,
++		ReadWithoutTimeout:   resourceMatchmakingRuleSetRead,
++		UpdateWithoutTimeout: resourceMatchmakingRuleSetUpdate,
++		DeleteWithoutTimeout: resourceMatchmakingRuleSetDelete,
+ 		Importer: &schema.ResourceImporter{
+ 			StateContext: schema.ImportStatePassthroughContext,
+ 		},
+@@ -57,7 +57,7 @@ func ResourceMatchmakingRuleSet() *schema.Resource {
+ 	}
+ }
+ 
+-func resourceMatchmakingRuleSetCreate(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingRuleSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 	tags := defaultTagsConfig.MergeTags(tftags.New(context.Background(), d.Get("tags").(map[string]interface{})))
+@@ -70,15 +70,15 @@ func resourceMatchmakingRuleSetCreate(d *schema.ResourceData, meta interface{})
+ 	log.Printf("[INFO] Creating GameLift Matchmaking Rule Set: %s", input)
+ 	out, err := conn.CreateMatchmakingRuleSet(&input)
+ 	if err != nil {
+-		return fmt.Errorf("error creating GameLift Matchmaking Rule Set: %s", err)
++		return diag.Errorf("error creating GameLift Matchmaking Rule Set: %s", err)
+ 	}
+ 
+ 	d.SetId(aws.StringValue(out.RuleSet.RuleSetName))
+ 
+-	return resourceMatchmakingRuleSetRead(d, meta)
++	return resourceMatchmakingRuleSetRead(ctx, d, meta)
+ }
+ 
+-func resourceMatchmakingRuleSetRead(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingRuleSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 
+@@ -92,7 +92,7 @@ func resourceMatchmakingRuleSetRead(d *schema.ResourceData, meta interface{}) er
+ 			d.SetId("")
+ 			return nil
+ 		}
+-		return fmt.Errorf("error reading GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
++		return diag.Errorf("error reading GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
+ 	}
+ 	ruleSets := out.RuleSets
+ 
+@@ -102,7 +102,7 @@ func resourceMatchmakingRuleSetRead(d *schema.ResourceData, meta interface{}) er
+ 		return nil
+ 	}
+ 	if len(ruleSets) != 1 {
+-		return fmt.Errorf("expected exactly 1 GameLift Matchmaking Rule Set, found %d under %q",
++		return diag.Errorf("expected exactly 1 GameLift Matchmaking Rule Set, found %d under %q",
+ 			len(ruleSets), d.Id())
+ 	}
+ 	ruleSet := ruleSets[0]
+@@ -112,24 +112,24 @@ func resourceMatchmakingRuleSetRead(d *schema.ResourceData, meta interface{}) er
+ 	d.Set("name", ruleSet.RuleSetName)
+ 	d.Set("rule_set_body", ruleSet.RuleSetBody)
+ 
+-	tags, err := ListTags(context.Background(), conn, arn)
++	tags, err := ListTags(ctx, conn, arn)
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error listing tags for GameLift Matchmaking Rule Set (%s): %s", arn, err)
++		return diag.Errorf("error listing tags for GameLift Matchmaking Rule Set (%s): %s", arn, err)
+ 	}
+ 
+ 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+-		return fmt.Errorf("error setting tags: %w", err)
++		return diag.Errorf("error setting tags: %w", err)
+ 	}
+ 
+ 	if err := d.Set("tags_all", tags.Map()); err != nil {
+-		return fmt.Errorf("error setting tags_all: %w", err)
++		return diag.Errorf("error setting tags_all: %w", err)
+ 	}
+ 
+ 	return nil
+ }
+ 
+-func resourceMatchmakingRuleSetUpdate(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingRuleSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 
+ 	log.Printf("[INFO] Updating GameLift Matchmaking Rule Set: %s", d.Id())
+@@ -138,15 +138,15 @@ func resourceMatchmakingRuleSetUpdate(d *schema.ResourceData, meta interface{})
+ 	if d.HasChange("tags_all") {
+ 		o, n := d.GetChange("tags_all")
+ 
+-		if err := UpdateTags(context.Background(), conn, arn, o, n); err != nil {
+-			return fmt.Errorf("error updating GameLift Matchmaking Rule Set (%s) tags: %s", arn, err)
++		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
++			return diag.Errorf("error updating GameLift Matchmaking Rule Set (%s) tags: %s", arn, err)
+ 		}
+ 	}
+ 
+-	return resourceMatchmakingRuleSetRead(d, meta)
++	return resourceMatchmakingRuleSetRead(ctx, d, meta)
+ }
+ 
+-func resourceMatchmakingRuleSetDelete(d *schema.ResourceData, meta interface{}) error {
++func resourceMatchmakingRuleSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	log.Printf("[INFO] Deleting GameLift Matchmaking Rule Set: %s", d.Id())
+ 	_, err := conn.DeleteMatchmakingRuleSet(&gamelift.DeleteMatchmakingRuleSetInput{
+@@ -156,7 +156,7 @@ func resourceMatchmakingRuleSetDelete(d *schema.ResourceData, meta interface{})
+ 		return nil
+ 	}
+ 	if err != nil {
+-		return fmt.Errorf("error deleting GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
++		return diag.Errorf("error deleting GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
+ 	}
+ 
+ 	return nil
+diff --git a/internal/service/globalaccelerator/accelerator_data_source_reverted.go b/internal/service/globalaccelerator/accelerator_data_source_reverted.go
+index 3bd69472c8..1259a80d52 100644
+--- a/internal/service/globalaccelerator/accelerator_data_source_reverted.go
++++ b/internal/service/globalaccelerator/accelerator_data_source_reverted.go
+@@ -142,7 +142,7 @@ func dataSourceAcceleratorRead(ctx context.Context, d *schema.ResourceData, meta
+ 		return diag.Errorf("error setting attributes: %w", err)
+ 	}
+ 
+-	tags, err := ListTags(context.Background(), conn, d.Id())
++	tags, err := ListTags(ctx, conn, d.Id())
+ 	if err != nil {
+ 		return diag.Errorf("error listing tags for Global Accelerator Accelerator (%s): %w", d.Id(), err)
+ 	}
+diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go
+index 8879116578..ba95f6c2b6 100644
+--- a/internal/service/s3legacy/bucket_legacy.go
++++ b/internal/service/s3legacy/bucket_legacy.go
+@@ -20,6 +20,7 @@ import (
+ 	"github.com/aws/aws-sdk-go/service/s3"
+ 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+ 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+@@ -34,10 +35,10 @@ import (
+ 
+ func ResourceBucketLegacy() *schema.Resource {
+ 	return &schema.Resource{
+-		Create: resourceBucketLegacyCreate,
+-		Read:   resourceBucketLegacyRead,
+-		Update: resourceBucketLegacyUpdate,
+-		Delete: resourceBucketLegacyDelete,
++		CreateWithoutTimeout: resourceBucketLegacyCreate,
++		ReadWithoutTimeout:   resourceBucketLegacyRead,
++		UpdateWithoutTimeout: resourceBucketLegacyUpdate,
++		DeleteWithoutTimeout: resourceBucketLegacyDelete,
+ 		Importer: &schema.ResourceImporter{
+ 			State: schema.ImportStatePassthrough,
+ 		},
+@@ -670,7 +671,7 @@ func ResourceBucketLegacy() *schema.Resource {
+ 	}
+ }
+ 
+-func resourceBucketLegacyCreate(d *schema.ResourceData, meta interface{}) error {
++func resourceBucketLegacyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).S3Conn()
+ 
+ 	// Get the bucket and acl
+@@ -708,7 +709,7 @@ func resourceBucketLegacyCreate(d *schema.ResourceData, meta interface{}) error
+ 	}
+ 
+ 	if err := ValidBucketNameLegacy(bucket, awsRegion); err != nil {
+-		return fmt.Errorf("Error validating S3 bucket name: %s", err)
++		return diag.Errorf("Error validating S3 bucket name: %s", err)
+ 	}
+ 
+ 	// S3 Object Lock can only be enabled on bucket creation.
+@@ -735,15 +736,15 @@ func resourceBucketLegacyCreate(d *schema.ResourceData, meta interface{}) error
+ 		_, err = conn.CreateBucket(req)
+ 	}
+ 	if err != nil {
+-		return fmt.Errorf("Error creating S3 bucket: %s", err)
++		return diag.Errorf("Error creating S3 bucket: %s", err)
+ 	}
+ 
+ 	// Assign the bucket name as the resource ID
+ 	d.SetId(bucket)
+-	return resourceBucketLegacyUpdate(d, meta)
++	return resourceBucketLegacyUpdate(ctx, d, meta)
+ }
+ 
+-func resourceBucketLegacyUpdate(d *schema.ResourceData, meta interface{}) error {
++func resourceBucketLegacyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).S3Conn()
+ 
+ 	if d.HasChange("tags_all") {
+@@ -755,25 +756,25 @@ func resourceBucketLegacyUpdate(d *schema.ResourceData, meta interface{}) error
+ 			return nil, terr
+ 		})
+ 		if err != nil {
+-			return fmt.Errorf("error updating S3 Bucket (%s) tags: %s", d.Id(), err)
++			return diag.Errorf("error updating S3 Bucket (%s) tags: %s", d.Id(), err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("policy") {
+-		if err := resourceBucketLegacyPolicyUpdate(conn, d); err != nil {
++		if err := resourceBucketLegacyPolicyUpdate(ctx, conn, d); err != nil {
+ 			return err
+ 		}
+ 	}
+ 
+ 	if d.HasChange("cors_rule") {
+ 		if err := resourceBucketLegacyCorsUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("website") {
+ 		if err := resourceBucketLegacyWebsiteUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+@@ -784,74 +785,74 @@ func resourceBucketLegacyUpdate(d *schema.ResourceData, meta interface{}) error
+ 			if versioning := expandVersioningWhenIsNewResourceLegacy(v); versioning != nil {
+ 				err := resourceBucketLegacyVersioningUpdate(conn, d.Id(), versioning)
+ 				if err != nil {
+-					return err
++					return diag.FromErr(err)
+ 				}
+ 			}
+ 		} else {
+ 			if err := resourceBucketLegacyVersioningUpdate(conn, d.Id(), expandVersioningLegacy(v)); err != nil {
+-				return err
++				return diag.FromErr(err)
+ 			}
+ 		}
+ 	}
+ 
+ 	if d.HasChange("acl") && !d.IsNewResource() {
+ 		if err := resourceBucketLegacyACLUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("grant") {
+-		if err := resourceBucketLegacyGrantsUpdate(conn, d); err != nil {
++		if err := resourceBucketLegacyGrantsUpdate(ctx, conn, d); err != nil {
+ 			return err
+ 		}
+ 	}
+ 
+ 	if d.HasChange("logging") {
+ 		if err := resourceBucketLegacyLoggingUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("lifecycle_rule") {
+ 		if err := resourceBucketLegacyLifecycleUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("acceleration_status") {
+ 		if err := resourceBucketLegacyAccelerationUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("request_payer") {
+ 		if err := resourceBucketLegacyRequestPayerUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("replication_configuration") {
+ 		if err := resourceBucketLegacyInternalReplicationConfigurationUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("server_side_encryption_configuration") {
+-		if err := resourceBucketLegacyServerSideEncryptionConfigurationUpdate(conn, d); err != nil {
+-			return err
++		if err := resourceBucketLegacyServerSideEncryptionConfigurationUpdate(ctx, conn, d); err != nil {
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+ 	if d.HasChange("object_lock_configuration") {
+ 		if err := resourceBucketLegacyObjectLockConfigurationUpdate(conn, d); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+-	return resourceBucketLegacyRead(d, meta)
++	return resourceBucketLegacyRead(ctx, d, meta)
+ }
+ 
+-func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
++func resourceBucketLegacyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).S3Conn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+@@ -895,7 +896,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	}
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error reading S3 Bucket (%s): %w", d.Id(), err)
++		return diag.Errorf("error reading S3 Bucket (%s): %w", d.Id(), err)
+ 	}
+ 
+ 	// In the import case, we won't have this
+@@ -916,24 +917,24 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		log.Printf("[DEBUG] S3 bucket: %s, read policy: %v", d.Id(), pol)
+ 		if err != nil {
+ 			if err := d.Set("policy", ""); err != nil {
+-				return err
++				return diag.FromErr(err)
+ 			}
+ 		} else {
+ 			if v := pol.(*s3.GetBucketPolicyOutput).Policy; v == nil {
+ 				if err := d.Set("policy", ""); err != nil {
+-					return err
++					return diag.FromErr(err)
+ 				}
+ 			} else {
+ 				policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.StringValue(v))
+ 
+ 				if err != nil {
+-					return fmt.Errorf("while setting policy (%s), encountered: %w", aws.StringValue(v), err)
++					return diag.Errorf("while setting policy (%s), encountered: %w", aws.StringValue(v), err)
+ 				}
+ 
+ 				policyToSet, err = structure.NormalizeJsonString(policyToSet)
+ 
+ 				if err != nil {
+-					return fmt.Errorf("policy (%s) contains invalid JSON: %w", d.Get("policy").(string), err)
++					return diag.Errorf("policy (%s) contains invalid JSON: %w", d.Get("policy").(string), err)
+ 				}
+ 
+ 				d.Set("policy", policyToSet)
+@@ -944,7 +945,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	//Read the Grant ACL. Reset if `acl` (canned ACL) is set.
+ 	if acl, ok := d.GetOk("acl"); ok && acl.(string) != "private" {
+ 		if err := d.Set("grant", nil); err != nil {
+-			return fmt.Errorf("error resetting grant %s", err)
++			return diag.Errorf("error resetting grant %s", err)
+ 		}
+ 	} else {
+ 		apResponse, err := retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
+@@ -953,12 +954,12 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 			})
+ 		})
+ 		if err != nil {
+-			return fmt.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
++			return diag.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
+ 		}
+ 		log.Printf("[DEBUG] S3 bucket: %s, read ACL grants policy: %+v", d.Id(), apResponse)
+ 		grants := flattenGrantsLegacy(apResponse.(*s3.GetBucketAclOutput))
+ 		if err := d.Set("grant", schema.NewSet(grantHashLegacy, grants)); err != nil {
+-			return fmt.Errorf("error setting grant %s", err)
++			return diag.Errorf("error setting grant %s", err)
+ 		}
+ 	}
+ 
+@@ -969,7 +970,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		})
+ 	})
+ 	if err != nil && !tfawserr.ErrMessageContains(err, "NoSuchCORSConfiguration", "") {
+-		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
++		return diag.Errorf("error getting S3 Bucket CORS configuration: %s", err)
+ 	}
+ 
+ 	corsRules := make([]map[string]interface{}, 0)
+@@ -991,7 +992,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		}
+ 	}
+ 	if err := d.Set("cors_rule", corsRules); err != nil {
+-		return fmt.Errorf("error setting cors_rule: %s", err)
++		return diag.Errorf("error setting cors_rule: %s", err)
+ 	}
+ 
+ 	// Read the website configuration
+@@ -1001,7 +1002,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		})
+ 	})
+ 	if err != nil && !tfawserr.ErrMessageContains(err, "NotImplemented", "") && !tfawserr.ErrMessageContains(err, "NoSuchWebsiteConfiguration", "") {
+-		return fmt.Errorf("error getting S3 Bucket website configuration: %s", err)
++		return diag.Errorf("error getting S3 Bucket website configuration: %s", err)
+ 	}
+ 
+ 	websites := make([]map[string]interface{}, 0, 1)
+@@ -1045,7 +1046,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		if v := ws.RoutingRules; v != nil {
+ 			rr, err := normalizeRoutingRulesLegacy(v)
+ 			if err != nil {
+-				return fmt.Errorf("Error while marshaling routing rules: %s", err)
++				return diag.Errorf("Error while marshaling routing rules: %s", err)
+ 			}
+ 			w["routing_rules"] = rr
+ 		}
+@@ -1057,7 +1058,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		}
+ 	}
+ 	if err := d.Set("website", websites); err != nil {
+-		return fmt.Errorf("error setting website: %s", err)
++		return diag.Errorf("error setting website: %s", err)
+ 	}
+ 
+ 	// Read the versioning configuration
+@@ -1069,12 +1070,12 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	})
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
++		return diag.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
+ 	}
+ 
+ 	if versioning, ok := versioningResponse.(*s3.GetBucketVersioningOutput); ok {
+ 		if err := d.Set("versioning", flattenVersioningLegacy(versioning)); err != nil {
+-			return fmt.Errorf("error setting versioning: %w", err)
++			return diag.Errorf("error setting versioning: %w", err)
+ 		}
+ 	}
+ 
+@@ -1088,7 +1089,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 
+ 	// Amazon S3 Transfer Acceleration might not be supported in the region
+ 	if err != nil && !tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") && !tfawserr.ErrMessageContains(err, "UnsupportedArgument", "") {
+-		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
++		return diag.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
+ 	}
+ 	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {
+ 		d.Set("acceleration_status", accelerate.Status)
+@@ -1103,7 +1104,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	})
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
++		return diag.Errorf("error getting S3 Bucket request payment: %s", err)
+ 	}
+ 
+ 	if payer, ok := payerResponse.(*s3.GetBucketRequestPaymentOutput); ok {
+@@ -1118,7 +1119,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	})
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error getting S3 Bucket logging: %s", err)
++		return diag.Errorf("error getting S3 Bucket logging: %s", err)
+ 	}
+ 
+ 	lcl := make([]map[string]interface{}, 0, 1)
+@@ -1134,7 +1135,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		lcl = append(lcl, lc)
+ 	}
+ 	if err := d.Set("logging", lcl); err != nil {
+-		return fmt.Errorf("error setting logging: %s", err)
++		return diag.Errorf("error setting logging: %s", err)
+ 	}
+ 
+ 	// Read the lifecycle configuration
+@@ -1145,7 +1146,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		})
+ 	})
+ 	if err != nil && !tfawserr.ErrMessageContains(err, "NoSuchLifecycleConfiguration", "") {
+-		return err
++		return diag.FromErr(err)
+ 	}
+ 
+ 	lifecycleRules := make([]map[string]interface{}, 0)
+@@ -1263,7 +1264,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		}
+ 	}
+ 	if err := d.Set("lifecycle_rule", lifecycleRules); err != nil {
+-		return fmt.Errorf("error setting lifecycle_rule: %s", err)
++		return diag.Errorf("error setting lifecycle_rule: %s", err)
+ 	}
+ 
+ 	// Read the bucket replication configuration
+@@ -1274,7 +1275,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		})
+ 	})
+ 	if err != nil && !tfawserr.ErrMessageContains(err, "ReplicationConfigurationNotFoundError", "") {
+-		return fmt.Errorf("error getting S3 Bucket replication: %s", err)
++		return diag.Errorf("error getting S3 Bucket replication: %s", err)
+ 	}
+ 
+ 	replicationConfiguration := make([]map[string]interface{}, 0)
+@@ -1282,7 +1283,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		replicationConfiguration = flattenBucketReplicationConfigurationLegacy(replication.ReplicationConfiguration)
+ 	}
+ 	if err := d.Set("replication_configuration", replicationConfiguration); err != nil {
+-		return fmt.Errorf("error setting replication_configuration: %s", err)
++		return diag.Errorf("error setting replication_configuration: %s", err)
+ 	}
+ 
+ 	// Read the bucket server side encryption configuration
+@@ -1293,7 +1294,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		})
+ 	})
+ 	if err != nil && !tfawserr.ErrMessageContains(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
+-		return fmt.Errorf("error getting S3 Bucket encryption: %s", err)
++		return diag.Errorf("error getting S3 Bucket encryption: %s", err)
+ 	}
+ 
+ 	serverSideEncryptionConfiguration := make([]map[string]interface{}, 0)
+@@ -1301,7 +1302,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		serverSideEncryptionConfiguration = flattenServerSideEncryptionConfigurationLegacy(encryption.ServerSideEncryptionConfiguration)
+ 	}
+ 	if err := d.Set("server_side_encryption_configuration", serverSideEncryptionConfiguration); err != nil {
+-		return fmt.Errorf("error setting server_side_encryption_configuration: %s", err)
++		return diag.Errorf("error setting server_side_encryption_configuration: %s", err)
+ 	}
+ 
+ 	// Object Lock configuration.
+@@ -1309,7 +1310,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 
+ 	// Object lock not supported in all partitions (extra guard, also guards in read func)
+ 	if err != nil && (meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID) {
+-		return fmt.Errorf("error getting S3 Bucket Object Lock configuration: %s", err)
++		return diag.Errorf("error getting S3 Bucket Object Lock configuration: %s", err)
+ 	}
+ 
+ 	if err != nil {
+@@ -1318,7 +1319,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 
+ 	if err == nil {
+ 		if err := d.Set("object_lock_configuration", conf); err != nil {
+-			return fmt.Errorf("error setting object_lock_configuration: %s", err)
++			return diag.Errorf("error setting object_lock_configuration: %s", err)
+ 		}
+ 	}
+ 
+@@ -1339,18 +1340,18 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 		})
+ 	})
+ 	if err != nil {
+-		return fmt.Errorf("error getting S3 Bucket location: %s", err)
++		return diag.Errorf("error getting S3 Bucket location: %s", err)
+ 	}
+ 
+ 	region := discoveredRegion.(string)
+ 	if err := d.Set("region", region); err != nil {
+-		return err
++		return diag.FromErr(err)
+ 	}
+ 
+ 	// Add the bucket_regional_domain_name as an attribute
+ 	regionalEndpoint, err := bucketLegacyRegionalDomainName(d.Get("bucket").(string), region)
+ 	if err != nil {
+-		return err
++		return diag.FromErr(err)
+ 	}
+ 	d.Set("bucket_regional_domain_name", regionalEndpoint)
+ 
+@@ -1365,14 +1366,14 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	// Add website_endpoint as an attribute
+ 	websiteEndpoint, err := websiteLegacyEndpoint(meta.(*conns.AWSClient), d)
+ 	if err != nil {
+-		return err
++		return diag.FromErr(err)
+ 	}
+ 	if websiteEndpoint != nil {
+ 		if err := d.Set("website_endpoint", websiteEndpoint.Endpoint); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 		if err := d.Set("website_domain", websiteEndpoint.Domain); err != nil {
+-			return err
++			return diag.FromErr(err)
+ 		}
+ 	}
+ 
+@@ -1382,24 +1383,24 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	})
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)
++		return diag.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)
+ 	}
+ 
+ 	tags, ok := tagsRaw.(tftags.KeyValueTags)
+ 
+ 	if !ok {
+-		return fmt.Errorf("error listing tags for S3 Bucket (%s): unable to convert tags", d.Id())
++		return diag.Errorf("error listing tags for S3 Bucket (%s): unable to convert tags", d.Id())
+ 	}
+ 
+ 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+ 
+ 	//lintignore:AWSR002
+ 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+-		return fmt.Errorf("error setting tags: %w", err)
++		return diag.Errorf("error setting tags: %w", err)
+ 	}
+ 
+ 	if err := d.Set("tags_all", tags.Map()); err != nil {
+-		return fmt.Errorf("error setting tags_all: %w", err)
++		return diag.Errorf("error setting tags_all: %w", err)
+ 	}
+ 
+ 	arn := arn.ARN{
+@@ -1412,7 +1413,7 @@ func resourceBucketLegacyRead(d *schema.ResourceData, meta interface{}) error {
+ 	return nil
+ }
+ 
+-func resourceBucketLegacyDelete(d *schema.ResourceData, meta interface{}) error {
++func resourceBucketLegacyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).S3Conn()
+ 
+ 	log.Printf("[DEBUG] S3 Delete Bucket: %s", d.Id())
+@@ -1444,28 +1445,28 @@ func resourceBucketLegacyDelete(d *schema.ResourceData, meta interface{}) error
+ 			err = DeleteAllObjectVersions(conn, d.Id(), "", objectLockEnabled, false)
+ 
+ 			if err != nil {
+-				return fmt.Errorf("error S3 Bucket force_destroy: %s", err)
++				return diag.Errorf("error S3 Bucket force_destroy: %s", err)
+ 			}
+ 
+ 			// this line recurses until all objects are deleted or an error is returned
+-			return resourceBucketLegacyDelete(d, meta)
++			return resourceBucketLegacyDelete(ctx, d, meta)
+ 		}
+ 	}
+ 
+ 	if err != nil {
+-		return fmt.Errorf("error deleting S3 Bucket (%s): %s", d.Id(), err)
++		return diag.Errorf("error deleting S3 Bucket (%s): %s", d.Id(), err)
+ 	}
+ 
+ 	return nil
+ }
+ 
+-func resourceBucketLegacyPolicyUpdate(conn *s3.S3, d *schema.ResourceData) error {
++func resourceBucketLegacyPolicyUpdate(ctx context.Context, conn *s3.S3, d *schema.ResourceData) diag.Diagnostics {
+ 	bucket := d.Get("bucket").(string)
+ 
+ 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+ 
+ 	if err != nil {
+-		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policy, err)
++		return diag.Errorf("policy (%s) is an invalid JSON: %w", policy, err)
+ 	}
+ 
+ 	if policy != "" {
+@@ -1490,7 +1491,7 @@ func resourceBucketLegacyPolicyUpdate(conn *s3.S3, d *schema.ResourceData) error
+ 			_, err = conn.PutBucketPolicy(params)
+ 		}
+ 		if err != nil {
+-			return fmt.Errorf("Error putting S3 policy: %s", err)
++			return diag.Errorf("Error putting S3 policy: %s", err)
+ 		}
+ 	} else {
+ 		log.Printf("[DEBUG] S3 bucket: %s, delete policy: %s", bucket, policy)
+@@ -1501,21 +1502,21 @@ func resourceBucketLegacyPolicyUpdate(conn *s3.S3, d *schema.ResourceData) error
+ 		})
+ 
+ 		if err != nil {
+-			return fmt.Errorf("Error deleting S3 policy: %s", err)
++			return diag.Errorf("Error deleting S3 policy: %s", err)
+ 		}
+ 	}
+ 
+ 	return nil
+ }
+ 
+-func resourceBucketLegacyGrantsUpdate(conn *s3.S3, d *schema.ResourceData) error {
++func resourceBucketLegacyGrantsUpdate(ctx context.Context, conn *s3.S3, d *schema.ResourceData) diag.Diagnostics {
+ 	bucket := d.Get("bucket").(string)
+ 	rawGrants := d.Get("grant").(*schema.Set).List()
+ 
+ 	if len(rawGrants) == 0 {
+ 		log.Printf("[DEBUG] S3 bucket: %s, Grants fallback to canned ACL", bucket)
+ 		if err := resourceBucketLegacyACLUpdate(conn, d); err != nil {
+-			return fmt.Errorf("Error fallback to canned ACL, %s", err)
++			return diag.Errorf("Error fallback to canned ACL, %s", err)
+ 		}
+ 	} else {
+ 		apResponse, err := retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
+@@ -1525,7 +1526,7 @@ func resourceBucketLegacyGrantsUpdate(conn *s3.S3, d *schema.ResourceData) error
+ 		})
+ 
+ 		if err != nil {
+-			return fmt.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
++			return diag.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
+ 		}
+ 
+ 		ap := apResponse.(*s3.GetBucketAclOutput)
+@@ -1570,7 +1571,7 @@ func resourceBucketLegacyGrantsUpdate(conn *s3.S3, d *schema.ResourceData) error
+ 		})
+ 
+ 		if err != nil {
+-			return fmt.Errorf("Error putting S3 Grants: %s", err)
++			return diag.Errorf("Error putting S3 Grants: %s", err)
+ 		}
+ 	}
+ 	return nil
+@@ -1948,7 +1949,7 @@ func resourceBucketLegacyRequestPayerUpdate(conn *s3.S3, d *schema.ResourceData)
+ 	return nil
+ }
+ 
+-func resourceBucketLegacyServerSideEncryptionConfigurationUpdate(conn *s3.S3, d *schema.ResourceData) error {
++func resourceBucketLegacyServerSideEncryptionConfigurationUpdate(ctx context.Context, conn *s3.S3, d *schema.ResourceData) error {
+ 	bucket := d.Get("bucket").(string)
+ 	serverSideEncryptionConfiguration := d.Get("server_side_encryption_configuration").([]interface{})
+ 	if len(serverSideEncryptionConfiguration) == 0 {
+@@ -2000,7 +2001,7 @@ func resourceBucketLegacyServerSideEncryptionConfigurationUpdate(conn *s3.S3, d
+ 	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
+ 
+ 	_, err := tfresource.RetryWhenAWSErrCodeEquals(
+-		context.Background(),
++		ctx,
+ 		propagationTimeout,
+ 		func() (interface{}, error) {
+ 			return conn.PutBucketEncryption(i)
+diff --git a/internal/service/s3legacy/wait.go b/internal/service/s3legacy/wait.go
+index 7a548d8d6d..9031539c19 100644
+--- a/internal/service/s3legacy/wait.go
++++ b/internal/service/s3legacy/wait.go
+@@ -13,6 +13,6 @@ const (
+ 	propagationTimeout   = 1 * time.Minute
+ )
+ 
+-func retryWhenBucketNotFound(f func() (interface{}, error)) (interface{}, error) {
+-	return tfresource.RetryWhenAWSErrCodeEquals(context.Background(), propagationTimeout, f, s3.ErrCodeNoSuchBucket)
++func retryWhenBucketNotFound(ctx context.Context, f func() (interface{}, error)) (interface{}, error) {
++	return tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, f, s3.ErrCodeNoSuchBucket)
+ }

--- a/upstream-patches/0022-Revert-Update-endpointHashIPAddress.patch
+++ b/upstream-patches/0022-Revert-Update-endpointHashIPAddress.patch
@@ -1,0 +1,26 @@
+From aaefdf1f5ae4022a4562bb500035e24c25b56fd3 Mon Sep 17 00:00:00 2001
+From: Thomas Kappler <tkappler@pulumi.com>
+Date: Fri, 3 Feb 2023 17:31:18 -0800
+Subject: [PATCH 22/25] Revert "Update endpointHashIPAddress"
+
+This reverts commit 2197a6c2c7a0ff306cec3432acb9f5680866f034.
+
+This commit causes never-converging diffs due to incorrect use of
+a computed property in hashing.
+---
+ internal/service/route53resolver/endpoint.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/internal/service/route53resolver/endpoint.go b/internal/service/route53resolver/endpoint.go
+index 51a301699e..9705af3b67 100644
+--- a/internal/service/route53resolver/endpoint.go
++++ b/internal/service/route53resolver/endpoint.go
+@@ -412,7 +412,7 @@ func waitEndpointDeleted(ctx context.Context, conn *route53resolver.Route53Resol
+ func endpointHashIPAddress(v interface{}) int {
+ 	var buf bytes.Buffer
+ 	m := v.(map[string]interface{})
+-	buf.WriteString(fmt.Sprintf("%s-%s-", m["subnet_id"].(string), m["ip"].(string)))
++	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+ 	return create.StringHashcode(buf.String())
+ }
+ 

--- a/upstream-patches/0023-Fixup-eks-formatting.patch
+++ b/upstream-patches/0023-Fixup-eks-formatting.patch
@@ -1,0 +1,26 @@
+From 5a197821cedad47c61889643b75b5595ab2cb29d Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Thu, 9 Mar 2023 14:50:36 +0000
+Subject: [PATCH 23/25] Fixup eks formatting
+
+---
+ internal/service/eks/wait.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/internal/service/eks/wait.go b/internal/service/eks/wait.go
+index 9027567ec8..760f618520 100644
+--- a/internal/service/eks/wait.go
++++ b/internal/service/eks/wait.go
+@@ -11,9 +11,9 @@ import (
+ )
+ 
+ const (
+-	addonCreatedTimeout = 20 * time.Minute
+-	addonUpdatedTimeout = 20 * time.Minute
+-	addonDeletedTimeout = 40 * time.Minute
++	addonCreatedTimeout       = 20 * time.Minute
++	addonUpdatedTimeout       = 20 * time.Minute
++	addonDeletedTimeout       = 40 * time.Minute
+ 	clusterDeleteRetryTimeout = 60 * time.Minute
+ )
+ 

--- a/upstream-patches/0024-Fixup-gamelift-context.patch
+++ b/upstream-patches/0024-Fixup-gamelift-context.patch
@@ -1,0 +1,36 @@
+From 93795c0ea13ac8ec783e1b42664de8ca048cdb1e Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Thu, 9 Mar 2023 14:50:51 +0000
+Subject: [PATCH 24/25] Fixup gamelift context
+
+---
+ internal/service/gamelift/matchmaking_configuration.go | 2 +-
+ internal/service/gamelift/matchmaking_rule_set.go      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go
+index d8ee20dc65..e17f71e6b6 100644
+--- a/internal/service/gamelift/matchmaking_configuration.go
++++ b/internal/service/gamelift/matchmaking_configuration.go
+@@ -148,7 +148,7 @@ func ResourceMatchMakingConfiguration() *schema.Resource {
+ func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+-	tags := defaultTagsConfig.MergeTags(tftags.New(context.Background(), d.Get("tags").(map[string]interface{})))
++	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+ 
+ 	input := gamelift.CreateMatchmakingConfigurationInput{
+ 		AcceptanceRequired:    aws.Bool(d.Get("acceptance_required").(bool)),
+diff --git a/internal/service/gamelift/matchmaking_rule_set.go b/internal/service/gamelift/matchmaking_rule_set.go
+index 8c1189199f..254c96efc6 100644
+--- a/internal/service/gamelift/matchmaking_rule_set.go
++++ b/internal/service/gamelift/matchmaking_rule_set.go
+@@ -60,7 +60,7 @@ func ResourceMatchmakingRuleSet() *schema.Resource {
+ func resourceMatchmakingRuleSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	conn := meta.(*conns.AWSClient).GameLiftConn()
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+-	tags := defaultTagsConfig.MergeTags(tftags.New(context.Background(), d.Get("tags").(map[string]interface{})))
++	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+ 
+ 	input := gamelift.CreateMatchmakingRuleSetInput{
+ 		Name:        aws.String(d.Get("name").(string)),

--- a/upstream-patches/0025-Change-default-descriptions-to-Managed-by-Pulumi.patch
+++ b/upstream-patches/0025-Change-default-descriptions-to-Managed-by-Pulumi.patch
@@ -1,0 +1,413 @@
+From fc7794404f569e5ee9f1c80963daee017ccb8f0f Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Tue, 28 Feb 2023 15:19:24 +0000
+Subject: [PATCH 25/25] Change default descriptions to "Managed by Pulumi"
+
+---
+ internal/service/apigateway/api_key.go               | 2 +-
+ internal/service/appsync/api_key.go                  | 2 +-
+ internal/service/cloudfront/origin_access_control.go | 2 +-
+ internal/service/docdb/cluster_parameter_group.go    | 2 +-
+ internal/service/docdb/subnet_group.go               | 2 +-
+ internal/service/ec2/vpc_security_group.go           | 2 +-
+ internal/service/elasticache/parameter_group.go      | 2 +-
+ internal/service/elasticache/security_group.go       | 2 +-
+ internal/service/elasticache/subnet_group.go         | 2 +-
+ internal/service/mediapackage/channel.go             | 2 +-
+ internal/service/memorydb/cluster.go                 | 2 +-
+ internal/service/memorydb/parameter_group.go         | 2 +-
+ internal/service/memorydb/subnet_group.go            | 2 +-
+ internal/service/neptune/cluster_parameter_group.go  | 2 +-
+ internal/service/neptune/parameter_group.go          | 2 +-
+ internal/service/neptune/subnet_group.go             | 2 +-
+ internal/service/rds/cluster_parameter_group.go      | 2 +-
+ internal/service/rds/option_group.go                 | 2 +-
+ internal/service/rds/parameter_group.go              | 2 +-
+ internal/service/rds/security_group.go               | 2 +-
+ internal/service/rds/subnet_group.go                 | 2 +-
+ internal/service/redshift/parameter_group.go         | 2 +-
+ internal/service/redshift/security_group.go          | 2 +-
+ internal/service/redshift/subnet_group.go            | 2 +-
+ internal/service/route53/record.go                   | 6 +++---
+ internal/service/route53/zone.go                     | 2 +-
+ internal/service/route53/zone_association.go         | 4 ++--
+ 27 files changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/internal/service/apigateway/api_key.go b/internal/service/apigateway/api_key.go
+index c870d16e4a..9b7163bd15 100644
+--- a/internal/service/apigateway/api_key.go
++++ b/internal/service/apigateway/api_key.go
+@@ -42,7 +42,7 @@ func ResourceAPIKey() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 
+ 			"enabled": {
+diff --git a/internal/service/appsync/api_key.go b/internal/service/appsync/api_key.go
+index bb9540d018..4df7ce2332 100644
+--- a/internal/service/appsync/api_key.go
++++ b/internal/service/appsync/api_key.go
+@@ -32,7 +32,7 @@ func ResourceAPIKey() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"api_id": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/cloudfront/origin_access_control.go b/internal/service/cloudfront/origin_access_control.go
+index 4b1f24063f..74e6721881 100644
+--- a/internal/service/cloudfront/origin_access_control.go
++++ b/internal/service/cloudfront/origin_access_control.go
+@@ -34,7 +34,7 @@ func ResourceOriginAccessControl() *schema.Resource {
+ 			"description": {
+ 				Type:         schema.TypeString,
+ 				Optional:     true,
+-				Default:      "Managed by Terraform",
++				Default:      "Managed by Pulumi",
+ 				ValidateFunc: validation.StringLenBetween(0, 256),
+ 			},
+ 			"etag": {
+diff --git a/internal/service/docdb/cluster_parameter_group.go b/internal/service/docdb/cluster_parameter_group.go
+index 47c4e53dae..1ce38ad2be 100644
+--- a/internal/service/docdb/cluster_parameter_group.go
++++ b/internal/service/docdb/cluster_parameter_group.go
+@@ -63,7 +63,7 @@ func ResourceClusterParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"parameter": {
+ 				Type:     schema.TypeSet,
+diff --git a/internal/service/docdb/subnet_group.go b/internal/service/docdb/subnet_group.go
+index 1566488795..c0cfdeeaa0 100644
+--- a/internal/service/docdb/subnet_group.go
++++ b/internal/service/docdb/subnet_group.go
+@@ -57,7 +57,7 @@ func ResourceSubnetGroup() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 
+ 			"subnet_ids": {
+diff --git a/internal/service/ec2/vpc_security_group.go b/internal/service/ec2/vpc_security_group.go
+index 24a79139aa..16e321f997 100644
+--- a/internal/service/ec2/vpc_security_group.go
++++ b/internal/service/ec2/vpc_security_group.go
+@@ -58,7 +58,7 @@ func ResourceSecurityGroup() *schema.Resource {
+ 				Type:         schema.TypeString,
+ 				Optional:     true,
+ 				ForceNew:     true,
+-				Default:      "Managed by Terraform",
++				Default:      "Managed by Pulumi",
+ 				ValidateFunc: validation.StringLenBetween(0, 255),
+ 			},
+ 			"egress":  securityGroupRuleSetNestedBlock,
+diff --git a/internal/service/elasticache/parameter_group.go b/internal/service/elasticache/parameter_group.go
+index f8367db885..1ca539b9fc 100644
+--- a/internal/service/elasticache/parameter_group.go
++++ b/internal/service/elasticache/parameter_group.go
+@@ -50,7 +50,7 @@ func ResourceParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"arn": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/elasticache/security_group.go b/internal/service/elasticache/security_group.go
+index 02c8fb3c67..75463425f1 100644
+--- a/internal/service/elasticache/security_group.go
++++ b/internal/service/elasticache/security_group.go
+@@ -31,7 +31,7 @@ func ResourceSecurityGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"name": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/elasticache/subnet_group.go b/internal/service/elasticache/subnet_group.go
+index b8f8ee102b..69d1185057 100644
+--- a/internal/service/elasticache/subnet_group.go
++++ b/internal/service/elasticache/subnet_group.go
+@@ -39,7 +39,7 @@ func ResourceSubnetGroup() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"name": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/mediapackage/channel.go b/internal/service/mediapackage/channel.go
+index 2ee5f9097e..7691497337 100644
+--- a/internal/service/mediapackage/channel.go
++++ b/internal/service/mediapackage/channel.go
+@@ -44,7 +44,7 @@ func ResourceChannel() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"hls_ingest": {
+ 				Type:     schema.TypeList,
+diff --git a/internal/service/memorydb/cluster.go b/internal/service/memorydb/cluster.go
+index 77ac05bee7..9b8da0c4dc 100644
+--- a/internal/service/memorydb/cluster.go
++++ b/internal/service/memorydb/cluster.go
+@@ -67,7 +67,7 @@ func ResourceCluster() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"engine_patch_version": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/memorydb/parameter_group.go b/internal/service/memorydb/parameter_group.go
+index fc523ab492..ba6d032934 100644
+--- a/internal/service/memorydb/parameter_group.go
++++ b/internal/service/memorydb/parameter_group.go
+@@ -44,7 +44,7 @@ func ResourceParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"family": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/memorydb/subnet_group.go b/internal/service/memorydb/subnet_group.go
+index 49b9bdc699..77eceb8676 100644
+--- a/internal/service/memorydb/subnet_group.go
++++ b/internal/service/memorydb/subnet_group.go
+@@ -40,7 +40,7 @@ func ResourceSubnetGroup() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"name": {
+ 				Type:          schema.TypeString,
+diff --git a/internal/service/neptune/cluster_parameter_group.go b/internal/service/neptune/cluster_parameter_group.go
+index 7c9cdb9501..b0e0c52196 100644
+--- a/internal/service/neptune/cluster_parameter_group.go
++++ b/internal/service/neptune/cluster_parameter_group.go
+@@ -60,7 +60,7 @@ func ResourceClusterParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"parameter": {
+ 				Type:     schema.TypeSet,
+diff --git a/internal/service/neptune/parameter_group.go b/internal/service/neptune/parameter_group.go
+index e3e4caa8d2..68e2501ed7 100644
+--- a/internal/service/neptune/parameter_group.go
++++ b/internal/service/neptune/parameter_group.go
+@@ -56,7 +56,7 @@ func ResourceParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"parameter": {
+ 				Type:     schema.TypeSet,
+diff --git a/internal/service/neptune/subnet_group.go b/internal/service/neptune/subnet_group.go
+index 41e99f7043..347a35e174 100644
+--- a/internal/service/neptune/subnet_group.go
++++ b/internal/service/neptune/subnet_group.go
+@@ -39,7 +39,7 @@ func ResourceSubnetGroup() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"name": {
+ 				Type:          schema.TypeString,
+diff --git a/internal/service/rds/cluster_parameter_group.go b/internal/service/rds/cluster_parameter_group.go
+index b43b394c70..45d2c278be 100644
+--- a/internal/service/rds/cluster_parameter_group.go
++++ b/internal/service/rds/cluster_parameter_group.go
+@@ -45,7 +45,7 @@ func ResourceClusterParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"family": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/rds/option_group.go b/internal/service/rds/option_group.go
+index 99a9277e1c..e54e47167e 100644
+--- a/internal/service/rds/option_group.go
++++ b/internal/service/rds/option_group.go
+@@ -72,7 +72,7 @@ func ResourceOptionGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 
+ 			"option": {
+diff --git a/internal/service/rds/parameter_group.go b/internal/service/rds/parameter_group.go
+index 801fd010ff..efe3dd67c4 100644
+--- a/internal/service/rds/parameter_group.go
++++ b/internal/service/rds/parameter_group.go
+@@ -46,7 +46,7 @@ func ResourceParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"family": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/rds/security_group.go b/internal/service/rds/security_group.go
+index 5ef357a4a9..e4c85c6aec 100644
+--- a/internal/service/rds/security_group.go
++++ b/internal/service/rds/security_group.go
+@@ -45,7 +45,7 @@ func ResourceSecurityGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 
+ 			"ingress": {
+diff --git a/internal/service/rds/subnet_group.go b/internal/service/rds/subnet_group.go
+index 02113d5656..4eb484129b 100644
+--- a/internal/service/rds/subnet_group.go
++++ b/internal/service/rds/subnet_group.go
+@@ -38,7 +38,7 @@ func ResourceSubnetGroup() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"name": {
+ 				Type:          schema.TypeString,
+diff --git a/internal/service/redshift/parameter_group.go b/internal/service/redshift/parameter_group.go
+index 193ce6355e..5e5480f96b 100644
+--- a/internal/service/redshift/parameter_group.go
++++ b/internal/service/redshift/parameter_group.go
+@@ -45,7 +45,7 @@ func ResourceParameterGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"family": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/redshift/security_group.go b/internal/service/redshift/security_group.go
+index 0ce8d2b03a..34f57c6a66 100644
+--- a/internal/service/redshift/security_group.go
++++ b/internal/service/redshift/security_group.go
+@@ -47,7 +47,7 @@ func ResourceSecurityGroup() *schema.Resource {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+ 				ForceNew: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 
+ 			"ingress": {
+diff --git a/internal/service/redshift/subnet_group.go b/internal/service/redshift/subnet_group.go
+index fda44e5cd5..ab359c94f6 100644
+--- a/internal/service/redshift/subnet_group.go
++++ b/internal/service/redshift/subnet_group.go
+@@ -40,7 +40,7 @@ func ResourceSubnetGroup() *schema.Resource {
+ 			"description": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+-				Default:  "Managed by Terraform",
++				Default:  "Managed by Pulumi",
+ 			},
+ 			"name": {
+ 				Type:     schema.TypeString,
+diff --git a/internal/service/route53/record.go b/internal/service/route53/record.go
+index 2f8ec880dd..fc2dc352ea 100644
+--- a/internal/service/route53/record.go
++++ b/internal/service/route53/record.go
+@@ -302,7 +302,7 @@ func resourceRecordCreate(ctx context.Context, d *schema.ResourceData, meta inte
+ 	// retry for us since Route53 sometimes returns errors about another
+ 	// operation happening at the same time.
+ 	changeBatch := &route53.ChangeBatch{
+-		Comment: aws.String("Managed by Terraform"),
++		Comment: aws.String("Managed by Pulumi"),
+ 		Changes: []*route53.Change{
+ 			{
+ 				Action:            aws.String(action),
+@@ -578,7 +578,7 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta inte
+ 	// StateChangeConf for this to retry for us since Route53 sometimes returns
+ 	// errors about another operation happening at the same time.
+ 	changeBatch := &route53.ChangeBatch{
+-		Comment: aws.String("Managed by Terraform"),
++		Comment: aws.String("Managed by Pulumi"),
+ 		Changes: []*route53.Change{
+ 			{
+ 				Action:            aws.String(route53.ChangeActionDelete),
+@@ -649,7 +649,7 @@ func resourceRecordDelete(ctx context.Context, d *schema.ResourceData, meta inte
+ 
+ 	// Change batch for deleting
+ 	changeBatch := &route53.ChangeBatch{
+-		Comment: aws.String("Deleted by Terraform"),
++		Comment: aws.String("Deleted by Pulumi"),
+ 		Changes: []*route53.Change{
+ 			{
+ 				Action:            aws.String(route53.ChangeActionDelete),
+diff --git a/internal/service/route53/zone.go b/internal/service/route53/zone.go
+index f51e4dbefa..4890cb45eb 100644
+--- a/internal/service/route53/zone.go
++++ b/internal/service/route53/zone.go
+@@ -52,7 +52,7 @@ func ResourceZone() *schema.Resource {
+ 			"comment": {
+ 				Type:         schema.TypeString,
+ 				Optional:     true,
+-				Default:      "Managed by Terraform",
++				Default:      "Managed by Pulumi",
+ 				ValidateFunc: validation.StringLenBetween(0, 256),
+ 			},
+ 			"delegation_set_id": {
+diff --git a/internal/service/route53/zone_association.go b/internal/service/route53/zone_association.go
+index 9d576d7b8b..a21723d7d0 100644
+--- a/internal/service/route53/zone_association.go
++++ b/internal/service/route53/zone_association.go
+@@ -73,7 +73,7 @@ func resourceZoneAssociationCreate(ctx context.Context, d *schema.ResourceData,
+ 			VPCId:     aws.String(vpcID),
+ 			VPCRegion: aws.String(vpcRegion),
+ 		},
+-		Comment: aws.String("Managed by Terraform"),
++		Comment: aws.String("Managed by Pulumi"),
+ 	}
+ 
+ 	output, err := conn.AssociateVPCWithHostedZoneWithContext(ctx, input)
+@@ -176,7 +176,7 @@ func resourceZoneAssociationDelete(ctx context.Context, d *schema.ResourceData,
+ 			VPCId:     aws.String(vpcID),
+ 			VPCRegion: aws.String(vpcRegion),
+ 		},
+-		Comment: aws.String("Managed by Terraform"),
++		Comment: aws.String("Managed by Pulumi"),
+ 	}
+ 
+ 	_, err = conn.DisassociateVPCFromHostedZoneWithContext(ctx, input)


### PR DESCRIPTION
Aim: We want to be able to review how patches have evolved between upgrades.

1. Find commits since the lastest tag in the upstream repo
2. Commit patch files into a subfolder for review

Example diff for last upgrade (noisy because of SDK changes): https://github.com/pulumi/pulumi-aws/compare/5.30.1-patches..export-patches-to-repo