### PR TITLE
Add go build caching for the shim testing job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -454,6 +454,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: Run test of provider shim
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -469,6 +469,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: Run test of provider shim
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -206,6 +206,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: Run test of provider shim
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -412,6 +412,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: Run test of provider shim
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,6 +439,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: Run test of provider shim
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -243,6 +243,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: Run test of provider shim
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Introduce Go caching on the "Run test of provider shim" job to reduce flaky timeouts and reduce runtime from 30min to <2 min total.