### PR TITLE
Cache Go builds on sdk/go.sum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -153,7 +153,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -201,7 +201,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -271,7 +271,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -333,7 +333,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -394,7 +394,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -504,7 +504,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -157,7 +157,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -207,7 +207,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -284,7 +284,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -347,7 +347,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -410,7 +410,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -521,7 +521,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -147,7 +147,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -250,7 +250,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -147,7 +147,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -224,7 +224,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -288,7 +288,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -351,7 +351,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -462,7 +462,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -161,7 +161,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -238,7 +238,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -301,7 +301,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -364,7 +364,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -489,7 +489,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -170,7 +170,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -290,7 +290,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/update-bridge.yml
+++ b/.github/workflows/update-bridge.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/update-upstream-provider.yml
+++ b/.github/workflows/update-upstream-provider.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
         cache-dependency-path: |
-            **/go.sum
+            sdk/go.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:


### PR DESCRIPTION
This is an unusual repository - go.sum changes all the time, while there are not so many parallel builds. This means that typically all PRs have cache misses because they edit some go.sum somewhere. It would be preferable to fetch the wrong build cache (and rewrite it in each PR), hoping some parts of it still speed up the build, than it is to accept a cache miss.

This PR relies on the fact that sdk/go.sum is fairly stable, and uses it as a key. This is less precise but might be preferable.