### PR TITLE
Nodejs lambda callbackfunction lifted policies

### DIFF
--- a/examples/callbackfunction/index.ts
+++ b/examples/callbackfunction/index.ts
@@ -22,6 +22,17 @@ const role = new aws.iam.Role("role", {
     assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" }),
 }, providerOpts);
 
+const policy = new aws.iam.Policy("policy", {
+    policy: {
+        Version: "2012-10-17",
+        Statement: [{
+            Action: ["s3:ListBucket"],
+            Effect: "Allow",
+            Resource: "arn:aws:s3:::*",
+        }],
+    }
+});
+
 const functions = [
     new aws.lambda.CallbackFunction("a", {
         callback: async () => ({ success: true }),
@@ -43,6 +54,10 @@ const functions = [
             const ret = { success: true };
             return async () => ret;
         },
+    }, providerOpts),
+    new aws.lambda.CallbackFunction("f", {
+        policies: { one: policy.arn },
+        callback: async () => ({ success: true }),
     }, providerOpts),
 ];
 


### PR DESCRIPTION
On the NodeJS SDK, `lambda.CallbackFunction` has a handy property for directly attaching policies.  However practically only managed policies used to be supported, because policies provisioned in the same pulumi stack would always have a lifted ARN.

This constraint was in place, because the ARN is used to generate a unique URN for the policy attachment and URNs cannot be lifted.

In this PR I have addressed the problem, allowing user-supplied unique labels for such policies, while still maintaining backward compatibility to avoid any breaking changes.