### PR TITLE
fixing example of log filtering for wafv2

### DIFF
--- a/sdk/python/pulumi_aws/wafv2/web_acl_logging_configuration.py
+++ b/sdk/python/pulumi_aws/wafv2/web_acl_logging_configuration.py
@@ -204,7 +204,7 @@ class WebAclLoggingConfiguration(pulumi.CustomResource):
                         behavior="DROP",
                         conditions=[
                             aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionArgs(
-                                action_condition=aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionActionConditionArgs(
+                                action_conditions=aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionActionConditionArgs(
                                     action="COUNT",
                                 ),
                             ),
@@ -219,7 +219,7 @@ class WebAclLoggingConfiguration(pulumi.CustomResource):
                     aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterArgs(
                         behavior="KEEP",
                         conditions=[aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionArgs(
-                            action_condition=aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionActionConditionArgs(
+                            action_conditions=aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionActionConditionArgs(
                                 action="ALLOW",
                             ),
                         )],


### PR DESCRIPTION
The example for log filtering with waf v2 has a typo, this fixes that typo.