### PR TITLE
Use Go 1.20.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:
@@ -182,7 +182,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -252,7 +252,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -308,7 +308,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -372,7 +372,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
   publish_sdk:
@@ -454,7 +454,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -591,7 +591,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:
@@ -186,7 +186,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -263,7 +263,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -320,7 +320,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -386,7 +386,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
   publish_sdk:
@@ -470,7 +470,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -608,7 +608,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:
@@ -198,7 +198,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -337,7 +337,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:
@@ -203,7 +203,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -261,7 +261,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -327,7 +327,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
   publish_sdk:
@@ -411,7 +411,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -549,7 +549,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:
@@ -217,7 +217,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -274,7 +274,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -340,7 +340,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
   publish_sdk:
@@ -424,7 +424,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -576,7 +576,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -118,7 +118,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:
@@ -226,7 +226,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:
@@ -377,7 +377,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         javaversion:
         - "11"
         language:

--- a/.github/workflows/update-bridge.yml
+++ b/.github/workflows/update-bridge.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:

--- a/.github/workflows/update-upstream-provider.yml
+++ b/.github/workflows/update-upstream-provider.yml
@@ -138,7 +138,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-aws/provider/v5
 
-go 1.18
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3


### PR DESCRIPTION
Upgrade CI to build and test on Go 1.20.x from Go 1.19.x.