### PR TITLE
Avoid importing full root `@pulumi/aws` module

### DIFF
--- a/examples/bucket/index.ts
+++ b/examples/bucket/index.ts
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+// Import the nested module directly to regression test:
+// https://github.com/pulumi/pulumi-aws/issues/772
+import { Bucket } from "@pulumi/aws/s3";
 import * as aws from "@pulumi/aws";
 
 const config = new pulumi.Config("aws");
 const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
 
-const bucket = new aws.s3.Bucket("testbucket", {
+const bucket = new Bucket("testbucket", {
     serverSideEncryptionConfiguration: {
         rule: {
             applyServerSideEncryptionByDefault: {
@@ -30,8 +33,9 @@ const bucket = new aws.s3.Bucket("testbucket", {
 }, providerOpts);
 
 bucket.onObjectCreated("bucket-callback", async (event) => {
-    const awssdk = await import("aws-sdk");
-    const s3 = new awssdk.S3();
+    // Use `aws.sdk` property directly to validate it resolves both 
+    // at type checking time and at runtime correctly.
+    const s3 = new aws.sdk.S3();
 
     const recordFile = "lastPutFile.json";
 

--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Directly import awsMixins.  We want to execute the code within it, but we don't want to import or
-// export any values from it.  Specifically, awsMixins adds a *getter* property (called "runtime")
-// to this @pulumi/aws module. If we actually *import* or *export* that property, the getter will
-// execute, which is not what we want at all.  Instead, we want to really just expose that we have
-// this "runtime" property on the typing, and we want to execute the code that jams the getter on.
-
-import "./awsMixins";
-
 import * as pulumi from "@pulumi/pulumi";
 import * as crypto from "crypto";
 


### PR DESCRIPTION
Every folder inside the AWS Node.js SDK that has a mixin was importing "../utils", which imports "./awsMixins" which itself was forcing import of "." which then goes back and tries to force import of everything.  There is no clear reason why forcing this root module import was ever necesary. Nothing that imports utils.ts depends on the side effects caused by "awsMixins", and the primary effect of adding the `sdk` getter onto the root module is only relevant if the end user loads that root module itself so they can access this property.

Also expands some existing test coverage to test this and use of `aws.sdk`, which is the related feature that could in principle be impacted by removing this forced side effect

Fixes #772.