### PR TITLE
Pin VERSION_PREFIX=5.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
+      run: echo "GORELEASER_CURRENT_TAG=v$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
@@ -360,7 +360,7 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -374,7 +374,7 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
@@ -242,7 +242,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
+      run: echo "GORELEASER_CURRENT_TAG=v$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
@@ -315,7 +315,7 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
@@ -256,7 +256,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
+      run: echo "GORELEASER_CURRENT_TAG=v$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
@@ -328,7 +328,7 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
@@ -441,8 +441,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic) && git push origin
+        sdk/v$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)
 
   go_test_shim:
     if: github.event_name == 'repository_dispatch' ||

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+      run: echo "PACKAGE_VERSION=$(VERSION_PREFIX=5.0.0 pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell VERSION_PREFIX=5.0.0 pulumictl get version)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.9.3
 TESTPARALLELISM := 10
@@ -48,9 +48,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell VERSION_PREFIX=5.0.0 pulumictl get version --language dotnet)
 build_dotnet: patch_upstream
-	pulumictl get version --language dotnet
+	VERSION_PREFIX=5.0.0 pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --overlays provider/overlays/dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,14 +60,14 @@ build_dotnet: patch_upstream
 build_go: patch_upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --overlays provider/overlays/go --out sdk/go/
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := $(shell VERSION_PREFIX=5.0.0 pulumictl get version --language generic)
 build_java: bin/pulumi-java-gen patch_upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell VERSION_PREFIX=5.0.0 pulumictl get version --language javascript)
 build_nodejs: patch_upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --overlays provider/overlays/nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -77,7 +77,7 @@ build_nodejs: patch_upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell VERSION_PREFIX=5.0.0 pulumictl get version --language python)
 build_python: patch_upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
 	cd sdk/python/ && \


### PR DESCRIPTION
This is a workaround to make master builds succeed until pulumi-aws v6.0.0 is merged to master and released.

Fixes https://github.com/pulumi/pulumi-aws/issues/2572


```
git grep -l 'pulumictl get version' | 
    xargs sed -i '' -e 's/pulumictl get version/VERSION_PREFIX=5.0.0 pulumictl get version/g'                                            
```