### PR TITLE
Add global replacement for "tf" prefixes

### DIFF
--- a/upstream-tools/global-replacements.json
+++ b/upstream-tools/global-replacements.json
@@ -11,6 +11,11 @@
         "regExp": true,
         "old": "names.AttrTagsAll:(\\s+)tftags.TagsSchemaComputed\\(\\)",
         "new": "names.AttrTagsAll:$1tftags.TagsSchemaTrulyComputed()"
+      },
+      {
+        "regExp": true,
+        "old": "PrefixedUniqueId\\(\"tf",
+        "new": "PrefixedUniqueId(\"pu"
       }
     ]
   },


### PR DESCRIPTION
Closes #2596

Auto-generate prefixes as "pu" instead of "tf". This is normally followed by a hyphen but is sometimes just "tf" alone.

To review: 
1. Does this affect existing resources or only new resources?

I think the large number of schema changes are actually stemming from the v6 branch rather than this PR as there's zero schema diff.