### PR TITLE
Add support for ruby 3.2 runtime

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5754,6 +5754,7 @@ func Provider() tfbridge.ProviderInfo {
 					{Value: "java11", Name: "Java11"},
 					{Value: "ruby2.5", Name: "Ruby2d5", DeprecationMessage: "This runtime is now deprecated"},
 					{Value: "ruby2.7", Name: "Ruby2d7"},
+					{Value: "ruby3.2", Name: "Ruby3d2"},
 					{Value: "nodejs10.x", Name: "NodeJS10dX", DeprecationMessage: "This runtime is now deprecated"},
 					{Value: "nodejs12.x", Name: "NodeJS12dX"},
 					{Value: "nodejs14.x", Name: "NodeJS14dX"},

--- a/sdk/dotnet/Lambda/Enums.cs
+++ b/sdk/dotnet/Lambda/Enums.cs
@@ -32,6 +32,7 @@ namespace Pulumi.Aws.Lambda
         [Obsolete(@"This runtime is now deprecated")]
         public static Runtime Ruby2d5 { get; } = new Runtime("ruby2.5");
         public static Runtime Ruby2d7 { get; } = new Runtime("ruby2.7");
+        public static Runtime Ruby3d2 { get; } = new Runtime("ruby3.2");
         [Obsolete(@"This runtime is now deprecated")]
         public static Runtime NodeJS10dX { get; } = new Runtime("nodejs10.x");
         public static Runtime NodeJS12dX { get; } = new Runtime("nodejs12.x");

--- a/sdk/go/aws/lambda/pulumiEnums.go
+++ b/sdk/go/aws/lambda/pulumiEnums.go
@@ -26,6 +26,7 @@ const (
 	// Deprecated: This runtime is now deprecated
 	RuntimeRuby2d5 = Runtime("ruby2.5")
 	RuntimeRuby2d7 = Runtime("ruby2.7")
+	RuntimeRuby3d2 = Runtime("ruby3.2")
 	// Deprecated: This runtime is now deprecated
 	RuntimeNodeJS10dX = Runtime("nodejs10.x")
 	RuntimeNodeJS12dX = Runtime("nodejs12.x")

--- a/sdk/java/src/main/java/com/pulumi/aws/lambda/enums/Runtime.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lambda/enums/Runtime.java
@@ -34,6 +34,7 @@ import java.util.StringJoiner;
         @Deprecated /* This runtime is now deprecated */
         Ruby2d5("ruby2.5"),
         Ruby2d7("ruby2.7"),
+        Ruby3d2("ruby3.2"),
         /**
          * @deprecated
          * This runtime is now deprecated

--- a/sdk/nodejs/types/enums/lambda/index.ts
+++ b/sdk/nodejs/types/enums/lambda/index.ts
@@ -19,6 +19,7 @@ export const Runtime = {
      */
     Ruby2d5: "ruby2.5",
     Ruby2d7: "ruby2.7",
+    Ruby3d2: "ruby3.2",
     /**
      * @deprecated This runtime is now deprecated
      */

--- a/sdk/python/pulumi_aws/lambda_/_enums.py
+++ b/sdk/python/pulumi_aws/lambda_/_enums.py
@@ -23,6 +23,7 @@ class Runtime(str, Enum):
     JAVA11 = "java11"
     RUBY2D5 = "ruby2.5"
     RUBY2D7 = "ruby2.7"
+    RUBY3D2 = "ruby3.2"
     NODE_JS10D_X = "nodejs10.x"
     NODE_JS12D_X = "nodejs12.x"
     NODE_JS14D_X = "nodejs14.x"


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/ruby-3-2-runtime-now-available-in-aws-lambda/