### PR TITLE
Add Python 3.11 as a supported runtime for Lambda

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5766,6 +5766,7 @@ func Provider() tfbridge.ProviderInfo {
 					{Value: "python3.8", Name: "Python3d8"},
 					{Value: "python3.9", Name: "Python3d9"},
 					{Value: "python3.10", Name: "Python3d10"},
+					{Value: "python3.11", Name: "Python3d11"},
 					{Value: "provided", Name: "Custom"},
 					{Value: "provided.al2", Name: "CustomAL2"},
 				},

--- a/sdk/dotnet/Lambda/Enums.cs
+++ b/sdk/dotnet/Lambda/Enums.cs
@@ -47,6 +47,7 @@ namespace Pulumi.Aws.Lambda
         public static Runtime Python3d8 { get; } = new Runtime("python3.8");
         public static Runtime Python3d9 { get; } = new Runtime("python3.9");
         public static Runtime Python3d10 { get; } = new Runtime("python3.10");
+        public static Runtime Python3d11 { get; } = new Runtime("python3.11");
         public static Runtime Custom { get; } = new Runtime("provided");
         public static Runtime CustomAL2 { get; } = new Runtime("provided.al2");
 

--- a/sdk/go/aws/lambda/pulumiEnums.go
+++ b/sdk/go/aws/lambda/pulumiEnums.go
@@ -41,6 +41,7 @@ const (
 	RuntimePython3d8  = Runtime("python3.8")
 	RuntimePython3d9  = Runtime("python3.9")
 	RuntimePython3d10 = Runtime("python3.10")
+	RuntimePython3d11 = Runtime("python3.11")
 	RuntimeCustom     = Runtime("provided")
 	RuntimeCustomAL2  = Runtime("provided.al2")
 )

--- a/sdk/java/src/main/java/com/pulumi/aws/lambda/enums/Runtime.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lambda/enums/Runtime.java
@@ -61,6 +61,7 @@ import java.util.StringJoiner;
         Python3d8("python3.8"),
         Python3d9("python3.9"),
         Python3d10("python3.10"),
+        Python3d11("python3.11"),
         Custom("provided"),
         CustomAL2("provided.al2");
 

--- a/sdk/nodejs/types/enums/lambda/index.ts
+++ b/sdk/nodejs/types/enums/lambda/index.ts
@@ -40,6 +40,7 @@ export const Runtime = {
     Python3d8: "python3.8",
     Python3d9: "python3.9",
     Python3d10: "python3.10",
+    Python3d11: "python3.11",
     Custom: "provided",
     CustomAL2: "provided.al2",
 } as const;

--- a/sdk/python/pulumi_aws/lambda_/_enums.py
+++ b/sdk/python/pulumi_aws/lambda_/_enums.py
@@ -35,5 +35,6 @@ class Runtime(str, Enum):
     PYTHON3D8 = "python3.8"
     PYTHON3D9 = "python3.9"
     PYTHON3D10 = "python3.10"
+    PYTHON3D11 = "python3.11"
     CUSTOM = "provided"
     CUSTOM_AL2 = "provided.al2"


### PR DESCRIPTION
Closes #2652