### PR TITLE
Remove aws-sdk npm dependency

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -6717,7 +6717,6 @@ func Provider() *tfbridge.ProviderInfo {
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
 				"@pulumi/pulumi":    "^3.0.0",
-				"aws-sdk":           "^2.0.0",
 				"mime":              "^2.0.0",
 				"builtin-modules":   "3.0.0",
 				"read-package-tree": "^5.2.1",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -15,7 +15,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "aws-sdk": "^2.0.0",
         "builtin-modules": "3.0.0",
         "mime": "^2.0.0",
         "read-package-tree": "^5.2.1",


### PR DESCRIPTION
We no longer use this since https://github.com/pulumi/pulumi-aws/pull/2584

Closes https://github.com/pulumi/pulumi-aws/issues/2656