### PR TITLE
Support AutoName for Plugin Framework based resources

### DIFF
--- a/examples/plugin-framework/Pulumi.yaml
+++ b/examples/plugin-framework/Pulumi.yaml
@@ -6,14 +6,6 @@ resources:
   bucket-example:
     type: aws:s3:Bucket
 
-  # It turns out that resourceexplorer can only be provisioned once per region, creating conflicts if this test run in
-  # parallel. Perhaps not a great example.
-  #
-  # resourceexplorer-example:
-  #   type: aws:resourceexplorer/index:Index
-  #   properties:
-  #     type: LOCAL
-
   # cidrcollection also tests auto-naming, it should get a random-suffixed name such as below, without specifying one:
   #     "name": "cidrcollection-example-8eb4b3b"
 

--- a/examples/plugin-framework/Pulumi.yaml
+++ b/examples/plugin-framework/Pulumi.yaml
@@ -5,12 +5,18 @@ outputs: {}
 resources:
   bucket-example:
     type: aws:s3:Bucket
-  resourceexplorer-example:
-    type: aws:resourceexplorer/index:Index
-    properties:
-      type: LOCAL
+
+  # It turns out that resourceexplorer can only be provisioned once per region, creating conflicts if this test run in
+  # parallel. Perhaps not a great example.
+  #
+  # resourceexplorer-example:
+  #   type: aws:resourceexplorer/index:Index
+  #   properties:
+  #     type: LOCAL
+
+  # cidrcollection also tests auto-naming, it should get a random-suffixed name such as below, without specifying one:
+  #     "name": "cidrcollection-example-8eb4b3b"
+
   cidrcollection-example:
     type: aws:route53/cidrCollection:CidrCollection
-    properties:
-     name: collection-example
 variables: {}

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -20,8 +20,8 @@ replace (
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 
-	github.com/pulumi/pulumi-terraform-bridge/pf => ../../pulumi-terraform-bridge/pf
-	github.com/pulumi/pulumi-terraform-bridge/v3 => ../../pulumi-terraform-bridge
+	github.com/pulumi/pulumi-terraform-bridge/pf => github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9
+	github.com/pulumi/pulumi-terraform-bridge/v3 => github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9
 )
 
 require (

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.32
 	github.com/hashicorp/terraform-provider-aws/shim v0.0.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.0
 	github.com/pulumi/pulumi/pkg/v3 v3.76.1
 	github.com/pulumi/pulumi/sdk/v3 v3.76.1
 	github.com/stretchr/testify v1.8.4

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.32
 	github.com/hashicorp/terraform-provider-aws/shim v0.0.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.14.1
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9
 	github.com/pulumi/pulumi/pkg/v3 v3.76.1
 	github.com/pulumi/pulumi/sdk/v3 v3.76.1
 	github.com/stretchr/testify v1.8.4
@@ -19,9 +19,6 @@ replace (
 	github.com/hashicorp/terraform-provider-aws => ../upstream
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
-
-	github.com/pulumi/pulumi-terraform-bridge/pf => github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9
-	github.com/pulumi/pulumi-terraform-bridge/v3 => github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9
 )
 
 require (

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -19,6 +19,9 @@ replace (
 	github.com/hashicorp/terraform-provider-aws => ../upstream
 	github.com/hashicorp/terraform-provider-aws/shim => ./shim
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
+
+	github.com/pulumi/pulumi-terraform-bridge/pf => ../../pulumi-terraform-bridge/pf
+	github.com/pulumi/pulumi-terraform-bridge/v3 => ../../pulumi-terraform-bridge
 )
 
 require (

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2278,11 +2278,7 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.4 h1:gIQZmlUI1o9ye8CL2XFqtmAX6Lwr9uj/+HzjboiSmK4=
 github.com/pulumi/pulumi-java/pkg v0.9.4/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.14.1 h1:5rUx8yFHic576DVHVGOqpYxEcoDyjuokuh8324aFP4c=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.14.1/go.mod h1:JnLxW6/U/BGCVdOqsPtPxnIumHp26wqsZv3Ywtgbdl8=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.0 h1:A33Ji/QSCYy2Jk5+1BzA5vFmK7Rvq6XFo8jS69QahVo=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.0/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6 h1:uy8P3aaAbrOrGvytvCb2KsYqZMA9TJiY8IKeVQgNAJo=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6/go.mod h1:uw1IN0Mlvi5SL0cmWzmKqZ+ZDNueRIXkr9aE+XQkrug=
 github.com/pulumi/pulumi-yaml v1.1.1 h1:8pyBNIU8+ym0wYpjhsCqN+cutygfK1XbhY2YEeNfyXY=

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2278,11 +2278,11 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.4 h1:gIQZmlUI1o9ye8CL2XFqtmAX6Lwr9uj/+HzjboiSmK4=
 github.com/pulumi/pulumi-java/pkg v0.9.4/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9 h1:XkoBYTSqCB/Bw85YbdshejgTlJajez3mYYDFadO9mCU=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9/go.mod h1:ziHnwUPOiiZsNA2vuoSJhZCvI4LfKRLqS4tKlcIBSCg=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.15.0 h1:9ODws24rjbjCUezcBqGeq0Zv4MnE5fsD9MOExHdQbE4=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.15.0/go.mod h1:78zmO88vcJDcWoCJZfaHAQReHTEhuNx6BxlE5MUlLJc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9 h1:ST/aNf4LC06b61ldNInUq+7A211BLohVMfOk1dTTPjk=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.0 h1:3ga+bvWnGH9+Ukxn24prZovhpIXcU7QRhu8iWzs905o=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.0/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6 h1:uy8P3aaAbrOrGvytvCb2KsYqZMA9TJiY8IKeVQgNAJo=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6/go.mod h1:uw1IN0Mlvi5SL0cmWzmKqZ+ZDNueRIXkr9aE+XQkrug=
 github.com/pulumi/pulumi-yaml v1.1.1 h1:8pyBNIU8+ym0wYpjhsCqN+cutygfK1XbhY2YEeNfyXY=

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2278,7 +2278,11 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.4 h1:gIQZmlUI1o9ye8CL2XFqtmAX6Lwr9uj/+HzjboiSmK4=
 github.com/pulumi/pulumi-java/pkg v0.9.4/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9 h1:XkoBYTSqCB/Bw85YbdshejgTlJajez3mYYDFadO9mCU=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.14.2-0.20230802145745-14057592edb9/go.mod h1:ziHnwUPOiiZsNA2vuoSJhZCvI4LfKRLqS4tKlcIBSCg=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9 h1:ST/aNf4LC06b61ldNInUq+7A211BLohVMfOk1dTTPjk=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.55.1-0.20230802145745-14057592edb9/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6 h1:uy8P3aaAbrOrGvytvCb2KsYqZMA9TJiY8IKeVQgNAJo=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6/go.mod h1:uw1IN0Mlvi5SL0cmWzmKqZ+ZDNueRIXkr9aE+XQkrug=
 github.com/pulumi/pulumi-yaml v1.1.1 h1:8pyBNIU8+ym0wYpjhsCqN+cutygfK1XbhY2YEeNfyXY=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -6985,8 +6985,6 @@ func Provider() *tfbridge.ProviderInfo {
 			Docs: &tfbridge.DocInfo{Source: "lb_target_group_attachment.html.markdown"},
 		})
 
-	prov.SetAutonaming(255, "-")
-
 	// Add a CSharp-specific override for aws_s3_bucket.bucket.
 	prov.Resources["aws_s3_bucket_legacy"].Fields["bucket"].CSharpName = "BucketName"
 
@@ -7119,6 +7117,8 @@ func Provider() *tfbridge.ProviderInfo {
 
 	// Fixes a spurious diff on repeat pulumi up for the aws_wafv2_web_acl resource (pulumi/pulumi#1423).
 	shimv2.SetInstanceStateStrategy(prov.P.ResourcesMap().Get("aws_wafv2_web_acl"), shimv2.CtyInstanceState)
+
+	prov.SetAutonaming(255, "-")
 
 	return &prov
 }

--- a/sdk/dotnet/AppIntegrations/DataIntegration.cs
+++ b/sdk/dotnet/AppIntegrations/DataIntegration.cs
@@ -24,7 +24,6 @@ namespace Pulumi.Aws.AppIntegrations
     /// {
     ///     var example = new Aws.AppIntegrations.DataIntegration("example", new()
     ///     {
-    ///         Name = "example",
     ///         Description = "example",
     ///         KmsKey = aws_kms_key.Test.Arn,
     ///         SourceUri = "Salesforce://AppFlow/example",
@@ -163,8 +162,8 @@ namespace Pulumi.Aws.AppIntegrations
         /// <summary>
         /// Specifies the name of the Data Integration.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.

--- a/sdk/dotnet/Auditmanager/Assessment.cs
+++ b/sdk/dotnet/Auditmanager/Assessment.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Auditmanager
     /// {
     ///     var test = new Aws.Auditmanager.Assessment("test", new()
     ///     {
-    ///         Name = "example",
     ///         AssessmentReportsDestination = new Aws.Auditmanager.Inputs.AssessmentAssessmentReportsDestinationArgs
     ///         {
     ///             Destination = $"s3://{aws_s3_bucket.Test.Id}",
@@ -205,8 +204,8 @@ namespace Pulumi.Aws.Auditmanager
         /// <summary>
         /// Name of the assessment.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("roles", required: true)]
         private InputList<Inputs.AssessmentRoleArgs>? _roles;

--- a/sdk/dotnet/Auditmanager/AssessmentReport.cs
+++ b/sdk/dotnet/Auditmanager/AssessmentReport.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Auditmanager
     /// {
     ///     var test = new Aws.Auditmanager.AssessmentReport("test", new()
     ///     {
-    ///         Name = "example",
     ///         AssessmentId = aws_auditmanager_assessment.Test.Id,
     ///     });
     /// 
@@ -138,8 +137,8 @@ namespace Pulumi.Aws.Auditmanager
         /// <summary>
         /// Name of the assessment report.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         public AssessmentReportArgs()
         {

--- a/sdk/dotnet/Auditmanager/Control.cs
+++ b/sdk/dotnet/Auditmanager/Control.cs
@@ -34,7 +34,6 @@ namespace Pulumi.Aws.Auditmanager
     ///                 SourceType = "MANUAL",
     ///             },
     ///         },
-    ///         Name = "example",
     ///     });
     /// 
     /// });
@@ -119,7 +118,7 @@ namespace Pulumi.Aws.Auditmanager
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Control(string name, ControlArgs args, CustomResourceOptions? options = null)
+        public Control(string name, ControlArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:auditmanager/control:Control", name, args ?? new ControlArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -192,8 +191,8 @@ namespace Pulumi.Aws.Auditmanager
         /// <summary>
         /// Name of the control.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/Auditmanager/Framework.cs
+++ b/sdk/dotnet/Auditmanager/Framework.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Auditmanager
     /// {
     ///     var test = new Aws.Auditmanager.Framework("test", new()
     ///     {
-    ///         Name = "example",
     ///         ControlSets = new[]
     ///         {
     ///             new Aws.Auditmanager.Inputs.FrameworkControlSetArgs
@@ -112,7 +111,7 @@ namespace Pulumi.Aws.Auditmanager
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Framework(string name, FrameworkArgs args, CustomResourceOptions? options = null)
+        public Framework(string name, FrameworkArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:auditmanager/framework:Framework", name, args ?? new FrameworkArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -179,8 +178,8 @@ namespace Pulumi.Aws.Auditmanager
         /// <summary>
         /// Name of the framework.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/Auditmanager/GetControl.cs
+++ b/sdk/dotnet/Auditmanager/GetControl.cs
@@ -61,7 +61,6 @@ namespace Pulumi.Aws.Auditmanager
         /// 
         ///     var exampleFramework = new Aws.Auditmanager.Framework("exampleFramework", new()
         ///     {
-        ///         Name = "example",
         ///         ControlSets = new[]
         ///         {
         ///             new Aws.Auditmanager.Inputs.FrameworkControlSetArgs
@@ -147,7 +146,6 @@ namespace Pulumi.Aws.Auditmanager
         /// 
         ///     var exampleFramework = new Aws.Auditmanager.Framework("exampleFramework", new()
         ///     {
-        ///         Name = "example",
         ///         ControlSets = new[]
         ///         {
         ///             new Aws.Auditmanager.Inputs.FrameworkControlSetArgs

--- a/sdk/dotnet/Chime/SdkvoiceSipMediaApplication.cs
+++ b/sdk/dotnet/Chime/SdkvoiceSipMediaApplication.cs
@@ -26,7 +26,6 @@ namespace Pulumi.Aws.Chime
     ///     var example = new Aws.Chime.SdkvoiceSipMediaApplication("example", new()
     ///     {
     ///         AwsRegion = "us-east-1",
-    ///         Name = "example-sip-media-application",
     ///         Endpoints = new Aws.Chime.Inputs.SdkvoiceSipMediaApplicationEndpointsArgs
     ///         {
     ///             LambdaArn = aws_lambda_function.Test.Arn,
@@ -148,8 +147,8 @@ namespace Pulumi.Aws.Chime
         /// 
         /// The following arguments are optional:
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/Chime/SdkvoiceSipRule.cs
+++ b/sdk/dotnet/Chime/SdkvoiceSipRule.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Chime
     /// {
     ///     var example = new Aws.Chime.SdkvoiceSipRule("example", new()
     ///     {
-    ///         Name = "example-sip-rule",
     ///         TriggerType = "RequestUriHostname",
     ///         TriggerValue = aws_chime_voice_connector.Example_voice_connector.Outbound_host_name,
     ///         TargetApplications = new[]
@@ -140,8 +139,8 @@ namespace Pulumi.Aws.Chime
         /// <summary>
         /// The name of the SIP rule.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("targetApplications", required: true)]
         private InputList<Inputs.SdkvoiceSipRuleTargetApplicationArgs>? _targetApplications;

--- a/sdk/dotnet/Chime/SdkvoiceVoiceProfileDomain.cs
+++ b/sdk/dotnet/Chime/SdkvoiceVoiceProfileDomain.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Aws.Chime
     /// 
     ///     var exampleSdkvoiceVoiceProfileDomain = new Aws.Chime.SdkvoiceVoiceProfileDomain("exampleSdkvoiceVoiceProfileDomain", new()
     ///     {
-    ///         Name = "ExampleVoiceProfileDomain",
     ///         ServerSideEncryptionConfiguration = new Aws.Chime.Inputs.SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs
     ///         {
     ///             KmsKeyArn = exampleKey.Arn,
@@ -142,8 +141,8 @@ namespace Pulumi.Aws.Chime
         /// <summary>
         /// Name of Voice Profile Domain.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// Configuration for server side encryption.

--- a/sdk/dotnet/CleanRooms/Collaboration.cs
+++ b/sdk/dotnet/CleanRooms/Collaboration.cs
@@ -49,7 +49,6 @@ namespace Pulumi.Aws.CleanRooms
     ///                 MemberAbilities = new[] {},
     ///             },
     ///         },
-    ///         Name = "pulumi-example-collaboration",
     ///         QueryLogStatus = "DISABLED",
     ///         Tags = 
     ///         {
@@ -254,8 +253,8 @@ namespace Pulumi.Aws.CleanRooms
         /// <summary>
         /// The name of the collaboration.  Collaboration names do not need to be unique.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// Determines if members of the collaboration can enable query logs within their own

--- a/sdk/dotnet/CloudFront/FieldLevelEncryptionProfile.cs
+++ b/sdk/dotnet/CloudFront/FieldLevelEncryptionProfile.cs
@@ -27,7 +27,6 @@ namespace Pulumi.Aws.CloudFront
     ///     {
     ///         Comment = "test public key",
     ///         EncodedKey = File.ReadAllText("public_key.pem"),
-    ///         Name = "test_key",
     ///     });
     /// 
     ///     var test = new Aws.CloudFront.FieldLevelEncryptionProfile("test", new()

--- a/sdk/dotnet/CloudFront/KeyGroup.cs
+++ b/sdk/dotnet/CloudFront/KeyGroup.cs
@@ -27,7 +27,6 @@ namespace Pulumi.Aws.CloudFront
     ///     {
     ///         Comment = "example public key",
     ///         EncodedKey = File.ReadAllText("public_key.pem"),
-    ///         Name = "example-key",
     ///     });
     /// 
     ///     var exampleKeyGroup = new Aws.CloudFront.KeyGroup("exampleKeyGroup", new()

--- a/sdk/dotnet/CloudFront/PublicKey.cs
+++ b/sdk/dotnet/CloudFront/PublicKey.cs
@@ -27,7 +27,6 @@ namespace Pulumi.Aws.CloudFront
     ///     {
     ///         Comment = "test public key",
     ///         EncodedKey = File.ReadAllText("public_key.pem"),
-    ///         Name = "test_key",
     ///     });
     /// 
     /// });

--- a/sdk/dotnet/EmrContainers/JobTemplate.cs
+++ b/sdk/dotnet/EmrContainers/JobTemplate.cs
@@ -37,7 +37,6 @@ namespace Pulumi.Aws.EmrContainers
     ///                 },
     ///             },
     ///         },
-    ///         Name = "example",
     ///     });
     /// 
     /// });
@@ -151,8 +150,8 @@ namespace Pulumi.Aws.EmrContainers
         /// <summary>
         /// The specified name of the job template.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/FinSpace/KxCluster.cs
+++ b/sdk/dotnet/FinSpace/KxCluster.cs
@@ -311,8 +311,8 @@ namespace Pulumi.Aws.FinSpace
         /// <summary>
         /// Unique name for the cluster that you want to create.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// Version of FinSpace Managed kdb to run.

--- a/sdk/dotnet/FinSpace/KxDatabase.cs
+++ b/sdk/dotnet/FinSpace/KxDatabase.cs
@@ -31,14 +31,12 @@ namespace Pulumi.Aws.FinSpace
     /// 
     ///     var exampleKxEnvironment = new Aws.FinSpace.KxEnvironment("exampleKxEnvironment", new()
     ///     {
-    ///         Name = "my-tf-kx-environment",
     ///         KmsKeyId = exampleKey.Arn,
     ///     });
     /// 
     ///     var exampleKxDatabase = new Aws.FinSpace.KxDatabase("exampleKxDatabase", new()
     ///     {
     ///         EnvironmentId = exampleKxEnvironment.Id,
-    ///         Name = "my-tf-kx-database",
     ///         Description = "Example database description",
     ///     });
     /// 
@@ -169,8 +167,8 @@ namespace Pulumi.Aws.FinSpace
         /// 
         /// The following arguments are optional:
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/FinSpace/KxEnvironment.cs
+++ b/sdk/dotnet/FinSpace/KxEnvironment.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Aws.FinSpace
     /// 
     ///     var exampleKxEnvironment = new Aws.FinSpace.KxEnvironment("exampleKxEnvironment", new()
     ///     {
-    ///         Name = "my-tf-kx-environment",
     ///         KmsKeyId = exampleKey.Arn,
     ///     });
     /// 
@@ -60,7 +59,6 @@ namespace Pulumi.Aws.FinSpace
     /// 
     ///     var exampleEnv = new Aws.FinSpace.KxEnvironment("exampleEnv", new()
     ///     {
-    ///         Name = "my-tf-kx-environment",
     ///         Description = "Environment description",
     ///         KmsKeyId = exampleKey.Arn,
     ///         TransitGatewayConfiguration = new Aws.FinSpace.Inputs.KxEnvironmentTransitGatewayConfigurationArgs
@@ -247,8 +245,8 @@ namespace Pulumi.Aws.FinSpace
         /// <summary>
         /// Name of the KX environment that you want to create.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/FinSpace/KxUser.cs
+++ b/sdk/dotnet/FinSpace/KxUser.cs
@@ -32,7 +32,6 @@ namespace Pulumi.Aws.FinSpace
     /// 
     ///     var exampleKxEnvironment = new Aws.FinSpace.KxEnvironment("exampleKxEnvironment", new()
     ///     {
-    ///         Name = "my-tf-kx-environment",
     ///         KmsKeyId = exampleKey.Arn,
     ///     });
     /// 
@@ -59,7 +58,6 @@ namespace Pulumi.Aws.FinSpace
     /// 
     ///     var exampleKxUser = new Aws.FinSpace.KxUser("exampleKxUser", new()
     ///     {
-    ///         Name = "my-tf-kx-user",
     ///         EnvironmentId = exampleKxEnvironment.Id,
     ///         IamRole = exampleRole.Arn,
     ///     });
@@ -179,8 +177,8 @@ namespace Pulumi.Aws.FinSpace
         /// <summary>
         /// A unique identifier for the user.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/GlobalAccelerator/CustomRoutingAccelerator.cs
+++ b/sdk/dotnet/GlobalAccelerator/CustomRoutingAccelerator.cs
@@ -36,7 +36,6 @@ namespace Pulumi.Aws.GlobalAccelerator
     ///         {
     ///             "1.2.3.4",
     ///         },
-    ///         Name = "Example",
     ///     });
     /// 
     /// });
@@ -123,7 +122,7 @@ namespace Pulumi.Aws.GlobalAccelerator
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public CustomRoutingAccelerator(string name, CustomRoutingAcceleratorArgs args, CustomResourceOptions? options = null)
+        public CustomRoutingAccelerator(string name, CustomRoutingAcceleratorArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:globalaccelerator/customRoutingAccelerator:CustomRoutingAccelerator", name, args ?? new CustomRoutingAcceleratorArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -194,8 +193,8 @@ namespace Pulumi.Aws.GlobalAccelerator
         /// <summary>
         /// The name of a custom routing accelerator.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/GlobalAccelerator/CustomRoutingListener.cs
+++ b/sdk/dotnet/GlobalAccelerator/CustomRoutingListener.cs
@@ -24,7 +24,6 @@ namespace Pulumi.Aws.GlobalAccelerator
     /// {
     ///     var exampleCustomRoutingAccelerator = new Aws.GlobalAccelerator.CustomRoutingAccelerator("exampleCustomRoutingAccelerator", new()
     ///     {
-    ///         Name = "Example",
     ///         IpAddressType = "IPV4",
     ///         Enabled = true,
     ///         Attributes = new Aws.GlobalAccelerator.Inputs.CustomRoutingAcceleratorAttributesArgs

--- a/sdk/dotnet/Glue/DataQualityRuleset.cs
+++ b/sdk/dotnet/Glue/DataQualityRuleset.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Glue
     /// {
     ///     var example = new Aws.Glue.DataQualityRuleset("example", new()
     ///     {
-    ///         Name = "example",
     ///         Ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
     ///     });
     /// 
@@ -44,7 +43,6 @@ namespace Pulumi.Aws.Glue
     ///     var example = new Aws.Glue.DataQualityRuleset("example", new()
     ///     {
     ///         Description = "example",
-    ///         Name = "example",
     ///         Ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
     ///     });
     /// 
@@ -62,7 +60,6 @@ namespace Pulumi.Aws.Glue
     /// {
     ///     var example = new Aws.Glue.DataQualityRuleset("example", new()
     ///     {
-    ///         Name = "example",
     ///         Ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
     ///         Tags = 
     ///         {
@@ -84,7 +81,6 @@ namespace Pulumi.Aws.Glue
     /// {
     ///     var example = new Aws.Glue.DataQualityRuleset("example", new()
     ///     {
-    ///         Name = "example",
     ///         Ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
     ///         TargetTable = new Aws.Glue.Inputs.DataQualityRulesetTargetTableArgs
     ///         {
@@ -222,8 +218,8 @@ namespace Pulumi.Aws.Glue
         /// <summary>
         /// Name of the data quality ruleset.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// A Data Quality Definition Language (DQDL) ruleset. For more information, see the AWS Glue developer guide.

--- a/sdk/dotnet/OpenSearch/ServerlessAccessPolicy.cs
+++ b/sdk/dotnet/OpenSearch/ServerlessAccessPolicy.cs
@@ -30,7 +30,6 @@ namespace Pulumi.Aws.OpenSearch
     /// 
     ///     var test = new Aws.OpenSearch.ServerlessAccessPolicy("test", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "data",
     ///         Policy = Output.Tuple(currentPartition, currentCallerIdentity).Apply(values =&gt;
     ///         {
@@ -169,8 +168,8 @@ namespace Pulumi.Aws.OpenSearch
         /// <summary>
         /// Name of the policy.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// JSON policy document to use as the content for the new policy

--- a/sdk/dotnet/OpenSearch/ServerlessCollection.cs
+++ b/sdk/dotnet/OpenSearch/ServerlessCollection.cs
@@ -26,7 +26,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var exampleServerlessSecurityPolicy = new Aws.OpenSearch.ServerlessSecurityPolicy("exampleServerlessSecurityPolicy", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "encryption",
     ///         Policy = JsonSerializer.Serialize(new Dictionary&lt;string, object?&gt;
     ///         {
@@ -47,7 +46,6 @@ namespace Pulumi.Aws.OpenSearch
     /// 
     ///     var exampleServerlessCollection = new Aws.OpenSearch.ServerlessCollection("exampleServerlessCollection", new()
     ///     {
-    ///         Name = "example",
     ///     }, new CustomResourceOptions
     ///     {
     ///         DependsOn = new[]
@@ -131,7 +129,7 @@ namespace Pulumi.Aws.OpenSearch
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public ServerlessCollection(string name, ServerlessCollectionArgs args, CustomResourceOptions? options = null)
+        public ServerlessCollection(string name, ServerlessCollectionArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:opensearch/serverlessCollection:ServerlessCollection", name, args ?? new ServerlessCollectionArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -180,8 +178,8 @@ namespace Pulumi.Aws.OpenSearch
         /// 
         /// The following arguments are optional:
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/OpenSearch/ServerlessSecurityConfig.cs
+++ b/sdk/dotnet/OpenSearch/ServerlessSecurityConfig.cs
@@ -112,8 +112,8 @@ namespace Pulumi.Aws.OpenSearch
         /// <summary>
         /// Name of the policy.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// Configuration block for SAML options.

--- a/sdk/dotnet/OpenSearch/ServerlessSecurityPolicy.cs
+++ b/sdk/dotnet/OpenSearch/ServerlessSecurityPolicy.cs
@@ -28,7 +28,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessSecurityPolicy("example", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "encryption",
     ///         Description = "encryption security policy for example-collection",
     ///         Policy = JsonSerializer.Serialize(new Dictionary&lt;string, object?&gt;
@@ -63,7 +62,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessSecurityPolicy("example", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "encryption",
     ///         Description = "encryption security policy for collections that begin with \"example\"",
     ///         Policy = JsonSerializer.Serialize(new Dictionary&lt;string, object?&gt;
@@ -98,7 +96,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessSecurityPolicy("example", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "encryption",
     ///         Description = "encryption security policy using customer KMS key",
     ///         Policy = JsonSerializer.Serialize(new Dictionary&lt;string, object?&gt;
@@ -135,7 +132,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessSecurityPolicy("example", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "network",
     ///         Description = "Public access",
     ///         Policy = JsonSerializer.Serialize(new[]
@@ -182,7 +178,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessSecurityPolicy("example", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "network",
     ///         Description = "VPC access",
     ///         Policy = JsonSerializer.Serialize(new[]
@@ -233,7 +228,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessSecurityPolicy("example", new()
     ///     {
-    ///         Name = "example",
     ///         Type = "network",
     ///         Description = "Mixed access for marketing and sales",
     ///         Policy = JsonSerializer.Serialize(new[]
@@ -386,8 +380,8 @@ namespace Pulumi.Aws.OpenSearch
         /// <summary>
         /// Name of the policy.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// JSON policy document to use as the content for the new policy

--- a/sdk/dotnet/OpenSearch/ServerlessVpcEndpoint.cs
+++ b/sdk/dotnet/OpenSearch/ServerlessVpcEndpoint.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.OpenSearch
     /// {
     ///     var example = new Aws.OpenSearch.ServerlessVpcEndpoint("example", new()
     ///     {
-    ///         Name = "myendpoint",
     ///         SubnetIds = new[]
     ///         {
     ///             aws_subnet.Example.Id,
@@ -125,8 +124,8 @@ namespace Pulumi.Aws.OpenSearch
         /// <summary>
         /// Name of the interface endpoint.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("securityGroupIds")]
         private InputList<string>? _securityGroupIds;

--- a/sdk/dotnet/Quicksight/Theme.cs
+++ b/sdk/dotnet/Quicksight/Theme.cs
@@ -180,8 +180,8 @@ namespace Pulumi.Aws.Quicksight
         /// <summary>
         /// Display name of the theme.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("permissions")]
         private InputList<Inputs.ThemePermissionArgs>? _permissions;

--- a/sdk/dotnet/Quicksight/VpcConnection.cs
+++ b/sdk/dotnet/Quicksight/VpcConnection.cs
@@ -77,7 +77,6 @@ namespace Pulumi.Aws.Quicksight
     ///     var example = new Aws.Quicksight.VpcConnection("example", new()
     ///     {
     ///         VpcConnectionId = "example-connection-id",
-    ///         Name = "Example Connection",
     ///         RoleArn = vpcConnectionRole.Arn,
     ///         SecurityGroupIds = new[]
     ///         {
@@ -242,8 +241,8 @@ namespace Pulumi.Aws.Quicksight
         /// <summary>
         /// The display name for the VPC connection.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// The IAM role to associate with the VPC connection.

--- a/sdk/dotnet/ResourceExplorer/View.cs
+++ b/sdk/dotnet/ResourceExplorer/View.cs
@@ -29,7 +29,6 @@ namespace Pulumi.Aws.ResourceExplorer
     /// 
     ///     var exampleView = new Aws.ResourceExplorer.View("exampleView", new()
     ///     {
-    ///         Name = "exampleview",
     ///         Filters = new Aws.ResourceExplorer.Inputs.ViewFiltersArgs
     ///         {
     ///             FilterString = "resourcetype:ec2:instance",
@@ -113,7 +112,7 @@ namespace Pulumi.Aws.ResourceExplorer
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public View(string name, ViewArgs args, CustomResourceOptions? options = null)
+        public View(string name, ViewArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:resourceexplorer/view:View", name, args ?? new ViewArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -178,8 +177,8 @@ namespace Pulumi.Aws.ResourceExplorer
         /// <summary>
         /// The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/Route53/CidrCollection.cs
+++ b/sdk/dotnet/Route53/CidrCollection.cs
@@ -22,10 +22,7 @@ namespace Pulumi.Aws.Route53
     /// 
     /// return await Deployment.RunAsync(() =&gt; 
     /// {
-    ///     var example = new Aws.Route53.CidrCollection("example", new()
-    ///     {
-    ///         Name = "collection-1",
-    ///     });
+    ///     var example = new Aws.Route53.CidrCollection("example");
     /// 
     /// });
     /// ```
@@ -67,7 +64,7 @@ namespace Pulumi.Aws.Route53
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public CidrCollection(string name, CidrCollectionArgs args, CustomResourceOptions? options = null)
+        public CidrCollection(string name, CidrCollectionArgs? args = null, CustomResourceOptions? options = null)
             : base("aws:route53/cidrCollection:CidrCollection", name, args ?? new CidrCollectionArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -108,8 +105,8 @@ namespace Pulumi.Aws.Route53
         /// <summary>
         /// Unique name for the CIDR collection.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         public CidrCollectionArgs()
         {

--- a/sdk/dotnet/Route53/CidrLocation.cs
+++ b/sdk/dotnet/Route53/CidrLocation.cs
@@ -22,15 +22,11 @@ namespace Pulumi.Aws.Route53
     /// 
     /// return await Deployment.RunAsync(() =&gt; 
     /// {
-    ///     var exampleCidrCollection = new Aws.Route53.CidrCollection("exampleCidrCollection", new()
-    ///     {
-    ///         Name = "collection-1",
-    ///     });
+    ///     var exampleCidrCollection = new Aws.Route53.CidrCollection("exampleCidrCollection");
     /// 
     ///     var exampleCidrLocation = new Aws.Route53.CidrLocation("exampleCidrLocation", new()
     ///     {
     ///         CidrCollectionId = exampleCidrCollection.Id,
-    ///         Name = "office",
     ///         CidrBlocks = new[]
     ///         {
     ///             "200.5.3.0/24",
@@ -137,8 +133,8 @@ namespace Pulumi.Aws.Route53
         /// <summary>
         /// Name for the CIDR location.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         public CidrLocationArgs()
         {

--- a/sdk/dotnet/Sfn/Alias.cs
+++ b/sdk/dotnet/Sfn/Alias.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Aws.Sfn
     /// {
     ///     var sfnAlias = new Aws.Sfn.Alias("sfnAlias", new()
     ///     {
-    ///         Name = "my_sfn_alias",
     ///         RoutingConfigurations = new[]
     ///         {
     ///             new Aws.Sfn.Inputs.AliasRoutingConfigurationArgs
@@ -38,7 +37,6 @@ namespace Pulumi.Aws.Sfn
     /// 
     ///     var mySfnAlias = new Aws.Sfn.Alias("mySfnAlias", new()
     ///     {
-    ///         Name = "my_sfn_alias",
     ///         RoutingConfigurations = new[]
     ///         {
     ///             new Aws.Sfn.Inputs.AliasRoutingConfigurationArgs
@@ -153,8 +151,8 @@ namespace Pulumi.Aws.Sfn
         /// <summary>
         /// Name for the alias you are creating.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         [Input("routingConfigurations", required: true)]
         private InputList<Inputs.AliasRoutingConfigurationArgs>? _routingConfigurations;

--- a/sdk/go/aws/appintegrations/dataIntegration.go
+++ b/sdk/go/aws/appintegrations/dataIntegration.go
@@ -29,7 +29,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := appintegrations.NewDataIntegration(ctx, "example", &appintegrations.DataIntegrationArgs{
-//				Name:        pulumi.String("example"),
 //				Description: pulumi.String("example"),
 //				KmsKey:      pulumi.Any(aws_kms_key.Test.Arn),
 //				SourceUri:   pulumi.String("Salesforce://AppFlow/example"),
@@ -88,9 +87,6 @@ func NewDataIntegration(ctx *pulumi.Context,
 
 	if args.KmsKey == nil {
 		return nil, errors.New("invalid value for required argument 'KmsKey'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	if args.ScheduleConfig == nil {
 		return nil, errors.New("invalid value for required argument 'ScheduleConfig'")
@@ -168,7 +164,7 @@ type dataIntegrationArgs struct {
 	// Specifies the KMS key Amazon Resource Name (ARN) for the Data Integration.
 	KmsKey string `pulumi:"kmsKey"`
 	// Specifies the name of the Data Integration.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
 	ScheduleConfig DataIntegrationScheduleConfig `pulumi:"scheduleConfig"`
 	// Specifies the URI of the data source. Create an AppFlow Connector Profile and reference the name of the profile in the URL. An example of this value for Salesforce is `Salesforce://AppFlow/example` where `example` is the name of the AppFlow Connector Profile.
@@ -184,7 +180,7 @@ type DataIntegrationArgs struct {
 	// Specifies the KMS key Amazon Resource Name (ARN) for the Data Integration.
 	KmsKey pulumi.StringInput
 	// Specifies the name of the Data Integration.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
 	ScheduleConfig DataIntegrationScheduleConfigInput
 	// Specifies the URI of the data source. Create an AppFlow Connector Profile and reference the name of the profile in the URL. An example of this value for Salesforce is `Salesforce://AppFlow/example` where `example` is the name of the AppFlow Connector Profile.

--- a/sdk/go/aws/auditmanager/assessment.go
+++ b/sdk/go/aws/auditmanager/assessment.go
@@ -32,7 +32,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := auditmanager.NewAssessment(ctx, "test", &auditmanager.AssessmentArgs{
-//				Name: pulumi.String("example"),
 //				AssessmentReportsDestination: &auditmanager.AssessmentAssessmentReportsDestinationArgs{
 //					Destination:     pulumi.String(fmt.Sprintf("s3://%v", aws_s3_bucket.Test.Id)),
 //					DestinationType: pulumi.String("S3"),
@@ -110,9 +109,6 @@ func NewAssessment(ctx *pulumi.Context,
 
 	if args.FrameworkId == nil {
 		return nil, errors.New("invalid value for required argument 'FrameworkId'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	if args.Roles == nil {
 		return nil, errors.New("invalid value for required argument 'Roles'")
@@ -203,7 +199,7 @@ type assessmentArgs struct {
 	// Unique identifier of the framework the assessment will be created from.
 	FrameworkId string `pulumi:"frameworkId"`
 	// Name of the assessment.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// List of roles for the assessment. See `roles` below.
 	Roles []AssessmentRole `pulumi:"roles"`
 	// Amazon Web Services accounts and services that are in scope for the assessment. See `scope` below.
@@ -223,7 +219,7 @@ type AssessmentArgs struct {
 	// Unique identifier of the framework the assessment will be created from.
 	FrameworkId pulumi.StringInput
 	// Name of the assessment.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// List of roles for the assessment. See `roles` below.
 	Roles AssessmentRoleArrayInput
 	// Amazon Web Services accounts and services that are in scope for the assessment. See `scope` below.

--- a/sdk/go/aws/auditmanager/assessmentReport.go
+++ b/sdk/go/aws/auditmanager/assessmentReport.go
@@ -30,7 +30,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := auditmanager.NewAssessmentReport(ctx, "test", &auditmanager.AssessmentReportArgs{
-//				Name:         pulumi.String("example"),
 //				AssessmentId: pulumi.Any(aws_auditmanager_assessment.Test.Id),
 //			})
 //			if err != nil {
@@ -75,9 +74,6 @@ func NewAssessmentReport(ctx *pulumi.Context,
 
 	if args.AssessmentId == nil {
 		return nil, errors.New("invalid value for required argument 'AssessmentId'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource AssessmentReport
@@ -143,7 +139,7 @@ type assessmentReportArgs struct {
 	// Description of the assessment report.
 	Description *string `pulumi:"description"`
 	// Name of the assessment report.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 // The set of arguments for constructing a AssessmentReport resource.
@@ -155,7 +151,7 @@ type AssessmentReportArgs struct {
 	// Description of the assessment report.
 	Description pulumi.StringPtrInput
 	// Name of the assessment report.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 }
 
 func (AssessmentReportArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/auditmanager/control.go
+++ b/sdk/go/aws/auditmanager/control.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -37,7 +36,6 @@ import (
 //						SourceType:        pulumi.String("MANUAL"),
 //					},
 //				},
-//				Name: pulumi.String("example"),
 //			})
 //			if err != nil {
 //				return err
@@ -86,12 +84,9 @@ type Control struct {
 func NewControl(ctx *pulumi.Context,
 	name string, args *ControlArgs, opts ...pulumi.ResourceOption) (*Control, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &ControlArgs{}
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Control
 	err := ctx.RegisterResource("aws:auditmanager/control:Control", name, args, &resource, opts...)
@@ -180,7 +175,7 @@ type controlArgs struct {
 	// Description of the control.
 	Description *string `pulumi:"description"`
 	// Name of the control.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A map of tags to assign to the control. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 	// Steps to follow to determine if the control is satisfied.
@@ -200,7 +195,7 @@ type ControlArgs struct {
 	// Description of the control.
 	Description pulumi.StringPtrInput
 	// Name of the control.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A map of tags to assign to the control. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 	// Steps to follow to determine if the control is satisfied.

--- a/sdk/go/aws/auditmanager/framework.go
+++ b/sdk/go/aws/auditmanager/framework.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -30,7 +29,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := auditmanager.NewFramework(ctx, "test", &auditmanager.FrameworkArgs{
-//				Name: pulumi.String("example"),
 //				ControlSets: auditmanager.FrameworkControlSetArray{
 //					&auditmanager.FrameworkControlSetArgs{
 //						Name: pulumi.String("example"),
@@ -85,12 +83,9 @@ type Framework struct {
 func NewFramework(ctx *pulumi.Context,
 	name string, args *FrameworkArgs, opts ...pulumi.ResourceOption) (*Framework, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &FrameworkArgs{}
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Framework
 	err := ctx.RegisterResource("aws:auditmanager/framework:Framework", name, args, &resource, opts...)
@@ -169,7 +164,7 @@ type frameworkArgs struct {
 	// Description of the framework.
 	Description *string `pulumi:"description"`
 	// Name of the framework.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A map of tags to assign to the framework. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -185,7 +180,7 @@ type FrameworkArgs struct {
 	// Description of the framework.
 	Description pulumi.StringPtrInput
 	// Name of the framework.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A map of tags to assign to the framework. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/auditmanager/getControl.go
+++ b/sdk/go/aws/auditmanager/getControl.go
@@ -69,7 +69,6 @@ import (
 //				return err
 //			}
 //			_, err = auditmanager.NewFramework(ctx, "exampleFramework", &auditmanager.FrameworkArgs{
-//				Name: pulumi.String("example"),
 //				ControlSets: auditmanager.FrameworkControlSetArray{
 //					&auditmanager.FrameworkControlSetArgs{
 //						Name: pulumi.String("example"),

--- a/sdk/go/aws/chime/sdkvoiceSipMediaApplication.go
+++ b/sdk/go/aws/chime/sdkvoiceSipMediaApplication.go
@@ -31,7 +31,6 @@ import (
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := chime.NewSdkvoiceSipMediaApplication(ctx, "example", &chime.SdkvoiceSipMediaApplicationArgs{
 //				AwsRegion: pulumi.String("us-east-1"),
-//				Name:      pulumi.String("example-sip-media-application"),
 //				Endpoints: &chime.SdkvoiceSipMediaApplicationEndpointsArgs{
 //					LambdaArn: pulumi.Any(aws_lambda_function.Test.Arn),
 //				},
@@ -83,9 +82,6 @@ func NewSdkvoiceSipMediaApplication(ctx *pulumi.Context,
 	}
 	if args.Endpoints == nil {
 		return nil, errors.New("invalid value for required argument 'Endpoints'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource SdkvoiceSipMediaApplication
@@ -155,7 +151,7 @@ type sdkvoiceSipMediaApplicationArgs struct {
 	// The name of the AWS Chime SDK Voice Sip Media Application.
 	//
 	// The following arguments are optional:
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -169,7 +165,7 @@ type SdkvoiceSipMediaApplicationArgs struct {
 	// The name of the AWS Chime SDK Voice Sip Media Application.
 	//
 	// The following arguments are optional:
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/chime/sdkvoiceSipRule.go
+++ b/sdk/go/aws/chime/sdkvoiceSipRule.go
@@ -30,7 +30,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := chime.NewSdkvoiceSipRule(ctx, "example", &chime.SdkvoiceSipRuleArgs{
-//				Name:         pulumi.String("example-sip-rule"),
 //				TriggerType:  pulumi.String("RequestUriHostname"),
 //				TriggerValue: pulumi.Any(aws_chime_voice_connector.ExampleVoiceConnector.Outbound_host_name),
 //				TargetApplications: chime.SdkvoiceSipRuleTargetApplicationArray{
@@ -81,9 +80,6 @@ func NewSdkvoiceSipRule(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.TargetApplications == nil {
 		return nil, errors.New("invalid value for required argument 'TargetApplications'")
 	}
@@ -153,7 +149,7 @@ type sdkvoiceSipRuleArgs struct {
 	// Enables or disables a rule. You must disable rules before you can delete them.
 	Disabled *bool `pulumi:"disabled"`
 	// The name of the SIP rule.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used. See `targetApplications`.
 	TargetApplications []SdkvoiceSipRuleTargetApplication `pulumi:"targetApplications"`
 	// The type of trigger assigned to the SIP rule in `triggerValue`. Valid values are `RequestUriHostname` or `ToPhoneNumber`.
@@ -169,7 +165,7 @@ type SdkvoiceSipRuleArgs struct {
 	// Enables or disables a rule. You must disable rules before you can delete them.
 	Disabled pulumi.BoolPtrInput
 	// The name of the SIP rule.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used. See `targetApplications`.
 	TargetApplications SdkvoiceSipRuleTargetApplicationArrayInput
 	// The type of trigger assigned to the SIP rule in `triggerValue`. Valid values are `RequestUriHostname` or `ToPhoneNumber`.

--- a/sdk/go/aws/chime/sdkvoiceVoiceProfileDomain.go
+++ b/sdk/go/aws/chime/sdkvoiceVoiceProfileDomain.go
@@ -38,7 +38,6 @@ import (
 //				return err
 //			}
 //			_, err = chime.NewSdkvoiceVoiceProfileDomain(ctx, "exampleSdkvoiceVoiceProfileDomain", &chime.SdkvoiceVoiceProfileDomainArgs{
-//				Name: pulumi.String("ExampleVoiceProfileDomain"),
 //				ServerSideEncryptionConfiguration: &chime.SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs{
 //					KmsKeyArn: exampleKey.Arn,
 //				},
@@ -85,9 +84,6 @@ func NewSdkvoiceVoiceProfileDomain(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.ServerSideEncryptionConfiguration == nil {
 		return nil, errors.New("invalid value for required argument 'ServerSideEncryptionConfiguration'")
 	}
@@ -147,7 +143,7 @@ type sdkvoiceVoiceProfileDomainArgs struct {
 	// Description of Voice Profile Domain.
 	Description *string `pulumi:"description"`
 	// Name of Voice Profile Domain.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Configuration for server side encryption.
 	ServerSideEncryptionConfiguration SdkvoiceVoiceProfileDomainServerSideEncryptionConfiguration `pulumi:"serverSideEncryptionConfiguration"`
 	Tags                              map[string]string                                           `pulumi:"tags"`
@@ -158,7 +154,7 @@ type SdkvoiceVoiceProfileDomainArgs struct {
 	// Description of Voice Profile Domain.
 	Description pulumi.StringPtrInput
 	// Name of Voice Profile Domain.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Configuration for server side encryption.
 	ServerSideEncryptionConfiguration SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationInput
 	Tags                              pulumi.StringMapInput

--- a/sdk/go/aws/cleanrooms/collaboration.go
+++ b/sdk/go/aws/cleanrooms/collaboration.go
@@ -50,7 +50,6 @@ import (
 //						MemberAbilities: pulumi.StringArray{},
 //					},
 //				},
-//				Name:           pulumi.String("pulumi-example-collaboration"),
 //				QueryLogStatus: pulumi.String("DISABLED"),
 //				Tags: pulumi.StringMap{
 //					"Project": pulumi.String("Pulumi"),
@@ -125,9 +124,6 @@ func NewCollaboration(ctx *pulumi.Context,
 	}
 	if args.Description == nil {
 		return nil, errors.New("invalid value for required argument 'Description'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	if args.QueryLogStatus == nil {
 		return nil, errors.New("invalid value for required argument 'QueryLogStatus'")
@@ -273,7 +269,7 @@ type collaborationArgs struct {
 	//   s
 	Members []CollaborationMember `pulumi:"members"`
 	// The name of the collaboration.  Collaboration names do not need to be unique.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Determines if members of the collaboration can enable query logs within their own
 	// emberships. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-Cr
 	// ateCollaboration-request-queryLogStatus).
@@ -310,7 +306,7 @@ type CollaborationArgs struct {
 	//   s
 	Members CollaborationMemberArrayInput
 	// The name of the collaboration.  Collaboration names do not need to be unique.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Determines if members of the collaboration can enable query logs within their own
 	// emberships. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-Cr
 	// ateCollaboration-request-queryLogStatus).

--- a/sdk/go/aws/cloudfront/fieldLevelEncryptionProfile.go
+++ b/sdk/go/aws/cloudfront/fieldLevelEncryptionProfile.go
@@ -41,7 +41,6 @@ import (
 //			example, err := cloudfront.NewPublicKey(ctx, "example", &cloudfront.PublicKeyArgs{
 //				Comment:    pulumi.String("test public key"),
 //				EncodedKey: readFileOrPanic("public_key.pem"),
-//				Name:       pulumi.String("test_key"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/aws/cloudfront/keyGroup.go
+++ b/sdk/go/aws/cloudfront/keyGroup.go
@@ -41,7 +41,6 @@ import (
 //			examplePublicKey, err := cloudfront.NewPublicKey(ctx, "examplePublicKey", &cloudfront.PublicKeyArgs{
 //				Comment:    pulumi.String("example public key"),
 //				EncodedKey: readFileOrPanic("public_key.pem"),
-//				Name:       pulumi.String("example-key"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/aws/cloudfront/publicKey.go
+++ b/sdk/go/aws/cloudfront/publicKey.go
@@ -41,7 +41,6 @@ import (
 //			_, err := cloudfront.NewPublicKey(ctx, "example", &cloudfront.PublicKeyArgs{
 //				Comment:    pulumi.String("test public key"),
 //				EncodedKey: readFileOrPanic("public_key.pem"),
-//				Name:       pulumi.String("test_key"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/aws/emrcontainers/jobTemplate.go
+++ b/sdk/go/aws/emrcontainers/jobTemplate.go
@@ -39,7 +39,6 @@ import (
 //						},
 //					},
 //				},
-//				Name: pulumi.String("example"),
 //			})
 //			if err != nil {
 //				return err
@@ -83,9 +82,6 @@ func NewJobTemplate(ctx *pulumi.Context,
 
 	if args.JobTemplateData == nil {
 		return nil, errors.New("invalid value for required argument 'JobTemplateData'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource JobTemplate
@@ -149,7 +145,7 @@ type jobTemplateArgs struct {
 	// The KMS key ARN used to encrypt the job template.
 	KmsKeyArn *string `pulumi:"kmsKeyArn"`
 	// The specified name of the job template.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -161,7 +157,7 @@ type JobTemplateArgs struct {
 	// The KMS key ARN used to encrypt the job template.
 	KmsKeyArn pulumi.StringPtrInput
 	// The specified name of the job template.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/finspace/kxCluster.go
+++ b/sdk/go/aws/finspace/kxCluster.go
@@ -97,9 +97,6 @@ func NewKxCluster(ctx *pulumi.Context,
 	if args.EnvironmentId == nil {
 		return nil, errors.New("invalid value for required argument 'EnvironmentId'")
 	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.ReleaseLabel == nil {
 		return nil, errors.New("invalid value for required argument 'ReleaseLabel'")
 	}
@@ -275,7 +272,7 @@ type kxClusterArgs struct {
 	// Path to Q program that will be run at launch of a cluster. This is a relative path within .zip file that contains the custom code, which will be loaded on the cluster. It must include the file name itself. For example, somedir/init.q.
 	InitializationScript *string `pulumi:"initializationScript"`
 	// Unique name for the cluster that you want to create.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Version of FinSpace Managed kdb to run.
 	ReleaseLabel string `pulumi:"releaseLabel"`
 	// Size and type of the temporary storage that is used to hold data during the savedown process. This parameter is required when you choose `type` as RDB. All the data written to this storage space is lost when the cluster node is restarted. See savedown_storage_configuration.
@@ -322,7 +319,7 @@ type KxClusterArgs struct {
 	// Path to Q program that will be run at launch of a cluster. This is a relative path within .zip file that contains the custom code, which will be loaded on the cluster. It must include the file name itself. For example, somedir/init.q.
 	InitializationScript pulumi.StringPtrInput
 	// Unique name for the cluster that you want to create.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Version of FinSpace Managed kdb to run.
 	ReleaseLabel pulumi.StringInput
 	// Size and type of the temporary storage that is used to hold data during the savedown process. This parameter is required when you choose `type` as RDB. All the data written to this storage space is lost when the cluster node is restarted. See savedown_storage_configuration.

--- a/sdk/go/aws/finspace/kxDatabase.go
+++ b/sdk/go/aws/finspace/kxDatabase.go
@@ -38,7 +38,6 @@ import (
 //				return err
 //			}
 //			exampleKxEnvironment, err := finspace.NewKxEnvironment(ctx, "exampleKxEnvironment", &finspace.KxEnvironmentArgs{
-//				Name:     pulumi.String("my-tf-kx-environment"),
 //				KmsKeyId: exampleKey.Arn,
 //			})
 //			if err != nil {
@@ -46,7 +45,6 @@ import (
 //			}
 //			_, err = finspace.NewKxDatabase(ctx, "exampleKxDatabase", &finspace.KxDatabaseArgs{
 //				EnvironmentId: exampleKxEnvironment.ID(),
-//				Name:          pulumi.String("my-tf-kx-database"),
 //				Description:   pulumi.String("Example database description"),
 //			})
 //			if err != nil {
@@ -97,9 +95,6 @@ func NewKxDatabase(ctx *pulumi.Context,
 
 	if args.EnvironmentId == nil {
 		return nil, errors.New("invalid value for required argument 'EnvironmentId'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource KxDatabase
@@ -177,7 +172,7 @@ type kxDatabaseArgs struct {
 	// Name of the KX database.
 	//
 	// The following arguments are optional:
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -191,7 +186,7 @@ type KxDatabaseArgs struct {
 	// Name of the KX database.
 	//
 	// The following arguments are optional:
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/finspace/kxEnvironment.go
+++ b/sdk/go/aws/finspace/kxEnvironment.go
@@ -38,7 +38,6 @@ import (
 //				return err
 //			}
 //			_, err = finspace.NewKxEnvironment(ctx, "exampleKxEnvironment", &finspace.KxEnvironmentArgs{
-//				Name:     pulumi.String("my-tf-kx-environment"),
 //				KmsKeyId: exampleKey.Arn,
 //			})
 //			if err != nil {
@@ -79,7 +78,6 @@ import (
 //				return err
 //			}
 //			_, err = finspace.NewKxEnvironment(ctx, "exampleEnv", &finspace.KxEnvironmentArgs{
-//				Name:        pulumi.String("my-tf-kx-environment"),
 //				Description: pulumi.String("Environment description"),
 //				KmsKeyId:    exampleKey.Arn,
 //				TransitGatewayConfiguration: &finspace.KxEnvironmentTransitGatewayConfigurationArgs{
@@ -151,9 +149,6 @@ func NewKxEnvironment(ctx *pulumi.Context,
 
 	if args.KmsKeyId == nil {
 		return nil, errors.New("invalid value for required argument 'KmsKeyId'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource KxEnvironment
@@ -253,7 +248,7 @@ type kxEnvironmentArgs struct {
 	// The following arguments are optional:
 	KmsKeyId string `pulumi:"kmsKeyId"`
 	// Name of the KX environment that you want to create.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 	// Transit gateway and network configuration that is used to connect the KX environment to an internal network. Defined below.
@@ -271,7 +266,7 @@ type KxEnvironmentArgs struct {
 	// The following arguments are optional:
 	KmsKeyId pulumi.StringInput
 	// Name of the KX environment that you want to create.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 	// Transit gateway and network configuration that is used to connect the KX environment to an internal network. Defined below.

--- a/sdk/go/aws/finspace/kxUser.go
+++ b/sdk/go/aws/finspace/kxUser.go
@@ -41,7 +41,6 @@ import (
 //				return err
 //			}
 //			exampleKxEnvironment, err := finspace.NewKxEnvironment(ctx, "exampleKxEnvironment", &finspace.KxEnvironmentArgs{
-//				Name:     pulumi.String("my-tf-kx-environment"),
 //				KmsKeyId: exampleKey.Arn,
 //			})
 //			if err != nil {
@@ -71,7 +70,6 @@ import (
 //				return err
 //			}
 //			_, err = finspace.NewKxUser(ctx, "exampleKxUser", &finspace.KxUserArgs{
-//				Name:          pulumi.String("my-tf-kx-user"),
 //				EnvironmentId: exampleKxEnvironment.ID(),
 //				IamRole:       exampleRole.Arn,
 //			})
@@ -122,9 +120,6 @@ func NewKxUser(ctx *pulumi.Context,
 	}
 	if args.IamRole == nil {
 		return nil, errors.New("invalid value for required argument 'IamRole'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource KxUser
@@ -194,7 +189,7 @@ type kxUserArgs struct {
 	// The following arguments are optional:
 	IamRole string `pulumi:"iamRole"`
 	// A unique identifier for the user.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -208,7 +203,7 @@ type KxUserArgs struct {
 	// The following arguments are optional:
 	IamRole pulumi.StringInput
 	// A unique identifier for the user.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/globalaccelerator/customRoutingAccelerator.go
+++ b/sdk/go/aws/globalaccelerator/customRoutingAccelerator.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -39,7 +38,6 @@ import (
 //				IpAddresses: pulumi.StringArray{
 //					pulumi.String("1.2.3.4"),
 //				},
-//				Name: pulumi.String("Example"),
 //			})
 //			if err != nil {
 //				return err
@@ -88,12 +86,9 @@ type CustomRoutingAccelerator struct {
 func NewCustomRoutingAccelerator(ctx *pulumi.Context,
 	name string, args *CustomRoutingAcceleratorArgs, opts ...pulumi.ResourceOption) (*CustomRoutingAccelerator, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &CustomRoutingAcceleratorArgs{}
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource CustomRoutingAccelerator
 	err := ctx.RegisterResource("aws:globalaccelerator/customRoutingAccelerator:CustomRoutingAccelerator", name, args, &resource, opts...)
@@ -180,7 +175,7 @@ type customRoutingAcceleratorArgs struct {
 	// The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses.
 	IpAddresses []string `pulumi:"ipAddresses"`
 	// The name of a custom routing accelerator.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -196,7 +191,7 @@ type CustomRoutingAcceleratorArgs struct {
 	// The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses.
 	IpAddresses pulumi.StringArrayInput
 	// The name of a custom routing accelerator.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/globalaccelerator/customRoutingListener.go
+++ b/sdk/go/aws/globalaccelerator/customRoutingListener.go
@@ -29,7 +29,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			exampleCustomRoutingAccelerator, err := globalaccelerator.NewCustomRoutingAccelerator(ctx, "exampleCustomRoutingAccelerator", &globalaccelerator.CustomRoutingAcceleratorArgs{
-//				Name:          pulumi.String("Example"),
 //				IpAddressType: pulumi.String("IPV4"),
 //				Enabled:       pulumi.Bool(true),
 //				Attributes: &globalaccelerator.CustomRoutingAcceleratorAttributesArgs{

--- a/sdk/go/aws/glue/dataQualityRuleset.go
+++ b/sdk/go/aws/glue/dataQualityRuleset.go
@@ -30,7 +30,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := glue.NewDataQualityRuleset(ctx, "example", &glue.DataQualityRulesetArgs{
-//				Name:    pulumi.String("example"),
 //				Ruleset: pulumi.String("Rules = [Completeness \"colA\" between 0.4 and 0.8]"),
 //			})
 //			if err != nil {
@@ -57,7 +56,6 @@ import (
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := glue.NewDataQualityRuleset(ctx, "example", &glue.DataQualityRulesetArgs{
 //				Description: pulumi.String("example"),
-//				Name:        pulumi.String("example"),
 //				Ruleset:     pulumi.String("Rules = [Completeness \"colA\" between 0.4 and 0.8]"),
 //			})
 //			if err != nil {
@@ -83,7 +81,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := glue.NewDataQualityRuleset(ctx, "example", &glue.DataQualityRulesetArgs{
-//				Name:    pulumi.String("example"),
 //				Ruleset: pulumi.String("Rules = [Completeness \"colA\" between 0.4 and 0.8]"),
 //				Tags: pulumi.StringMap{
 //					"hello": pulumi.String("world"),
@@ -112,7 +109,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := glue.NewDataQualityRuleset(ctx, "example", &glue.DataQualityRulesetArgs{
-//				Name:    pulumi.String("example"),
 //				Ruleset: pulumi.String("Rules = [Completeness \"colA\" between 0.4 and 0.8]"),
 //				TargetTable: &glue.DataQualityRulesetTargetTableArgs{
 //					DatabaseName: pulumi.Any(aws_glue_catalog_database.Example.Name),
@@ -167,9 +163,6 @@ func NewDataQualityRuleset(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.Ruleset == nil {
 		return nil, errors.New("invalid value for required argument 'Ruleset'")
 	}
@@ -249,7 +242,7 @@ type dataQualityRulesetArgs struct {
 	// Description of the data quality ruleset.
 	Description *string `pulumi:"description"`
 	// Name of the data quality ruleset.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A Data Quality Definition Language (DQDL) ruleset. For more information, see the AWS Glue developer guide.
 	Ruleset string `pulumi:"ruleset"`
 	// Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -263,7 +256,7 @@ type DataQualityRulesetArgs struct {
 	// Description of the data quality ruleset.
 	Description pulumi.StringPtrInput
 	// Name of the data quality ruleset.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A Data Quality Definition Language (DQDL) ruleset. For more information, see the AWS Glue developer guide.
 	Ruleset pulumi.StringInput
 	// Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.

--- a/sdk/go/aws/opensearch/serverlessAccessPolicy.go
+++ b/sdk/go/aws/opensearch/serverlessAccessPolicy.go
@@ -68,7 +68,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessAccessPolicy(ctx, "test", &opensearch.ServerlessAccessPolicyArgs{
-//				Name:   pulumi.String("example"),
 //				Type:   pulumi.String("data"),
 //				Policy: pulumi.String(json0),
 //			})
@@ -112,9 +111,6 @@ func NewServerlessAccessPolicy(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.Policy == nil {
 		return nil, errors.New("invalid value for required argument 'Policy'")
 	}
@@ -181,7 +177,7 @@ type serverlessAccessPolicyArgs struct {
 	// Description of the policy. Typically used to store information about the permissions defined in the policy.
 	Description *string `pulumi:"description"`
 	// Name of the policy.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// JSON policy document to use as the content for the new policy
 	Policy string `pulumi:"policy"`
 	// Type of access policy. Must be `data`.
@@ -195,7 +191,7 @@ type ServerlessAccessPolicyArgs struct {
 	// Description of the policy. Typically used to store information about the permissions defined in the policy.
 	Description pulumi.StringPtrInput
 	// Name of the policy.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// JSON policy document to use as the content for the new policy
 	Policy pulumi.StringInput
 	// Type of access policy. Must be `data`.

--- a/sdk/go/aws/opensearch/serverlessCollection.go
+++ b/sdk/go/aws/opensearch/serverlessCollection.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -47,16 +46,13 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			exampleServerlessSecurityPolicy, err := opensearch.NewServerlessSecurityPolicy(ctx, "exampleServerlessSecurityPolicy", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:   pulumi.String("example"),
 //				Type:   pulumi.String("encryption"),
 //				Policy: pulumi.String(json0),
 //			})
 //			if err != nil {
 //				return err
 //			}
-//			_, err = opensearch.NewServerlessCollection(ctx, "exampleServerlessCollection", &opensearch.ServerlessCollectionArgs{
-//				Name: pulumi.String("example"),
-//			}, pulumi.DependsOn([]pulumi.Resource{
+//			_, err = opensearch.NewServerlessCollection(ctx, "exampleServerlessCollection", nil, pulumi.DependsOn([]pulumi.Resource{
 //				exampleServerlessSecurityPolicy,
 //			}))
 //			if err != nil {
@@ -103,12 +99,9 @@ type ServerlessCollection struct {
 func NewServerlessCollection(ctx *pulumi.Context,
 	name string, args *ServerlessCollectionArgs, opts ...pulumi.ResourceOption) (*ServerlessCollection, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &ServerlessCollectionArgs{}
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource ServerlessCollection
 	err := ctx.RegisterResource("aws:opensearch/serverlessCollection:ServerlessCollection", name, args, &resource, opts...)
@@ -185,7 +178,7 @@ type serverlessCollectionArgs struct {
 	// Name of the collection.
 	//
 	// The following arguments are optional:
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A map of tags to assign to the collection. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags     map[string]string             `pulumi:"tags"`
 	Timeouts *ServerlessCollectionTimeouts `pulumi:"timeouts"`
@@ -200,7 +193,7 @@ type ServerlessCollectionArgs struct {
 	// Name of the collection.
 	//
 	// The following arguments are optional:
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A map of tags to assign to the collection. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags     pulumi.StringMapInput
 	Timeouts ServerlessCollectionTimeoutsPtrInput

--- a/sdk/go/aws/opensearch/serverlessSecurityConfig.go
+++ b/sdk/go/aws/opensearch/serverlessSecurityConfig.go
@@ -47,9 +47,6 @@ func NewServerlessSecurityConfig(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.Type == nil {
 		return nil, errors.New("invalid value for required argument 'Type'")
 	}
@@ -113,7 +110,7 @@ type serverlessSecurityConfigArgs struct {
 	// Description of the security configuration.
 	Description *string `pulumi:"description"`
 	// Name of the policy.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Configuration block for SAML options.
 	SamlOptions *ServerlessSecurityConfigSamlOptions `pulumi:"samlOptions"`
 	// Type of configuration. Must be `saml`.
@@ -127,7 +124,7 @@ type ServerlessSecurityConfigArgs struct {
 	// Description of the security configuration.
 	Description pulumi.StringPtrInput
 	// Name of the policy.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Configuration block for SAML options.
 	SamlOptions ServerlessSecurityConfigSamlOptionsPtrInput
 	// Type of configuration. Must be `saml`.

--- a/sdk/go/aws/opensearch/serverlessSecurityPolicy.go
+++ b/sdk/go/aws/opensearch/serverlessSecurityPolicy.go
@@ -49,7 +49,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessSecurityPolicy(ctx, "example", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:        pulumi.String("example"),
 //				Type:        pulumi.String("encryption"),
 //				Description: pulumi.String("encryption security policy for example-collection"),
 //				Policy:      pulumi.String(json0),
@@ -94,7 +93,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessSecurityPolicy(ctx, "example", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:        pulumi.String("example"),
 //				Type:        pulumi.String("encryption"),
 //				Description: pulumi.String("encryption security policy for collections that begin with \"example\""),
 //				Policy:      pulumi.String(json0),
@@ -140,7 +138,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessSecurityPolicy(ctx, "example", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:        pulumi.String("example"),
 //				Type:        pulumi.String("encryption"),
 //				Description: pulumi.String("encryption security policy using customer KMS key"),
 //				Policy:      pulumi.String(json0),
@@ -195,7 +192,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessSecurityPolicy(ctx, "example", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:        pulumi.String("example"),
 //				Type:        pulumi.String("network"),
 //				Description: pulumi.String("Public access"),
 //				Policy:      pulumi.String(json0),
@@ -252,7 +248,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessSecurityPolicy(ctx, "example", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:        pulumi.String("example"),
 //				Type:        pulumi.String("network"),
 //				Description: pulumi.String("VPC access"),
 //				Policy:      pulumi.String(json0),
@@ -321,7 +316,6 @@ import (
 //			}
 //			json0 := string(tmpJSON0)
 //			_, err = opensearch.NewServerlessSecurityPolicy(ctx, "example", &opensearch.ServerlessSecurityPolicyArgs{
-//				Name:        pulumi.String("example"),
 //				Type:        pulumi.String("network"),
 //				Description: pulumi.String("Mixed access for marketing and sales"),
 //				Policy:      pulumi.String(json0),
@@ -366,9 +360,6 @@ func NewServerlessSecurityPolicy(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.Policy == nil {
 		return nil, errors.New("invalid value for required argument 'Policy'")
 	}
@@ -435,7 +426,7 @@ type serverlessSecurityPolicyArgs struct {
 	// Description of the policy. Typically used to store information about the permissions defined in the policy.
 	Description *string `pulumi:"description"`
 	// Name of the policy.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// JSON policy document to use as the content for the new policy
 	Policy string `pulumi:"policy"`
 	// Type of security policy. One of `encryption` or `network`.
@@ -449,7 +440,7 @@ type ServerlessSecurityPolicyArgs struct {
 	// Description of the policy. Typically used to store information about the permissions defined in the policy.
 	Description pulumi.StringPtrInput
 	// Name of the policy.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// JSON policy document to use as the content for the new policy
 	Policy pulumi.StringInput
 	// Type of security policy. One of `encryption` or `network`.

--- a/sdk/go/aws/opensearch/serverlessVpcEndpoint.go
+++ b/sdk/go/aws/opensearch/serverlessVpcEndpoint.go
@@ -30,7 +30,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := opensearch.NewServerlessVpcEndpoint(ctx, "example", &opensearch.ServerlessVpcEndpointArgs{
-//				Name: pulumi.String("myendpoint"),
 //				SubnetIds: pulumi.StringArray{
 //					aws_subnet.Example.Id,
 //				},
@@ -75,9 +74,6 @@ func NewServerlessVpcEndpoint(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.SubnetIds == nil {
 		return nil, errors.New("invalid value for required argument 'SubnetIds'")
 	}
@@ -140,7 +136,7 @@ func (ServerlessVpcEndpointState) ElementType() reflect.Type {
 
 type serverlessVpcEndpointArgs struct {
 	// Name of the interface endpoint.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// One or more security groups that define the ports, protocols, and sources for inbound traffic that you are authorizing into your endpoint. Up to 5 security groups can be provided.
 	SecurityGroupIds []string `pulumi:"securityGroupIds"`
 	// One or more subnet IDs from which you'll access OpenSearch Serverless. Up to 6 subnets can be provided.
@@ -155,7 +151,7 @@ type serverlessVpcEndpointArgs struct {
 // The set of arguments for constructing a ServerlessVpcEndpoint resource.
 type ServerlessVpcEndpointArgs struct {
 	// Name of the interface endpoint.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// One or more security groups that define the ports, protocols, and sources for inbound traffic that you are authorizing into your endpoint. Up to 5 security groups can be provided.
 	SecurityGroupIds pulumi.StringArrayInput
 	// One or more subnet IDs from which you'll access OpenSearch Serverless. Up to 6 subnets can be provided.

--- a/sdk/go/aws/quicksight/theme.go
+++ b/sdk/go/aws/quicksight/theme.go
@@ -68,9 +68,6 @@ func NewTheme(ctx *pulumi.Context,
 	if args.BaseThemeId == nil {
 		return nil, errors.New("invalid value for required argument 'BaseThemeId'")
 	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.ThemeId == nil {
 		return nil, errors.New("invalid value for required argument 'ThemeId'")
 	}
@@ -176,7 +173,7 @@ type themeArgs struct {
 	// The following arguments are optional:
 	Configuration *ThemeConfiguration `pulumi:"configuration"`
 	// Display name of the theme.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// A set of resource permissions on the theme. Maximum of 64 items. See permissions.
 	Permissions []ThemePermission `pulumi:"permissions"`
 	// Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -198,7 +195,7 @@ type ThemeArgs struct {
 	// The following arguments are optional:
 	Configuration ThemeConfigurationPtrInput
 	// Display name of the theme.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// A set of resource permissions on the theme. Maximum of 64 items. See permissions.
 	Permissions ThemePermissionArrayInput
 	// Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.

--- a/sdk/go/aws/quicksight/vpcConnection.go
+++ b/sdk/go/aws/quicksight/vpcConnection.go
@@ -84,7 +84,6 @@ import (
 //			}
 //			_, err = quicksight.NewVpcConnection(ctx, "example", &quicksight.VpcConnectionArgs{
 //				VpcConnectionId: pulumi.String("example-connection-id"),
-//				Name:            pulumi.String("Example Connection"),
 //				RoleArn:         vpcConnectionRole.Arn,
 //				SecurityGroupIds: pulumi.StringArray{
 //					pulumi.String("sg-00000000000000000"),
@@ -147,9 +146,6 @@ func NewVpcConnection(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.RoleArn == nil {
 		return nil, errors.New("invalid value for required argument 'RoleArn'")
 	}
@@ -250,7 +246,7 @@ type vpcConnectionArgs struct {
 	// A list of IP addresses of DNS resolver endpoints for the VPC connection.
 	DnsResolvers []string `pulumi:"dnsResolvers"`
 	// The display name for the VPC connection.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// The IAM role to associate with the VPC connection.
 	RoleArn string `pulumi:"roleArn"`
 	// A list of security group IDs for the VPC connection.
@@ -273,7 +269,7 @@ type VpcConnectionArgs struct {
 	// A list of IP addresses of DNS resolver endpoints for the VPC connection.
 	DnsResolvers pulumi.StringArrayInput
 	// The display name for the VPC connection.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// The IAM role to associate with the VPC connection.
 	RoleArn pulumi.StringInput
 	// A list of security group IDs for the VPC connection.

--- a/sdk/go/aws/resourceexplorer/view.go
+++ b/sdk/go/aws/resourceexplorer/view.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -35,7 +34,6 @@ import (
 //				return err
 //			}
 //			_, err = resourceexplorer.NewView(ctx, "exampleView", &resourceexplorer.ViewArgs{
-//				Name: pulumi.String("exampleview"),
 //				Filters: &resourceexplorer.ViewFiltersArgs{
 //					FilterString: pulumi.String("resourcetype:ec2:instance"),
 //				},
@@ -86,12 +84,9 @@ type View struct {
 func NewView(ctx *pulumi.Context,
 	name string, args *ViewArgs, opts ...pulumi.ResourceOption) (*View, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &ViewArgs{}
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource View
 	err := ctx.RegisterResource("aws:resourceexplorer/view:View", name, args, &resource, opts...)
@@ -160,7 +155,7 @@ type viewArgs struct {
 	// Optional fields to be included in search results from this view. See Included Properties below for more details.
 	IncludedProperties []ViewIncludedProperty `pulumi:"includedProperties"`
 	// The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -174,7 +169,7 @@ type ViewArgs struct {
 	// Optional fields to be included in search results from this view. See Included Properties below for more details.
 	IncludedProperties ViewIncludedPropertyArrayInput
 	// The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/route53/cidrCollection.go
+++ b/sdk/go/aws/route53/cidrCollection.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -28,9 +27,7 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			_, err := route53.NewCidrCollection(ctx, "example", &route53.CidrCollectionArgs{
-//				Name: pulumi.String("collection-1"),
-//			})
+//			_, err := route53.NewCidrCollection(ctx, "example", nil)
 //			if err != nil {
 //				return err
 //			}
@@ -62,12 +59,9 @@ type CidrCollection struct {
 func NewCidrCollection(ctx *pulumi.Context,
 	name string, args *CidrCollectionArgs, opts ...pulumi.ResourceOption) (*CidrCollection, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &CidrCollectionArgs{}
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource CidrCollection
 	err := ctx.RegisterResource("aws:route53/cidrCollection:CidrCollection", name, args, &resource, opts...)
@@ -114,13 +108,13 @@ func (CidrCollectionState) ElementType() reflect.Type {
 
 type cidrCollectionArgs struct {
 	// Unique name for the CIDR collection.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 // The set of arguments for constructing a CidrCollection resource.
 type CidrCollectionArgs struct {
 	// Unique name for the CIDR collection.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 }
 
 func (CidrCollectionArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/route53/cidrLocation.go
+++ b/sdk/go/aws/route53/cidrLocation.go
@@ -28,15 +28,12 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			exampleCidrCollection, err := route53.NewCidrCollection(ctx, "exampleCidrCollection", &route53.CidrCollectionArgs{
-//				Name: pulumi.String("collection-1"),
-//			})
+//			exampleCidrCollection, err := route53.NewCidrCollection(ctx, "exampleCidrCollection", nil)
 //			if err != nil {
 //				return err
 //			}
 //			_, err = route53.NewCidrLocation(ctx, "exampleCidrLocation", &route53.CidrLocationArgs{
 //				CidrCollectionId: exampleCidrCollection.ID(),
-//				Name:             pulumi.String("office"),
 //				CidrBlocks: pulumi.StringArray{
 //					pulumi.String("200.5.3.0/24"),
 //					pulumi.String("200.6.3.0/24"),
@@ -81,9 +78,6 @@ func NewCidrLocation(ctx *pulumi.Context,
 	}
 	if args.CidrCollectionId == nil {
 		return nil, errors.New("invalid value for required argument 'CidrCollectionId'")
-	}
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource CidrLocation
@@ -135,7 +129,7 @@ type cidrLocationArgs struct {
 	// The ID of the CIDR collection to update.
 	CidrCollectionId string `pulumi:"cidrCollectionId"`
 	// Name for the CIDR location.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 // The set of arguments for constructing a CidrLocation resource.
@@ -145,7 +139,7 @@ type CidrLocationArgs struct {
 	// The ID of the CIDR collection to update.
 	CidrCollectionId pulumi.StringInput
 	// Name for the CIDR location.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 }
 
 func (CidrLocationArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/sfn/alias.go
+++ b/sdk/go/aws/sfn/alias.go
@@ -30,7 +30,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := sfn.NewAlias(ctx, "sfnAlias", &sfn.AliasArgs{
-//				Name: pulumi.String("my_sfn_alias"),
 //				RoutingConfigurations: sfn.AliasRoutingConfigurationArray{
 //					&sfn.AliasRoutingConfigurationArgs{
 //						StateMachineVersionArn: pulumi.Any(aws_sfn_state_machine.Sfn_test.State_machine_version_arn),
@@ -42,7 +41,6 @@ import (
 //				return err
 //			}
 //			_, err = sfn.NewAlias(ctx, "mySfnAlias", &sfn.AliasArgs{
-//				Name: pulumi.String("my_sfn_alias"),
 //				RoutingConfigurations: sfn.AliasRoutingConfigurationArray{
 //					&sfn.AliasRoutingConfigurationArgs{
 //						StateMachineVersionArn: pulumi.String("arn:aws:states:us-east-1:12345:stateMachine:demo:3"),
@@ -92,9 +90,6 @@ func NewAlias(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.RoutingConfigurations == nil {
 		return nil, errors.New("invalid value for required argument 'RoutingConfigurations'")
 	}
@@ -154,7 +149,7 @@ type aliasArgs struct {
 	// Description of the alias.
 	Description *string `pulumi:"description"`
 	// Name for the alias you are creating.
-	Name string `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// The StateMachine alias' route configuration settings. Fields documented below
 	RoutingConfigurations []AliasRoutingConfiguration `pulumi:"routingConfigurations"`
 }
@@ -164,7 +159,7 @@ type AliasArgs struct {
 	// Description of the alias.
 	Description pulumi.StringPtrInput
 	// Name for the alias you are creating.
-	Name pulumi.StringInput
+	Name pulumi.StringPtrInput
 	// The StateMachine alias' route configuration settings. Fields documented below
 	RoutingConfigurations AliasRoutingConfigurationArrayInput
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/appintegrations/DataIntegration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/appintegrations/DataIntegration.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new DataIntegration(&#34;example&#34;, DataIntegrationArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .description(&#34;example&#34;)
  *             .kmsKey(aws_kms_key.test().arn())
  *             .sourceUri(&#34;Salesforce://AppFlow/example&#34;)

--- a/sdk/java/src/main/java/com/pulumi/aws/appintegrations/DataIntegrationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/appintegrations/DataIntegrationArgs.java
@@ -51,15 +51,15 @@ public final class DataIntegrationArgs extends com.pulumi.resources.ResourceArgs
      * Specifies the name of the Data Integration.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Specifies the name of the Data Integration.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -184,7 +184,7 @@ public final class DataIntegrationArgs extends com.pulumi.resources.ResourceArgs
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -264,7 +264,6 @@ public final class DataIntegrationArgs extends com.pulumi.resources.ResourceArgs
 
         public DataIntegrationArgs build() {
             $.kmsKey = Objects.requireNonNull($.kmsKey, "expected parameter 'kmsKey' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.scheduleConfig = Objects.requireNonNull($.scheduleConfig, "expected parameter 'scheduleConfig' to be non-null");
             $.sourceUri = Objects.requireNonNull($.sourceUri, "expected parameter 'sourceUri' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/Assessment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/Assessment.java
@@ -50,7 +50,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var test = new Assessment(&#34;test&#34;, AssessmentArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .assessmentReportsDestination(AssessmentAssessmentReportsDestinationArgs.builder()
  *                 .destination(String.format(&#34;s3://%s&#34;, aws_s3_bucket.test().id()))
  *                 .destinationType(&#34;S3&#34;)

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AssessmentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AssessmentArgs.java
@@ -69,15 +69,15 @@ public final class AssessmentArgs extends com.pulumi.resources.ResourceArgs {
      * Name of the assessment.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the assessment.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -228,7 +228,7 @@ public final class AssessmentArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -322,7 +322,6 @@ public final class AssessmentArgs extends com.pulumi.resources.ResourceArgs {
 
         public AssessmentArgs build() {
             $.frameworkId = Objects.requireNonNull($.frameworkId, "expected parameter 'frameworkId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.roles = Objects.requireNonNull($.roles, "expected parameter 'roles' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AssessmentReport.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AssessmentReport.java
@@ -41,7 +41,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var test = new AssessmentReport(&#34;test&#34;, AssessmentReportArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .assessmentId(aws_auditmanager_assessment.test().id())
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AssessmentReportArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AssessmentReportArgs.java
@@ -53,15 +53,15 @@ public final class AssessmentReportArgs extends com.pulumi.resources.ResourceArg
      * Name of the assessment report.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the assessment report.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     private AssessmentReportArgs() {}
@@ -142,7 +142,7 @@ public final class AssessmentReportArgs extends com.pulumi.resources.ResourceArg
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -159,7 +159,6 @@ public final class AssessmentReportArgs extends com.pulumi.resources.ResourceArg
 
         public AssessmentReportArgs build() {
             $.assessmentId = Objects.requireNonNull($.assessmentId, "expected parameter 'assessmentId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AuditmanagerFunctions.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/AuditmanagerFunctions.java
@@ -87,7 +87,6 @@ public final class AuditmanagerFunctions {
      *             .build());
      * 
      *         var exampleFramework = new Framework(&#34;exampleFramework&#34;, FrameworkArgs.builder()        
-     *             .name(&#34;example&#34;)
      *             .controlSets(            
      *                 FrameworkControlSetArgs.builder()
      *                     .name(&#34;example&#34;)
@@ -181,7 +180,6 @@ public final class AuditmanagerFunctions {
      *             .build());
      * 
      *         var exampleFramework = new Framework(&#34;exampleFramework&#34;, FrameworkArgs.builder()        
-     *             .name(&#34;example&#34;)
      *             .controlSets(            
      *                 FrameworkControlSetArgs.builder()
      *                     .name(&#34;example&#34;)
@@ -275,7 +273,6 @@ public final class AuditmanagerFunctions {
      *             .build());
      * 
      *         var exampleFramework = new Framework(&#34;exampleFramework&#34;, FrameworkArgs.builder()        
-     *             .name(&#34;example&#34;)
      *             .controlSets(            
      *                 FrameworkControlSetArgs.builder()
      *                     .name(&#34;example&#34;)
@@ -369,7 +366,6 @@ public final class AuditmanagerFunctions {
      *             .build());
      * 
      *         var exampleFramework = new Framework(&#34;exampleFramework&#34;, FrameworkArgs.builder()        
-     *             .name(&#34;example&#34;)
      *             .controlSets(            
      *                 FrameworkControlSetArgs.builder()
      *                     .name(&#34;example&#34;)

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/Control.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/Control.java
@@ -50,7 +50,6 @@ import javax.annotation.Nullable;
  *                 .sourceSetUpOption(&#34;Procedural_Controls_Mapping&#34;)
  *                 .sourceType(&#34;MANUAL&#34;)
  *                 .build())
- *             .name(&#34;example&#34;)
  *             .build());
  * 
  *     }
@@ -219,7 +218,7 @@ public class Control extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public Control(String name, ControlArgs args) {
+    public Control(String name, @Nullable ControlArgs args) {
         this(name, args, null);
     }
     /**
@@ -228,7 +227,7 @@ public class Control extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public Control(String name, ControlArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public Control(String name, @Nullable ControlArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("aws:auditmanager/control:Control", name, args == null ? ControlArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/ControlArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/ControlArgs.java
@@ -86,15 +86,15 @@ public final class ControlArgs extends com.pulumi.resources.ResourceArgs {
      * Name of the control.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the control.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -263,7 +263,7 @@ public final class ControlArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -321,7 +321,6 @@ public final class ControlArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ControlArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/Framework.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/Framework.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var test = new Framework(&#34;test&#34;, FrameworkArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .controlSets(FrameworkControlSetArgs.builder()
  *                 .name(&#34;example&#34;)
  *                 .controls(FrameworkControlSetControlArgs.builder()
@@ -192,7 +191,7 @@ public class Framework extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public Framework(String name, FrameworkArgs args) {
+    public Framework(String name, @Nullable FrameworkArgs args) {
         this(name, args, null);
     }
     /**
@@ -201,7 +200,7 @@ public class Framework extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public Framework(String name, FrameworkArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public Framework(String name, @Nullable FrameworkArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("aws:auditmanager/framework:Framework", name, args == null ? FrameworkArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/aws/auditmanager/FrameworkArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/auditmanager/FrameworkArgs.java
@@ -71,15 +71,15 @@ public final class FrameworkArgs extends com.pulumi.resources.ResourceArgs {
      * Name of the framework.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the framework.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -210,7 +210,7 @@ public final class FrameworkArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -247,7 +247,6 @@ public final class FrameworkArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public FrameworkArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipMediaApplication.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipMediaApplication.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var example = new SdkvoiceSipMediaApplication(&#34;example&#34;, SdkvoiceSipMediaApplicationArgs.builder()        
  *             .awsRegion(&#34;us-east-1&#34;)
- *             .name(&#34;example-sip-media-application&#34;)
  *             .endpoints(SdkvoiceSipMediaApplicationEndpointsArgs.builder()
  *                 .lambdaArn(aws_lambda_function.test().arn())
  *                 .build())

--- a/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipMediaApplicationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipMediaApplicationArgs.java
@@ -53,8 +53,8 @@ public final class SdkvoiceSipMediaApplicationArgs extends com.pulumi.resources.
      * The following arguments are optional:
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The name of the AWS Chime SDK Voice Sip Media Application.
@@ -62,8 +62,8 @@ public final class SdkvoiceSipMediaApplicationArgs extends com.pulumi.resources.
      * The following arguments are optional:
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -158,7 +158,7 @@ public final class SdkvoiceSipMediaApplicationArgs extends com.pulumi.resources.
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -199,7 +199,6 @@ public final class SdkvoiceSipMediaApplicationArgs extends com.pulumi.resources.
         public SdkvoiceSipMediaApplicationArgs build() {
             $.awsRegion = Objects.requireNonNull($.awsRegion, "expected parameter 'awsRegion' to be non-null");
             $.endpoints = Objects.requireNonNull($.endpoints, "expected parameter 'endpoints' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipRule.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new SdkvoiceSipRule(&#34;example&#34;, SdkvoiceSipRuleArgs.builder()        
- *             .name(&#34;example-sip-rule&#34;)
  *             .triggerType(&#34;RequestUriHostname&#34;)
  *             .triggerValue(aws_chime_voice_connector.example-voice-connector().outbound_host_name())
  *             .targetApplications(SdkvoiceSipRuleTargetApplicationArgs.builder()

--- a/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceSipRuleArgs.java
@@ -37,15 +37,15 @@ public final class SdkvoiceSipRuleArgs extends com.pulumi.resources.ResourceArgs
      * The name of the SIP rule.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The name of the SIP rule.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -152,7 +152,7 @@ public final class SdkvoiceSipRuleArgs extends com.pulumi.resources.ResourceArgs
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -245,7 +245,6 @@ public final class SdkvoiceSipRuleArgs extends com.pulumi.resources.ResourceArgs
         }
 
         public SdkvoiceSipRuleArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.targetApplications = Objects.requireNonNull($.targetApplications, "expected parameter 'targetApplications' to be non-null");
             $.triggerType = Objects.requireNonNull($.triggerType, "expected parameter 'triggerType' to be non-null");
             $.triggerValue = Objects.requireNonNull($.triggerValue, "expected parameter 'triggerValue' to be non-null");

--- a/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceVoiceProfileDomain.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceVoiceProfileDomain.java
@@ -51,7 +51,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleSdkvoiceVoiceProfileDomain = new SdkvoiceVoiceProfileDomain(&#34;exampleSdkvoiceVoiceProfileDomain&#34;, SdkvoiceVoiceProfileDomainArgs.builder()        
- *             .name(&#34;ExampleVoiceProfileDomain&#34;)
  *             .serverSideEncryptionConfiguration(SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs.builder()
  *                 .kmsKeyArn(exampleKey.arn())
  *                 .build())

--- a/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceVoiceProfileDomainArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/chime/SdkvoiceVoiceProfileDomainArgs.java
@@ -36,15 +36,15 @@ public final class SdkvoiceVoiceProfileDomainArgs extends com.pulumi.resources.R
      * Name of Voice Profile Domain.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of Voice Profile Domain.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -123,7 +123,7 @@ public final class SdkvoiceVoiceProfileDomainArgs extends com.pulumi.resources.R
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -169,7 +169,6 @@ public final class SdkvoiceVoiceProfileDomainArgs extends com.pulumi.resources.R
         }
 
         public SdkvoiceVoiceProfileDomainArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.serverSideEncryptionConfiguration = Objects.requireNonNull($.serverSideEncryptionConfiguration, "expected parameter 'serverSideEncryptionConfiguration' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/cleanrooms/Collaboration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cleanrooms/Collaboration.java
@@ -64,7 +64,6 @@ import javax.annotation.Nullable;
  *                 .displayName(&#34;Other member&#34;)
  *                 .memberAbilities()
  *                 .build())
- *             .name(&#34;pulumi-example-collaboration&#34;)
  *             .queryLogStatus(&#34;DISABLED&#34;)
  *             .tags(Map.of(&#34;Project&#34;, &#34;Pulumi&#34;))
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/aws/cleanrooms/CollaborationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cleanrooms/CollaborationArgs.java
@@ -128,15 +128,15 @@ public final class CollaborationArgs extends com.pulumi.resources.ResourceArgs {
      * The name of the collaboration.  Collaboration names do not need to be unique.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The name of the collaboration.  Collaboration names do not need to be unique.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -371,7 +371,7 @@ public final class CollaborationArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -436,7 +436,6 @@ public final class CollaborationArgs extends com.pulumi.resources.ResourceArgs {
             $.creatorDisplayName = Objects.requireNonNull($.creatorDisplayName, "expected parameter 'creatorDisplayName' to be non-null");
             $.creatorMemberAbilities = Objects.requireNonNull($.creatorMemberAbilities, "expected parameter 'creatorMemberAbilities' to be non-null");
             $.description = Objects.requireNonNull($.description, "expected parameter 'description' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.queryLogStatus = Objects.requireNonNull($.queryLogStatus, "expected parameter 'queryLogStatus' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/FieldLevelEncryptionProfile.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/FieldLevelEncryptionProfile.java
@@ -46,7 +46,6 @@ import javax.annotation.Nullable;
  *         var example = new PublicKey(&#34;example&#34;, PublicKeyArgs.builder()        
  *             .comment(&#34;test public key&#34;)
  *             .encodedKey(Files.readString(Paths.get(&#34;public_key.pem&#34;)))
- *             .name(&#34;test_key&#34;)
  *             .build());
  * 
  *         var test = new FieldLevelEncryptionProfile(&#34;test&#34;, FieldLevelEncryptionProfileArgs.builder()        

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/KeyGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/KeyGroup.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
  *         var examplePublicKey = new PublicKey(&#34;examplePublicKey&#34;, PublicKeyArgs.builder()        
  *             .comment(&#34;example public key&#34;)
  *             .encodedKey(Files.readString(Paths.get(&#34;public_key.pem&#34;)))
- *             .name(&#34;example-key&#34;)
  *             .build());
  * 
  *         var exampleKeyGroup = new KeyGroup(&#34;exampleKeyGroup&#34;, KeyGroupArgs.builder()        

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/PublicKey.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/PublicKey.java
@@ -42,7 +42,6 @@ import javax.annotation.Nullable;
  *         var example = new PublicKey(&#34;example&#34;, PublicKeyArgs.builder()        
  *             .comment(&#34;test public key&#34;)
  *             .encodedKey(Files.readString(Paths.get(&#34;public_key.pem&#34;)))
- *             .name(&#34;test_key&#34;)
  *             .build());
  * 
  *     }

--- a/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/JobTemplate.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/JobTemplate.java
@@ -55,7 +55,6 @@ import javax.annotation.Nullable;
  *                         .build())
  *                     .build())
  *                 .build())
- *             .name(&#34;example&#34;)
  *             .build());
  * 
  *     }

--- a/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/JobTemplateArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/JobTemplateArgs.java
@@ -51,15 +51,15 @@ public final class JobTemplateArgs extends com.pulumi.resources.ResourceArgs {
      * The specified name of the job template.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The specified name of the job template.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -152,7 +152,7 @@ public final class JobTemplateArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -190,7 +190,6 @@ public final class JobTemplateArgs extends com.pulumi.resources.ResourceArgs {
 
         public JobTemplateArgs build() {
             $.jobTemplateData = Objects.requireNonNull($.jobTemplateData, "expected parameter 'jobTemplateData' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxCluster.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxCluster.java
@@ -56,7 +56,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new KxCluster(&#34;example&#34;, KxClusterArgs.builder()        
- *             .name(&#34;my-tf-kx-cluster&#34;)
  *             .environmentId(aws_finspace_kx_environment.example().id())
  *             .type(&#34;HDB&#34;)
  *             .releaseLabel(&#34;1.0&#34;)

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxClusterArgs.java
@@ -212,15 +212,15 @@ public final class KxClusterArgs extends com.pulumi.resources.ResourceArgs {
      * Unique name for the cluster that you want to create.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Unique name for the cluster that you want to create.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -631,7 +631,7 @@ public final class KxClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -765,7 +765,6 @@ public final class KxClusterArgs extends com.pulumi.resources.ResourceArgs {
             $.azMode = Objects.requireNonNull($.azMode, "expected parameter 'azMode' to be non-null");
             $.capacityConfiguration = Objects.requireNonNull($.capacityConfiguration, "expected parameter 'capacityConfiguration' to be non-null");
             $.environmentId = Objects.requireNonNull($.environmentId, "expected parameter 'environmentId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.releaseLabel = Objects.requireNonNull($.releaseLabel, "expected parameter 'releaseLabel' to be non-null");
             $.type = Objects.requireNonNull($.type, "expected parameter 'type' to be non-null");
             $.vpcConfiguration = Objects.requireNonNull($.vpcConfiguration, "expected parameter 'vpcConfiguration' to be non-null");

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxDatabase.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxDatabase.java
@@ -51,13 +51,11 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleKxEnvironment = new KxEnvironment(&#34;exampleKxEnvironment&#34;, KxEnvironmentArgs.builder()        
- *             .name(&#34;my-tf-kx-environment&#34;)
  *             .kmsKeyId(exampleKey.arn())
  *             .build());
  * 
  *         var exampleKxDatabase = new KxDatabase(&#34;exampleKxDatabase&#34;, KxDatabaseArgs.builder()        
  *             .environmentId(exampleKxEnvironment.id())
- *             .name(&#34;my-tf-kx-database&#34;)
  *             .description(&#34;Example database description&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxDatabaseArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxDatabaseArgs.java
@@ -52,8 +52,8 @@ public final class KxDatabaseArgs extends com.pulumi.resources.ResourceArgs {
      * The following arguments are optional:
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the KX database.
@@ -61,8 +61,8 @@ public final class KxDatabaseArgs extends com.pulumi.resources.ResourceArgs {
      * The following arguments are optional:
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -157,7 +157,7 @@ public final class KxDatabaseArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -197,7 +197,6 @@ public final class KxDatabaseArgs extends com.pulumi.resources.ResourceArgs {
 
         public KxDatabaseArgs build() {
             $.environmentId = Objects.requireNonNull($.environmentId, "expected parameter 'environmentId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxEnvironment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxEnvironment.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleKxEnvironment = new KxEnvironment(&#34;exampleKxEnvironment&#34;, KxEnvironmentArgs.builder()        
- *             .name(&#34;my-tf-kx-environment&#34;)
  *             .kmsKeyId(exampleKey.arn())
  *             .build());
  * 
@@ -97,7 +96,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleEnv = new KxEnvironment(&#34;exampleEnv&#34;, KxEnvironmentArgs.builder()        
- *             .name(&#34;my-tf-kx-environment&#34;)
  *             .description(&#34;Environment description&#34;)
  *             .kmsKeyId(exampleKey.arn())
  *             .transitGatewayConfiguration(KxEnvironmentTransitGatewayConfigurationArgs.builder()

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxEnvironmentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxEnvironmentArgs.java
@@ -72,15 +72,15 @@ public final class KxEnvironmentArgs extends com.pulumi.resources.ResourceArgs {
      * Name of the KX environment that you want to create.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the KX environment that you want to create.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -225,7 +225,7 @@ public final class KxEnvironmentArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -284,7 +284,6 @@ public final class KxEnvironmentArgs extends com.pulumi.resources.ResourceArgs {
 
         public KxEnvironmentArgs build() {
             $.kmsKeyId = Objects.requireNonNull($.kmsKeyId, "expected parameter 'kmsKeyId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxUser.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxUser.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleKxEnvironment = new KxEnvironment(&#34;exampleKxEnvironment&#34;, KxEnvironmentArgs.builder()        
- *             .name(&#34;my-tf-kx-environment&#34;)
  *             .kmsKeyId(exampleKey.arn())
  *             .build());
  * 
@@ -74,7 +73,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleKxUser = new KxUser(&#34;exampleKxUser&#34;, KxUserArgs.builder()        
- *             .name(&#34;my-tf-kx-user&#34;)
  *             .environmentId(exampleKxEnvironment.id())
  *             .iamRole(exampleRole.arn())
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/aws/finspace/KxUserArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/finspace/KxUserArgs.java
@@ -54,15 +54,15 @@ public final class KxUserArgs extends com.pulumi.resources.ResourceArgs {
      * A unique identifier for the user.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return A unique identifier for the user.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -159,7 +159,7 @@ public final class KxUserArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -198,7 +198,6 @@ public final class KxUserArgs extends com.pulumi.resources.ResourceArgs {
         public KxUserArgs build() {
             $.environmentId = Objects.requireNonNull($.environmentId, "expected parameter 'environmentId' to be non-null");
             $.iamRole = Objects.requireNonNull($.iamRole, "expected parameter 'iamRole' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/globalaccelerator/CustomRoutingAccelerator.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/globalaccelerator/CustomRoutingAccelerator.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
  *             .enabled(true)
  *             .ipAddressType(&#34;IPV4&#34;)
  *             .ipAddresses(&#34;1.2.3.4&#34;)
- *             .name(&#34;Example&#34;)
  *             .build());
  * 
  *     }
@@ -229,7 +228,7 @@ public class CustomRoutingAccelerator extends com.pulumi.resources.CustomResourc
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public CustomRoutingAccelerator(String name, CustomRoutingAcceleratorArgs args) {
+    public CustomRoutingAccelerator(String name, @Nullable CustomRoutingAcceleratorArgs args) {
         this(name, args, null);
     }
     /**
@@ -238,7 +237,7 @@ public class CustomRoutingAccelerator extends com.pulumi.resources.CustomResourc
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public CustomRoutingAccelerator(String name, CustomRoutingAcceleratorArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public CustomRoutingAccelerator(String name, @Nullable CustomRoutingAcceleratorArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("aws:globalaccelerator/customRoutingAccelerator:CustomRoutingAccelerator", name, args == null ? CustomRoutingAcceleratorArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/aws/globalaccelerator/CustomRoutingAcceleratorArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/globalaccelerator/CustomRoutingAcceleratorArgs.java
@@ -83,15 +83,15 @@ public final class CustomRoutingAcceleratorArgs extends com.pulumi.resources.Res
      * The name of a custom routing accelerator.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The name of a custom routing accelerator.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -238,7 +238,7 @@ public final class CustomRoutingAcceleratorArgs extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -275,7 +275,6 @@ public final class CustomRoutingAcceleratorArgs extends com.pulumi.resources.Res
         }
 
         public CustomRoutingAcceleratorArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/globalaccelerator/CustomRoutingListener.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/globalaccelerator/CustomRoutingListener.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var exampleCustomRoutingAccelerator = new CustomRoutingAccelerator(&#34;exampleCustomRoutingAccelerator&#34;, CustomRoutingAcceleratorArgs.builder()        
- *             .name(&#34;Example&#34;)
  *             .ipAddressType(&#34;IPV4&#34;)
  *             .enabled(true)
  *             .attributes(CustomRoutingAcceleratorAttributesArgs.builder()

--- a/sdk/java/src/main/java/com/pulumi/aws/glue/DataQualityRuleset.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/glue/DataQualityRuleset.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new DataQualityRuleset(&#34;example&#34;, DataQualityRulesetArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .ruleset(&#34;Rules = [Completeness \&#34;colA\&#34; between 0.4 and 0.8]&#34;)
  *             .build());
  * 
@@ -74,7 +73,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var example = new DataQualityRuleset(&#34;example&#34;, DataQualityRulesetArgs.builder()        
  *             .description(&#34;example&#34;)
- *             .name(&#34;example&#34;)
  *             .ruleset(&#34;Rules = [Completeness \&#34;colA\&#34; between 0.4 and 0.8]&#34;)
  *             .build());
  * 
@@ -104,7 +102,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new DataQualityRuleset(&#34;example&#34;, DataQualityRulesetArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .ruleset(&#34;Rules = [Completeness \&#34;colA\&#34; between 0.4 and 0.8]&#34;)
  *             .tags(Map.of(&#34;hello&#34;, &#34;world&#34;))
  *             .build());
@@ -136,7 +133,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new DataQualityRuleset(&#34;example&#34;, DataQualityRulesetArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .ruleset(&#34;Rules = [Completeness \&#34;colA\&#34; between 0.4 and 0.8]&#34;)
  *             .targetTable(DataQualityRulesetTargetTableArgs.builder()
  *                 .databaseName(aws_glue_catalog_database.example().name())

--- a/sdk/java/src/main/java/com/pulumi/aws/glue/DataQualityRulesetArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/glue/DataQualityRulesetArgs.java
@@ -36,15 +36,15 @@ public final class DataQualityRulesetArgs extends com.pulumi.resources.ResourceA
      * Name of the data quality ruleset.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the data quality ruleset.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -147,7 +147,7 @@ public final class DataQualityRulesetArgs extends com.pulumi.resources.ResourceA
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -226,7 +226,6 @@ public final class DataQualityRulesetArgs extends com.pulumi.resources.ResourceA
         }
 
         public DataQualityRulesetArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.ruleset = Objects.requireNonNull($.ruleset, "expected parameter 'ruleset' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessAccessPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessAccessPolicy.java
@@ -49,7 +49,6 @@ import javax.annotation.Nullable;
  *         final var currentPartition = AwsFunctions.getPartition();
  * 
  *         var test = new ServerlessAccessPolicy(&#34;test&#34;, ServerlessAccessPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;data&#34;)
  *             .policy(serializeJson(
  *                 jsonArray(jsonObject(

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessAccessPolicyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessAccessPolicyArgs.java
@@ -34,15 +34,15 @@ public final class ServerlessAccessPolicyArgs extends com.pulumi.resources.Resou
      * Name of the policy.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the policy.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -133,7 +133,7 @@ public final class ServerlessAccessPolicyArgs extends com.pulumi.resources.Resou
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -195,7 +195,6 @@ public final class ServerlessAccessPolicyArgs extends com.pulumi.resources.Resou
         }
 
         public ServerlessAccessPolicyArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.policy = Objects.requireNonNull($.policy, "expected parameter 'policy' to be non-null");
             $.type = Objects.requireNonNull($.type, "expected parameter 'type' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessCollection.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessCollection.java
@@ -47,7 +47,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var exampleServerlessSecurityPolicy = new ServerlessSecurityPolicy(&#34;exampleServerlessSecurityPolicy&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;encryption&#34;)
  *             .policy(serializeJson(
  *                 jsonObject(
@@ -59,11 +58,9 @@ import javax.annotation.Nullable;
  *                 )))
  *             .build());
  * 
- *         var exampleServerlessCollection = new ServerlessCollection(&#34;exampleServerlessCollection&#34;, ServerlessCollectionArgs.builder()        
- *             .name(&#34;example&#34;)
- *             .build(), CustomResourceOptions.builder()
- *                 .dependsOn(exampleServerlessSecurityPolicy)
- *                 .build());
+ *         var exampleServerlessCollection = new ServerlessCollection(&#34;exampleServerlessCollection&#34;, ServerlessCollectionArgs.Empty, CustomResourceOptions.builder()
+ *             .dependsOn(exampleServerlessSecurityPolicy)
+ *             .build());
  * 
  *     }
  * }
@@ -213,7 +210,7 @@ public class ServerlessCollection extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public ServerlessCollection(String name, ServerlessCollectionArgs args) {
+    public ServerlessCollection(String name, @Nullable ServerlessCollectionArgs args) {
         this(name, args, null);
     }
     /**
@@ -222,7 +219,7 @@ public class ServerlessCollection extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public ServerlessCollection(String name, ServerlessCollectionArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public ServerlessCollection(String name, @Nullable ServerlessCollectionArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("aws:opensearch/serverlessCollection:ServerlessCollection", name, args == null ? ServerlessCollectionArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessCollectionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessCollectionArgs.java
@@ -38,8 +38,8 @@ public final class ServerlessCollectionArgs extends com.pulumi.resources.Resourc
      * The following arguments are optional:
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the collection.
@@ -47,8 +47,8 @@ public final class ServerlessCollectionArgs extends com.pulumi.resources.Resourc
      * The following arguments are optional:
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -145,7 +145,7 @@ public final class ServerlessCollectionArgs extends com.pulumi.resources.Resourc
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -214,7 +214,6 @@ public final class ServerlessCollectionArgs extends com.pulumi.resources.Resourc
         }
 
         public ServerlessCollectionArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityConfig.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityConfig(&#34;example&#34;, ServerlessSecurityConfigArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;saml&#34;)
  *             .samlOptions(ServerlessSecurityConfigSamlOptionsArgs.builder()
  *                 .metadata(Files.readString(Paths.get(String.format(&#34;%s/idp-metadata.xml&#34;, path.module()))))

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityConfigArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityConfigArgs.java
@@ -35,15 +35,15 @@ public final class ServerlessSecurityConfigArgs extends com.pulumi.resources.Res
      * Name of the policy.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the policy.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class ServerlessSecurityConfigArgs extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -196,7 +196,6 @@ public final class ServerlessSecurityConfigArgs extends com.pulumi.resources.Res
         }
 
         public ServerlessSecurityConfigArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.type = Objects.requireNonNull($.type, "expected parameter 'type' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityPolicy.java
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityPolicy(&#34;example&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;encryption&#34;)
  *             .description(&#34;encryption security policy for example-collection&#34;)
  *             .policy(serializeJson(
@@ -84,7 +83,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityPolicy(&#34;example&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;encryption&#34;)
  *             .description(&#34;encryption security policy for collections that begin with \&#34;example\&#34;&#34;)
  *             .policy(serializeJson(
@@ -124,7 +122,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityPolicy(&#34;example&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;encryption&#34;)
  *             .description(&#34;encryption security policy using customer KMS key&#34;)
  *             .policy(serializeJson(
@@ -166,7 +163,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityPolicy(&#34;example&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;network&#34;)
  *             .description(&#34;Public access&#34;)
  *             .policy(serializeJson(
@@ -213,7 +209,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityPolicy(&#34;example&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;network&#34;)
  *             .description(&#34;VPC access&#34;)
  *             .policy(serializeJson(
@@ -261,7 +256,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessSecurityPolicy(&#34;example&#34;, ServerlessSecurityPolicyArgs.builder()        
- *             .name(&#34;example&#34;)
  *             .type(&#34;network&#34;)
  *             .description(&#34;Mixed access for marketing and sales&#34;)
  *             .policy(serializeJson(

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityPolicyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessSecurityPolicyArgs.java
@@ -34,15 +34,15 @@ public final class ServerlessSecurityPolicyArgs extends com.pulumi.resources.Res
      * Name of the policy.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the policy.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -133,7 +133,7 @@ public final class ServerlessSecurityPolicyArgs extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -195,7 +195,6 @@ public final class ServerlessSecurityPolicyArgs extends com.pulumi.resources.Res
         }
 
         public ServerlessSecurityPolicyArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.policy = Objects.requireNonNull($.policy, "expected parameter 'policy' to be non-null");
             $.type = Objects.requireNonNull($.type, "expected parameter 'type' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessVpcEndpoint.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessVpcEndpoint.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var example = new ServerlessVpcEndpoint(&#34;example&#34;, ServerlessVpcEndpointArgs.builder()        
- *             .name(&#34;myendpoint&#34;)
  *             .subnetIds(aws_subnet.example().id())
  *             .vpcId(aws_vpc.example().id())
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessVpcEndpointArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/ServerlessVpcEndpointArgs.java
@@ -21,15 +21,15 @@ public final class ServerlessVpcEndpointArgs extends com.pulumi.resources.Resour
      * Name of the interface endpoint.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name of the interface endpoint.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -122,7 +122,7 @@ public final class ServerlessVpcEndpointArgs extends com.pulumi.resources.Resour
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -234,7 +234,6 @@ public final class ServerlessVpcEndpointArgs extends com.pulumi.resources.Resour
         }
 
         public ServerlessVpcEndpointArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.subnetIds = Objects.requireNonNull($.subnetIds, "expected parameter 'subnetIds' to be non-null");
             $.vpcId = Objects.requireNonNull($.vpcId, "expected parameter 'vpcId' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/aws/quicksight/Theme.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/quicksight/Theme.java
@@ -69,7 +69,6 @@ import javax.annotation.Nullable;
  *                         &#34;#111111&#34;)
  *                     .build())
  *                 .build())
- *             .name(&#34;example&#34;)
  *             .themeId(&#34;example&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/aws/quicksight/ThemeArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/quicksight/ThemeArgs.java
@@ -72,15 +72,15 @@ public final class ThemeArgs extends com.pulumi.resources.ResourceArgs {
      * Display name of the theme.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Display name of the theme.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -247,7 +247,7 @@ public final class ThemeArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -358,7 +358,6 @@ public final class ThemeArgs extends com.pulumi.resources.ResourceArgs {
 
         public ThemeArgs build() {
             $.baseThemeId = Objects.requireNonNull($.baseThemeId, "expected parameter 'baseThemeId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.themeId = Objects.requireNonNull($.themeId, "expected parameter 'themeId' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/quicksight/VpcConnection.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/quicksight/VpcConnection.java
@@ -81,7 +81,6 @@ import javax.annotation.Nullable;
  * 
  *         var example = new VpcConnection(&#34;example&#34;, VpcConnectionArgs.builder()        
  *             .vpcConnectionId(&#34;example-connection-id&#34;)
- *             .name(&#34;Example Connection&#34;)
  *             .roleArn(vpcConnectionRole.arn())
  *             .securityGroupIds(&#34;sg-00000000000000000&#34;)
  *             .subnetIds(            

--- a/sdk/java/src/main/java/com/pulumi/aws/quicksight/VpcConnectionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/quicksight/VpcConnectionArgs.java
@@ -52,15 +52,15 @@ public final class VpcConnectionArgs extends com.pulumi.resources.ResourceArgs {
      * The display name for the VPC connection.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The display name for the VPC connection.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -239,7 +239,7 @@ public final class VpcConnectionArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -395,7 +395,6 @@ public final class VpcConnectionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public VpcConnectionArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.roleArn = Objects.requireNonNull($.roleArn, "expected parameter 'roleArn' to be non-null");
             $.securityGroupIds = Objects.requireNonNull($.securityGroupIds, "expected parameter 'securityGroupIds' to be non-null");
             $.subnetIds = Objects.requireNonNull($.subnetIds, "expected parameter 'subnetIds' to be non-null");

--- a/sdk/java/src/main/java/com/pulumi/aws/resourceexplorer/View.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/resourceexplorer/View.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleView = new View(&#34;exampleView&#34;, ViewArgs.builder()        
- *             .name(&#34;exampleview&#34;)
  *             .filters(ViewFiltersArgs.builder()
  *                 .filterString(&#34;resourcetype:ec2:instance&#34;)
  *                 .build())
@@ -191,7 +190,7 @@ public class View extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public View(String name, ViewArgs args) {
+    public View(String name, @Nullable ViewArgs args) {
         this(name, args, null);
     }
     /**
@@ -200,7 +199,7 @@ public class View extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public View(String name, ViewArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public View(String name, @Nullable ViewArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("aws:resourceexplorer/view:View", name, args == null ? ViewArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/aws/resourceexplorer/ViewArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/resourceexplorer/ViewArgs.java
@@ -69,15 +69,15 @@ public final class ViewArgs extends com.pulumi.resources.ResourceArgs {
      * The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -202,7 +202,7 @@ public final class ViewArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -239,7 +239,6 @@ public final class ViewArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ViewArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/CidrCollection.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/CidrCollection.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
  * import com.pulumi.Pulumi;
  * import com.pulumi.core.Output;
  * import com.pulumi.aws.route53.CidrCollection;
- * import com.pulumi.aws.route53.CidrCollectionArgs;
  * import java.util.List;
  * import java.util.ArrayList;
  * import java.util.Map;
@@ -39,9 +38,7 @@ import javax.annotation.Nullable;
  *     }
  * 
  *     public static void stack(Context ctx) {
- *         var example = new CidrCollection(&#34;example&#34;, CidrCollectionArgs.builder()        
- *             .name(&#34;collection-1&#34;)
- *             .build());
+ *         var example = new CidrCollection(&#34;example&#34;);
  * 
  *     }
  * }
@@ -113,7 +110,7 @@ public class CidrCollection extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public CidrCollection(String name, CidrCollectionArgs args) {
+    public CidrCollection(String name, @Nullable CidrCollectionArgs args) {
         this(name, args, null);
     }
     /**
@@ -122,7 +119,7 @@ public class CidrCollection extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public CidrCollection(String name, CidrCollectionArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public CidrCollection(String name, @Nullable CidrCollectionArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("aws:route53/cidrCollection:CidrCollection", name, args == null ? CidrCollectionArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/CidrCollectionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/CidrCollectionArgs.java
@@ -7,6 +7,8 @@ import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.String;
 import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 
 public final class CidrCollectionArgs extends com.pulumi.resources.ResourceArgs {
@@ -17,15 +19,15 @@ public final class CidrCollectionArgs extends com.pulumi.resources.ResourceArgs 
      * Unique name for the CIDR collection.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Unique name for the CIDR collection.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     private CidrCollectionArgs() {}
@@ -58,7 +60,7 @@ public final class CidrCollectionArgs extends com.pulumi.resources.ResourceArgs 
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -74,7 +76,6 @@ public final class CidrCollectionArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         public CidrCollectionArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/CidrLocation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/CidrLocation.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
  * import com.pulumi.Pulumi;
  * import com.pulumi.core.Output;
  * import com.pulumi.aws.route53.CidrCollection;
- * import com.pulumi.aws.route53.CidrCollectionArgs;
  * import com.pulumi.aws.route53.CidrLocation;
  * import com.pulumi.aws.route53.CidrLocationArgs;
  * import java.util.List;
@@ -41,13 +40,10 @@ import javax.annotation.Nullable;
  *     }
  * 
  *     public static void stack(Context ctx) {
- *         var exampleCidrCollection = new CidrCollection(&#34;exampleCidrCollection&#34;, CidrCollectionArgs.builder()        
- *             .name(&#34;collection-1&#34;)
- *             .build());
+ *         var exampleCidrCollection = new CidrCollection(&#34;exampleCidrCollection&#34;);
  * 
  *         var exampleCidrLocation = new CidrLocation(&#34;exampleCidrLocation&#34;, CidrLocationArgs.builder()        
  *             .cidrCollectionId(exampleCidrCollection.id())
- *             .name(&#34;office&#34;)
  *             .cidrBlocks(            
  *                 &#34;200.5.3.0/24&#34;,
  *                 &#34;200.6.3.0/24&#34;)

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/CidrLocationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/CidrLocationArgs.java
@@ -8,6 +8,8 @@ import com.pulumi.core.annotations.Import;
 import java.lang.String;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 
 public final class CidrLocationArgs extends com.pulumi.resources.ResourceArgs {
@@ -48,15 +50,15 @@ public final class CidrLocationArgs extends com.pulumi.resources.ResourceArgs {
      * Name for the CIDR location.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name for the CIDR location.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     private CidrLocationArgs() {}
@@ -143,7 +145,7 @@ public final class CidrLocationArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -161,7 +163,6 @@ public final class CidrLocationArgs extends com.pulumi.resources.ResourceArgs {
         public CidrLocationArgs build() {
             $.cidrBlocks = Objects.requireNonNull($.cidrBlocks, "expected parameter 'cidrBlocks' to be non-null");
             $.cidrCollectionId = Objects.requireNonNull($.cidrCollectionId, "expected parameter 'cidrCollectionId' to be non-null");
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/aws/sfn/Alias.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/sfn/Alias.java
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var sfnAlias = new Alias(&#34;sfnAlias&#34;, AliasArgs.builder()        
- *             .name(&#34;my_sfn_alias&#34;)
  *             .routingConfigurations(AliasRoutingConfigurationArgs.builder()
  *                 .stateMachineVersionArn(aws_sfn_state_machine.sfn_test().state_machine_version_arn())
  *                 .weight(100)
@@ -52,7 +51,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var mySfnAlias = new Alias(&#34;mySfnAlias&#34;, AliasArgs.builder()        
- *             .name(&#34;my_sfn_alias&#34;)
  *             .routingConfigurations(            
  *                 AliasRoutingConfigurationArgs.builder()
  *                     .stateMachineVersionArn(&#34;arn:aws:states:us-east-1:12345:stateMachine:demo:3&#34;)

--- a/sdk/java/src/main/java/com/pulumi/aws/sfn/AliasArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/sfn/AliasArgs.java
@@ -36,15 +36,15 @@ public final class AliasArgs extends com.pulumi.resources.ResourceArgs {
      * Name for the alias you are creating.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
      * @return Name for the alias you are creating.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -115,7 +115,7 @@ public final class AliasArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
@@ -162,7 +162,6 @@ public final class AliasArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public AliasArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.routingConfigurations = Objects.requireNonNull($.routingConfigurations, "expected parameter 'routingConfigurations' to be non-null");
             return $;
         }

--- a/sdk/nodejs/appintegrations/dataIntegration.ts
+++ b/sdk/nodejs/appintegrations/dataIntegration.ts
@@ -17,7 +17,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.appintegrations.DataIntegration("example", {
- *     name: "example",
  *     description: "example",
  *     kmsKey: aws_kms_key.test.arn,
  *     sourceUri: "Salesforce://AppFlow/example",
@@ -127,9 +126,6 @@ export class DataIntegration extends pulumi.CustomResource {
             if ((!args || args.kmsKey === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'kmsKey'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.scheduleConfig === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'scheduleConfig'");
             }
@@ -203,7 +199,7 @@ export interface DataIntegrationArgs {
     /**
      * Specifies the name of the Data Integration.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
      */

--- a/sdk/nodejs/auditmanager/assessment.ts
+++ b/sdk/nodejs/auditmanager/assessment.ts
@@ -18,7 +18,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const test = new aws.auditmanager.Assessment("test", {
- *     name: "example",
  *     assessmentReportsDestination: {
  *         destination: `s3://${aws_s3_bucket.test.id}`,
  *         destinationType: "S3",
@@ -148,9 +147,6 @@ export class Assessment extends pulumi.CustomResource {
             if ((!args || args.frameworkId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'frameworkId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.roles === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'roles'");
             }
@@ -239,7 +235,7 @@ export interface AssessmentArgs {
     /**
      * Name of the assessment.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * List of roles for the assessment. See `roles` below.
      */

--- a/sdk/nodejs/auditmanager/assessmentReport.ts
+++ b/sdk/nodejs/auditmanager/assessmentReport.ts
@@ -14,10 +14,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const test = new aws.auditmanager.AssessmentReport("test", {
- *     name: "example",
- *     assessmentId: aws_auditmanager_assessment.test.id,
- * });
+ * const test = new aws.auditmanager.AssessmentReport("test", {assessmentId: aws_auditmanager_assessment.test.id});
  * ```
  *
  * ## Import
@@ -102,9 +99,6 @@ export class AssessmentReport extends pulumi.CustomResource {
             if ((!args || args.assessmentId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'assessmentId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["assessmentId"] = args ? args.assessmentId : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
@@ -161,5 +155,5 @@ export interface AssessmentReportArgs {
     /**
      * Name of the assessment report.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/auditmanager/control.ts
+++ b/sdk/nodejs/auditmanager/control.ts
@@ -17,14 +17,11 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const example = new aws.auditmanager.Control("example", {
- *     controlMappingSources: [{
- *         sourceName: "example",
- *         sourceSetUpOption: "Procedural_Controls_Mapping",
- *         sourceType: "MANUAL",
- *     }],
- *     name: "example",
- * });
+ * const example = new aws.auditmanager.Control("example", {controlMappingSources: [{
+ *     sourceName: "example",
+ *     sourceSetUpOption: "Procedural_Controls_Mapping",
+ *     sourceType: "MANUAL",
+ * }]});
  * ```
  *
  * ## Import
@@ -111,7 +108,7 @@ export class Control extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ControlArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: ControlArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: ControlArgs | ControlState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -129,9 +126,6 @@ export class Control extends pulumi.CustomResource {
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ControlArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["actionPlanInstructions"] = args ? args.actionPlanInstructions : undefined;
             resourceInputs["actionPlanTitle"] = args ? args.actionPlanTitle : undefined;
             resourceInputs["controlMappingSources"] = args ? args.controlMappingSources : undefined;
@@ -219,7 +213,7 @@ export interface ControlArgs {
     /**
      * Name of the control.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A map of tags to assign to the control. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/auditmanager/framework.ts
+++ b/sdk/nodejs/auditmanager/framework.ts
@@ -17,15 +17,12 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const test = new aws.auditmanager.Framework("test", {
+ * const test = new aws.auditmanager.Framework("test", {controlSets: [{
  *     name: "example",
- *     controlSets: [{
- *         name: "example",
- *         controls: [{
- *             id: aws_auditmanager_control.test.id,
- *         }],
+ *     controls: [{
+ *         id: aws_auditmanager_control.test.id,
  *     }],
- * });
+ * }]});
  * ```
  *
  * ## Import
@@ -104,7 +101,7 @@ export class Framework extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: FrameworkArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: FrameworkArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: FrameworkArgs | FrameworkState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -120,9 +117,6 @@ export class Framework extends pulumi.CustomResource {
             resourceInputs["tagsAll"] = state ? state.tagsAll : undefined;
         } else {
             const args = argsOrState as FrameworkArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["complianceType"] = args ? args.complianceType : undefined;
             resourceInputs["controlSets"] = args ? args.controlSets : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
@@ -196,7 +190,7 @@ export interface FrameworkArgs {
     /**
      * Name of the framework.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A map of tags to assign to the framework. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/auditmanager/getControl.ts
+++ b/sdk/nodejs/auditmanager/getControl.ts
@@ -36,23 +36,20 @@ import * as utilities from "../utilities";
  *     name: "2. Personnel",
  *     type: "Standard",
  * });
- * const exampleFramework = new aws.auditmanager.Framework("exampleFramework", {
- *     name: "example",
- *     controlSets: [
- *         {
- *             name: "example",
- *             controls: [{
- *                 id: exampleControl.then(exampleControl => exampleControl.id),
- *             }],
- *         },
- *         {
- *             name: "example2",
- *             controls: [{
- *                 id: example2.then(example2 => example2.id),
- *             }],
- *         },
- *     ],
- * });
+ * const exampleFramework = new aws.auditmanager.Framework("exampleFramework", {controlSets: [
+ *     {
+ *         name: "example",
+ *         controls: [{
+ *             id: exampleControl.then(exampleControl => exampleControl.id),
+ *         }],
+ *     },
+ *     {
+ *         name: "example2",
+ *         controls: [{
+ *             id: example2.then(example2 => example2.id),
+ *         }],
+ *     },
+ * ]});
  * ```
  */
 export function getControl(args: GetControlArgs, opts?: pulumi.InvokeOptions): Promise<GetControlResult> {
@@ -124,23 +121,20 @@ export interface GetControlResult {
  *     name: "2. Personnel",
  *     type: "Standard",
  * });
- * const exampleFramework = new aws.auditmanager.Framework("exampleFramework", {
- *     name: "example",
- *     controlSets: [
- *         {
- *             name: "example",
- *             controls: [{
- *                 id: exampleControl.then(exampleControl => exampleControl.id),
- *             }],
- *         },
- *         {
- *             name: "example2",
- *             controls: [{
- *                 id: example2.then(example2 => example2.id),
- *             }],
- *         },
- *     ],
- * });
+ * const exampleFramework = new aws.auditmanager.Framework("exampleFramework", {controlSets: [
+ *     {
+ *         name: "example",
+ *         controls: [{
+ *             id: exampleControl.then(exampleControl => exampleControl.id),
+ *         }],
+ *     },
+ *     {
+ *         name: "example2",
+ *         controls: [{
+ *             id: example2.then(example2 => example2.id),
+ *         }],
+ *     },
+ * ]});
  * ```
  */
 export function getControlOutput(args: GetControlOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetControlResult> {

--- a/sdk/nodejs/chime/sdkvoiceSipMediaApplication.ts
+++ b/sdk/nodejs/chime/sdkvoiceSipMediaApplication.ts
@@ -19,7 +19,6 @@ import * as utilities from "../utilities";
  *
  * const example = new aws.chime.SdkvoiceSipMediaApplication("example", {
  *     awsRegion: "us-east-1",
- *     name: "example-sip-media-application",
  *     endpoints: {
  *         lambdaArn: aws_lambda_function.test.arn,
  *     },
@@ -116,9 +115,6 @@ export class SdkvoiceSipMediaApplication extends pulumi.CustomResource {
             if ((!args || args.endpoints === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'endpoints'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["awsRegion"] = args ? args.awsRegion : undefined;
             resourceInputs["endpoints"] = args ? args.endpoints : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
@@ -180,7 +176,7 @@ export interface SdkvoiceSipMediaApplicationArgs {
      *
      * The following arguments are optional:
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/chime/sdkvoiceSipRule.ts
+++ b/sdk/nodejs/chime/sdkvoiceSipRule.ts
@@ -18,7 +18,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.chime.SdkvoiceSipRule("example", {
- *     name: "example-sip-rule",
  *     triggerType: "RequestUriHostname",
  *     triggerValue: aws_chime_voice_connector["example-voice-connector"].outbound_host_name,
  *     targetApplications: [{
@@ -108,9 +107,6 @@ export class SdkvoiceSipRule extends pulumi.CustomResource {
             resourceInputs["triggerValue"] = state ? state.triggerValue : undefined;
         } else {
             const args = argsOrState as SdkvoiceSipRuleArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.targetApplications === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'targetApplications'");
             }
@@ -170,7 +166,7 @@ export interface SdkvoiceSipRuleArgs {
     /**
      * The name of the SIP rule.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used. See `targetApplications`.
      */

--- a/sdk/nodejs/chime/sdkvoiceVoiceProfileDomain.ts
+++ b/sdk/nodejs/chime/sdkvoiceVoiceProfileDomain.ts
@@ -22,7 +22,6 @@ import * as utilities from "../utilities";
  *     deletionWindowInDays: 7,
  * });
  * const exampleSdkvoiceVoiceProfileDomain = new aws.chime.SdkvoiceVoiceProfileDomain("exampleSdkvoiceVoiceProfileDomain", {
- *     name: "ExampleVoiceProfileDomain",
  *     serverSideEncryptionConfiguration: {
  *         kmsKeyArn: exampleKey.arn,
  *     },
@@ -109,9 +108,6 @@ export class SdkvoiceVoiceProfileDomain extends pulumi.CustomResource {
             resourceInputs["tagsAll"] = state ? state.tagsAll : undefined;
         } else {
             const args = argsOrState as SdkvoiceVoiceProfileDomainArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.serverSideEncryptionConfiguration === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'serverSideEncryptionConfiguration'");
             }
@@ -162,7 +158,7 @@ export interface SdkvoiceVoiceProfileDomainArgs {
     /**
      * Name of Voice Profile Domain.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Configuration for server side encryption.
      */

--- a/sdk/nodejs/cleanrooms/collaboration.ts
+++ b/sdk/nodejs/cleanrooms/collaboration.ts
@@ -36,7 +36,6 @@ import * as utilities from "../utilities";
  *         displayName: "Other member",
  *         memberAbilities: [],
  *     }],
- *     name: "pulumi-example-collaboration",
  *     queryLogStatus: "DISABLED",
  *     tags: {
  *         Project: "Pulumi",
@@ -170,9 +169,6 @@ export class Collaboration extends pulumi.CustomResource {
             if ((!args || args.description === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'description'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.queryLogStatus === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'queryLogStatus'");
             }
@@ -303,7 +299,7 @@ export interface CollaborationArgs {
     /**
      * The name of the collaboration.  Collaboration names do not need to be unique.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Determines if members of the collaboration can enable query logs within their own
      * emberships. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-Cr

--- a/sdk/nodejs/cloudfront/fieldLevelEncryptionProfile.ts
+++ b/sdk/nodejs/cloudfront/fieldLevelEncryptionProfile.ts
@@ -20,7 +20,6 @@ import * as utilities from "../utilities";
  * const example = new aws.cloudfront.PublicKey("example", {
  *     comment: "test public key",
  *     encodedKey: fs.readFileSync("public_key.pem"),
- *     name: "test_key",
  * });
  * const test = new aws.cloudfront.FieldLevelEncryptionProfile("test", {
  *     comment: "test comment",

--- a/sdk/nodejs/cloudfront/keyGroup.ts
+++ b/sdk/nodejs/cloudfront/keyGroup.ts
@@ -17,7 +17,6 @@ import * as utilities from "../utilities";
  * const examplePublicKey = new aws.cloudfront.PublicKey("examplePublicKey", {
  *     comment: "example public key",
  *     encodedKey: fs.readFileSync("public_key.pem"),
- *     name: "example-key",
  * });
  * const exampleKeyGroup = new aws.cloudfront.KeyGroup("exampleKeyGroup", {
  *     comment: "example key group",

--- a/sdk/nodejs/cloudfront/publicKey.ts
+++ b/sdk/nodejs/cloudfront/publicKey.ts
@@ -17,7 +17,6 @@ import * as utilities from "../utilities";
  * const example = new aws.cloudfront.PublicKey("example", {
  *     comment: "test public key",
  *     encodedKey: fs.readFileSync("public_key.pem"),
- *     name: "test_key",
  * });
  * ```
  *

--- a/sdk/nodejs/emrcontainers/jobTemplate.ts
+++ b/sdk/nodejs/emrcontainers/jobTemplate.ts
@@ -17,18 +17,15 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const example = new aws.emrcontainers.JobTemplate("example", {
- *     jobTemplateData: {
- *         executionRoleArn: aws_iam_role.example.arn,
- *         releaseLabel: "emr-6.10.0-latest",
- *         jobDriver: {
- *             sparkSqlJobDriver: {
- *                 entryPoint: "default",
- *             },
+ * const example = new aws.emrcontainers.JobTemplate("example", {jobTemplateData: {
+ *     executionRoleArn: aws_iam_role.example.arn,
+ *     releaseLabel: "emr-6.10.0-latest",
+ *     jobDriver: {
+ *         sparkSqlJobDriver: {
+ *             entryPoint: "default",
  *         },
  *     },
- *     name: "example",
- * });
+ * }});
  * ```
  *
  * ## Import
@@ -116,9 +113,6 @@ export class JobTemplate extends pulumi.CustomResource {
             if ((!args || args.jobTemplateData === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'jobTemplateData'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["jobTemplateData"] = args ? args.jobTemplateData : undefined;
             resourceInputs["kmsKeyArn"] = args ? args.kmsKeyArn : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
@@ -176,7 +170,7 @@ export interface JobTemplateArgs {
     /**
      * The specified name of the job template.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/finspace/kxCluster.ts
+++ b/sdk/nodejs/finspace/kxCluster.ts
@@ -194,9 +194,6 @@ export class KxCluster extends pulumi.CustomResource {
             if ((!args || args.environmentId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'environmentId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.releaseLabel === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'releaseLabel'");
             }
@@ -396,7 +393,7 @@ export interface KxClusterArgs {
     /**
      * Unique name for the cluster that you want to create.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Version of FinSpace Managed kdb to run.
      */

--- a/sdk/nodejs/finspace/kxDatabase.ts
+++ b/sdk/nodejs/finspace/kxDatabase.ts
@@ -18,13 +18,9 @@ import * as utilities from "../utilities";
  *     description: "Example KMS Key",
  *     deletionWindowInDays: 7,
  * });
- * const exampleKxEnvironment = new aws.finspace.KxEnvironment("exampleKxEnvironment", {
- *     name: "my-tf-kx-environment",
- *     kmsKeyId: exampleKey.arn,
- * });
+ * const exampleKxEnvironment = new aws.finspace.KxEnvironment("exampleKxEnvironment", {kmsKeyId: exampleKey.arn});
  * const exampleKxDatabase = new aws.finspace.KxDatabase("exampleKxDatabase", {
  *     environmentId: exampleKxEnvironment.id,
- *     name: "my-tf-kx-database",
  *     description: "Example database description",
  * });
  * ```
@@ -126,9 +122,6 @@ export class KxDatabase extends pulumi.CustomResource {
             if ((!args || args.environmentId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'environmentId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["environmentId"] = args ? args.environmentId : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
@@ -200,7 +193,7 @@ export interface KxDatabaseArgs {
      *
      * The following arguments are optional:
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/finspace/kxEnvironment.ts
+++ b/sdk/nodejs/finspace/kxEnvironment.ts
@@ -21,10 +21,7 @@ import * as utilities from "../utilities";
  *     description: "Sample KMS Key",
  *     deletionWindowInDays: 7,
  * });
- * const exampleKxEnvironment = new aws.finspace.KxEnvironment("exampleKxEnvironment", {
- *     name: "my-tf-kx-environment",
- *     kmsKeyId: exampleKey.arn,
- * });
+ * const exampleKxEnvironment = new aws.finspace.KxEnvironment("exampleKxEnvironment", {kmsKeyId: exampleKey.arn});
  * ```
  * ### With Network Setup
  *
@@ -38,7 +35,6 @@ import * as utilities from "../utilities";
  * });
  * const exampleTransitGateway = new aws.ec2transitgateway.TransitGateway("exampleTransitGateway", {description: "example"});
  * const exampleEnv = new aws.finspace.KxEnvironment("exampleEnv", {
- *     name: "my-tf-kx-environment",
  *     description: "Environment description",
  *     kmsKeyId: exampleKey.arn,
  *     transitGatewayConfiguration: {
@@ -174,9 +170,6 @@ export class KxEnvironment extends pulumi.CustomResource {
             if ((!args || args.kmsKeyId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'kmsKeyId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["customDnsConfigurations"] = args ? args.customDnsConfigurations : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["kmsKeyId"] = args ? args.kmsKeyId : undefined;
@@ -277,7 +270,7 @@ export interface KxEnvironmentArgs {
     /**
      * Name of the KX environment that you want to create.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/finspace/kxUser.ts
+++ b/sdk/nodejs/finspace/kxUser.ts
@@ -18,10 +18,7 @@ import * as utilities from "../utilities";
  *     description: "Example KMS Key",
  *     deletionWindowInDays: 7,
  * });
- * const exampleKxEnvironment = new aws.finspace.KxEnvironment("exampleKxEnvironment", {
- *     name: "my-tf-kx-environment",
- *     kmsKeyId: exampleKey.arn,
- * });
+ * const exampleKxEnvironment = new aws.finspace.KxEnvironment("exampleKxEnvironment", {kmsKeyId: exampleKey.arn});
  * const exampleRole = new aws.iam.Role("exampleRole", {assumeRolePolicy: JSON.stringify({
  *     Version: "2012-10-17",
  *     Statement: [{
@@ -34,7 +31,6 @@ import * as utilities from "../utilities";
  *     }],
  * })});
  * const exampleKxUser = new aws.finspace.KxUser("exampleKxUser", {
- *     name: "my-tf-kx-user",
  *     environmentId: exampleKxEnvironment.id,
  *     iamRole: exampleRole.arn,
  * });
@@ -130,9 +126,6 @@ export class KxUser extends pulumi.CustomResource {
             if ((!args || args.iamRole === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'iamRole'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["environmentId"] = args ? args.environmentId : undefined;
             resourceInputs["iamRole"] = args ? args.iamRole : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
@@ -194,7 +187,7 @@ export interface KxUserArgs {
     /**
      * A unique identifier for the user.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Key-value mapping of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/globalaccelerator/customRoutingAccelerator.ts
+++ b/sdk/nodejs/globalaccelerator/customRoutingAccelerator.ts
@@ -25,7 +25,6 @@ import * as utilities from "../utilities";
  *     enabled: true,
  *     ipAddressType: "IPV4",
  *     ipAddresses: ["1.2.3.4"],
- *     name: "Example",
  * });
  * ```
  *
@@ -115,7 +114,7 @@ export class CustomRoutingAccelerator extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: CustomRoutingAcceleratorArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: CustomRoutingAcceleratorArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: CustomRoutingAcceleratorArgs | CustomRoutingAcceleratorState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -133,9 +132,6 @@ export class CustomRoutingAccelerator extends pulumi.CustomResource {
             resourceInputs["tagsAll"] = state ? state.tagsAll : undefined;
         } else {
             const args = argsOrState as CustomRoutingAcceleratorArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["attributes"] = args ? args.attributes : undefined;
             resourceInputs["enabled"] = args ? args.enabled : undefined;
             resourceInputs["ipAddressType"] = args ? args.ipAddressType : undefined;
@@ -223,7 +219,7 @@ export interface CustomRoutingAcceleratorArgs {
     /**
      * The name of a custom routing accelerator.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/globalaccelerator/customRoutingListener.ts
+++ b/sdk/nodejs/globalaccelerator/customRoutingListener.ts
@@ -17,7 +17,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const exampleCustomRoutingAccelerator = new aws.globalaccelerator.CustomRoutingAccelerator("exampleCustomRoutingAccelerator", {
- *     name: "Example",
  *     ipAddressType: "IPV4",
  *     enabled: true,
  *     attributes: {

--- a/sdk/nodejs/glue/dataQualityRuleset.ts
+++ b/sdk/nodejs/glue/dataQualityRuleset.ts
@@ -17,10 +17,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const example = new aws.glue.DataQualityRuleset("example", {
- *     name: "example",
- *     ruleset: "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
- * });
+ * const example = new aws.glue.DataQualityRuleset("example", {ruleset: "Rules = [Completeness \"colA\" between 0.4 and 0.8]"});
  * ```
  * ### With description
  *
@@ -30,7 +27,6 @@ import * as utilities from "../utilities";
  *
  * const example = new aws.glue.DataQualityRuleset("example", {
  *     description: "example",
- *     name: "example",
  *     ruleset: "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
  * });
  * ```
@@ -41,7 +37,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.glue.DataQualityRuleset("example", {
- *     name: "example",
  *     ruleset: "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
  *     tags: {
  *         hello: "world",
@@ -55,7 +50,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.glue.DataQualityRuleset("example", {
- *     name: "example",
  *     ruleset: "Rules = [Completeness \"colA\" between 0.4 and 0.8]",
  *     targetTable: {
  *         databaseName: aws_glue_catalog_database.example.name,
@@ -166,9 +160,6 @@ export class DataQualityRuleset extends pulumi.CustomResource {
             resourceInputs["targetTable"] = state ? state.targetTable : undefined;
         } else {
             const args = argsOrState as DataQualityRulesetArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.ruleset === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'ruleset'");
             }
@@ -245,7 +236,7 @@ export interface DataQualityRulesetArgs {
     /**
      * Name of the data quality ruleset.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A Data Quality Definition Language (DQDL) ruleset. For more information, see the AWS Glue developer guide.
      */

--- a/sdk/nodejs/opensearch/serverlessAccessPolicy.ts
+++ b/sdk/nodejs/opensearch/serverlessAccessPolicy.ts
@@ -17,7 +17,6 @@ import * as utilities from "../utilities";
  * const currentCallerIdentity = aws.getCallerIdentity({});
  * const currentPartition = aws.getPartition({});
  * const test = new aws.opensearch.ServerlessAccessPolicy("test", {
- *     name: "example",
  *     type: "data",
  *     policy: Promise.all([currentPartition, currentCallerIdentity]).then(([currentPartition, currentCallerIdentity]) => JSON.stringify([{
  *         Rules: [{
@@ -115,9 +114,6 @@ export class ServerlessAccessPolicy extends pulumi.CustomResource {
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ServerlessAccessPolicyArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.policy === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policy'");
             }
@@ -174,7 +170,7 @@ export interface ServerlessAccessPolicyArgs {
     /**
      * Name of the policy.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * JSON policy document to use as the content for the new policy
      */

--- a/sdk/nodejs/opensearch/serverlessCollection.ts
+++ b/sdk/nodejs/opensearch/serverlessCollection.ts
@@ -18,7 +18,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const exampleServerlessSecurityPolicy = new aws.opensearch.ServerlessSecurityPolicy("exampleServerlessSecurityPolicy", {
- *     name: "example",
  *     type: "encryption",
  *     policy: JSON.stringify({
  *         Rules: [{
@@ -28,7 +27,7 @@ import * as utilities from "../utilities";
  *         AWSOwnedKey: true,
  *     }),
  * });
- * const exampleServerlessCollection = new aws.opensearch.ServerlessCollection("exampleServerlessCollection", {name: "example"}, {
+ * const exampleServerlessCollection = new aws.opensearch.ServerlessCollection("exampleServerlessCollection", {}, {
  *     dependsOn: [exampleServerlessSecurityPolicy],
  * });
  * ```
@@ -110,7 +109,7 @@ export class ServerlessCollection extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ServerlessCollectionArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: ServerlessCollectionArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: ServerlessCollectionArgs | ServerlessCollectionState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -128,9 +127,6 @@ export class ServerlessCollection extends pulumi.CustomResource {
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ServerlessCollectionArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
@@ -199,7 +195,7 @@ export interface ServerlessCollectionArgs {
      *
      * The following arguments are optional:
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A map of tags to assign to the collection. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/opensearch/serverlessSecurityConfig.ts
+++ b/sdk/nodejs/opensearch/serverlessSecurityConfig.ts
@@ -91,9 +91,6 @@ export class ServerlessSecurityConfig extends pulumi.CustomResource {
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ServerlessSecurityConfigArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.type === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'type'");
             }
@@ -147,7 +144,7 @@ export interface ServerlessSecurityConfigArgs {
     /**
      * Name of the policy.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Configuration block for SAML options.
      */

--- a/sdk/nodejs/opensearch/serverlessSecurityPolicy.ts
+++ b/sdk/nodejs/opensearch/serverlessSecurityPolicy.ts
@@ -17,7 +17,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessSecurityPolicy("example", {
- *     name: "example",
  *     type: "encryption",
  *     description: "encryption security policy for example-collection",
  *     policy: JSON.stringify({
@@ -36,7 +35,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessSecurityPolicy("example", {
- *     name: "example",
  *     type: "encryption",
  *     description: "encryption security policy for collections that begin with \"example\"",
  *     policy: JSON.stringify({
@@ -55,7 +53,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessSecurityPolicy("example", {
- *     name: "example",
  *     type: "encryption",
  *     description: "encryption security policy using customer KMS key",
  *     policy: JSON.stringify({
@@ -76,7 +73,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessSecurityPolicy("example", {
- *     name: "example",
  *     type: "network",
  *     description: "Public access",
  *     policy: JSON.stringify([{
@@ -102,7 +98,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessSecurityPolicy("example", {
- *     name: "example",
  *     type: "network",
  *     description: "VPC access",
  *     policy: JSON.stringify([{
@@ -129,7 +124,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessSecurityPolicy("example", {
- *     name: "example",
  *     type: "network",
  *     description: "Mixed access for marketing and sales",
  *     policy: JSON.stringify([
@@ -239,9 +233,6 @@ export class ServerlessSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as ServerlessSecurityPolicyArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.policy === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policy'");
             }
@@ -298,7 +289,7 @@ export interface ServerlessSecurityPolicyArgs {
     /**
      * Name of the policy.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * JSON policy document to use as the content for the new policy
      */

--- a/sdk/nodejs/opensearch/serverlessVpcEndpoint.ts
+++ b/sdk/nodejs/opensearch/serverlessVpcEndpoint.ts
@@ -18,7 +18,6 @@ import * as utilities from "../utilities";
  * import * as aws from "@pulumi/aws";
  *
  * const example = new aws.opensearch.ServerlessVpcEndpoint("example", {
- *     name: "myendpoint",
  *     subnetIds: [aws_subnet.example.id],
  *     vpcId: aws_vpc.example.id,
  * });
@@ -100,9 +99,6 @@ export class ServerlessVpcEndpoint extends pulumi.CustomResource {
             resourceInputs["vpcId"] = state ? state.vpcId : undefined;
         } else {
             const args = argsOrState as ServerlessVpcEndpointArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.subnetIds === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'subnetIds'");
             }
@@ -152,7 +148,7 @@ export interface ServerlessVpcEndpointArgs {
     /**
      * Name of the interface endpoint.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * One or more security groups that define the ports, protocols, and sources for inbound traffic that you are authorizing into your endpoint. Up to 5 security groups can be provided.
      */

--- a/sdk/nodejs/quicksight/theme.ts
+++ b/sdk/nodejs/quicksight/theme.ts
@@ -139,9 +139,6 @@ export class Theme extends pulumi.CustomResource {
             if ((!args || args.baseThemeId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'baseThemeId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.themeId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'themeId'");
             }
@@ -250,7 +247,7 @@ export interface ThemeArgs {
     /**
      * Display name of the theme.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * A set of resource permissions on the theme. Maximum of 64 items. See permissions.
      */

--- a/sdk/nodejs/quicksight/vpcConnection.ts
+++ b/sdk/nodejs/quicksight/vpcConnection.ts
@@ -48,7 +48,6 @@ import * as utilities from "../utilities";
  * });
  * const example = new aws.quicksight.VpcConnection("example", {
  *     vpcConnectionId: "example-connection-id",
- *     name: "Example Connection",
  *     roleArn: vpcConnectionRole.arn,
  *     securityGroupIds: ["sg-00000000000000000"],
  *     subnetIds: [
@@ -169,9 +168,6 @@ export class VpcConnection extends pulumi.CustomResource {
             resourceInputs["vpcConnectionId"] = state ? state.vpcConnectionId : undefined;
         } else {
             const args = argsOrState as VpcConnectionArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.roleArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'roleArn'");
             }
@@ -270,7 +266,7 @@ export interface VpcConnectionArgs {
     /**
      * The display name for the VPC connection.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * The IAM role to associate with the VPC connection.
      */

--- a/sdk/nodejs/resourceexplorer/view.ts
+++ b/sdk/nodejs/resourceexplorer/view.ts
@@ -18,7 +18,6 @@ import * as utilities from "../utilities";
  *
  * const exampleIndex = new aws.resourceexplorer.Index("exampleIndex", {type: "LOCAL"});
  * const exampleView = new aws.resourceexplorer.View("exampleView", {
- *     name: "exampleview",
  *     filters: {
  *         filterString: "resourcetype:ec2:instance",
  *     },
@@ -102,7 +101,7 @@ export class View extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ViewArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: ViewArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: ViewArgs | ViewState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -117,9 +116,6 @@ export class View extends pulumi.CustomResource {
             resourceInputs["tagsAll"] = state ? state.tagsAll : undefined;
         } else {
             const args = argsOrState as ViewArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["defaultView"] = args ? args.defaultView : undefined;
             resourceInputs["filters"] = args ? args.filters : undefined;
             resourceInputs["includedProperties"] = args ? args.includedProperties : undefined;
@@ -186,7 +182,7 @@ export interface ViewArgs {
     /**
      * The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * Key-value map of resource tags. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/route53/cidrCollection.ts
+++ b/sdk/nodejs/route53/cidrCollection.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const example = new aws.route53.CidrCollection("example", {name: "collection-1"});
+ * const example = new aws.route53.CidrCollection("example", {});
  * ```
  *
  * ## Import
@@ -72,7 +72,7 @@ export class CidrCollection extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: CidrCollectionArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: CidrCollectionArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: CidrCollectionArgs | CidrCollectionState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -83,9 +83,6 @@ export class CidrCollection extends pulumi.CustomResource {
             resourceInputs["version"] = state ? state.version : undefined;
         } else {
             const args = argsOrState as CidrCollectionArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["arn"] = undefined /*out*/;
             resourceInputs["version"] = undefined /*out*/;
@@ -120,5 +117,5 @@ export interface CidrCollectionArgs {
     /**
      * Unique name for the CIDR collection.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/route53/cidrLocation.ts
+++ b/sdk/nodejs/route53/cidrLocation.ts
@@ -13,10 +13,9 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const exampleCidrCollection = new aws.route53.CidrCollection("exampleCidrCollection", {name: "collection-1"});
+ * const exampleCidrCollection = new aws.route53.CidrCollection("exampleCidrCollection", {});
  * const exampleCidrLocation = new aws.route53.CidrLocation("exampleCidrLocation", {
  *     cidrCollectionId: exampleCidrCollection.id,
- *     name: "office",
  *     cidrBlocks: [
  *         "200.5.3.0/24",
  *         "200.6.3.0/24",
@@ -97,9 +96,6 @@ export class CidrLocation extends pulumi.CustomResource {
             if ((!args || args.cidrCollectionId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'cidrCollectionId'");
             }
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             resourceInputs["cidrBlocks"] = args ? args.cidrBlocks : undefined;
             resourceInputs["cidrCollectionId"] = args ? args.cidrCollectionId : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
@@ -142,5 +138,5 @@ export interface CidrLocationArgs {
     /**
      * Name for the CIDR location.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/sfn/alias.ts
+++ b/sdk/nodejs/sfn/alias.ts
@@ -17,26 +17,20 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const sfnAlias = new aws.sfn.Alias("sfnAlias", {
- *     name: "my_sfn_alias",
- *     routingConfigurations: [{
- *         stateMachineVersionArn: aws_sfn_state_machine.sfn_test.state_machine_version_arn,
- *         weight: 100,
- *     }],
- * });
- * const mySfnAlias = new aws.sfn.Alias("mySfnAlias", {
- *     name: "my_sfn_alias",
- *     routingConfigurations: [
- *         {
- *             stateMachineVersionArn: "arn:aws:states:us-east-1:12345:stateMachine:demo:3",
- *             weight: 50,
- *         },
- *         {
- *             stateMachineVersionArn: "arn:aws:states:us-east-1:12345:stateMachine:demo:2",
- *             weight: 50,
- *         },
- *     ],
- * });
+ * const sfnAlias = new aws.sfn.Alias("sfnAlias", {routingConfigurations: [{
+ *     stateMachineVersionArn: aws_sfn_state_machine.sfn_test.state_machine_version_arn,
+ *     weight: 100,
+ * }]});
+ * const mySfnAlias = new aws.sfn.Alias("mySfnAlias", {routingConfigurations: [
+ *     {
+ *         stateMachineVersionArn: "arn:aws:states:us-east-1:12345:stateMachine:demo:3",
+ *         weight: 50,
+ *     },
+ *     {
+ *         stateMachineVersionArn: "arn:aws:states:us-east-1:12345:stateMachine:demo:2",
+ *         weight: 50,
+ *     },
+ * ]});
  * ```
  *
  * ## Import
@@ -116,9 +110,6 @@ export class Alias extends pulumi.CustomResource {
             resourceInputs["routingConfigurations"] = state ? state.routingConfigurations : undefined;
         } else {
             const args = argsOrState as AliasArgs | undefined;
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.routingConfigurations === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'routingConfigurations'");
             }
@@ -170,7 +161,7 @@ export interface AliasArgs {
     /**
      * Name for the alias you are creating.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * The StateMachine alias' route configuration settings. Fields documented below
      */

--- a/sdk/python/pulumi_aws/appintegrations/data_integration.py
+++ b/sdk/python/pulumi_aws/appintegrations/data_integration.py
@@ -17,26 +17,27 @@ __all__ = ['DataIntegrationArgs', 'DataIntegration']
 class DataIntegrationArgs:
     def __init__(__self__, *,
                  kms_key: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  schedule_config: pulumi.Input['DataIntegrationScheduleConfigArgs'],
                  source_uri: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a DataIntegration resource.
         :param pulumi.Input[str] kms_key: Specifies the KMS key Amazon Resource Name (ARN) for the Data Integration.
-        :param pulumi.Input[str] name: Specifies the name of the Data Integration.
         :param pulumi.Input['DataIntegrationScheduleConfigArgs'] schedule_config: A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
         :param pulumi.Input[str] source_uri: Specifies the URI of the data source. Create an AppFlow Connector Profile and reference the name of the profile in the URL. An example of this value for Salesforce is `Salesforce://AppFlow/example` where `example` is the name of the AppFlow Connector Profile.
         :param pulumi.Input[str] description: Specifies the description of the Data Integration.
+        :param pulumi.Input[str] name: Specifies the name of the Data Integration.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Tags to apply to the Data Integration. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         pulumi.set(__self__, "kms_key", kms_key)
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "schedule_config", schedule_config)
         pulumi.set(__self__, "source_uri", source_uri)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -51,18 +52,6 @@ class DataIntegrationArgs:
     @kms_key.setter
     def kms_key(self, value: pulumi.Input[str]):
         pulumi.set(self, "kms_key", value)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Specifies the name of the Data Integration.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="scheduleConfig")
@@ -99,6 +88,18 @@ class DataIntegrationArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Specifies the name of the Data Integration.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -271,7 +272,6 @@ class DataIntegration(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.appintegrations.DataIntegration("example",
-            name="example",
             description="example",
             kms_key=aws_kms_key["test"]["arn"],
             source_uri="Salesforce://AppFlow/example",
@@ -318,7 +318,6 @@ class DataIntegration(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.appintegrations.DataIntegration("example",
-            name="example",
             description="example",
             kms_key=aws_kms_key["test"]["arn"],
             source_uri="Salesforce://AppFlow/example",
@@ -374,8 +373,6 @@ class DataIntegration(pulumi.CustomResource):
             if kms_key is None and not opts.urn:
                 raise TypeError("Missing required property 'kms_key'")
             __props__.__dict__["kms_key"] = kms_key
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if schedule_config is None and not opts.urn:
                 raise TypeError("Missing required property 'schedule_config'")

--- a/sdk/python/pulumi_aws/auditmanager/assessment.py
+++ b/sdk/python/pulumi_aws/auditmanager/assessment.py
@@ -17,31 +17,32 @@ __all__ = ['AssessmentArgs', 'Assessment']
 class AssessmentArgs:
     def __init__(__self__, *,
                  framework_id: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  roles: pulumi.Input[Sequence[pulumi.Input['AssessmentRoleArgs']]],
                  assessment_reports_destination: Optional[pulumi.Input['AssessmentAssessmentReportsDestinationArgs']] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  scope: Optional[pulumi.Input['AssessmentScopeArgs']] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Assessment resource.
         :param pulumi.Input[str] framework_id: Unique identifier of the framework the assessment will be created from.
-        :param pulumi.Input[str] name: Name of the assessment.
         :param pulumi.Input[Sequence[pulumi.Input['AssessmentRoleArgs']]] roles: List of roles for the assessment. See `roles` below.
         :param pulumi.Input['AssessmentAssessmentReportsDestinationArgs'] assessment_reports_destination: Assessment report storage destination configuration. See `assessment_reports_destination` below.
         :param pulumi.Input[str] description: Description of the assessment.
+        :param pulumi.Input[str] name: Name of the assessment.
         :param pulumi.Input['AssessmentScopeArgs'] scope: Amazon Web Services accounts and services that are in scope for the assessment. See `scope` below.
                
                The following arguments are optional:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the assessment. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         pulumi.set(__self__, "framework_id", framework_id)
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "roles", roles)
         if assessment_reports_destination is not None:
             pulumi.set(__self__, "assessment_reports_destination", assessment_reports_destination)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if scope is not None:
             pulumi.set(__self__, "scope", scope)
         if tags is not None:
@@ -58,18 +59,6 @@ class AssessmentArgs:
     @framework_id.setter
     def framework_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "framework_id", value)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the assessment.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -106,6 +95,18 @@ class AssessmentArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the assessment.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -342,7 +343,6 @@ class Assessment(pulumi.CustomResource):
         import pulumi_aws as aws
 
         test = aws.auditmanager.Assessment("test",
-            name="example",
             assessment_reports_destination=aws.auditmanager.AssessmentAssessmentReportsDestinationArgs(
                 destination=f"s3://{aws_s3_bucket['test']['id']}",
                 destination_type="S3",
@@ -399,7 +399,6 @@ class Assessment(pulumi.CustomResource):
         import pulumi_aws as aws
 
         test = aws.auditmanager.Assessment("test",
-            name="example",
             assessment_reports_destination=aws.auditmanager.AssessmentAssessmentReportsDestinationArgs(
                 destination=f"s3://{aws_s3_bucket['test']['id']}",
                 destination_type="S3",
@@ -463,8 +462,6 @@ class Assessment(pulumi.CustomResource):
             if framework_id is None and not opts.urn:
                 raise TypeError("Missing required property 'framework_id'")
             __props__.__dict__["framework_id"] = framework_id
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if roles is None and not opts.urn:
                 raise TypeError("Missing required property 'roles'")

--- a/sdk/python/pulumi_aws/auditmanager/assessment_report.py
+++ b/sdk/python/pulumi_aws/auditmanager/assessment_report.py
@@ -15,20 +15,21 @@ __all__ = ['AssessmentReportArgs', 'AssessmentReport']
 class AssessmentReportArgs:
     def __init__(__self__, *,
                  assessment_id: pulumi.Input[str],
-                 name: pulumi.Input[str],
-                 description: Optional[pulumi.Input[str]] = None):
+                 description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a AssessmentReport resource.
         :param pulumi.Input[str] assessment_id: Unique identifier of the assessment to create the report from.
                
                The following arguments are optional:
-        :param pulumi.Input[str] name: Name of the assessment report.
         :param pulumi.Input[str] description: Description of the assessment report.
+        :param pulumi.Input[str] name: Name of the assessment report.
         """
         pulumi.set(__self__, "assessment_id", assessment_id)
-        pulumi.set(__self__, "name", name)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter(name="assessmentId")
@@ -46,18 +47,6 @@ class AssessmentReportArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the assessment report.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
-
-    @property
-    @pulumi.getter
     def description(self) -> Optional[pulumi.Input[str]]:
         """
         Description of the assessment report.
@@ -67,6 +56,18 @@ class AssessmentReportArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the assessment report.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
@@ -180,9 +181,7 @@ class AssessmentReport(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        test = aws.auditmanager.AssessmentReport("test",
-            name="example",
-            assessment_id=aws_auditmanager_assessment["test"]["id"])
+        test = aws.auditmanager.AssessmentReport("test", assessment_id=aws_auditmanager_assessment["test"]["id"])
         ```
 
         ## Import
@@ -217,9 +216,7 @@ class AssessmentReport(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        test = aws.auditmanager.AssessmentReport("test",
-            name="example",
-            assessment_id=aws_auditmanager_assessment["test"]["id"])
+        test = aws.auditmanager.AssessmentReport("test", assessment_id=aws_auditmanager_assessment["test"]["id"])
         ```
 
         ## Import
@@ -261,8 +258,6 @@ class AssessmentReport(pulumi.CustomResource):
                 raise TypeError("Missing required property 'assessment_id'")
             __props__.__dict__["assessment_id"] = assessment_id
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["author"] = None
             __props__.__dict__["status"] = None

--- a/sdk/python/pulumi_aws/auditmanager/control.py
+++ b/sdk/python/pulumi_aws/auditmanager/control.py
@@ -16,26 +16,25 @@ __all__ = ['ControlArgs', 'Control']
 @pulumi.input_type
 class ControlArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  action_plan_instructions: Optional[pulumi.Input[str]] = None,
                  action_plan_title: Optional[pulumi.Input[str]] = None,
                  control_mapping_sources: Optional[pulumi.Input[Sequence[pulumi.Input['ControlControlMappingSourceArgs']]]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  testing_information: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Control resource.
-        :param pulumi.Input[str] name: Name of the control.
         :param pulumi.Input[str] action_plan_instructions: Recommended actions to carry out if the control isn't fulfilled.
         :param pulumi.Input[str] action_plan_title: Title of the action plan for remediating the control.
         :param pulumi.Input[Sequence[pulumi.Input['ControlControlMappingSourceArgs']]] control_mapping_sources: Data mapping sources. See `control_mapping_sources` below.
                
                The following arguments are optional:
         :param pulumi.Input[str] description: Description of the control.
+        :param pulumi.Input[str] name: Name of the control.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the control. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param pulumi.Input[str] testing_information: Steps to follow to determine if the control is satisfied.
         """
-        pulumi.set(__self__, "name", name)
         if action_plan_instructions is not None:
             pulumi.set(__self__, "action_plan_instructions", action_plan_instructions)
         if action_plan_title is not None:
@@ -44,22 +43,12 @@ class ControlArgs:
             pulumi.set(__self__, "control_mapping_sources", control_mapping_sources)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
         if testing_information is not None:
             pulumi.set(__self__, "testing_information", testing_information)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the control.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="actionPlanInstructions")
@@ -110,6 +99,18 @@ class ControlArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the control.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -329,13 +330,11 @@ class Control(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.auditmanager.Control("example",
-            control_mapping_sources=[aws.auditmanager.ControlControlMappingSourceArgs(
-                source_name="example",
-                source_set_up_option="Procedural_Controls_Mapping",
-                source_type="MANUAL",
-            )],
-            name="example")
+        example = aws.auditmanager.Control("example", control_mapping_sources=[aws.auditmanager.ControlControlMappingSourceArgs(
+            source_name="example",
+            source_set_up_option="Procedural_Controls_Mapping",
+            source_type="MANUAL",
+        )])
         ```
 
         ## Import
@@ -362,7 +361,7 @@ class Control(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: ControlArgs,
+                 args: Optional[ControlArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource for managing an AWS Audit Manager Control.
@@ -374,13 +373,11 @@ class Control(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.auditmanager.Control("example",
-            control_mapping_sources=[aws.auditmanager.ControlControlMappingSourceArgs(
-                source_name="example",
-                source_set_up_option="Procedural_Controls_Mapping",
-                source_type="MANUAL",
-            )],
-            name="example")
+        example = aws.auditmanager.Control("example", control_mapping_sources=[aws.auditmanager.ControlControlMappingSourceArgs(
+            source_name="example",
+            source_set_up_option="Procedural_Controls_Mapping",
+            source_type="MANUAL",
+        )])
         ```
 
         ## Import
@@ -426,8 +423,6 @@ class Control(pulumi.CustomResource):
             __props__.__dict__["action_plan_title"] = action_plan_title
             __props__.__dict__["control_mapping_sources"] = control_mapping_sources
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["testing_information"] = testing_information

--- a/sdk/python/pulumi_aws/auditmanager/framework.py
+++ b/sdk/python/pulumi_aws/auditmanager/framework.py
@@ -16,42 +16,31 @@ __all__ = ['FrameworkArgs', 'Framework']
 @pulumi.input_type
 class FrameworkArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  compliance_type: Optional[pulumi.Input[str]] = None,
                  control_sets: Optional[pulumi.Input[Sequence[pulumi.Input['FrameworkControlSetArgs']]]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Framework resource.
-        :param pulumi.Input[str] name: Name of the framework.
         :param pulumi.Input[str] compliance_type: Compliance type that the new custom framework supports, such as `CIS` or `HIPAA`.
         :param pulumi.Input[Sequence[pulumi.Input['FrameworkControlSetArgs']]] control_sets: Control sets that are associated with the framework. See `control_sets` below.
                
                The following arguments are optional:
         :param pulumi.Input[str] description: Description of the framework.
+        :param pulumi.Input[str] name: Name of the framework.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the framework. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
-        pulumi.set(__self__, "name", name)
         if compliance_type is not None:
             pulumi.set(__self__, "compliance_type", compliance_type)
         if control_sets is not None:
             pulumi.set(__self__, "control_sets", control_sets)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the framework.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="complianceType")
@@ -90,6 +79,18 @@ class FrameworkArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the framework.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -263,14 +264,12 @@ class Framework(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        test = aws.auditmanager.Framework("test",
+        test = aws.auditmanager.Framework("test", control_sets=[aws.auditmanager.FrameworkControlSetArgs(
             name="example",
-            control_sets=[aws.auditmanager.FrameworkControlSetArgs(
-                name="example",
-                controls=[aws.auditmanager.FrameworkControlSetControlArgs(
-                    id=aws_auditmanager_control["test"]["id"],
-                )],
-            )])
+            controls=[aws.auditmanager.FrameworkControlSetControlArgs(
+                id=aws_auditmanager_control["test"]["id"],
+            )],
+        )])
         ```
 
         ## Import
@@ -295,7 +294,7 @@ class Framework(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: FrameworkArgs,
+                 args: Optional[FrameworkArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource for managing an AWS Audit Manager Framework.
@@ -307,14 +306,12 @@ class Framework(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        test = aws.auditmanager.Framework("test",
+        test = aws.auditmanager.Framework("test", control_sets=[aws.auditmanager.FrameworkControlSetArgs(
             name="example",
-            control_sets=[aws.auditmanager.FrameworkControlSetArgs(
-                name="example",
-                controls=[aws.auditmanager.FrameworkControlSetControlArgs(
-                    id=aws_auditmanager_control["test"]["id"],
-                )],
-            )])
+            controls=[aws.auditmanager.FrameworkControlSetControlArgs(
+                id=aws_auditmanager_control["test"]["id"],
+            )],
+        )])
         ```
 
         ## Import
@@ -357,8 +354,6 @@ class Framework(pulumi.CustomResource):
             __props__.__dict__["compliance_type"] = compliance_type
             __props__.__dict__["control_sets"] = control_sets
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None

--- a/sdk/python/pulumi_aws/auditmanager/get_control.py
+++ b/sdk/python/pulumi_aws/auditmanager/get_control.py
@@ -151,22 +151,20 @@ def get_control(control_mapping_sources: Optional[Sequence[pulumi.InputType['Get
         type="Standard")
     example2 = aws.auditmanager.get_control(name="2. Personnel",
         type="Standard")
-    example_framework = aws.auditmanager.Framework("exampleFramework",
-        name="example",
-        control_sets=[
-            aws.auditmanager.FrameworkControlSetArgs(
-                name="example",
-                controls=[aws.auditmanager.FrameworkControlSetControlArgs(
-                    id=example_control.id,
-                )],
-            ),
-            aws.auditmanager.FrameworkControlSetArgs(
-                name="example2",
-                controls=[aws.auditmanager.FrameworkControlSetControlArgs(
-                    id=example2.id,
-                )],
-            ),
-        ])
+    example_framework = aws.auditmanager.Framework("exampleFramework", control_sets=[
+        aws.auditmanager.FrameworkControlSetArgs(
+            name="example",
+            controls=[aws.auditmanager.FrameworkControlSetControlArgs(
+                id=example_control.id,
+            )],
+        ),
+        aws.auditmanager.FrameworkControlSetArgs(
+            name="example2",
+            controls=[aws.auditmanager.FrameworkControlSetControlArgs(
+                id=example2.id,
+            )],
+        ),
+    ])
     ```
 
 
@@ -221,22 +219,20 @@ def get_control_output(control_mapping_sources: Optional[pulumi.Input[Optional[S
         type="Standard")
     example2 = aws.auditmanager.get_control(name="2. Personnel",
         type="Standard")
-    example_framework = aws.auditmanager.Framework("exampleFramework",
-        name="example",
-        control_sets=[
-            aws.auditmanager.FrameworkControlSetArgs(
-                name="example",
-                controls=[aws.auditmanager.FrameworkControlSetControlArgs(
-                    id=example_control.id,
-                )],
-            ),
-            aws.auditmanager.FrameworkControlSetArgs(
-                name="example2",
-                controls=[aws.auditmanager.FrameworkControlSetControlArgs(
-                    id=example2.id,
-                )],
-            ),
-        ])
+    example_framework = aws.auditmanager.Framework("exampleFramework", control_sets=[
+        aws.auditmanager.FrameworkControlSetArgs(
+            name="example",
+            controls=[aws.auditmanager.FrameworkControlSetControlArgs(
+                id=example_control.id,
+            )],
+        ),
+        aws.auditmanager.FrameworkControlSetArgs(
+            name="example2",
+            controls=[aws.auditmanager.FrameworkControlSetControlArgs(
+                id=example2.id,
+            )],
+        ),
+    ])
     ```
 
 

--- a/sdk/python/pulumi_aws/chime/sdkvoice_sip_media_application.py
+++ b/sdk/python/pulumi_aws/chime/sdkvoice_sip_media_application.py
@@ -18,7 +18,7 @@ class SdkvoiceSipMediaApplicationArgs:
     def __init__(__self__, *,
                  aws_region: pulumi.Input[str],
                  endpoints: pulumi.Input['SdkvoiceSipMediaApplicationEndpointsArgs'],
-                 name: pulumi.Input[str],
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a SdkvoiceSipMediaApplication resource.
@@ -31,7 +31,8 @@ class SdkvoiceSipMediaApplicationArgs:
         """
         pulumi.set(__self__, "aws_region", aws_region)
         pulumi.set(__self__, "endpoints", endpoints)
-        pulumi.set(__self__, "name", name)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -61,7 +62,7 @@ class SdkvoiceSipMediaApplicationArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
+    def name(self) -> Optional[pulumi.Input[str]]:
         """
         The name of the AWS Chime SDK Voice Sip Media Application.
 
@@ -70,7 +71,7 @@ class SdkvoiceSipMediaApplicationArgs:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: pulumi.Input[str]):
+    def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
     @property
@@ -216,7 +217,6 @@ class SdkvoiceSipMediaApplication(pulumi.CustomResource):
 
         example = aws.chime.SdkvoiceSipMediaApplication("example",
             aws_region="us-east-1",
-            name="example-sip-media-application",
             endpoints=aws.chime.SdkvoiceSipMediaApplicationEndpointsArgs(
                 lambda_arn=aws_lambda_function["test"]["arn"],
             ))
@@ -257,7 +257,6 @@ class SdkvoiceSipMediaApplication(pulumi.CustomResource):
 
         example = aws.chime.SdkvoiceSipMediaApplication("example",
             aws_region="us-east-1",
-            name="example-sip-media-application",
             endpoints=aws.chime.SdkvoiceSipMediaApplicationEndpointsArgs(
                 lambda_arn=aws_lambda_function["test"]["arn"],
             ))
@@ -305,8 +304,6 @@ class SdkvoiceSipMediaApplication(pulumi.CustomResource):
             if endpoints is None and not opts.urn:
                 raise TypeError("Missing required property 'endpoints'")
             __props__.__dict__["endpoints"] = endpoints
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None

--- a/sdk/python/pulumi_aws/chime/sdkvoice_sip_rule.py
+++ b/sdk/python/pulumi_aws/chime/sdkvoice_sip_rule.py
@@ -16,39 +16,28 @@ __all__ = ['SdkvoiceSipRuleArgs', 'SdkvoiceSipRule']
 @pulumi.input_type
 class SdkvoiceSipRuleArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  target_applications: pulumi.Input[Sequence[pulumi.Input['SdkvoiceSipRuleTargetApplicationArgs']]],
                  trigger_type: pulumi.Input[str],
                  trigger_value: pulumi.Input[str],
-                 disabled: Optional[pulumi.Input[bool]] = None):
+                 disabled: Optional[pulumi.Input[bool]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a SdkvoiceSipRule resource.
-        :param pulumi.Input[str] name: The name of the SIP rule.
         :param pulumi.Input[Sequence[pulumi.Input['SdkvoiceSipRuleTargetApplicationArgs']]] target_applications: List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used. See `target_applications`.
         :param pulumi.Input[str] trigger_type: The type of trigger assigned to the SIP rule in `trigger_value`. Valid values are `RequestUriHostname` or `ToPhoneNumber`.
         :param pulumi.Input[str] trigger_value: If `trigger_type` is `RequestUriHostname`, the value can be the outbound host name of an Amazon Chime Voice Connector. If `trigger_type` is `ToPhoneNumber`, the value can be a customer-owned phone number in the E164 format. The Sip Media Application specified in the Sip Rule is triggered if the request URI in an incoming SIP request matches the `RequestUriHostname`, or if the "To" header in the incoming SIP request matches the `ToPhoneNumber` value.
                
                The following arguments are optional:
         :param pulumi.Input[bool] disabled: Enables or disables a rule. You must disable rules before you can delete them.
+        :param pulumi.Input[str] name: The name of the SIP rule.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "target_applications", target_applications)
         pulumi.set(__self__, "trigger_type", trigger_type)
         pulumi.set(__self__, "trigger_value", trigger_value)
         if disabled is not None:
             pulumi.set(__self__, "disabled", disabled)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The name of the SIP rule.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter(name="targetApplications")
@@ -99,6 +88,18 @@ class SdkvoiceSipRuleArgs:
     @disabled.setter
     def disabled(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "disabled", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the SIP rule.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
@@ -215,7 +216,6 @@ class SdkvoiceSipRule(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.chime.SdkvoiceSipRule("example",
-            name="example-sip-rule",
             trigger_type="RequestUriHostname",
             trigger_value=aws_chime_voice_connector["example-voice-connector"]["outbound_host_name"],
             target_applications=[aws.chime.SdkvoiceSipRuleTargetApplicationArgs(
@@ -260,7 +260,6 @@ class SdkvoiceSipRule(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.chime.SdkvoiceSipRule("example",
-            name="example-sip-rule",
             trigger_type="RequestUriHostname",
             trigger_value=aws_chime_voice_connector["example-voice-connector"]["outbound_host_name"],
             target_applications=[aws.chime.SdkvoiceSipRuleTargetApplicationArgs(
@@ -308,8 +307,6 @@ class SdkvoiceSipRule(pulumi.CustomResource):
             __props__ = SdkvoiceSipRuleArgs.__new__(SdkvoiceSipRuleArgs)
 
             __props__.__dict__["disabled"] = disabled
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if target_applications is None and not opts.urn:
                 raise TypeError("Missing required property 'target_applications'")

--- a/sdk/python/pulumi_aws/chime/sdkvoice_voice_profile_domain.py
+++ b/sdk/python/pulumi_aws/chime/sdkvoice_voice_profile_domain.py
@@ -16,34 +16,23 @@ __all__ = ['SdkvoiceVoiceProfileDomainArgs', 'SdkvoiceVoiceProfileDomain']
 @pulumi.input_type
 class SdkvoiceVoiceProfileDomainArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  server_side_encryption_configuration: pulumi.Input['SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs'],
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a SdkvoiceVoiceProfileDomain resource.
-        :param pulumi.Input[str] name: Name of Voice Profile Domain.
         :param pulumi.Input['SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs'] server_side_encryption_configuration: Configuration for server side encryption.
         :param pulumi.Input[str] description: Description of Voice Profile Domain.
+        :param pulumi.Input[str] name: Name of Voice Profile Domain.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "server_side_encryption_configuration", server_side_encryption_configuration)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of Voice Profile Domain.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="serverSideEncryptionConfiguration")
@@ -68,6 +57,18 @@ class SdkvoiceVoiceProfileDomainArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of Voice Profile Domain.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -199,7 +200,6 @@ class SdkvoiceVoiceProfileDomain(pulumi.CustomResource):
             description="KMS Key for Voice Profile Domain",
             deletion_window_in_days=7)
         example_sdkvoice_voice_profile_domain = aws.chime.SdkvoiceVoiceProfileDomain("exampleSdkvoiceVoiceProfileDomain",
-            name="ExampleVoiceProfileDomain",
             server_side_encryption_configuration=aws.chime.SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs(
                 kms_key_arn=example_key.arn,
             ),
@@ -243,7 +243,6 @@ class SdkvoiceVoiceProfileDomain(pulumi.CustomResource):
             description="KMS Key for Voice Profile Domain",
             deletion_window_in_days=7)
         example_sdkvoice_voice_profile_domain = aws.chime.SdkvoiceVoiceProfileDomain("exampleSdkvoiceVoiceProfileDomain",
-            name="ExampleVoiceProfileDomain",
             server_side_encryption_configuration=aws.chime.SdkvoiceVoiceProfileDomainServerSideEncryptionConfigurationArgs(
                 kms_key_arn=example_key.arn,
             ),
@@ -290,8 +289,6 @@ class SdkvoiceVoiceProfileDomain(pulumi.CustomResource):
             __props__ = SdkvoiceVoiceProfileDomainArgs.__new__(SdkvoiceVoiceProfileDomainArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if server_side_encryption_configuration is None and not opts.urn:
                 raise TypeError("Missing required property 'server_side_encryption_configuration'")

--- a/sdk/python/pulumi_aws/cleanrooms/collaboration.py
+++ b/sdk/python/pulumi_aws/cleanrooms/collaboration.py
@@ -19,10 +19,10 @@ class CollaborationArgs:
                  creator_display_name: pulumi.Input[str],
                  creator_member_abilities: pulumi.Input[Sequence[pulumi.Input[str]]],
                  description: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  query_log_status: pulumi.Input[str],
                  data_encryption_metadata: Optional[pulumi.Input['CollaborationDataEncryptionMetadataArgs']] = None,
                  members: Optional[pulumi.Input[Sequence[pulumi.Input['CollaborationMemberArgs']]]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Collaboration resource.
@@ -31,7 +31,6 @@ class CollaborationArgs:
                lues [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-CreateCollaboration-re
                uest-creatorMemberAbilities)
         :param pulumi.Input[str] description: A description for a collaboration.
-        :param pulumi.Input[str] name: The name of the collaboration.  Collaboration names do not need to be unique.
         :param pulumi.Input[str] query_log_status: Determines if members of the collaboration can enable query logs within their own
                emberships. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-Cr
                ateCollaboration-request-queryLogStatus).
@@ -50,17 +49,19 @@ class CollaborationArgs:
                * `member.display_name` - (Required - Forces new resource) - The display name for the invited member
                * `member.member_abilities` - (Required - Forces new resource) - The list of abilities for the invited member. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-CreateCollaboration-request-creatorMemberAbiliti
                s
+        :param pulumi.Input[str] name: The name of the collaboration.  Collaboration names do not need to be unique.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key value pairs which tag the collaboration.
         """
         pulumi.set(__self__, "creator_display_name", creator_display_name)
         pulumi.set(__self__, "creator_member_abilities", creator_member_abilities)
         pulumi.set(__self__, "description", description)
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "query_log_status", query_log_status)
         if data_encryption_metadata is not None:
             pulumi.set(__self__, "data_encryption_metadata", data_encryption_metadata)
         if members is not None:
             pulumi.set(__self__, "members", members)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -101,18 +102,6 @@ class CollaborationArgs:
     @description.setter
     def description(self, value: pulumi.Input[str]):
         pulumi.set(self, "description", value)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The name of the collaboration.  Collaboration names do not need to be unique.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="queryLogStatus")
@@ -164,6 +153,18 @@ class CollaborationArgs:
     @members.setter
     def members(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CollaborationMemberArgs']]]]):
         pulumi.set(self, "members", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the collaboration.  Collaboration names do not need to be unique.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -451,7 +452,6 @@ class Collaboration(pulumi.CustomResource):
                 display_name="Other member",
                 member_abilities=[],
             )],
-            name="pulumi-example-collaboration",
             query_log_status="DISABLED",
             tags={
                 "Project": "Pulumi",
@@ -521,7 +521,6 @@ class Collaboration(pulumi.CustomResource):
                 display_name="Other member",
                 member_abilities=[],
             )],
-            name="pulumi-example-collaboration",
             query_log_status="DISABLED",
             tags={
                 "Project": "Pulumi",
@@ -571,8 +570,6 @@ class Collaboration(pulumi.CustomResource):
                 raise TypeError("Missing required property 'description'")
             __props__.__dict__["description"] = description
             __props__.__dict__["members"] = members
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if query_log_status is None and not opts.urn:
                 raise TypeError("Missing required property 'query_log_status'")

--- a/sdk/python/pulumi_aws/cloudfront/field_level_encryption_profile.py
+++ b/sdk/python/pulumi_aws/cloudfront/field_level_encryption_profile.py
@@ -176,8 +176,7 @@ class FieldLevelEncryptionProfile(pulumi.CustomResource):
 
         example = aws.cloudfront.PublicKey("example",
             comment="test public key",
-            encoded_key=(lambda path: open(path).read())("public_key.pem"),
-            name="test_key")
+            encoded_key=(lambda path: open(path).read())("public_key.pem"))
         test = aws.cloudfront.FieldLevelEncryptionProfile("test",
             comment="test comment",
             encryption_entities=aws.cloudfront.FieldLevelEncryptionProfileEncryptionEntitiesArgs(
@@ -222,8 +221,7 @@ class FieldLevelEncryptionProfile(pulumi.CustomResource):
 
         example = aws.cloudfront.PublicKey("example",
             comment="test public key",
-            encoded_key=(lambda path: open(path).read())("public_key.pem"),
-            name="test_key")
+            encoded_key=(lambda path: open(path).read())("public_key.pem"))
         test = aws.cloudfront.FieldLevelEncryptionProfile("test",
             comment="test comment",
             encryption_entities=aws.cloudfront.FieldLevelEncryptionProfileEncryptionEntitiesArgs(

--- a/sdk/python/pulumi_aws/cloudfront/key_group.py
+++ b/sdk/python/pulumi_aws/cloudfront/key_group.py
@@ -158,8 +158,7 @@ class KeyGroup(pulumi.CustomResource):
 
         example_public_key = aws.cloudfront.PublicKey("examplePublicKey",
             comment="example public key",
-            encoded_key=(lambda path: open(path).read())("public_key.pem"),
-            name="example-key")
+            encoded_key=(lambda path: open(path).read())("public_key.pem"))
         example_key_group = aws.cloudfront.KeyGroup("exampleKeyGroup",
             comment="example key group",
             items=[example_public_key.id])
@@ -196,8 +195,7 @@ class KeyGroup(pulumi.CustomResource):
 
         example_public_key = aws.cloudfront.PublicKey("examplePublicKey",
             comment="example public key",
-            encoded_key=(lambda path: open(path).read())("public_key.pem"),
-            name="example-key")
+            encoded_key=(lambda path: open(path).read())("public_key.pem"))
         example_key_group = aws.cloudfront.KeyGroup("exampleKeyGroup",
             comment="example key group",
             items=[example_public_key.id])

--- a/sdk/python/pulumi_aws/cloudfront/public_key.py
+++ b/sdk/python/pulumi_aws/cloudfront/public_key.py
@@ -215,8 +215,7 @@ class PublicKey(pulumi.CustomResource):
 
         example = aws.cloudfront.PublicKey("example",
             comment="test public key",
-            encoded_key=(lambda path: open(path).read())("public_key.pem"),
-            name="test_key")
+            encoded_key=(lambda path: open(path).read())("public_key.pem"))
         ```
 
         ## Import
@@ -253,8 +252,7 @@ class PublicKey(pulumi.CustomResource):
 
         example = aws.cloudfront.PublicKey("example",
             comment="test public key",
-            encoded_key=(lambda path: open(path).read())("public_key.pem"),
-            name="test_key")
+            encoded_key=(lambda path: open(path).read())("public_key.pem"))
         ```
 
         ## Import

--- a/sdk/python/pulumi_aws/emrcontainers/job_template.py
+++ b/sdk/python/pulumi_aws/emrcontainers/job_template.py
@@ -17,20 +17,21 @@ __all__ = ['JobTemplateArgs', 'JobTemplate']
 class JobTemplateArgs:
     def __init__(__self__, *,
                  job_template_data: pulumi.Input['JobTemplateJobTemplateDataArgs'],
-                 name: pulumi.Input[str],
                  kms_key_arn: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a JobTemplate resource.
         :param pulumi.Input['JobTemplateJobTemplateDataArgs'] job_template_data: The job template data which holds values of StartJobRun API request.
-        :param pulumi.Input[str] name: The specified name of the job template.
         :param pulumi.Input[str] kms_key_arn: The KMS key ARN used to encrypt the job template.
+        :param pulumi.Input[str] name: The specified name of the job template.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         pulumi.set(__self__, "job_template_data", job_template_data)
-        pulumi.set(__self__, "name", name)
         if kms_key_arn is not None:
             pulumi.set(__self__, "kms_key_arn", kms_key_arn)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -47,18 +48,6 @@ class JobTemplateArgs:
         pulumi.set(self, "job_template_data", value)
 
     @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The specified name of the job template.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
-
-    @property
     @pulumi.getter(name="kmsKeyArn")
     def kms_key_arn(self) -> Optional[pulumi.Input[str]]:
         """
@@ -69,6 +58,18 @@ class JobTemplateArgs:
     @kms_key_arn.setter
     def kms_key_arn(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "kms_key_arn", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The specified name of the job template.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -207,17 +208,15 @@ class JobTemplate(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.emrcontainers.JobTemplate("example",
-            job_template_data=aws.emrcontainers.JobTemplateJobTemplateDataArgs(
-                execution_role_arn=aws_iam_role["example"]["arn"],
-                release_label="emr-6.10.0-latest",
-                job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverArgs(
-                    spark_sql_job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverSparkSqlJobDriverArgs(
-                        entry_point="default",
-                    ),
+        example = aws.emrcontainers.JobTemplate("example", job_template_data=aws.emrcontainers.JobTemplateJobTemplateDataArgs(
+            execution_role_arn=aws_iam_role["example"]["arn"],
+            release_label="emr-6.10.0-latest",
+            job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverArgs(
+                spark_sql_job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverSparkSqlJobDriverArgs(
+                    entry_point="default",
                 ),
             ),
-            name="example")
+        ))
         ```
 
         ## Import
@@ -251,17 +250,15 @@ class JobTemplate(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.emrcontainers.JobTemplate("example",
-            job_template_data=aws.emrcontainers.JobTemplateJobTemplateDataArgs(
-                execution_role_arn=aws_iam_role["example"]["arn"],
-                release_label="emr-6.10.0-latest",
-                job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverArgs(
-                    spark_sql_job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverSparkSqlJobDriverArgs(
-                        entry_point="default",
-                    ),
+        example = aws.emrcontainers.JobTemplate("example", job_template_data=aws.emrcontainers.JobTemplateJobTemplateDataArgs(
+            execution_role_arn=aws_iam_role["example"]["arn"],
+            release_label="emr-6.10.0-latest",
+            job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverArgs(
+                spark_sql_job_driver=aws.emrcontainers.JobTemplateJobTemplateDataJobDriverSparkSqlJobDriverArgs(
+                    entry_point="default",
                 ),
             ),
-            name="example")
+        ))
         ```
 
         ## Import
@@ -304,8 +301,6 @@ class JobTemplate(pulumi.CustomResource):
                 raise TypeError("Missing required property 'job_template_data'")
             __props__.__dict__["job_template_data"] = job_template_data
             __props__.__dict__["kms_key_arn"] = kms_key_arn
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None

--- a/sdk/python/pulumi_aws/finspace/kx_cluster.py
+++ b/sdk/python/pulumi_aws/finspace/kx_cluster.py
@@ -19,7 +19,6 @@ class KxClusterArgs:
                  az_mode: pulumi.Input[str],
                  capacity_configuration: pulumi.Input['KxClusterCapacityConfigurationArgs'],
                  environment_id: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  release_label: pulumi.Input[str],
                  type: pulumi.Input[str],
                  vpc_configuration: pulumi.Input['KxClusterVpcConfigurationArgs'],
@@ -32,6 +31,7 @@ class KxClusterArgs:
                  description: Optional[pulumi.Input[str]] = None,
                  execution_role: Optional[pulumi.Input[str]] = None,
                  initialization_script: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  savedown_storage_configuration: Optional[pulumi.Input['KxClusterSavedownStorageConfigurationArgs']] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
@@ -41,7 +41,6 @@ class KxClusterArgs:
                * MULTI - Assigns all the availability zones per cluster.
         :param pulumi.Input['KxClusterCapacityConfigurationArgs'] capacity_configuration: Structure for the metadata of a cluster. Includes information like the CPUs needed, memory of instances, and number of instances. See capacity_configuration.
         :param pulumi.Input[str] environment_id: Unique identifier for the KX environment.
-        :param pulumi.Input[str] name: Unique name for the cluster that you want to create.
         :param pulumi.Input[str] release_label: Version of FinSpace Managed kdb to run.
         :param pulumi.Input[str] type: Type of KDB database. The following types are available:
                * HDB - Historical Database. The data is only accessible with read-only permissions from one of the FinSpace managed KX databases mounted to the cluster.
@@ -59,13 +58,13 @@ class KxClusterArgs:
         :param pulumi.Input[str] description: Description of the cluster.
         :param pulumi.Input[str] execution_role: An IAM role that defines a set of permissions associated with a cluster. These permissions are assumed when a cluster attempts to access another cluster.
         :param pulumi.Input[str] initialization_script: Path to Q program that will be run at launch of a cluster. This is a relative path within .zip file that contains the custom code, which will be loaded on the cluster. It must include the file name itself. For example, somedir/init.q.
+        :param pulumi.Input[str] name: Unique name for the cluster that you want to create.
         :param pulumi.Input['KxClusterSavedownStorageConfigurationArgs'] savedown_storage_configuration: Size and type of the temporary storage that is used to hold data during the savedown process. This parameter is required when you choose `type` as RDB. All the data written to this storage space is lost when the cluster node is restarted. See savedown_storage_configuration.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         pulumi.set(__self__, "az_mode", az_mode)
         pulumi.set(__self__, "capacity_configuration", capacity_configuration)
         pulumi.set(__self__, "environment_id", environment_id)
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "release_label", release_label)
         pulumi.set(__self__, "type", type)
         pulumi.set(__self__, "vpc_configuration", vpc_configuration)
@@ -87,6 +86,8 @@ class KxClusterArgs:
             pulumi.set(__self__, "execution_role", execution_role)
         if initialization_script is not None:
             pulumi.set(__self__, "initialization_script", initialization_script)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if savedown_storage_configuration is not None:
             pulumi.set(__self__, "savedown_storage_configuration", savedown_storage_configuration)
         if tags is not None:
@@ -129,18 +130,6 @@ class KxClusterArgs:
     @environment_id.setter
     def environment_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "environment_id", value)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Unique name for the cluster that you want to create.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="releaseLabel")
@@ -290,6 +279,18 @@ class KxClusterArgs:
     @initialization_script.setter
     def initialization_script(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "initialization_script", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Unique name for the cluster that you want to create.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="savedownStorageConfiguration")
@@ -858,8 +859,6 @@ class KxCluster(pulumi.CustomResource):
             __props__.__dict__["environment_id"] = environment_id
             __props__.__dict__["execution_role"] = execution_role
             __props__.__dict__["initialization_script"] = initialization_script
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if release_label is None and not opts.urn:
                 raise TypeError("Missing required property 'release_label'")

--- a/sdk/python/pulumi_aws/finspace/kx_database.py
+++ b/sdk/python/pulumi_aws/finspace/kx_database.py
@@ -15,22 +15,23 @@ __all__ = ['KxDatabaseArgs', 'KxDatabase']
 class KxDatabaseArgs:
     def __init__(__self__, *,
                  environment_id: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a KxDatabase resource.
         :param pulumi.Input[str] environment_id: Unique identifier for the KX environment.
+        :param pulumi.Input[str] description: Description of the KX database.
         :param pulumi.Input[str] name: Name of the KX database.
                
                The following arguments are optional:
-        :param pulumi.Input[str] description: Description of the KX database.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         pulumi.set(__self__, "environment_id", environment_id)
-        pulumi.set(__self__, "name", name)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -48,20 +49,6 @@ class KxDatabaseArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the KX database.
-
-        The following arguments are optional:
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
-
-    @property
-    @pulumi.getter
     def description(self) -> Optional[pulumi.Input[str]]:
         """
         Description of the KX database.
@@ -71,6 +58,20 @@ class KxDatabaseArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the KX database.
+
+        The following arguments are optional:
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -248,12 +249,9 @@ class KxDatabase(pulumi.CustomResource):
         example_key = aws.kms.Key("exampleKey",
             description="Example KMS Key",
             deletion_window_in_days=7)
-        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment",
-            name="my-tf-kx-environment",
-            kms_key_id=example_key.arn)
+        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment", kms_key_id=example_key.arn)
         example_kx_database = aws.finspace.KxDatabase("exampleKxDatabase",
             environment_id=example_kx_environment.id,
-            name="my-tf-kx-database",
             description="Example database description")
         ```
 
@@ -293,12 +291,9 @@ class KxDatabase(pulumi.CustomResource):
         example_key = aws.kms.Key("exampleKey",
             description="Example KMS Key",
             deletion_window_in_days=7)
-        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment",
-            name="my-tf-kx-environment",
-            kms_key_id=example_key.arn)
+        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment", kms_key_id=example_key.arn)
         example_kx_database = aws.finspace.KxDatabase("exampleKxDatabase",
             environment_id=example_kx_environment.id,
-            name="my-tf-kx-database",
             description="Example database description")
         ```
 
@@ -342,8 +337,6 @@ class KxDatabase(pulumi.CustomResource):
             if environment_id is None and not opts.urn:
                 raise TypeError("Missing required property 'environment_id'")
             __props__.__dict__["environment_id"] = environment_id
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None

--- a/sdk/python/pulumi_aws/finspace/kx_environment.py
+++ b/sdk/python/pulumi_aws/finspace/kx_environment.py
@@ -17,9 +17,9 @@ __all__ = ['KxEnvironmentArgs', 'KxEnvironment']
 class KxEnvironmentArgs:
     def __init__(__self__, *,
                  kms_key_id: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  custom_dns_configurations: Optional[pulumi.Input[Sequence[pulumi.Input['KxEnvironmentCustomDnsConfigurationArgs']]]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  transit_gateway_configuration: Optional[pulumi.Input['KxEnvironmentTransitGatewayConfigurationArgs']] = None):
         """
@@ -27,18 +27,19 @@ class KxEnvironmentArgs:
         :param pulumi.Input[str] kms_key_id: KMS key ID to encrypt your data in the FinSpace environment.
                
                The following arguments are optional:
-        :param pulumi.Input[str] name: Name of the KX environment that you want to create.
         :param pulumi.Input[Sequence[pulumi.Input['KxEnvironmentCustomDnsConfigurationArgs']]] custom_dns_configurations: List of DNS server name and server IP. This is used to set up Route-53 outbound resolvers. Defined below.
         :param pulumi.Input[str] description: Description for the KX environment.
+        :param pulumi.Input[str] name: Name of the KX environment that you want to create.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param pulumi.Input['KxEnvironmentTransitGatewayConfigurationArgs'] transit_gateway_configuration: Transit gateway and network configuration that is used to connect the KX environment to an internal network. Defined below.
         """
         pulumi.set(__self__, "kms_key_id", kms_key_id)
-        pulumi.set(__self__, "name", name)
         if custom_dns_configurations is not None:
             pulumi.set(__self__, "custom_dns_configurations", custom_dns_configurations)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
         if transit_gateway_configuration is not None:
@@ -57,18 +58,6 @@ class KxEnvironmentArgs:
     @kms_key_id.setter
     def kms_key_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "kms_key_id", value)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the KX environment that you want to create.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="customDnsConfigurations")
@@ -93,6 +82,18 @@ class KxEnvironmentArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the KX environment that you want to create.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -364,9 +365,7 @@ class KxEnvironment(pulumi.CustomResource):
         example_key = aws.kms.Key("exampleKey",
             description="Sample KMS Key",
             deletion_window_in_days=7)
-        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment",
-            name="my-tf-kx-environment",
-            kms_key_id=example_key.arn)
+        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment", kms_key_id=example_key.arn)
         ```
         ### With Network Setup
 
@@ -379,7 +378,6 @@ class KxEnvironment(pulumi.CustomResource):
             deletion_window_in_days=7)
         example_transit_gateway = aws.ec2transitgateway.TransitGateway("exampleTransitGateway", description="example")
         example_env = aws.finspace.KxEnvironment("exampleEnv",
-            name="my-tf-kx-environment",
             description="Environment description",
             kms_key_id=example_key.arn,
             transit_gateway_configuration=aws.finspace.KxEnvironmentTransitGatewayConfigurationArgs(
@@ -430,9 +428,7 @@ class KxEnvironment(pulumi.CustomResource):
         example_key = aws.kms.Key("exampleKey",
             description="Sample KMS Key",
             deletion_window_in_days=7)
-        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment",
-            name="my-tf-kx-environment",
-            kms_key_id=example_key.arn)
+        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment", kms_key_id=example_key.arn)
         ```
         ### With Network Setup
 
@@ -445,7 +441,6 @@ class KxEnvironment(pulumi.CustomResource):
             deletion_window_in_days=7)
         example_transit_gateway = aws.ec2transitgateway.TransitGateway("exampleTransitGateway", description="example")
         example_env = aws.finspace.KxEnvironment("exampleEnv",
-            name="my-tf-kx-environment",
             description="Environment description",
             kms_key_id=example_key.arn,
             transit_gateway_configuration=aws.finspace.KxEnvironmentTransitGatewayConfigurationArgs(
@@ -501,8 +496,6 @@ class KxEnvironment(pulumi.CustomResource):
             if kms_key_id is None and not opts.urn:
                 raise TypeError("Missing required property 'kms_key_id'")
             __props__.__dict__["kms_key_id"] = kms_key_id
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["transit_gateway_configuration"] = transit_gateway_configuration

--- a/sdk/python/pulumi_aws/finspace/kx_user.py
+++ b/sdk/python/pulumi_aws/finspace/kx_user.py
@@ -16,7 +16,7 @@ class KxUserArgs:
     def __init__(__self__, *,
                  environment_id: pulumi.Input[str],
                  iam_role: pulumi.Input[str],
-                 name: pulumi.Input[str],
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a KxUser resource.
@@ -29,7 +29,8 @@ class KxUserArgs:
         """
         pulumi.set(__self__, "environment_id", environment_id)
         pulumi.set(__self__, "iam_role", iam_role)
-        pulumi.set(__self__, "name", name)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -61,14 +62,14 @@ class KxUserArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
+    def name(self) -> Optional[pulumi.Input[str]]:
         """
         A unique identifier for the user.
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: pulumi.Input[str]):
+    def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
     @property
@@ -216,9 +217,7 @@ class KxUser(pulumi.CustomResource):
         example_key = aws.kms.Key("exampleKey",
             description="Example KMS Key",
             deletion_window_in_days=7)
-        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment",
-            name="my-tf-kx-environment",
-            kms_key_id=example_key.arn)
+        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment", kms_key_id=example_key.arn)
         example_role = aws.iam.Role("exampleRole", assume_role_policy=json.dumps({
             "Version": "2012-10-17",
             "Statement": [{
@@ -231,7 +230,6 @@ class KxUser(pulumi.CustomResource):
             }],
         }))
         example_kx_user = aws.finspace.KxUser("exampleKxUser",
-            name="my-tf-kx-user",
             environment_id=example_kx_environment.id,
             iam_role=example_role.arn)
         ```
@@ -273,9 +271,7 @@ class KxUser(pulumi.CustomResource):
         example_key = aws.kms.Key("exampleKey",
             description="Example KMS Key",
             deletion_window_in_days=7)
-        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment",
-            name="my-tf-kx-environment",
-            kms_key_id=example_key.arn)
+        example_kx_environment = aws.finspace.KxEnvironment("exampleKxEnvironment", kms_key_id=example_key.arn)
         example_role = aws.iam.Role("exampleRole", assume_role_policy=json.dumps({
             "Version": "2012-10-17",
             "Statement": [{
@@ -288,7 +284,6 @@ class KxUser(pulumi.CustomResource):
             }],
         }))
         example_kx_user = aws.finspace.KxUser("exampleKxUser",
-            name="my-tf-kx-user",
             environment_id=example_kx_environment.id,
             iam_role=example_role.arn)
         ```
@@ -335,8 +330,6 @@ class KxUser(pulumi.CustomResource):
             if iam_role is None and not opts.urn:
                 raise TypeError("Missing required property 'iam_role'")
             __props__.__dict__["iam_role"] = iam_role
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None

--- a/sdk/python/pulumi_aws/globalaccelerator/custom_routing_accelerator.py
+++ b/sdk/python/pulumi_aws/globalaccelerator/custom_routing_accelerator.py
@@ -16,22 +16,21 @@ __all__ = ['CustomRoutingAcceleratorArgs', 'CustomRoutingAccelerator']
 @pulumi.input_type
 class CustomRoutingAcceleratorArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  attributes: Optional[pulumi.Input['CustomRoutingAcceleratorAttributesArgs']] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  ip_address_type: Optional[pulumi.Input[str]] = None,
                  ip_addresses: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a CustomRoutingAccelerator resource.
-        :param pulumi.Input[str] name: The name of a custom routing accelerator.
         :param pulumi.Input['CustomRoutingAcceleratorAttributesArgs'] attributes: The attributes of the accelerator. Fields documented below.
         :param pulumi.Input[bool] enabled: Indicates whether the accelerator is enabled. Defaults to `true`. Valid values: `true`, `false`.
         :param pulumi.Input[str] ip_address_type: The IP address type that an accelerator supports. For a custom routing accelerator, the value must be `"IPV4"`.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_addresses: The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses.
+        :param pulumi.Input[str] name: The name of a custom routing accelerator.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
-        pulumi.set(__self__, "name", name)
         if attributes is not None:
             pulumi.set(__self__, "attributes", attributes)
         if enabled is not None:
@@ -40,20 +39,10 @@ class CustomRoutingAcceleratorArgs:
             pulumi.set(__self__, "ip_address_type", ip_address_type)
         if ip_addresses is not None:
             pulumi.set(__self__, "ip_addresses", ip_addresses)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The name of a custom routing accelerator.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -102,6 +91,18 @@ class CustomRoutingAcceleratorArgs:
     @ip_addresses.setter
     def ip_addresses(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "ip_addresses", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of a custom routing accelerator.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -317,8 +318,7 @@ class CustomRoutingAccelerator(pulumi.CustomResource):
             ),
             enabled=True,
             ip_address_type="IPV4",
-            ip_addresses=["1.2.3.4"],
-            name="Example")
+            ip_addresses=["1.2.3.4"])
         ```
 
         ## Import
@@ -342,7 +342,7 @@ class CustomRoutingAccelerator(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: CustomRoutingAcceleratorArgs,
+                 args: Optional[CustomRoutingAcceleratorArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Creates a Global Accelerator custom routing accelerator.
@@ -361,8 +361,7 @@ class CustomRoutingAccelerator(pulumi.CustomResource):
             ),
             enabled=True,
             ip_address_type="IPV4",
-            ip_addresses=["1.2.3.4"],
-            name="Example")
+            ip_addresses=["1.2.3.4"])
         ```
 
         ## Import
@@ -407,8 +406,6 @@ class CustomRoutingAccelerator(pulumi.CustomResource):
             __props__.__dict__["enabled"] = enabled
             __props__.__dict__["ip_address_type"] = ip_address_type
             __props__.__dict__["ip_addresses"] = ip_addresses
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["dns_name"] = None

--- a/sdk/python/pulumi_aws/globalaccelerator/custom_routing_listener.py
+++ b/sdk/python/pulumi_aws/globalaccelerator/custom_routing_listener.py
@@ -109,7 +109,6 @@ class CustomRoutingListener(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example_custom_routing_accelerator = aws.globalaccelerator.CustomRoutingAccelerator("exampleCustomRoutingAccelerator",
-            name="Example",
             ip_address_type="IPV4",
             enabled=True,
             attributes=aws.globalaccelerator.CustomRoutingAcceleratorAttributesArgs(
@@ -154,7 +153,6 @@ class CustomRoutingListener(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example_custom_routing_accelerator = aws.globalaccelerator.CustomRoutingAccelerator("exampleCustomRoutingAccelerator",
-            name="Example",
             ip_address_type="IPV4",
             enabled=True,
             attributes=aws.globalaccelerator.CustomRoutingAcceleratorAttributesArgs(

--- a/sdk/python/pulumi_aws/glue/data_quality_ruleset.py
+++ b/sdk/python/pulumi_aws/glue/data_quality_ruleset.py
@@ -16,39 +16,28 @@ __all__ = ['DataQualityRulesetArgs', 'DataQualityRuleset']
 @pulumi.input_type
 class DataQualityRulesetArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  ruleset: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  target_table: Optional[pulumi.Input['DataQualityRulesetTargetTableArgs']] = None):
         """
         The set of arguments for constructing a DataQualityRuleset resource.
-        :param pulumi.Input[str] name: Name of the data quality ruleset.
         :param pulumi.Input[str] ruleset: A Data Quality Definition Language (DQDL) ruleset. For more information, see the AWS Glue developer guide.
         :param pulumi.Input[str] description: Description of the data quality ruleset.
+        :param pulumi.Input[str] name: Name of the data quality ruleset.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value map of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param pulumi.Input['DataQualityRulesetTargetTableArgs'] target_table: A Configuration block specifying a target table associated with the data quality ruleset. See `target_table` below.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "ruleset", ruleset)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
         if target_table is not None:
             pulumi.set(__self__, "target_table", target_table)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the data quality ruleset.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -73,6 +62,18 @@ class DataQualityRulesetArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the data quality ruleset.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -288,9 +289,7 @@ class DataQualityRuleset(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.glue.DataQualityRuleset("example",
-            name="example",
-            ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]")
+        example = aws.glue.DataQualityRuleset("example", ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]")
         ```
         ### With description
 
@@ -300,7 +299,6 @@ class DataQualityRuleset(pulumi.CustomResource):
 
         example = aws.glue.DataQualityRuleset("example",
             description="example",
-            name="example",
             ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]")
         ```
         ### With tags
@@ -310,7 +308,6 @@ class DataQualityRuleset(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.glue.DataQualityRuleset("example",
-            name="example",
             ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]",
             tags={
                 "hello": "world",
@@ -323,7 +320,6 @@ class DataQualityRuleset(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.glue.DataQualityRuleset("example",
-            name="example",
             ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]",
             target_table=aws.glue.DataQualityRulesetTargetTableArgs(
                 database_name=aws_glue_catalog_database["example"]["name"],
@@ -363,9 +359,7 @@ class DataQualityRuleset(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.glue.DataQualityRuleset("example",
-            name="example",
-            ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]")
+        example = aws.glue.DataQualityRuleset("example", ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]")
         ```
         ### With description
 
@@ -375,7 +369,6 @@ class DataQualityRuleset(pulumi.CustomResource):
 
         example = aws.glue.DataQualityRuleset("example",
             description="example",
-            name="example",
             ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]")
         ```
         ### With tags
@@ -385,7 +378,6 @@ class DataQualityRuleset(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.glue.DataQualityRuleset("example",
-            name="example",
             ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]",
             tags={
                 "hello": "world",
@@ -398,7 +390,6 @@ class DataQualityRuleset(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.glue.DataQualityRuleset("example",
-            name="example",
             ruleset="Rules = [Completeness \\"colA\\" between 0.4 and 0.8]",
             target_table=aws.glue.DataQualityRulesetTargetTableArgs(
                 database_name=aws_glue_catalog_database["example"]["name"],
@@ -444,8 +435,6 @@ class DataQualityRuleset(pulumi.CustomResource):
             __props__ = DataQualityRulesetArgs.__new__(DataQualityRulesetArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if ruleset is None and not opts.urn:
                 raise TypeError("Missing required property 'ruleset'")

--- a/sdk/python/pulumi_aws/opensearch/serverless_access_policy.py
+++ b/sdk/python/pulumi_aws/opensearch/serverless_access_policy.py
@@ -14,36 +14,25 @@ __all__ = ['ServerlessAccessPolicyArgs', 'ServerlessAccessPolicy']
 @pulumi.input_type
 class ServerlessAccessPolicyArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  policy: pulumi.Input[str],
                  type: pulumi.Input[str],
-                 description: Optional[pulumi.Input[str]] = None):
+                 description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ServerlessAccessPolicy resource.
-        :param pulumi.Input[str] name: Name of the policy.
         :param pulumi.Input[str] policy: JSON policy document to use as the content for the new policy
         :param pulumi.Input[str] type: Type of access policy. Must be `data`.
                
                The following arguments are optional:
         :param pulumi.Input[str] description: Description of the policy. Typically used to store information about the permissions defined in the policy.
+        :param pulumi.Input[str] name: Name of the policy.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "policy", policy)
         pulumi.set(__self__, "type", type)
         if description is not None:
             pulumi.set(__self__, "description", description)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the policy.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter
@@ -82,6 +71,18 @@ class ServerlessAccessPolicyArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the policy.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
@@ -200,7 +201,6 @@ class ServerlessAccessPolicy(pulumi.CustomResource):
         current_caller_identity = aws.get_caller_identity()
         current_partition = aws.get_partition()
         test = aws.opensearch.ServerlessAccessPolicy("test",
-            name="example",
             type="data",
             policy=json.dumps([{
                 "Rules": [{
@@ -255,7 +255,6 @@ class ServerlessAccessPolicy(pulumi.CustomResource):
         current_caller_identity = aws.get_caller_identity()
         current_partition = aws.get_partition()
         test = aws.opensearch.ServerlessAccessPolicy("test",
-            name="example",
             type="data",
             policy=json.dumps([{
                 "Rules": [{
@@ -310,8 +309,6 @@ class ServerlessAccessPolicy(pulumi.CustomResource):
             __props__ = ServerlessAccessPolicyArgs.__new__(ServerlessAccessPolicyArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if policy is None and not opts.urn:
                 raise TypeError("Missing required property 'policy'")

--- a/sdk/python/pulumi_aws/opensearch/serverless_collection.py
+++ b/sdk/python/pulumi_aws/opensearch/serverless_collection.py
@@ -16,43 +16,30 @@ __all__ = ['ServerlessCollectionArgs', 'ServerlessCollection']
 @pulumi.input_type
 class ServerlessCollectionArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  timeouts: Optional[pulumi.Input['ServerlessCollectionTimeoutsArgs']] = None,
                  type: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ServerlessCollection resource.
+        :param pulumi.Input[str] description: Description of the collection.
         :param pulumi.Input[str] name: Name of the collection.
                
                The following arguments are optional:
-        :param pulumi.Input[str] description: Description of the collection.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the collection. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param pulumi.Input[str] type: Type of collection. One of `SEARCH` or `TIMESERIES`.
         """
-        pulumi.set(__self__, "name", name)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
         if timeouts is not None:
             pulumi.set(__self__, "timeouts", timeouts)
         if type is not None:
             pulumi.set(__self__, "type", type)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the collection.
-
-        The following arguments are optional:
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -65,6 +52,20 @@ class ServerlessCollectionArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the collection.
+
+        The following arguments are optional:
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -283,7 +284,6 @@ class ServerlessCollection(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example_serverless_security_policy = aws.opensearch.ServerlessSecurityPolicy("exampleServerlessSecurityPolicy",
-            name="example",
             type="encryption",
             policy=json.dumps({
                 "Rules": [{
@@ -292,8 +292,7 @@ class ServerlessCollection(pulumi.CustomResource):
                 }],
                 "AWSOwnedKey": True,
             }))
-        example_serverless_collection = aws.opensearch.ServerlessCollection("exampleServerlessCollection", name="example",
-        opts=pulumi.ResourceOptions(depends_on=[example_serverless_security_policy]))
+        example_serverless_collection = aws.opensearch.ServerlessCollection("exampleServerlessCollection", opts=pulumi.ResourceOptions(depends_on=[example_serverless_security_policy]))
         ```
 
         ## Import
@@ -317,7 +316,7 @@ class ServerlessCollection(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: ServerlessCollectionArgs,
+                 args: Optional[ServerlessCollectionArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource for managing an AWS OpenSearch Serverless Collection.
@@ -331,7 +330,6 @@ class ServerlessCollection(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example_serverless_security_policy = aws.opensearch.ServerlessSecurityPolicy("exampleServerlessSecurityPolicy",
-            name="example",
             type="encryption",
             policy=json.dumps({
                 "Rules": [{
@@ -340,8 +338,7 @@ class ServerlessCollection(pulumi.CustomResource):
                 }],
                 "AWSOwnedKey": True,
             }))
-        example_serverless_collection = aws.opensearch.ServerlessCollection("exampleServerlessCollection", name="example",
-        opts=pulumi.ResourceOptions(depends_on=[example_serverless_security_policy]))
+        example_serverless_collection = aws.opensearch.ServerlessCollection("exampleServerlessCollection", opts=pulumi.ResourceOptions(depends_on=[example_serverless_security_policy]))
         ```
 
         ## Import
@@ -382,8 +379,6 @@ class ServerlessCollection(pulumi.CustomResource):
             __props__ = ServerlessCollectionArgs.__new__(ServerlessCollectionArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["timeouts"] = timeouts

--- a/sdk/python/pulumi_aws/opensearch/serverless_security_config.py
+++ b/sdk/python/pulumi_aws/opensearch/serverless_security_config.py
@@ -16,37 +16,26 @@ __all__ = ['ServerlessSecurityConfigArgs', 'ServerlessSecurityConfig']
 @pulumi.input_type
 class ServerlessSecurityConfigArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  type: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  saml_options: Optional[pulumi.Input['ServerlessSecurityConfigSamlOptionsArgs']] = None):
         """
         The set of arguments for constructing a ServerlessSecurityConfig resource.
-        :param pulumi.Input[str] name: Name of the policy.
         :param pulumi.Input[str] type: Type of configuration. Must be `saml`.
                
                The following arguments are optional:
         :param pulumi.Input[str] description: Description of the security configuration.
+        :param pulumi.Input[str] name: Name of the policy.
         :param pulumi.Input['ServerlessSecurityConfigSamlOptionsArgs'] saml_options: Configuration block for SAML options.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "type", type)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if saml_options is not None:
             pulumi.set(__self__, "saml_options", saml_options)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the policy.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -73,6 +62,18 @@ class ServerlessSecurityConfigArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the policy.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="samlOptions")
@@ -259,8 +260,6 @@ class ServerlessSecurityConfig(pulumi.CustomResource):
             __props__ = ServerlessSecurityConfigArgs.__new__(ServerlessSecurityConfigArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["saml_options"] = saml_options
             if type is None and not opts.urn:

--- a/sdk/python/pulumi_aws/opensearch/serverless_security_policy.py
+++ b/sdk/python/pulumi_aws/opensearch/serverless_security_policy.py
@@ -14,36 +14,25 @@ __all__ = ['ServerlessSecurityPolicyArgs', 'ServerlessSecurityPolicy']
 @pulumi.input_type
 class ServerlessSecurityPolicyArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  policy: pulumi.Input[str],
                  type: pulumi.Input[str],
-                 description: Optional[pulumi.Input[str]] = None):
+                 description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ServerlessSecurityPolicy resource.
-        :param pulumi.Input[str] name: Name of the policy.
         :param pulumi.Input[str] policy: JSON policy document to use as the content for the new policy
         :param pulumi.Input[str] type: Type of security policy. One of `encryption` or `network`.
                
                The following arguments are optional:
         :param pulumi.Input[str] description: Description of the policy. Typically used to store information about the permissions defined in the policy.
+        :param pulumi.Input[str] name: Name of the policy.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "policy", policy)
         pulumi.set(__self__, "type", type)
         if description is not None:
             pulumi.set(__self__, "description", description)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the policy.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter
@@ -82,6 +71,18 @@ class ServerlessSecurityPolicyArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the policy.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
@@ -200,7 +201,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="encryption",
             description="encryption security policy for example-collection",
             policy=json.dumps({
@@ -219,7 +219,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="encryption",
             description="encryption security policy for collections that begin with \\"example\\"",
             policy=json.dumps({
@@ -238,7 +237,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="encryption",
             description="encryption security policy using customer KMS key",
             policy=json.dumps({
@@ -259,7 +257,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="network",
             description="Public access",
             policy=json.dumps([{
@@ -285,7 +282,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="network",
             description="VPC access",
             policy=json.dumps([{
@@ -312,7 +308,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="network",
             description="Mixed access for marketing and sales",
             policy=json.dumps([
@@ -379,7 +374,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="encryption",
             description="encryption security policy for example-collection",
             policy=json.dumps({
@@ -398,7 +392,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="encryption",
             description="encryption security policy for collections that begin with \\"example\\"",
             policy=json.dumps({
@@ -417,7 +410,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="encryption",
             description="encryption security policy using customer KMS key",
             policy=json.dumps({
@@ -438,7 +430,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="network",
             description="Public access",
             policy=json.dumps([{
@@ -464,7 +455,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="network",
             description="VPC access",
             policy=json.dumps([{
@@ -491,7 +481,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessSecurityPolicy("example",
-            name="example",
             type="network",
             description="Mixed access for marketing and sales",
             policy=json.dumps([
@@ -558,8 +547,6 @@ class ServerlessSecurityPolicy(pulumi.CustomResource):
             __props__ = ServerlessSecurityPolicyArgs.__new__(ServerlessSecurityPolicyArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if policy is None and not opts.urn:
                 raise TypeError("Missing required property 'policy'")

--- a/sdk/python/pulumi_aws/opensearch/serverless_vpc_endpoint.py
+++ b/sdk/python/pulumi_aws/opensearch/serverless_vpc_endpoint.py
@@ -16,39 +16,28 @@ __all__ = ['ServerlessVpcEndpointArgs', 'ServerlessVpcEndpoint']
 @pulumi.input_type
 class ServerlessVpcEndpointArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  vpc_id: pulumi.Input[str],
+                 name: Optional[pulumi.Input[str]] = None,
                  security_group_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  timeouts: Optional[pulumi.Input['ServerlessVpcEndpointTimeoutsArgs']] = None):
         """
         The set of arguments for constructing a ServerlessVpcEndpoint resource.
-        :param pulumi.Input[str] name: Name of the interface endpoint.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: One or more subnet IDs from which you'll access OpenSearch Serverless. Up to 6 subnets can be provided.
         :param pulumi.Input[str] vpc_id: ID of the VPC from which you'll access OpenSearch Serverless.
                
                The following arguments are optional:
+        :param pulumi.Input[str] name: Name of the interface endpoint.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] security_group_ids: One or more security groups that define the ports, protocols, and sources for inbound traffic that you are authorizing into your endpoint. Up to 5 security groups can be provided.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "subnet_ids", subnet_ids)
         pulumi.set(__self__, "vpc_id", vpc_id)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if security_group_ids is not None:
             pulumi.set(__self__, "security_group_ids", security_group_ids)
         if timeouts is not None:
             pulumi.set(__self__, "timeouts", timeouts)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name of the interface endpoint.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="subnetIds")
@@ -75,6 +64,18 @@ class ServerlessVpcEndpointArgs:
     @vpc_id.setter
     def vpc_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "vpc_id", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the interface endpoint.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="securityGroupIds")
@@ -208,7 +209,6 @@ class ServerlessVpcEndpoint(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessVpcEndpoint("example",
-            name="myendpoint",
             subnet_ids=[aws_subnet["example"]["id"]],
             vpc_id=aws_vpc["example"]["id"])
         ```
@@ -247,7 +247,6 @@ class ServerlessVpcEndpoint(pulumi.CustomResource):
         import pulumi_aws as aws
 
         example = aws.opensearch.ServerlessVpcEndpoint("example",
-            name="myendpoint",
             subnet_ids=[aws_subnet["example"]["id"]],
             vpc_id=aws_vpc["example"]["id"])
         ```
@@ -289,8 +288,6 @@ class ServerlessVpcEndpoint(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ServerlessVpcEndpointArgs.__new__(ServerlessVpcEndpointArgs)
 
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["security_group_ids"] = security_group_ids
             if subnet_ids is None and not opts.urn:

--- a/sdk/python/pulumi_aws/quicksight/theme.py
+++ b/sdk/python/pulumi_aws/quicksight/theme.py
@@ -17,33 +17,34 @@ __all__ = ['ThemeArgs', 'Theme']
 class ThemeArgs:
     def __init__(__self__, *,
                  base_theme_id: pulumi.Input[str],
-                 name: pulumi.Input[str],
                  theme_id: pulumi.Input[str],
                  aws_account_id: Optional[pulumi.Input[str]] = None,
                  configuration: Optional[pulumi.Input['ThemeConfigurationArgs']] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input['ThemePermissionArgs']]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  version_description: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Theme resource.
         :param pulumi.Input[str] base_theme_id: The ID of the theme that a custom theme will inherit from. All themes inherit from one of the starting themes defined by Amazon QuickSight. For a list of the starting themes, use ListThemes or choose Themes from within an analysis.
-        :param pulumi.Input[str] name: Display name of the theme.
         :param pulumi.Input[str] theme_id: Identifier of the theme.
         :param pulumi.Input[str] aws_account_id: AWS account ID.
         :param pulumi.Input['ThemeConfigurationArgs'] configuration: The theme configuration, which contains the theme display properties. See configuration.
                
                The following arguments are optional:
+        :param pulumi.Input[str] name: Display name of the theme.
         :param pulumi.Input[Sequence[pulumi.Input['ThemePermissionArgs']]] permissions: A set of resource permissions on the theme. Maximum of 64 items. See permissions.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value map of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param pulumi.Input[str] version_description: A description of the current theme version being created/updated.
         """
         pulumi.set(__self__, "base_theme_id", base_theme_id)
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "theme_id", theme_id)
         if aws_account_id is not None:
             pulumi.set(__self__, "aws_account_id", aws_account_id)
         if configuration is not None:
             pulumi.set(__self__, "configuration", configuration)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if permissions is not None:
             pulumi.set(__self__, "permissions", permissions)
         if tags is not None:
@@ -62,18 +63,6 @@ class ThemeArgs:
     @base_theme_id.setter
     def base_theme_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "base_theme_id", value)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Display name of the theme.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="themeId")
@@ -112,6 +101,18 @@ class ThemeArgs:
     @configuration.setter
     def configuration(self, value: Optional[pulumi.Input['ThemeConfigurationArgs']]):
         pulumi.set(self, "configuration", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Display name of the theme.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -482,8 +483,6 @@ class Theme(pulumi.CustomResource):
                 raise TypeError("Missing required property 'base_theme_id'")
             __props__.__dict__["base_theme_id"] = base_theme_id
             __props__.__dict__["configuration"] = configuration
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["permissions"] = permissions
             __props__.__dict__["tags"] = tags

--- a/sdk/python/pulumi_aws/quicksight/vpc_connection.py
+++ b/sdk/python/pulumi_aws/quicksight/vpc_connection.py
@@ -16,18 +16,17 @@ __all__ = ['VpcConnectionArgs', 'VpcConnection']
 @pulumi.input_type
 class VpcConnectionArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  role_arn: pulumi.Input[str],
                  security_group_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  vpc_connection_id: pulumi.Input[str],
                  aws_account_id: Optional[pulumi.Input[str]] = None,
                  dns_resolvers: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  timeouts: Optional[pulumi.Input['VpcConnectionTimeoutsArgs']] = None):
         """
         The set of arguments for constructing a VpcConnection resource.
-        :param pulumi.Input[str] name: The display name for the VPC connection.
         :param pulumi.Input[str] role_arn: The IAM role to associate with the VPC connection.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] security_group_ids: A list of security group IDs for the VPC connection.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: A list of subnet IDs for the VPC connection.
@@ -36,9 +35,9 @@ class VpcConnectionArgs:
         :param pulumi.Input[str] vpc_connection_id: The ID of the VPC connection.
         :param pulumi.Input[str] aws_account_id: AWS account ID.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] dns_resolvers: A list of IP addresses of DNS resolver endpoints for the VPC connection.
+        :param pulumi.Input[str] name: The display name for the VPC connection.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value map of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "role_arn", role_arn)
         pulumi.set(__self__, "security_group_ids", security_group_ids)
         pulumi.set(__self__, "subnet_ids", subnet_ids)
@@ -47,22 +46,12 @@ class VpcConnectionArgs:
             pulumi.set(__self__, "aws_account_id", aws_account_id)
         if dns_resolvers is not None:
             pulumi.set(__self__, "dns_resolvers", dns_resolvers)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
         if timeouts is not None:
             pulumi.set(__self__, "timeouts", timeouts)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The display name for the VPC connection.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="roleArn")
@@ -137,6 +126,18 @@ class VpcConnectionArgs:
     @dns_resolvers.setter
     def dns_resolvers(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "dns_resolvers", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The display name for the VPC connection.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -416,7 +417,6 @@ class VpcConnection(pulumi.CustomResource):
             )])
         example = aws.quicksight.VpcConnection("example",
             vpc_connection_id="example-connection-id",
-            name="Example Connection",
             role_arn=vpc_connection_role.arn,
             security_group_ids=["sg-00000000000000000"],
             subnet_ids=[
@@ -493,7 +493,6 @@ class VpcConnection(pulumi.CustomResource):
             )])
         example = aws.quicksight.VpcConnection("example",
             vpc_connection_id="example-connection-id",
-            name="Example Connection",
             role_arn=vpc_connection_role.arn,
             security_group_ids=["sg-00000000000000000"],
             subnet_ids=[
@@ -545,8 +544,6 @@ class VpcConnection(pulumi.CustomResource):
 
             __props__.__dict__["aws_account_id"] = aws_account_id
             __props__.__dict__["dns_resolvers"] = dns_resolvers
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if role_arn is None and not opts.urn:
                 raise TypeError("Missing required property 'role_arn'")

--- a/sdk/python/pulumi_aws/resourceexplorer/view.py
+++ b/sdk/python/pulumi_aws/resourceexplorer/view.py
@@ -16,40 +16,29 @@ __all__ = ['ViewArgs', 'View']
 @pulumi.input_type
 class ViewArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  default_view: Optional[pulumi.Input[bool]] = None,
                  filters: Optional[pulumi.Input['ViewFiltersArgs']] = None,
                  included_properties: Optional[pulumi.Input[Sequence[pulumi.Input['ViewIncludedPropertyArgs']]]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a View resource.
-        :param pulumi.Input[str] name: The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
         :param pulumi.Input[bool] default_view: Specifies whether the view is the [_default view_](https://docs.aws.amazon.com/resource-explorer/latest/userguide/manage-views-about.html#manage-views-about-default) for the AWS Region. Default: `false`.
         :param pulumi.Input['ViewFiltersArgs'] filters: Specifies which resources are included in the results of queries made using this view. See Filters below for more details.
         :param pulumi.Input[Sequence[pulumi.Input['ViewIncludedPropertyArgs']]] included_properties: Optional fields to be included in search results from this view. See Included Properties below for more details.
+        :param pulumi.Input[str] name: The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value map of resource tags. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
-        pulumi.set(__self__, "name", name)
         if default_view is not None:
             pulumi.set(__self__, "default_view", default_view)
         if filters is not None:
             pulumi.set(__self__, "filters", filters)
         if included_properties is not None:
             pulumi.set(__self__, "included_properties", included_properties)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="defaultView")
@@ -86,6 +75,18 @@ class ViewArgs:
     @included_properties.setter
     def included_properties(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ViewIncludedPropertyArgs']]]]):
         pulumi.set(self, "included_properties", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the view. The name must be no more than 64 characters long, and can include letters, digits, and the dash (-) character. The name must be unique within its AWS Region.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -242,7 +243,6 @@ class View(pulumi.CustomResource):
 
         example_index = aws.resourceexplorer.Index("exampleIndex", type="LOCAL")
         example_view = aws.resourceexplorer.View("exampleView",
-            name="exampleview",
             filters=aws.resourceexplorer.ViewFiltersArgs(
                 filter_string="resourcetype:ec2:instance",
             ),
@@ -272,7 +272,7 @@ class View(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: ViewArgs,
+                 args: Optional[ViewArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Provides a resource to manage a Resource Explorer view.
@@ -285,7 +285,6 @@ class View(pulumi.CustomResource):
 
         example_index = aws.resourceexplorer.Index("exampleIndex", type="LOCAL")
         example_view = aws.resourceexplorer.View("exampleView",
-            name="exampleview",
             filters=aws.resourceexplorer.ViewFiltersArgs(
                 filter_string="resourcetype:ec2:instance",
             ),
@@ -335,8 +334,6 @@ class View(pulumi.CustomResource):
             __props__.__dict__["default_view"] = default_view
             __props__.__dict__["filters"] = filters
             __props__.__dict__["included_properties"] = included_properties
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None

--- a/sdk/python/pulumi_aws/route53/cidr_collection.py
+++ b/sdk/python/pulumi_aws/route53/cidr_collection.py
@@ -14,23 +14,24 @@ __all__ = ['CidrCollectionArgs', 'CidrCollection']
 @pulumi.input_type
 class CidrCollectionArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str]):
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a CidrCollection resource.
         :param pulumi.Input[str] name: Unique name for the CIDR collection.
         """
-        pulumi.set(__self__, "name", name)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
+    def name(self) -> Optional[pulumi.Input[str]]:
         """
         Unique name for the CIDR collection.
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: pulumi.Input[str]):
+    def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
 
@@ -106,7 +107,7 @@ class CidrCollection(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.route53.CidrCollection("example", name="collection-1")
+        example = aws.route53.CidrCollection("example")
         ```
 
         ## Import
@@ -125,7 +126,7 @@ class CidrCollection(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: CidrCollectionArgs,
+                 args: Optional[CidrCollectionArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Provides a Route53 CIDR collection resource.
@@ -136,7 +137,7 @@ class CidrCollection(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.route53.CidrCollection("example", name="collection-1")
+        example = aws.route53.CidrCollection("example")
         ```
 
         ## Import
@@ -172,8 +173,6 @@ class CidrCollection(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = CidrCollectionArgs.__new__(CidrCollectionArgs)
 
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             __props__.__dict__["arn"] = None
             __props__.__dict__["version"] = None

--- a/sdk/python/pulumi_aws/route53/cidr_location.py
+++ b/sdk/python/pulumi_aws/route53/cidr_location.py
@@ -16,7 +16,7 @@ class CidrLocationArgs:
     def __init__(__self__, *,
                  cidr_blocks: pulumi.Input[Sequence[pulumi.Input[str]]],
                  cidr_collection_id: pulumi.Input[str],
-                 name: pulumi.Input[str]):
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a CidrLocation resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cidr_blocks: CIDR blocks for the location.
@@ -25,7 +25,8 @@ class CidrLocationArgs:
         """
         pulumi.set(__self__, "cidr_blocks", cidr_blocks)
         pulumi.set(__self__, "cidr_collection_id", cidr_collection_id)
-        pulumi.set(__self__, "name", name)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter(name="cidrBlocks")
@@ -53,14 +54,14 @@ class CidrLocationArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
+    def name(self) -> Optional[pulumi.Input[str]]:
         """
         Name for the CIDR location.
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: pulumi.Input[str]):
+    def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
 
@@ -138,10 +139,9 @@ class CidrLocation(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example_cidr_collection = aws.route53.CidrCollection("exampleCidrCollection", name="collection-1")
+        example_cidr_collection = aws.route53.CidrCollection("exampleCidrCollection")
         example_cidr_location = aws.route53.CidrLocation("exampleCidrLocation",
             cidr_collection_id=example_cidr_collection.id,
-            name="office",
             cidr_blocks=[
                 "200.5.3.0/24",
                 "200.6.3.0/24",
@@ -177,10 +177,9 @@ class CidrLocation(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        example_cidr_collection = aws.route53.CidrCollection("exampleCidrCollection", name="collection-1")
+        example_cidr_collection = aws.route53.CidrCollection("exampleCidrCollection")
         example_cidr_location = aws.route53.CidrLocation("exampleCidrLocation",
             cidr_collection_id=example_cidr_collection.id,
-            name="office",
             cidr_blocks=[
                 "200.5.3.0/24",
                 "200.6.3.0/24",
@@ -228,8 +227,6 @@ class CidrLocation(pulumi.CustomResource):
             if cidr_collection_id is None and not opts.urn:
                 raise TypeError("Missing required property 'cidr_collection_id'")
             __props__.__dict__["cidr_collection_id"] = cidr_collection_id
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
         super(CidrLocation, __self__).__init__(
             'aws:route53/cidrLocation:CidrLocation',

--- a/sdk/python/pulumi_aws/sfn/alias.py
+++ b/sdk/python/pulumi_aws/sfn/alias.py
@@ -16,31 +16,20 @@ __all__ = ['AliasArgs', 'Alias']
 @pulumi.input_type
 class AliasArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  routing_configurations: pulumi.Input[Sequence[pulumi.Input['AliasRoutingConfigurationArgs']]],
-                 description: Optional[pulumi.Input[str]] = None):
+                 description: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Alias resource.
-        :param pulumi.Input[str] name: Name for the alias you are creating.
         :param pulumi.Input[Sequence[pulumi.Input['AliasRoutingConfigurationArgs']]] routing_configurations: The StateMachine alias' route configuration settings. Fields documented below
         :param pulumi.Input[str] description: Description of the alias.
+        :param pulumi.Input[str] name: Name for the alias you are creating.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "routing_configurations", routing_configurations)
         if description is not None:
             pulumi.set(__self__, "description", description)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        Name for the alias you are creating.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter(name="routingConfigurations")
@@ -65,6 +54,18 @@ class AliasArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name for the alias you are creating.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
@@ -174,24 +175,20 @@ class Alias(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        sfn_alias = aws.sfn.Alias("sfnAlias",
-            name="my_sfn_alias",
-            routing_configurations=[aws.sfn.AliasRoutingConfigurationArgs(
-                state_machine_version_arn=aws_sfn_state_machine["sfn_test"]["state_machine_version_arn"],
-                weight=100,
-            )])
-        my_sfn_alias = aws.sfn.Alias("mySfnAlias",
-            name="my_sfn_alias",
-            routing_configurations=[
-                aws.sfn.AliasRoutingConfigurationArgs(
-                    state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:3",
-                    weight=50,
-                ),
-                aws.sfn.AliasRoutingConfigurationArgs(
-                    state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:2",
-                    weight=50,
-                ),
-            ])
+        sfn_alias = aws.sfn.Alias("sfnAlias", routing_configurations=[aws.sfn.AliasRoutingConfigurationArgs(
+            state_machine_version_arn=aws_sfn_state_machine["sfn_test"]["state_machine_version_arn"],
+            weight=100,
+        )])
+        my_sfn_alias = aws.sfn.Alias("mySfnAlias", routing_configurations=[
+            aws.sfn.AliasRoutingConfigurationArgs(
+                state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:3",
+                weight=50,
+            ),
+            aws.sfn.AliasRoutingConfigurationArgs(
+                state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:2",
+                weight=50,
+            ),
+        ])
         ```
 
         ## Import
@@ -224,24 +221,20 @@ class Alias(pulumi.CustomResource):
         import pulumi
         import pulumi_aws as aws
 
-        sfn_alias = aws.sfn.Alias("sfnAlias",
-            name="my_sfn_alias",
-            routing_configurations=[aws.sfn.AliasRoutingConfigurationArgs(
-                state_machine_version_arn=aws_sfn_state_machine["sfn_test"]["state_machine_version_arn"],
-                weight=100,
-            )])
-        my_sfn_alias = aws.sfn.Alias("mySfnAlias",
-            name="my_sfn_alias",
-            routing_configurations=[
-                aws.sfn.AliasRoutingConfigurationArgs(
-                    state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:3",
-                    weight=50,
-                ),
-                aws.sfn.AliasRoutingConfigurationArgs(
-                    state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:2",
-                    weight=50,
-                ),
-            ])
+        sfn_alias = aws.sfn.Alias("sfnAlias", routing_configurations=[aws.sfn.AliasRoutingConfigurationArgs(
+            state_machine_version_arn=aws_sfn_state_machine["sfn_test"]["state_machine_version_arn"],
+            weight=100,
+        )])
+        my_sfn_alias = aws.sfn.Alias("mySfnAlias", routing_configurations=[
+            aws.sfn.AliasRoutingConfigurationArgs(
+                state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:3",
+                weight=50,
+            ),
+            aws.sfn.AliasRoutingConfigurationArgs(
+                state_machine_version_arn="arn:aws:states:us-east-1:12345:stateMachine:demo:2",
+                weight=50,
+            ),
+        ])
         ```
 
         ## Import
@@ -280,8 +273,6 @@ class Alias(pulumi.CustomResource):
             __props__ = AliasArgs.__new__(AliasArgs)
 
             __props__.__dict__["description"] = description
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if routing_configurations is None and not opts.urn:
                 raise TypeError("Missing required property 'routing_configurations'")


### PR DESCRIPTION
This is on top of https://github.com/pulumi/pulumi-terraform-bridge/pull/1321

Fixes https://github.com/pulumi/pulumi-aws/issues/2644

Auto-naming is now supported for PF so besides fixing the warning for requested resources it rolls it out to all of these:

- resource:aws_appconfig_environment
- resource:aws_auditmanager_assessment
- resource:aws_auditmanager_assessment_report
- resource:aws_auditmanager_control
- resource:aws_auditmanager_framework
- resource:aws_cognito_user_pool_client
- resource:aws_opensearchserverless_access_policy
- resource:aws_opensearchserverless_collection
- resource:aws_opensearchserverless_security_config
- resource:aws_opensearchserverless_security_policy
- resource:aws_opensearchserverless_vpc_endpoint
- resource:aws_quicksight_vpc_connection
- resource:aws_resourceexplorer2_view
- resource:aws_route53_cidr_collection
- resource:aws_route53_cidr_location
- resource:aws_simpledb_domain

TODOs:

- [x] release underlying bridge support
- [x] verify end to end on one of these resources
- [x] rebuild schema and SDKs
