### PR TITLE
Bridge dependency updates

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.32
 	github.com/hashicorp/terraform-provider-aws/shim v0.0.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.1
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.2
 	github.com/pulumi/pulumi/pkg/v3 v3.76.1
 	github.com/pulumi/pulumi/sdk/v3 v3.76.1
 	github.com/stretchr/testify v1.8.4

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.32
 	github.com/hashicorp/terraform-provider-aws/shim v0.0.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.1
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.2
 	github.com/pulumi/pulumi/pkg/v3 v3.76.1
 	github.com/pulumi/pulumi/sdk/v3 v3.76.1

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2291,11 +2291,11 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.4 h1:gIQZmlUI1o9ye8CL2XFqtmAX6Lwr9uj/+HzjboiSmK4=
 github.com/pulumi/pulumi-java/pkg v0.9.4/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.15.0 h1:9ODws24rjbjCUezcBqGeq0Zv4MnE5fsD9MOExHdQbE4=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.15.0/go.mod h1:78zmO88vcJDcWoCJZfaHAQReHTEhuNx6BxlE5MUlLJc=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.15.1 h1:srgFgBtMUsuMbUL+pe1TUx4m1gNFGo0bzkFDF5s5Wx0=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.15.1/go.mod h1:78zmO88vcJDcWoCJZfaHAQReHTEhuNx6BxlE5MUlLJc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.0 h1:3ga+bvWnGH9+Ukxn24prZovhpIXcU7QRhu8iWzs905o=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.0/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.2 h1:NY9kPxzquV8rW/YYYlu0o7LLF/NmfUGEY/uZ06h/CMw=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.2/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096 h1:1nzT9XuyTHdcWJboYNMPPdW0B0mQdXYg8Az5tF96MXY=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096/go.mod h1:1pLAP9kryYta3Xrw99oh7BmxY6PYb+z2m7ENNCJMIRQ=
 github.com/pulumi/pulumi-yaml v1.1.1 h1:8pyBNIU8+ym0wYpjhsCqN+cutygfK1XbhY2YEeNfyXY=

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2291,8 +2291,8 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.4 h1:gIQZmlUI1o9ye8CL2XFqtmAX6Lwr9uj/+HzjboiSmK4=
 github.com/pulumi/pulumi-java/pkg v0.9.4/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.15.1 h1:srgFgBtMUsuMbUL+pe1TUx4m1gNFGo0bzkFDF5s5Wx0=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.15.1/go.mod h1:78zmO88vcJDcWoCJZfaHAQReHTEhuNx6BxlE5MUlLJc=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2 h1:zKAzAHk9AKk+EF9FG4vT9u3jYiZFES/Mjq+s9mgoRs8=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2/go.mod h1:XdOy385fEso7q3NuL+zAS3I1i+X47Bg01AlVD5aJRS4=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.2 h1:NY9kPxzquV8rW/YYYlu0o7LLF/NmfUGEY/uZ06h/CMw=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.56.2/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=


### PR DESCRIPTION
bridge: v3.56.2
bridge/pf: v0.15.2

Propagates bugfixes, most importantly GetRawConfig() no longer panics.