### PR TITLE
Enable auto-aliasing

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1968,18 +1968,6 @@ func Provider() *tfbridge.ProviderInfo {
 				},
 			},
 			// ECS for Kubernetes
-			"aws_eks_cluster": {
-				Tok: awsResource(eksMod, "Cluster"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					// TODO: This will be set correctly in v5.8.0.
-					// After we upgrade, removing this will be a no-op
-					// and the stickiness will be enforced with
-					// [prov.MustApplyAutoAliasing].
-					"certificate_authority": {
-						MaxItemsOne: ref(true),
-					},
-				},
-			},
 			"aws_eks_node_group": {
 				Tok: awsResource(eksMod, "NodeGroup"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -7161,6 +7149,8 @@ func Provider() *tfbridge.ProviderInfo {
 	shimv2.SetInstanceStateStrategy(prov.P.ResourcesMap().Get("aws_wafv2_web_acl"), shimv2.CtyInstanceState)
 
 	prov.SetAutonaming(255, "-")
+
+	prov.MustApplyAutoAliases()
 
 	return &prov
 }


### PR DESCRIPTION
Now that we have a stable release and no longer intend to make backwards incompatible changes, we turn on auto-aliasing. This prevents several classes of breaking changes from effecting our users.

Resolves https://github.com/pulumi/pulumi-aws/issues/2691