### PR TITLE
Pin Pulumi CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -160,7 +161,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -208,7 +210,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -279,7 +282,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -341,7 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -402,7 +407,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -512,7 +518,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -162,7 +163,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -211,7 +213,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -283,7 +286,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -346,7 +350,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -408,7 +413,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -519,7 +525,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -50,7 +50,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -165,7 +166,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -231,7 +233,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -315,7 +318,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -378,7 +382,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -441,7 +446,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -552,7 +558,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -167,7 +168,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -234,7 +236,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -319,7 +322,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -383,7 +387,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -447,7 +452,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -559,7 +565,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -49,7 +49,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -154,7 +155,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -269,7 +271,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -50,7 +50,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -156,7 +157,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -272,7 +274,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -50,7 +50,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -159,7 +160,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -242,7 +244,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -306,7 +309,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -369,7 +373,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -480,7 +485,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -51,7 +51,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -161,7 +162,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -245,7 +247,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -310,7 +313,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -374,7 +378,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -486,7 +491,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -174,7 +175,8 @@ jobs:
         registry-url: https://registry.npmjs.org
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -258,7 +260,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -322,7 +325,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -386,7 +390,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -512,7 +517,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -172,7 +173,8 @@ jobs:
         node-version: ${{matrix.nodeversion}}
         registry-url: https://registry.npmjs.org
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -255,7 +257,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -318,7 +321,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -381,7 +385,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -506,7 +511,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -54,7 +54,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -183,7 +184,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -314,7 +316,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -55,7 +55,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -185,7 +186,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -317,7 +319,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/update-bridge.yml
+++ b/.github/workflows/update-bridge.yml
@@ -27,7 +27,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup DotNet
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/update-bridge.yml
+++ b/.github/workflows/update-bridge.yml
@@ -28,7 +28,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup DotNet
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/update-upstream-provider.yml
+++ b/.github/workflows/update-upstream-provider.yml
@@ -53,7 +53,8 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
-      pulumi-version: v3.77.1
+      with:
+        pulumi-version: v3.77.1
     - name: Setup DotNet
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/update-upstream-provider.yml
+++ b/.github/workflows/update-upstream-provider.yml
@@ -52,7 +52,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      pulumi-version: v3.77.1
     - name: Setup DotNet
       uses: actions/setup-dotnet@v1
       with:

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -7138,9 +7138,7 @@ func Provider() *tfbridge.ProviderInfo {
 // the Terraform provider sees any resource configuration, we can give a consistent,
 // reliable and good experience for Pulumi users.
 func applyTags(
-	ctx context.Context,
-	config resource.PropertyMap,
-	meta resource.PropertyMap,
+	ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
 ) (resource.PropertyMap, error) {
 	var defaultTags awsShim.TagConfig
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -7138,7 +7138,9 @@ func Provider() *tfbridge.ProviderInfo {
 // the Terraform provider sees any resource configuration, we can give a consistent,
 // reliable and good experience for Pulumi users.
 func applyTags(
-	ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
+	ctx context.Context,
+	config resource.PropertyMap,
+	meta resource.PropertyMap,
 ) (resource.PropertyMap, error) {
 	var defaultTags awsShim.TagConfig
 


### PR DESCRIPTION
- Fix broken master build
- It appears that the tests broke on an ambient Pulumi CLI update
- This PR pins Pulumi CLI to a specific version to avoid this breakage in the future
- We need to follow through with automatically standing up upgrade PRs to keep up-to-date
-  pulumi/action-install-pulumi-cli is deprecated in favor of pulumi/actions, doing it here