### PR TITLE
Remove VERSION_PREFIX

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,5 @@
 env:
   AWS_REGION: us-west-2
-  VERSION_PREFIX: '6.0.0'
   DOTNETVERSION: |
     6.0.x
     3.1.301

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,6 +1,5 @@
 env:
   AWS_REGION: us-west-2
-  VERSION_PREFIX: '6.0.0'
   DOTNETVERSION: |
     6.0.x
     3.1.301

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -22,7 +22,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: '6.0.0'
 jobs:
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ PROVIDER_PATH := provider/v6
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-# We need to set VERSION_PREFIX before we set VERSION
-export VERSION_PREFIX := 6.0.0
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.9.5


### PR DESCRIPTION
Having VERSION_PREFIX set to 6.0.0 makes pulumictl compute 6.0.0 versions for releases even when trying to release 6.0.2-alpha.1, which is unfortunate. Removing VERSION_PREFIX makes pulumictl consult the recent tag history and start computing appropriate 6.1.x versions. I hope to follow up on this PR by releasing 6.0.2-alpha.2 and having that go through the release workflow.

Here's the build for the v6.0.2-alpha.1 tag that versions the artifact as 6.0.0, illustrating the problem: 
https://github.com/pulumi/pulumi-aws/actions/runs/5837637745/job/15834490164#step:9:87