### PR TITLE
Enable quick replay of upgrade tests

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,10 @@ require (
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.16.0
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi/pkg/v3 v3.76.1
+	github.com/pulumi/pulumi/sdk/v3 v3.76.1
 	github.com/stretchr/testify v1.8.4
+	google.golang.org/protobuf v1.31.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 // Replace to allow for correctly linking the aws provider.
@@ -244,7 +247,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.57.0 // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096 // indirect
-	github.com/pulumi/pulumi/sdk/v3 v3.76.1 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
@@ -291,10 +293,8 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.56.1 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect

--- a/examples/provider_upgrade_test.go
+++ b/examples/provider_upgrade_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	jsonpb "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"gopkg.in/yaml.v2"
 
 	providerRC "github.com/pulumi/pulumi-aws/provider/v6"
@@ -49,12 +51,6 @@ var (
 )
 
 func TestProviderUpgradeQuick(t *testing.T) {
-	// This is currently looking at Diff calls. Replaying V5 Diff calls against V6
-	// provider is close but still not quite right. In the upgrade scenario we need to
-	// compute hybrid Diff calls that take olds from V5 Diff calls and news from V6
-	// Check, and ensure that these do not make replace plans.
-	t.Skip("Skipping due to a spurious failure")
-
 	info := newProviderUpgradeInfo(t)
 
 	bytes, err := os.ReadFile(info.grpcFile)
@@ -63,20 +59,20 @@ func TestProviderUpgradeQuick(t *testing.T) {
 			"TestProviderUpgradeRecord %w", err))
 	}
 
-	n := 0
+	eng := &mockPulumiEngine{
+		provider:              providerServer(t),
+		lastCheckRequestByURN: map[string]*pulumirpc.CheckRequest{},
+	}
+
 	for _, line := range strings.Split(string(bytes), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-
-		if isPureMethod(t, line) {
-			line = ignoreStables(t, line)
-			n++
-			testutils.Replay(t, providerServer(t), line)
-		}
+		line = ignoreStables(t, line)
+		eng.replayGRPCLog(t, line)
 	}
-	require.NotEmptyf(t, n, "Need at least one replay test")
+	require.NotEmptyf(t, eng.verifiedDiffResourceCounter, "Need at least one replay test")
 }
 
 func TestProviderUpgradeRecord(t *testing.T) {
@@ -278,21 +274,6 @@ func parseProviderVersion(t *testing.T, yamlFile string) string {
 	return v
 }
 
-func isPureMethod(t *testing.T, grpcLogEntry string) bool {
-	type model struct {
-		Method string `json:"method"`
-	}
-	var m model
-	err := json.Unmarshal([]byte(grpcLogEntry), &m)
-	require.NoError(t, err)
-	switch m.Method {
-	case "/pulumirpc.ResourceProvider/Diff":
-		return true
-	default:
-		return false
-	}
-}
-
 func ignoreStables(t *testing.T, grpcLogEntry string) string {
 	var v map[string]any
 	err := json.Unmarshal([]byte(grpcLogEntry), &v)
@@ -322,4 +303,68 @@ func providerServer(t *testing.T) pulumirpc.ResourceProviderServer {
 	)(nil)
 	require.NoError(t, err)
 	return p
+}
+
+type mockPulumiEngine struct {
+	provider                    pulumirpc.ResourceProviderServer
+	lastCheckRequestByURN       map[string]*pulumirpc.CheckRequest
+	verifiedDiffResourceCounter int
+}
+
+func (e *mockPulumiEngine) replayGRPCLog(t *testing.T, jsonLog string) {
+	var entry jsonLogEntry
+	err := json.Unmarshal([]byte(jsonLog), &entry)
+	require.NoError(t, err)
+
+	switch entry.Method {
+	case "/pulumirpc.ResourceProvider/Check":
+		req := unmarshalProto(t, entry.Request, new(pulumirpc.CheckRequest))
+		e.recordCheck(t, req)
+	case "/pulumirpc.ResourceProvider/Diff":
+		req := unmarshalProto(t, entry.Request, new(pulumirpc.DiffRequest))
+		e.fixupDiff(t, req)
+		entry.Request = marshalProto(t, req)
+		b, err := json.Marshal(entry)
+		require.NoError(t, err)
+		testutils.Replay(t, e.provider, string(b))
+		e.verifiedDiffResourceCounter++
+		t.Logf("Replayed Diff on %v", req.Urn)
+	}
+}
+
+func (e *mockPulumiEngine) recordCheck(t *testing.T, checkReq *pulumirpc.CheckRequest) {
+	e.lastCheckRequestByURN[checkReq.Urn] = checkReq
+}
+
+func (e *mockPulumiEngine) fixupDiff(t *testing.T, diffReq *pulumirpc.DiffRequest) {
+	ctx := context.Background()
+	lastCheck, ok := e.lastCheckRequestByURN[diffReq.Urn]
+	require.Truef(t, ok, "Diff called for %q but there is no recent Check for this URN", diffReq.Urn)
+
+	// Assuming here that CheckRequest does not depend on the provider version, so that replaying
+	// a pre-recorded Check request from old provider on the new RC provider is reasonable.
+	checkResp, err := e.provider.Check(ctx, lastCheck)
+	require.NoError(t, err)
+
+	// Emulate the real engine would be passing checked inputs into the News field of the
+	// DiffRequest and then replay this updated request against the provider.
+	diffReq.News = checkResp.GetInputs()
+}
+
+type jsonLogEntry struct {
+	Method   string          `json:"method"`
+	Request  json.RawMessage `json:"request,omitempty"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+func unmarshalProto[T protoreflect.ProtoMessage](t *testing.T, data json.RawMessage, req T) T {
+	err := jsonpb.Unmarshal([]byte(data), req)
+	require.NoError(t, err)
+	return req
+}
+
+func marshalProto[T protoreflect.ProtoMessage](t *testing.T, req T) json.RawMessage {
+	bytes, err := jsonpb.Marshal(req)
+	require.NoError(t, err)
+	return bytes
 }


### PR DESCRIPTION
I'm getting success replaying eks.Cluster and rds.Instance test logs in memory, but it needs a slightly more complicated algorithm. The way we do this is we replay Check, Diff in tandem. We borrow old unchecked inputs from the log, we pass them through the provider to get checked inputs, and then we modify the recorded Diff to have these checked inputs part of the call. This is more realistic I think to what the engine does.

```
=== RUN   TestProviderUpgradeQuick
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:iam/role:Role::ekscluster1role
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:ec2/vpc:Vpc::vpc1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:rds/instance:Instance::rdsinstancewithname
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:s3/bucket:Bucket::s3.bucket.simple
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:iam/rolePolicyAttachment:RolePolicyAttachment::ekscluster1roleattach2
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:iam/rolePolicyAttachment:RolePolicyAttachment::ekscluster1roleattach1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:ec2/subnet:Subnet::subnet1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:ec2/subnet:Subnet::subnet2
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:eks/cluster:Cluster::ekscluster1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:iam/role:Role::ekscluster1role
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:ec2/vpc:Vpc::vpc1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:rds/instance:Instance::rdsinstancewithname
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:s3/bucket:Bucket::s3.bucket.simple
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:iam/rolePolicyAttachment:RolePolicyAttachment::ekscluster1roleattach1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:iam/rolePolicyAttachment:RolePolicyAttachment::ekscluster1roleattach2
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:ec2/subnet:Subnet::subnet1
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:ec2/subnet:Subnet::subnet2
    provider_upgrade_test.go:331: Replayed Diff on urn:pulumi:p-it-antons-mac-resources-3a5a9fc3::resources::aws:eks/cluster:Cluster::ekscluster1
--- PASS: TestProviderUpgradeQuick (0.42s)
PASS
```