### PR TITLE
Always run extra test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -450,7 +450,6 @@ jobs:
         - go
         - java
   go_test_shim:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: Run test of provider shim
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -450,7 +450,6 @@ jobs:
         - go
         - java
   go_test_shim:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: Run test of provider shim
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -401,7 +401,6 @@ jobs:
         - go
         - java
   go_test_shim:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: Run test of provider shim
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,6 @@ jobs:
         - go
         - java
   go_test_shim:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: Run test of provider shim
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -368,7 +368,6 @@ jobs:
         - go
         - java
   go_test_shim:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: Run test of provider shim
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
Under the new workflow files, this test is included whenever we run our other tests. Importantly, the post-test phase of the relevant workflows depend on this test running successfully. We can't skip the test (for example [during releases](https://github.com/pulumi/pulumi-aws/actions/runs/6032096288), since that blocks the post-test actions).

This PR reflects the changes made in https://github.com/pulumi/ci-mgmt/pull/538.