### PR TITLE
Adding codecov to this repo

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -383,7 +383,11 @@ jobs:
           - name: go test
             run: |
               cd provider/shim
-              go test -v .
+              go test -v -coverprofile="coverage.txt" .
+          - name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v3
+            env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       timeout-minutes: 60
 
 name: run-acceptance-tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn.lock
 **/pulumiManifest.go
 
 ci-scripts
+provider/shim/coverage.txt
 provider/**/schema-embed.json
 **/version.txt
 **/nuget

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ provider: tfgen install_plugins
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION) -X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
 test:
-	cd provider/shim && go test -v .
+	cd provider/shim && go test -v -coverprofile="coverage.txt" .
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
 tfgen: install_plugins upstream

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This adds basic code coverage for our provider binaries as exercised by our unit tests. An example of the comment produced by the tool occurs on this PR; the coverage report is informational only (will not block PR checks). 

Note: Since this only applies to unittests, we're not covering much here. The only unittests in this repo today are on the shim.


