### PR TITLE
Remove deprecation warning on `aws_s3_bucket_object`

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -3,7 +3,9 @@
 package examples
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -284,4 +286,91 @@ func TestRegressUnknownTags(t *testing.T) {
 	]
 	`
 	replay(t, repro)
+}
+
+// Assert that we don't regress on https://github.com/pulumi/pulumi-aws/issues/2796
+func TestS3BucketObjectDeprecation(t *testing.T) {
+	repro := `[
+  {
+    "metadata": {
+      "kind": "resource",
+      "mode": "client",
+      "name": "aws"
+    },
+    "method": "/pulumirpc.ResourceProvider/Check",
+    "request": {
+      "news": {
+        "bucket": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+        "content": "CONTENT"
+      },
+      "olds": {},
+      "randomSeed": "BoD5xyY00fW+jTMLexVckztJvRX8NUs3a6SIkldxdlQ=",
+      "urn": "urn:pulumi:dev::secret-random-yaml::aws:s3/bucketObject:BucketObject::o1"
+    },
+    "response": {
+      "inputs": {
+        "__defaults": [
+          "acl",
+          "forceDestroy",
+          "key"
+        ],
+        "acl": "private",
+        "bucket": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+        "content": "CONTENT",
+        "forceDestroy": false,
+        "key": "o1"
+      }
+    }
+  },
+  {
+    "metadata": {
+      "kind": "resource",
+      "mode": "client",
+      "name": "aws"
+    },
+    "method": "/pulumirpc.ResourceProvider/Create",
+    "request": {
+      "preview": true,
+      "properties": {
+        "__defaults": [
+          "acl",
+          "forceDestroy",
+          "key"
+        ],
+        "acl": "private",
+        "bucket": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+        "content": "CONTENT",
+        "forceDestroy": false,
+        "key": "o1"
+      },
+      "urn": "urn:pulumi:dev::secret-random-yaml::aws:s3/bucketObject:BucketObject::o1"
+    },
+    "response": {
+      "properties": {
+        "acl": "private",
+        "content": "CONTENT",
+        "forceDestroy": false,
+        "id": "",
+        "key": "o1"
+      }
+    }
+  }
+]`
+	old := os.Stdout // keep backup of the real stdout
+	defer func() { os.Stdout = old }()
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	replay(t, repro)
+
+	outC := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	w.Close()
+	out := <-outC
+	assert.NotContains(t, out, "aws_s3_object")
 }

--- a/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
+++ b/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
@@ -1,4 +1,4 @@
-From 0c357d6546d4703b6da082f2f234b47ace17bccc Mon Sep 17 00:00:00 2001
+From 3e5ecb8c064f9b763d45f658193e20eb3ed80eb5 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 16:49:08 +0000
 Subject: [PATCH 01/29] Add TagsSchemaTrulyComputed definition

--- a/patches/0002-Conns-user-agent.patch
+++ b/patches/0002-Conns-user-agent.patch
@@ -1,4 +1,4 @@
-From 919bca31ab7c024ea7fcc24cd8842d09f787f649 Mon Sep 17 00:00:00 2001
+From da1bdae365c2b57670f2b5891893a82d3a618864 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:03:31 +0000
 Subject: [PATCH 02/29] Conns user agent

--- a/patches/0003-Add-S3-legacy-bucket-to-resources.patch
+++ b/patches/0003-Add-S3-legacy-bucket-to-resources.patch
@@ -1,4 +1,4 @@
-From 4f0283e83147b9e1cabcb79bd780681ab0f832fd Mon Sep 17 00:00:00 2001
+From f844f520d7da553aef6252b4e754aea006f8c7cd Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:05:11 +0000
 Subject: [PATCH 03/29] Add S3 legacy bucket to resources

--- a/patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
+++ b/patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
@@ -1,4 +1,4 @@
-From 9d9da9b74f07a5edaf3c9a8d016964601c5fb932 Mon Sep 17 00:00:00 2001
+From dd7641f930d4aef08f9fa1878c6cb67d8aa1ac88 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Thu, 9 Mar 2023 09:47:49 -0600
 Subject: [PATCH 04/29] Marks SSE Configuration as Computed for Legacy S3

--- a/patches/0005-De-deprecate-bucket_object.patch
+++ b/patches/0005-De-deprecate-bucket_object.patch
@@ -1,14 +1,14 @@
-From ab452aa961e4ea862f2d9e98f00a9592f4b9eb85 Mon Sep 17 00:00:00 2001
+From f3398d9463cbb1da45e52d698e08ae60e8fbe30f Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:06:11 +0000
 Subject: [PATCH 05/29] De-deprecate bucket_object
 
 ---
- internal/service/s3/bucket_object.go | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ internal/service/s3/bucket_object.go | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/internal/service/s3/bucket_object.go b/internal/service/s3/bucket_object.go
-index 0d2e713604..4f88ff05ac 100644
+index 0d2e713604..da10d94324 100644
 --- a/internal/service/s3/bucket_object.go
 +++ b/internal/service/s3/bucket_object.go
 @@ -63,7 +63,7 @@ func ResourceBucketObject() *schema.Resource {
@@ -29,6 +29,17 @@ index 0d2e713604..4f88ff05ac 100644
  				Type:         schema.TypeString,
  				Required:     true,
  				ForceNew:     true,
+@@ -193,7 +193,9 @@ func ResourceBucketObject() *schema.Resource {
+ 			},
+ 		},
+ 
+-		DeprecationMessage: `use the aws_s3_object resource instead`,
++		// We are keeping aws_s3_bucket_object alive just like aws_s3_bucket.
++		//
++		// DeprecationMessage: `use the aws_s3_object resource instead`,
+ 	}
+ }
+ 
 -- 
 2.41.0
 

--- a/patches/0006-Remove-lakeformation-catalog_resource-default.patch
+++ b/patches/0006-Remove-lakeformation-catalog_resource-default.patch
@@ -1,4 +1,4 @@
-From 0483d7d383a7cb44f11a7a5b4220384b58e39af4 Mon Sep 17 00:00:00 2001
+From 86cd43ca06dc1788d66d42ecc04bbd21d0eae17c Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:08:23 +0000
 Subject: [PATCH 06/29] Remove lakeformation catalog_resource default

--- a/patches/0007-Workaround-SSM-Parameter-tier-bug.patch
+++ b/patches/0007-Workaround-SSM-Parameter-tier-bug.patch
@@ -1,4 +1,4 @@
-From 568c6ba004737a1e77e4bdaf501e88f070b427ce Mon Sep 17 00:00:00 2001
+From 7528a52574595b5179788dc8e65caa4312942c46 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:24:42 +0000
 Subject: [PATCH 07/29] Workaround SSM Parameter tier bug

--- a/patches/0008-Add-EKS-cluster-default_addons_to_remove.patch
+++ b/patches/0008-Add-EKS-cluster-default_addons_to_remove.patch
@@ -1,4 +1,4 @@
-From 9dd00da8b5bbee12a5b03ebc134b00df45f645fa Mon Sep 17 00:00:00 2001
+From 1c43db28650e4966fccc8919e2fb7b6624ba1b6a Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:31:27 +0000
 Subject: [PATCH 08/29] Add EKS cluster default_addons_to_remove

--- a/patches/0009-Add-EKS-cluster-certificate_authorities-plural.patch
+++ b/patches/0009-Add-EKS-cluster-certificate_authorities-plural.patch
@@ -1,4 +1,4 @@
-From cc19f3b9ec5fb25c3c7c4cad8d82bfe816490655 Mon Sep 17 00:00:00 2001
+From dc421cb90dc1a7f6f9fd43be663b720828adb135 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:32:49 +0000
 Subject: [PATCH 09/29] Add EKS cluster certificate_authorities (plural)

--- a/patches/0010-Workaround-Autoscaling-launch_configuration-associat.patch
+++ b/patches/0010-Workaround-Autoscaling-launch_configuration-associat.patch
@@ -1,4 +1,4 @@
-From c4028133721f0aea3f5746d5111b116e43681a1c Mon Sep 17 00:00:00 2001
+From 23a7ede2d2ac3d3fbd8fd4571eff1d85542826f8 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:34:56 +0000
 Subject: [PATCH 10/29] Workaround Autoscaling launch_configuration

--- a/patches/0011-Add-ECR-credentials_data_source.patch
+++ b/patches/0011-Add-ECR-credentials_data_source.patch
@@ -1,4 +1,4 @@
-From 4b8bd64ed0c1f11444a3ec1b0fe48049b93a5be9 Mon Sep 17 00:00:00 2001
+From e862e14fab95195f924b48747b6553f30f733a6c Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:36:34 +0000
 Subject: [PATCH 11/29] Add ECR credentials_data_source

--- a/patches/0012-Add-custom-appautoscaling-examples.patch
+++ b/patches/0012-Add-custom-appautoscaling-examples.patch
@@ -1,4 +1,4 @@
-From 43f57884cfd25f90c5148ef5fe806d7bba8ed7bc Mon Sep 17 00:00:00 2001
+From 045ca1c8d2c9dd77c69639690e4d0b806eb24f5d Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Wed, 9 Nov 2022 17:37:35 +0000
 Subject: [PATCH 12/29] Add custom appautoscaling examples

--- a/patches/0013-Add-dedicated_host-docs.patch
+++ b/patches/0013-Add-dedicated_host-docs.patch
@@ -1,4 +1,4 @@
-From bb6c9f54bf8b1ab747373da0a5f9dcef86504028 Mon Sep 17 00:00:00 2001
+From 1ea305152e8b7b5a12a237b2e219a32d38cc0ef5 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 10:08:05 +0000
 Subject: [PATCH 13/29] Add dedicated_host docs

--- a/patches/0014-Revert-WAF-schema-changes.patch
+++ b/patches/0014-Revert-WAF-schema-changes.patch
@@ -1,4 +1,4 @@
-From 7cf3da5ad3acae2d52946c741a70af87f27d0e46 Mon Sep 17 00:00:00 2001
+From 7372f5b2db194ef864edb62c3d760421bee563f3 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 13:59:57 +0000
 Subject: [PATCH 14/29] Revert WAF schema changes

--- a/patches/0015-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
+++ b/patches/0015-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
@@ -1,4 +1,4 @@
-From 47464f9fbb7d6e6d98a6fa53348d54f48a2fdd62 Mon Sep 17 00:00:00 2001
+From 7828866b02d805a32bdd939c44ab13173a6c2676 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@gmail.com>
 Date: Thu, 1 Dec 2022 10:56:32 -0800
 Subject: [PATCH 15/29] Catch cty panic in new

--- a/patches/0016-add-matchmaking-configuration-72.patch
+++ b/patches/0016-add-matchmaking-configuration-72.patch
@@ -1,4 +1,4 @@
-From 4debbe519cf7db8bf8cbb0fe32077f0a65cde6b6 Mon Sep 17 00:00:00 2001
+From e3b31ed769a6f2d5a1009aad549967024914896d Mon Sep 17 00:00:00 2001
 From: Lee Briggs <jaxxstorm@users.noreply.github.com>
 Date: Wed, 21 Dec 2022 12:23:59 -0800
 Subject: [PATCH 16/29] add matchmaking configuration (#72)

--- a/patches/0017-fix-Adding-back-in-removeAddons.patch
+++ b/patches/0017-fix-Adding-back-in-removeAddons.patch
@@ -1,4 +1,4 @@
-From cc29c8a3b4bfa7dc6716b004e21c8962099f9a32 Mon Sep 17 00:00:00 2001
+From 9cbffea124804c0151c3a47ed344c324e692e3a5 Mon Sep 17 00:00:00 2001
 From: Richard Shade <richard@pulumi.com>
 Date: Fri, 6 Jan 2023 15:31:22 -0600
 Subject: [PATCH 17/29] fix: Adding back in removeAddons

--- a/patches/0018-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
+++ b/patches/0018-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
@@ -1,4 +1,4 @@
-From 69f35c5b148b2fcadce7cedf90d3ef64b0b312d6 Mon Sep 17 00:00:00 2001
+From 75af8994da64733a609d1d0fe29b1c7a80778ac3 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Fri, 27 Jan 2023 09:37:43 -0600
 Subject: [PATCH 18/29] Reverts patches to S3BucketLegacy and GameLift

--- a/patches/0019-Revert-Update-endpointHashIPAddress.patch
+++ b/patches/0019-Revert-Update-endpointHashIPAddress.patch
@@ -1,4 +1,4 @@
-From 57def10628f2bb907a01df829542563b3062c81c Mon Sep 17 00:00:00 2001
+From 3b4ebcac5cfa60365943362729c032fbca13c439 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@pulumi.com>
 Date: Fri, 3 Feb 2023 17:31:18 -0800
 Subject: [PATCH 19/29] Revert "Update endpointHashIPAddress"

--- a/patches/0020-Fixup-eks-formatting.patch
+++ b/patches/0020-Fixup-eks-formatting.patch
@@ -1,4 +1,4 @@
-From fd550b46f40ce3a0403cc9e82175feeba18772b6 Mon Sep 17 00:00:00 2001
+From fcb400060a06635229571faabb123b210a50b6d1 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Thu, 9 Mar 2023 14:50:36 +0000
 Subject: [PATCH 20/29] Fixup eks formatting

--- a/patches/0021-Fixup-gamelift-context.patch
+++ b/patches/0021-Fixup-gamelift-context.patch
@@ -1,4 +1,4 @@
-From 1c3127071f41b68b6f612e65068e271b96f75f0c Mon Sep 17 00:00:00 2001
+From d6c558dbf4588e9bdf3d39d6c4447e632547b3ec Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Thu, 9 Mar 2023 14:50:51 +0000
 Subject: [PATCH 21/29] Fixup gamelift context

--- a/patches/0022-Change-default-descriptions-to-Managed-by-Pulumi.patch
+++ b/patches/0022-Change-default-descriptions-to-Managed-by-Pulumi.patch
@@ -1,4 +1,4 @@
-From 23b81def627f2444109b834f5323d7229a9d0b97 Mon Sep 17 00:00:00 2001
+From 059d292240e25e65b216dbaba89d5aa39e120f72 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 28 Feb 2023 15:19:24 +0000
 Subject: [PATCH 22/29] Change default descriptions to "Managed by Pulumi"

--- a/patches/0023-remove-required-elements-from-schema-and-fix-tests-7.patch
+++ b/patches/0023-remove-required-elements-from-schema-and-fix-tests-7.patch
@@ -1,4 +1,4 @@
-From 6760db13ebcdb0f8516e1a20f08027feb09a47fc Mon Sep 17 00:00:00 2001
+From 8773639ddd7d49a329a7bde65e38c665b246ad09 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel.dbphoto@gmail.com>
 Date: Tue, 28 Mar 2023 19:54:00 +0100
 Subject: [PATCH 23/29] remove required elements from schema and fix tests

--- a/patches/0024-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
+++ b/patches/0024-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
@@ -1,4 +1,4 @@
-From 4504890f7476b2b09460abe2ced078f08c10e9e9 Mon Sep 17 00:00:00 2001
+From 2ca04311dc510a6b012446825045da934df370e5 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 24 Apr 2023 10:36:36 -0400
 Subject: [PATCH 24/29] Temp remove cognito_identity_pool_roles_attachment

--- a/patches/0025-Fix-elbv2-target-group-read.patch
+++ b/patches/0025-Fix-elbv2-target-group-read.patch
@@ -1,4 +1,4 @@
-From e0f101aad95d60e48d8517f4f4d1838333a949df Mon Sep 17 00:00:00 2001
+From e36ed18830c8dd2a1522197bf8ca206e228d90cb Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 12 May 2023 10:55:42 +0100
 Subject: [PATCH 25/29] Fix elbv2 target group read

--- a/patches/0026-Fix-spurrious-json-diff-for-redrive_policy.patch
+++ b/patches/0026-Fix-spurrious-json-diff-for-redrive_policy.patch
@@ -1,4 +1,4 @@
-From 199570accb9f0a107afbf550e9086f7f867e15b2 Mon Sep 17 00:00:00 2001
+From 8a2d97cbf0ed2d198de97fb56bc046e0b76aff0e Mon Sep 17 00:00:00 2001
 From: Ramon Quitales <ramon@pulumi.com>
 Date: Thu, 18 May 2023 15:21:33 -0700
 Subject: [PATCH 26/29] Fix spurrious json diff for redrive_policy

--- a/patches/0027-Provide-context-to-conns.patch
+++ b/patches/0027-Provide-context-to-conns.patch
@@ -1,4 +1,4 @@
-From 098b72c2fa6ff8aa0bbe19ddfc83730bfb8932b0 Mon Sep 17 00:00:00 2001
+From f00668d048b130a8e86233118da28b8e01c39648 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Mon, 10 Jul 2023 11:51:24 +0200
 Subject: [PATCH 27/29] Provide context to conns

--- a/patches/0028-Match-the-tags-behavior-of-other-resources.patch
+++ b/patches/0028-Match-the-tags-behavior-of-other-resources.patch
@@ -1,4 +1,4 @@
-From c2a4264f3c6904ecbc50c8f04f0455b036c3ccff Mon Sep 17 00:00:00 2001
+From ab40d57d3634fdd2e12e1c9a6341a7fc467f246b Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Wed, 2 Aug 2023 14:12:03 +0200
 Subject: [PATCH 28/29] Match the "tags" behavior of other resources

--- a/patches/0029-move-shim-logic-to-upstream-as-a-patch.patch
+++ b/patches/0029-move-shim-logic-to-upstream-as-a-patch.patch
@@ -1,4 +1,4 @@
-From 691facac9e70b95ca923a38074bf1a0005f7518a Mon Sep 17 00:00:00 2001
+From 5e8fc215493cc88d08ea66d6cc56bbe70fd42956 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 6 Sep 2023 10:43:30 -0700
 Subject: [PATCH 29/29] move shim logic to upstream as a patch


### PR DESCRIPTION
Fixes #2796

Upstream has added a depreciation warning to `aws_s3_bucket_object`, deprecating it in favor of `aws_s3_object` (`aws:s3/bucketObjectV2:BucketObjectV2`).

This PR is the quick fix, simply removing the message.

Long term, we should come up with a plan to right upstream against s3:
1. Deprecate `aws:s3/bucketObject:BucketObject` and `aws:s3/bucketObjectV2:BucketObjectV2` in favor of `aws:s3/object:Object`.

  If we can confirm it is safe to use `aws_s3_object` with our `aws:s3/bucket:Bucket`, we can hard alias `aws:s3/bucketObjectV2:BucketObjectV2` to `aws:s3/object:Object` and restore the deprecation warnings. If not, we will need to wait until we can resolve (2) to resolve (1).

2. Find a migration path back to where `aws:s3/bucket:Bucket` is the preferred bucket to use (mirroring upstream). Then deprecate `aws:s3/bucketV2:BucketV2` in favor of `aws:s3/bucket:Bucket`.