### PR TITLE
Upgrade upstream to v5.17.0

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/aws/aws-sdk-go v1.45.6
 	github.com/pulumi/pulumi-aws/provider/v6 v6.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.16.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi/pkg/v3 v3.81.0
 	github.com/pulumi/pulumi/sdk/v3 v3.81.0
@@ -262,7 +262,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0 // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2337,12 +2337,12 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.16.0 h1:0Z6cmTjb/1p2z3W4L4e7OwhmsE6FJUbyxTihtyNs9y4=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.16.0/go.mod h1:XdOy385fEso7q3NuL+zAS3I1i+X47Bg01AlVD5aJRS4=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1 h1:fdedACdg9+11sy/0UZoN5sKbhlGsgUOfRyKpfWhaPig=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1/go.mod h1:d/Gr5Q+guqusxOnvqruuxqKqUEI0dCv7g+c6zYHNlE4=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1/go.mod h1:7OeUPH8rpt5ipyj9EFcnXpuzQ8SHL0dyqdfa8nOacdk=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0 h1:55mlXQtnYo2Pa1y0VeILi1W382vK10raX4z69LX2jn0=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0/go.mod h1:o0Vfch2UXtHOnGYpNElzGg4htT6B8X8hS9fa5AguP7g=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0 h1:MPhSwNLJJlqLFHGfrXIRXZHzFIu05YLQldAJRYpOHRs=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0/go.mod h1:o0Vfch2UXtHOnGYpNElzGg4htT6B8X8hS9fa5AguP7g=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096 h1:1nzT9XuyTHdcWJboYNMPPdW0B0mQdXYg8Az5tF96MXY=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096/go.mod h1:1pLAP9kryYta3Xrw99oh7BmxY6PYb+z2m7ENNCJMIRQ=
 github.com/pulumi/pulumi/pkg/v3 v3.81.0 h1:6rf2farQLszi8inHCu9YdJtDvK0fqNguix51b3FEDRQ=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220923175450-ca71523cdc36
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0
 	github.com/pulumi/pulumi/pkg/v3 v3.81.0
 	github.com/pulumi/pulumi/sdk/v3 v3.81.0
 	github.com/stretchr/testify v1.8.4

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2361,12 +2361,12 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.6 h1:UJrOAsYHRchwb4QlfI9Q224qg1TOI3rIsI6DDTUnn30=
 github.com/pulumi/pulumi-java/pkg v0.9.6/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2 h1:zKAzAHk9AKk+EF9FG4vT9u3jYiZFES/Mjq+s9mgoRs8=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2/go.mod h1:XdOy385fEso7q3NuL+zAS3I1i+X47Bg01AlVD5aJRS4=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1 h1:fdedACdg9+11sy/0UZoN5sKbhlGsgUOfRyKpfWhaPig=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1/go.mod h1:d/Gr5Q+guqusxOnvqruuxqKqUEI0dCv7g+c6zYHNlE4=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1/go.mod h1:7OeUPH8rpt5ipyj9EFcnXpuzQ8SHL0dyqdfa8nOacdk=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0 h1:55mlXQtnYo2Pa1y0VeILi1W382vK10raX4z69LX2jn0=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0/go.mod h1:o0Vfch2UXtHOnGYpNElzGg4htT6B8X8hS9fa5AguP7g=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0 h1:MPhSwNLJJlqLFHGfrXIRXZHzFIu05YLQldAJRYpOHRs=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0/go.mod h1:o0Vfch2UXtHOnGYpNElzGg4htT6B8X8hS9fa5AguP7g=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096 h1:1nzT9XuyTHdcWJboYNMPPdW0B0mQdXYg8Az5tF96MXY=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20230801203955-5d215c892096/go.mod h1:1pLAP9kryYta3Xrw99oh7BmxY6PYb+z2m7ENNCJMIRQ=
 github.com/pulumi/pulumi-yaml v1.2.2 h1:W6BeUBLhDrJ2GSU0em1AUVelG9PBI4ABY61DdhJOO3E=


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/2812
Fixes https://github.com/pulumi/pulumi-aws/issues/2806

We could not use upgrade-provider for this operation because there was a conflict between upstream changes editing a go.sum and one of our patches doing the same, so the patch did not apply cleanly. Resolved manually by rebating upstream and rebuilding the patch set.

The new upstream version targeted here is 5.17.0.

On top of the upstream upgrade, this PR updates dependencies from pulumi-terraform-bridge to propagate bugfixes:

- github.com/pulumi/pulumi-terraform-bridge/pf v0.16.1
- github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0