### PR TITLE
DO NOT MERGE: measure startup overhead

### DIFF
--- a/provider/fast_test.go
+++ b/provider/fast_test.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-aws/provider/v6/pkg/version"
+	//"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func init() {
+	version.Version = "1.2.3"
+}
+
+func BenchmarkProviderBare(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Provider()
+	}
+}
+
+func BenchmarkProviderMetadataInfo(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Provider("MetadataInfo")
+	}
+}
+
+func BenchmarkProviderAliases(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Provider("Aliases")
+	}
+}
+
+func BenchmarkProvider(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Provider("Aliases", "MetadataInfo")
+	}
+}


### PR DESCRIPTION
```
cd provider && go test -bench .

```

```
t0yv0@Antons-MacBook-Pro> go test -bench .                                                                                                                                                                     ~/code/pulumi-aws/provider
goos: darwin
goarch: amd64
pkg: github.com/pulumi/pulumi-aws/provider/v6
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkProviderBare-12                      12         118326943 ns/op
BenchmarkProviderMetadataInfo-12               4         333109448 ns/op
BenchmarkProviderAliases-12                    6         195651928 ns/op
BenchmarkProvider-12                           2         567590818 ns/op
```

Here's a build that uses jsoniter in the bridge in a few key positions:

```
go test -bench . -benchtime=25s                            ~/code/pulumi-aws/provider
goos: darwin
goarch: amd64
pkg: github.com/pulumi/pulumi-aws/provider/v6
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkProviderBare-12                     338          99265672 ns/op
BenchmarkProviderMetadataInfo-12             198         161237123 ns/op
BenchmarkProviderAliases-12                  120         271869386 ns/op
BenchmarkProvider-12                          84         361376502 ns/op
PASS
ok      github.com/pulumi/pulumi-aws/provider/v6        181.902s
```