### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_aws"
   description = "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "importlib-metadata>=6.0.0,<7.0.0;python_version<'3.8'"]
   keywords = ["pulumi", "aws"]
   readme = "README.md"
   requires-python = ">=3.7"


### PR DESCRIPTION
<blockquote>
<p>Use of <code class="docutils literal notranslate"><span class="pre">pkg_resources</span></code> is deprecated in favor of
<a class="hxr-hoverxref hxr-tooltip reference external tooltipstered" href="https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources"><code class="xref py py-mod docutils literal notranslate"><span class="pre">importlib.resources</span></code></a>, <a class="hxr-hoverxref hxr-tooltip reference external tooltipstered" href="https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata"><code class="xref py py-mod docutils literal notranslate"><span class="pre">importlib.metadata</span></code></a>
and their backports (<a class="reference external" href="https://pypi.org/project/importlib_resources">importlib_resources</a>, <a class="reference external" href="https://pypi.org/project/importlib_metadata">importlib_metadata</a>).
Some useful APIs are also provided by <a class="reference external" href="https://pypi.org/project/packaging">packaging</a> (e.g. requirements
and version parsing).
Users should refrain from new usage of <code class="docutils literal notranslate"><span class="pre">pkg_resources</span></code> and
should work to port to importlib-based solutions.</p>
</blockquote>

https://setuptools.pypa.io/en/latest/pkg_resources.html