### PR TITLE
Format diagnostics from GetAwsConfig as readable strings instead of %v format dump

### DIFF
--- a/provider/diag.go
+++ b/provider/diag.go
@@ -1,0 +1,22 @@
+// Copyright 2016-2023, Pulumi Corporation.
+
+package provider
+
+import (
+	"github.com/hashicorp/aws-sdk-go-base/v2/diag"
+)
+
+// formatDiags converts AWS SDK Diagnostics into a human-readable string.
+func formatDiags(diag diag.Diagnostics) string {
+	details := ""
+	for _, d := range diag {
+		if details != "" {
+			details += "\n"
+		}
+		details += d.Summary()
+		if d.Detail() != "" {
+			details += ". " + d.Detail()
+		}
+	}
+	return details
+}

--- a/provider/diag.go
+++ b/provider/diag.go
@@ -3,20 +3,23 @@
 package provider
 
 import (
+	"strings"
+
 	"github.com/hashicorp/aws-sdk-go-base/v2/diag"
 )
 
 // formatDiags converts AWS SDK Diagnostics into a human-readable string.
 func formatDiags(diag diag.Diagnostics) string {
-	details := ""
+	var sb strings.Builder
 	for _, d := range diag {
-		if details != "" {
-			details += "\n"
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
 		}
-		details += d.Summary()
+		sb.WriteString(d.Summary())
 		if d.Detail() != "" {
-			details += ". " + d.Detail()
+			sb.WriteString(". ")
+			sb.WriteString(d.Detail())
 		}
 	}
-	return details
+	return sb.String()
 }

--- a/provider/diag_test.go
+++ b/provider/diag_test.go
@@ -1,0 +1,59 @@
+// Copyright 2016-2023, Pulumi Corporation.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/aws-sdk-go-base/v2/diag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatDiags(t *testing.T) {
+	type testCase struct {
+		name   string
+		config diag.Diagnostics
+		expect string
+	}
+	testCases := []testCase{
+		{
+			name:   "empty",
+			config: diag.Diagnostics{},
+			expect: "",
+		},
+		{
+			name: "single error no details",
+			config: diag.Diagnostics{
+				diag.NewErrorDiagnostic("something bad happened", ""),
+			},
+			expect: "something bad happened",
+		},
+		{
+			name: "single error with details",
+			config: diag.Diagnostics{
+				diag.NewErrorDiagnostic("something bad happened", "take a look at the manual page 523"),
+			},
+			expect: "something bad happened. take a look at the manual page 523",
+		},
+		{
+			name: "multiple errors",
+			config: diag.Diagnostics{
+				diag.NewErrorDiagnostic("something bad happened", "take a look at the manual page 523"),
+				diag.NewErrorDiagnostic("another error", ""),
+				diag.NewErrorDiagnostic("one more", "with details"),
+				diag.NewErrorDiagnostic("one more without details", ""),
+			},
+			expect: `something bad happened. take a look at the manual page 523
+another error
+one more. with details
+one more without details`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := formatDiags(tc.config)
+			require.Equal(t, tc.expect, r)
+		})
+	}
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -614,10 +614,10 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 
 	config.SharedConfigFiles = []string{configPath}
 
-	if _, _, err := awsbase.GetAwsConfig(context.Background(), config); err != nil {
+	if _, _, diag := awsbase.GetAwsConfig(context.Background(), config); diag != nil && diag.HasError() {
 		return fmt.Errorf("unable to validate AWS credentials. \n"+
-			"Details: %v\n"+
-			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n", err)
+			"Details: %s\n"+
+			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n", formatDiags(diag))
 	}
 
 	return nil


### PR DESCRIPTION
A tactical improvement for https://github.com/pulumi/pulumi-aws/issues/2285 to avoid Go pointers leaking into error messages.

Before:

> unable to validate AWS credentials.
    Details: [{0x14009acaee0}]
    Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`.

After:

> unable to validate AWS credentials.
    Details: validating provider credentials: retrieving caller identity from STS: operation error STS: GetCallerIdentity, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region
    Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`.