### PR TITLE
Replace TODOs in imports

### DIFF
--- a/provider/doc_edits.go
+++ b/provider/doc_edits.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"regexp"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func editRules(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
+	return append(defaults, fixupImports)
+}
+
+const tfOrTODO = `([tT]erraform|TODO)`
+
+var inlineImportRegexp = regexp.MustCompile("% " + tfOrTODO + " import")
+var quotedImportRegexp = regexp.MustCompile("`" + tfOrTODO + " import`")
+
+// (?s) makes the '.' match newlines (in addition to everything else).
+var blockImportRegexp = regexp.MustCompile("(?s)In " + tfOrTODO + " v[0-9]+\\.[0-9]+\\.[0-9]+ and later," +
+	" use an `import` block.*?```.+?```\n")
+
+var fixupImports = tfbridge.DocsEdit{
+	Path: "*",
+	Edit: func(path string, content []byte) ([]byte, error) {
+		content = blockImportRegexp.ReplaceAllLiteral(content, nil)
+		content = inlineImportRegexp.ReplaceAllLiteral(content, []byte("% pulumi import"))
+		content = quotedImportRegexp.ReplaceAllLiteral(content, []byte("`pulumi import`"))
+		return content, nil
+	},
+}

--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInlineImport(t *testing.T) {
+	tests := []struct{ text, expected string }{
+		{
+			"% TODO import thing",
+			"% pulumi import thing",
+		},
+		{
+			"% terraform import thing",
+			"% pulumi import thing",
+		},
+		{
+			"% FOO import thing",
+			"% FOO import thing",
+		},
+		{
+			"`TODO import`",
+			"`pulumi import`",
+		},
+		{
+			"In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For example:\n" +
+				"\n" +
+				"```terraform" + `
+import {
+  to = aws_verifiedaccess_trust_provider.example
+  id = "vatp-8012925589"
+}` + "\n```\n" + `post text:
+` + "```yaml" + `
+foo: bar
+` + "```\n",
+			`post text:
+` + "```yaml" + `
+foo: bar
+` + "```\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+			actual, err := fixupImports.Edit("doc.md", []byte(tt.text))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(actual))
+		})
+	}
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -648,6 +648,7 @@ func Provider() *tfbridge.ProviderInfo {
 		Version:          version.Version,
 		GitHubOrg:        "hashicorp",
 		UpstreamRepoPath: "./upstream",
+		DocRules:         &tfbridge.DocRuleInfo{EditRules: editRules},
 
 		MetadataInfo: tfbridge.NewProviderMetadata(metadata),
 
@@ -691,10 +692,8 @@ func Provider() *tfbridge.ProviderInfo {
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// AWS Certificate Manager
 			"aws_acm_certificate_validation": {
-				Tok: awsResource(acmMod, "CertificateValidation"),
-				Docs: &tfbridge.DocInfo{
-					ReplaceExamplesSection: true,
-				},
+				Tok:  awsResource(acmMod, "CertificateValidation"),
+				Docs: &tfbridge.DocInfo{ReplaceExamplesSection: true},
 			},
 			// AWS Private Certificate Authority
 			"aws_acmpca_certificate_authority": {Tok: awsResource(acmpcaMod, "CertificateAuthority")},

--- a/sdk/dotnet/ApiGateway/ApiKey.cs
+++ b/sdk/dotnet/ApiGateway/ApiKey.cs
@@ -31,11 +31,11 @@ namespace Pulumi.Aws.ApiGateway
     /// 
     /// ## Import
     /// 
-    /// terraform import {
+    /// Using `pulumi import`, import API Gateway Keys using the `id`. For example:
     /// 
-    ///  to = aws_api_gateway_api_key.example
-    /// 
-    ///  id = "8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk" } Using `pulumi import`, import API Gateway Keys using the `id`. For exampleconsole % TODO import aws_api_gateway_api_key.example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+    /// ```sh
+    ///  $ pulumi import aws:apigateway/apiKey:ApiKey example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+    /// ```
     /// </summary>
     [AwsResourceType("aws:apigateway/apiKey:ApiKey")]
     public partial class ApiKey : global::Pulumi.CustomResource

--- a/sdk/dotnet/ApiGateway/Response.cs
+++ b/sdk/dotnet/ApiGateway/Response.cs
@@ -44,11 +44,11 @@ namespace Pulumi.Aws.ApiGateway
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleterraform import {
+    /// Using `pulumi import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For example:
     /// 
-    ///  to = aws_api_gateway_gateway_response.example
-    /// 
-    ///  id = "12345abcde/UNAUTHORIZED" } Using `TODO import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleconsole % TODO import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+    /// ```sh
+    ///  $ pulumi import aws:apigateway/response:Response example 12345abcde/UNAUTHORIZED
+    /// ```
     /// </summary>
     [AwsResourceType("aws:apigateway/response:Response")]
     public partial class Response : global::Pulumi.CustomResource

--- a/sdk/dotnet/Cfg/AggregateAuthorization.cs
+++ b/sdk/dotnet/Cfg/AggregateAuthorization.cs
@@ -33,11 +33,11 @@ namespace Pulumi.Aws.Cfg
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Config aggregate authorizations using `account_id:region`. For exampleterraform import {
+    /// Using `pulumi import`, import Config aggregate authorizations using `account_id:region`. For example:
     /// 
-    ///  to = aws_config_aggregate_authorization.example
-    /// 
-    ///  id = "123456789012:us-east-1" } Using `TODO import`, import Config aggregate authorizations using `account_id:region`. For exampleconsole % TODO import aws_config_aggregate_authorization.example 123456789012:us-east-1
+    /// ```sh
+    ///  $ pulumi import aws:cfg/aggregateAuthorization:AggregateAuthorization example 123456789012:us-east-1
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cfg/aggregateAuthorization:AggregateAuthorization")]
     public partial class AggregateAuthorization : global::Pulumi.CustomResource

--- a/sdk/dotnet/CleanRooms/ConfiguredTable.cs
+++ b/sdk/dotnet/CleanRooms/ConfiguredTable.cs
@@ -49,11 +49,11 @@ namespace Pulumi.Aws.CleanRooms
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_cleanrooms_configured_table` using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
     /// 
-    ///  to = aws_cleanrooms_configured_table.table
-    /// 
-    ///  id = "1234abcd-12ab-34cd-56ef-1234567890ab" } Using `TODO import`, import `aws_cleanrooms_configured_table` using the `id`. For exampleconsole % TODO import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+    /// ```sh
+    ///  $ pulumi import aws:cleanrooms/configuredTable:ConfiguredTable table 1234abcd-12ab-34cd-56ef-1234567890ab
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cleanrooms/configuredTable:ConfiguredTable")]
     public partial class ConfiguredTable : global::Pulumi.CustomResource

--- a/sdk/dotnet/Cloud9/EnvironmentMembership.cs
+++ b/sdk/dotnet/Cloud9/EnvironmentMembership.cs
@@ -41,11 +41,11 @@ namespace Pulumi.Aws.Cloud9
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Cloud9 environment membership using the `environment-id#user-arn`. For exampleterraform import {
+    /// Using `pulumi import`, import Cloud9 environment membership using the `environment-id#user-arn`. For example:
     /// 
-    ///  to = aws_cloud9_environment_membership.test
-    /// 
-    ///  id = "environment-id#user-arn" } Using `TODO import`, import Cloud9 environment membership using the `environment-id#user-arn`. For exampleconsole % TODO import aws_cloud9_environment_membership.test environment-id#user-arn
+    /// ```sh
+    ///  $ pulumi import aws:cloud9/environmentMembership:EnvironmentMembership test environment-id#user-arn
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cloud9/environmentMembership:EnvironmentMembership")]
     public partial class EnvironmentMembership : global::Pulumi.CustomResource

--- a/sdk/dotnet/CloudFormation/StackSet.cs
+++ b/sdk/dotnet/CloudFormation/StackSet.cs
@@ -138,7 +138,7 @@ namespace Pulumi.Aws.CloudFormation
     /// ```sh
     ///  $ pulumi import aws:cloudformation/stackSet:StackSet example example
     /// ```
-    ///  Using `TODO import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
+    ///  Using `pulumi import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
     /// 
     /// ```sh
     ///  $ pulumi import aws:cloudformation/stackSet:StackSet example example,DELEGATED_ADMIN

--- a/sdk/dotnet/CloudFormation/StackSetInstance.cs
+++ b/sdk/dotnet/CloudFormation/StackSetInstance.cs
@@ -134,23 +134,21 @@ namespace Pulumi.Aws.CloudFormation
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
-    /// 
     /// Import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
     /// 
     /// Import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
     /// 
-    /// Using `TODO import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
+    /// Using `pulumi import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
     /// 
     /// ```sh
     ///  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,123456789012,us-east-1
     /// ```
-    ///  Using `TODO import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
+    ///  Using `pulumi import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
     /// 
     /// ```sh
     ///  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1
     /// ```
-    ///  Using `TODO import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
+    ///  Using `pulumi import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
     /// 
     /// ```sh
     ///  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1,DELEGATED_ADMIN

--- a/sdk/dotnet/CloudFront/ContinuousDeploymentPolicy.cs
+++ b/sdk/dotnet/CloudFront/ContinuousDeploymentPolicy.cs
@@ -135,11 +135,11 @@ namespace Pulumi.Aws.CloudFront
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CloudFront Continuous Deployment Policy using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
     /// 
-    ///  to = aws_cloudfront_continuous_deployment_policy.example
-    /// 
-    ///  id = "abcd-1234" } Using `TODO import`, import CloudFront Continuous Deployment Policy using the `id`. For exampleconsole % TODO import aws_cloudfront_continuous_deployment_policy.example abcd-1234
+    /// ```sh
+    ///  $ pulumi import aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy example abcd-1234
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy")]
     public partial class ContinuousDeploymentPolicy : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodeCatalyst/Project.cs
+++ b/sdk/dotnet/CodeCatalyst/Project.cs
@@ -35,11 +35,11 @@ namespace Pulumi.Aws.CodeCatalyst
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Project using the `example_id_arg`. For exampleterraform import {
+    /// Using `pulumi import`, import CodeCatalyst Project using the `example_id_arg`. For example:
     /// 
-    ///  to = aws_codecatalyst_project.example
-    /// 
-    ///  id = "project-id-12345678" } Using `TODO import`, import CodeCatalyst Project using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_project.example project-id-12345678
+    /// ```sh
+    ///  $ pulumi import aws:codecatalyst/project:Project example project-id-12345678
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codecatalyst/project:Project")]
     public partial class Project : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodeCatalyst/SourceRepository.cs
+++ b/sdk/dotnet/CodeCatalyst/SourceRepository.cs
@@ -34,11 +34,11 @@ namespace Pulumi.Aws.CodeCatalyst
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Source Repository using the `example_id_arg`. For exampleterraform import {
+    /// Using `pulumi import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
     /// 
-    ///  to = aws_codecatalyst_source_repository.example
-    /// 
-    ///  id = "source_repository-id-12345678" } Using `TODO import`, import CodeCatalyst Source Repository using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_source_repository.example source_repository-id-12345678
+    /// ```sh
+    ///  $ pulumi import aws:codecatalyst/sourceRepository:SourceRepository example source_repository-id-12345678
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codecatalyst/sourceRepository:SourceRepository")]
     public partial class SourceRepository : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodeCommit/Repository.cs
+++ b/sdk/dotnet/CodeCommit/Repository.cs
@@ -33,9 +33,7 @@ namespace Pulumi.Aws.CodeCommit
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodeCommit repository using repository name. For example:
-    /// 
-    /// Using `TODO import`, import CodeCommit repository using repository name. For example:
+    /// Using `pulumi import`, import CodeCommit repository using repository name. For example:
     /// 
     /// ```sh
     ///  $ pulumi import aws:codecommit/repository:Repository imported ExistingRepo

--- a/sdk/dotnet/CodePipeline/Pipeline.cs
+++ b/sdk/dotnet/CodePipeline/Pipeline.cs
@@ -231,11 +231,11 @@ namespace Pulumi.Aws.CodePipeline
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodePipelines using the name. For exampleterraform import {
+    /// Using `pulumi import`, import CodePipelines using the name. For example:
     /// 
-    ///  to = aws_codepipeline.foo
-    /// 
-    ///  id = "example" } Using `TODO import`, import CodePipelines using the name. For exampleconsole % TODO import aws_codepipeline.foo example
+    /// ```sh
+    ///  $ pulumi import aws:codepipeline/pipeline:Pipeline foo example
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codepipeline/pipeline:Pipeline")]
     public partial class Pipeline : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodePipeline/Webhook.cs
+++ b/sdk/dotnet/CodePipeline/Webhook.cs
@@ -135,11 +135,11 @@ namespace Pulumi.Aws.CodePipeline
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodePipeline Webhooks using their ARN. For exampleterraform import {
+    /// Using `pulumi import`, import CodePipeline Webhooks using their ARN. For example:
     /// 
-    ///  to = aws_codepipeline_webhook.example
-    /// 
-    ///  id = "arn:aws:codepipeline:us-west-2:123456789012:webhook:example" } Using `TODO import`, import CodePipeline Webhooks using their ARN. For exampleconsole % TODO import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+    /// ```sh
+    ///  $ pulumi import aws:codepipeline/webhook:Webhook example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codepipeline/webhook:Webhook")]
     public partial class Webhook : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodeStarConnections/Connection.cs
+++ b/sdk/dotnet/CodeStarConnections/Connection.cs
@@ -87,11 +87,11 @@ namespace Pulumi.Aws.CodeStarConnections
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodeStar connections using the ARN. For exampleterraform import {
+    /// Using `pulumi import`, import CodeStar connections using the ARN. For example:
     /// 
-    ///  to = aws_codestarconnections_connection.test-connection
-    /// 
-    ///  id = "arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar connections using the ARN. For exampleconsole % TODO import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+    /// ```sh
+    ///  $ pulumi import aws:codestarconnections/connection:Connection test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codestarconnections/connection:Connection")]
     public partial class Connection : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodeStarConnections/Host.cs
+++ b/sdk/dotnet/CodeStarConnections/Host.cs
@@ -35,11 +35,11 @@ namespace Pulumi.Aws.CodeStarConnections
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodeStar Host using the ARN. For exampleterraform import {
+    /// Using `pulumi import`, import CodeStar Host using the ARN. For example:
     /// 
-    ///  to = aws_codestarconnections_host.example-host
-    /// 
-    ///  id = "arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar Host using the ARN. For exampleconsole % TODO import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+    /// ```sh
+    ///  $ pulumi import aws:codestarconnections/host:Host example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codestarconnections/host:Host")]
     public partial class Host : global::Pulumi.CustomResource

--- a/sdk/dotnet/CodeStarNotifications/NotificationRule.cs
+++ b/sdk/dotnet/CodeStarNotifications/NotificationRule.cs
@@ -86,11 +86,11 @@ namespace Pulumi.Aws.CodeStarNotifications
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import CodeStar notification rule using the ARN. For exampleterraform import {
+    /// Using `pulumi import`, import CodeStar notification rule using the ARN. For example:
     /// 
-    ///  to = aws_codestarnotifications_notification_rule.foo
-    /// 
-    ///  id = "arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b" } Using `TODO import`, import CodeStar notification rule using the ARN. For exampleconsole % TODO import aws_codestarnotifications_notification_rule.foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+    /// ```sh
+    ///  $ pulumi import aws:codestarnotifications/notificationRule:NotificationRule foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+    /// ```
     /// </summary>
     [AwsResourceType("aws:codestarnotifications/notificationRule:NotificationRule")]
     public partial class NotificationRule : global::Pulumi.CustomResource

--- a/sdk/dotnet/Cognito/IdentityPool.cs
+++ b/sdk/dotnet/Cognito/IdentityPool.cs
@@ -68,11 +68,11 @@ namespace Pulumi.Aws.Cognito
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool using its ID. For exampleterraform import {
+    /// Using `pulumi import`, import Cognito Identity Pool using its ID. For example:
     /// 
-    ///  to = aws_cognito_identity_pool.mypool
-    /// 
-    ///  id = "us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3" } Using `TODO import`, import Cognito Identity Pool using its ID. For exampleconsole % TODO import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+    /// ```sh
+    ///  $ pulumi import aws:cognito/identityPool:IdentityPool mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cognito/identityPool:IdentityPool")]
     public partial class IdentityPool : global::Pulumi.CustomResource

--- a/sdk/dotnet/Cognito/IdentityPoolProviderPrincipalTag.cs
+++ b/sdk/dotnet/Cognito/IdentityPoolProviderPrincipalTag.cs
@@ -14,11 +14,11 @@ namespace Pulumi.Aws.Cognito
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleterraform import {
+    /// Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For example:
     /// 
-    ///  to = aws_cognito_identity_pool_provider_principal_tag.example
-    /// 
-    ///  id = "us-west-2_abc123:CorpAD" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleconsole % TODO import aws_cognito_identity_pool_provider_principal_tag.example us-west-2_abc123:CorpAD
+    /// ```sh
+    ///  $ pulumi import aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag example us-west-2_abc123:CorpAD
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag")]
     public partial class IdentityPoolProviderPrincipalTag : global::Pulumi.CustomResource

--- a/sdk/dotnet/Cognito/IdentityPoolRoleAttachment.cs
+++ b/sdk/dotnet/Cognito/IdentityPoolRoleAttachment.cs
@@ -14,11 +14,11 @@ namespace Pulumi.Aws.Cognito
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleterraform import {
+    /// Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For example:
     /// 
-    ///  to = aws_cognito_identity_pool_roles_attachment.example
-    /// 
-    ///  id = "us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleconsole % TODO import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+    /// ```sh
+    ///  $ pulumi import aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment")]
     public partial class IdentityPoolRoleAttachment : global::Pulumi.CustomResource

--- a/sdk/dotnet/Cognito/UserPool.cs
+++ b/sdk/dotnet/Cognito/UserPool.cs
@@ -91,11 +91,11 @@ namespace Pulumi.Aws.Cognito
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Cognito User Pools using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import Cognito User Pools using the `id`. For example:
     /// 
-    ///  to = aws_cognito_user_pool.pool
-    /// 
-    ///  id = "us-west-2_abc123" } Using `TODO import`, import Cognito User Pools using the `id`. For exampleconsole % TODO import aws_cognito_user_pool.pool us-west-2_abc123
+    /// ```sh
+    ///  $ pulumi import aws:cognito/userPool:UserPool pool us-west-2_abc123
+    /// ```
     /// </summary>
     [AwsResourceType("aws:cognito/userPool:UserPool")]
     public partial class UserPool : global::Pulumi.CustomResource

--- a/sdk/dotnet/Connect/BotAssociation.cs
+++ b/sdk/dotnet/Connect/BotAssociation.cs
@@ -117,11 +117,11 @@ namespace Pulumi.Aws.Connect
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleterraform import {
+    /// Using `pulumi import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For example:
     /// 
-    ///  to = aws_connect_bot_association.example
-    /// 
-    ///  id = "aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2" } Using `TODO import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleconsole % TODO import aws_connect_bot_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+    /// ```sh
+    ///  $ pulumi import aws:connect/botAssociation:BotAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+    /// ```
     /// </summary>
     [AwsResourceType("aws:connect/botAssociation:BotAssociation")]
     public partial class BotAssociation : global::Pulumi.CustomResource

--- a/sdk/dotnet/Connect/LambdaFunctionAssociation.cs
+++ b/sdk/dotnet/Connect/LambdaFunctionAssociation.cs
@@ -34,11 +34,11 @@ namespace Pulumi.Aws.Connect
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleterraform import {
+    /// Using `pulumi import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For example:
     /// 
-    ///  to = aws_connect_lambda_function_association.example
-    /// 
-    ///  id = "aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example" } Using `TODO import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleconsole % TODO import aws_connect_lambda_function_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+    /// ```sh
+    ///  $ pulumi import aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+    /// ```
     /// </summary>
     [AwsResourceType("aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation")]
     public partial class LambdaFunctionAssociation : global::Pulumi.CustomResource

--- a/sdk/dotnet/DataSync/LocationAzureBlob.cs
+++ b/sdk/dotnet/DataSync/LocationAzureBlob.cs
@@ -43,11 +43,11 @@ namespace Pulumi.Aws.DataSync
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleterraform import {
+    /// Using `pulumi import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For example:
     /// 
-    ///  to = aws_datasync_location_azure_blob.example
-    /// 
-    ///  id = "arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567" } Using `TODO import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleconsole % TODO import aws_datasync_location_azure_blob.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+    /// ```sh
+    ///  $ pulumi import aws:datasync/locationAzureBlob:LocationAzureBlob example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+    /// ```
     /// </summary>
     [AwsResourceType("aws:datasync/locationAzureBlob:LocationAzureBlob")]
     public partial class LocationAzureBlob : global::Pulumi.CustomResource

--- a/sdk/dotnet/DataSync/LocationFsxOntapFileSystem.cs
+++ b/sdk/dotnet/DataSync/LocationFsxOntapFileSystem.cs
@@ -16,11 +16,11 @@ namespace Pulumi.Aws.DataSync
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleterraform import {
+    /// Using `pulumi import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For example:
     /// 
-    ///  to = aws_datasync_location_fsx_ontap_file_system.example
-    /// 
-    ///  id = "arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123" } Using `TODO import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleconsole % TODO import aws_datasync_location_fsx_ontap_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+    /// ```sh
+    ///  $ pulumi import aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+    /// ```
     /// </summary>
     [AwsResourceType("aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem")]
     public partial class LocationFsxOntapFileSystem : global::Pulumi.CustomResource

--- a/sdk/dotnet/DirectConnect/GatewayAssociationProposal.cs
+++ b/sdk/dotnet/DirectConnect/GatewayAssociationProposal.cs
@@ -38,7 +38,7 @@ namespace Pulumi.Aws.DirectConnect
     /// 
     /// Using a proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`:
     /// 
-    /// __With `TODO import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
+    /// __With `pulumi import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
     /// 
     /// Using a proposal ID:
     /// 

--- a/sdk/dotnet/Dlm/LifecyclePolicy.cs
+++ b/sdk/dotnet/Dlm/LifecyclePolicy.cs
@@ -81,11 +81,11 @@ namespace Pulumi.Aws.Dlm
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import DLM lifecycle policies using their policy ID. For exampleterraform import {
+    /// Using `pulumi import`, import DLM lifecycle policies using their policy ID. For example:
     /// 
-    ///  to = aws_dlm_lifecycle_policy.example
-    /// 
-    ///  id = "policy-abcdef12345678901" } Using `TODO import`, import DLM lifecycle policies using their policy ID. For exampleconsole % TODO import aws_dlm_lifecycle_policy.example policy-abcdef12345678901
+    /// ```sh
+    ///  $ pulumi import aws:dlm/lifecyclePolicy:LifecyclePolicy example policy-abcdef12345678901
+    /// ```
     /// </summary>
     [AwsResourceType("aws:dlm/lifecyclePolicy:LifecyclePolicy")]
     public partial class LifecyclePolicy : global::Pulumi.CustomResource

--- a/sdk/dotnet/Dms/ReplicationConfig.cs
+++ b/sdk/dotnet/Dms/ReplicationConfig.cs
@@ -50,11 +50,11 @@ namespace Pulumi.Aws.Dms
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import replication configs using the `arn`. For exampleterraform import {
+    /// Using `pulumi import`, import a replication config using the `arn`. For example:
     /// 
-    ///  to = aws_dms_replication_config.example
-    /// 
-    ///  id = "arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI" } Using `TODO import`, import a replication config using the `arn`. For exampleconsole % TODO import aws_dms_replication_config.example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+    /// ```sh
+    ///  $ pulumi import aws:dms/replicationConfig:ReplicationConfig example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+    /// ```
     /// </summary>
     [AwsResourceType("aws:dms/replicationConfig:ReplicationConfig")]
     public partial class ReplicationConfig : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ec2/NetworkInterface.cs
+++ b/sdk/dotnet/Ec2/NetworkInterface.cs
@@ -64,11 +64,11 @@ namespace Pulumi.Aws.Ec2
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Network Interfaces using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import Network Interfaces using the `id`. For example:
     /// 
-    ///  to = aws_network_interface.test
-    /// 
-    ///  id = "eni-e5aa89a3" } Using `TODO import`, import Network Interfaces using the `id`. For exampleconsole % TODO import aws_network_interface.test eni-e5aa89a3
+    /// ```sh
+    ///  $ pulumi import aws:ec2/networkInterface:NetworkInterface test eni-e5aa89a3
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ec2/networkInterface:NetworkInterface")]
     public partial class NetworkInterface : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ec2/VpcIpamPoolCidr.cs
+++ b/sdk/dotnet/Ec2/VpcIpamPoolCidr.cs
@@ -19,11 +19,15 @@ namespace Pulumi.Aws.Ec2
     /// 
     /// ## Import
     /// 
-    /// terraform import {
+    /// __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
     /// 
-    ///  to = aws_vpc_ipam_pool_cidr.example
+    /// Using `pulumi import`, import IPAMs using the `&lt;cidr&gt;_&lt;ipam-pool-id&gt;`. For example:
     /// 
-    ///  id = "172.20.0.0/24_ipam-pool-0e634f5a1517cccdc" } Using `pulumi import`, import IPAMs using the `&lt;cidr&gt;_&lt;ipam-pool-id&gt;`. For exampleconsole % TODO import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+    /// __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
+    /// 
+    /// ```sh
+    ///  $ pulumi import aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr")]
     public partial class VpcIpamPoolCidr : global::Pulumi.CustomResource

--- a/sdk/dotnet/EmrContainers/JobTemplate.cs
+++ b/sdk/dotnet/EmrContainers/JobTemplate.cs
@@ -44,11 +44,11 @@ namespace Pulumi.Aws.EmrContainers
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import EKS job templates using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import EKS job templates using the `id`. For example:
     /// 
-    ///  to = aws_emrcontainers_job_template.example
-    /// 
-    ///  id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS job templates using the `id`. For exampleconsole % TODO import aws_emrcontainers_job_template.example a1b2c3d4e5f6g7h8i9j10k11l
+    /// ```sh
+    ///  $ pulumi import aws:emrcontainers/jobTemplate:JobTemplate example a1b2c3d4e5f6g7h8i9j10k11l
+    /// ```
     /// </summary>
     [AwsResourceType("aws:emrcontainers/jobTemplate:JobTemplate")]
     public partial class JobTemplate : global::Pulumi.CustomResource

--- a/sdk/dotnet/EmrContainers/VirtualCluster.cs
+++ b/sdk/dotnet/EmrContainers/VirtualCluster.cs
@@ -44,11 +44,11 @@ namespace Pulumi.Aws.EmrContainers
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import EKS Clusters using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import EKS Clusters using the `id`. For example:
     /// 
-    ///  to = aws_emrcontainers_virtual_cluster.example
-    /// 
-    ///  id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS Clusters using the `id`. For exampleconsole % TODO import aws_emrcontainers_virtual_cluster.example a1b2c3d4e5f6g7h8i9j10k11l
+    /// ```sh
+    ///  $ pulumi import aws:emrcontainers/virtualCluster:VirtualCluster example a1b2c3d4e5f6g7h8i9j10k11l
+    /// ```
     /// </summary>
     [AwsResourceType("aws:emrcontainers/virtualCluster:VirtualCluster")]
     public partial class VirtualCluster : global::Pulumi.CustomResource

--- a/sdk/dotnet/EmrServerless/Application.cs
+++ b/sdk/dotnet/EmrServerless/Application.cs
@@ -91,11 +91,11 @@ namespace Pulumi.Aws.EmrServerless
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import EMR Severless applications using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import EMR Severless applications using the `id`. For example:
     /// 
-    ///  to = aws_emrserverless_application.example
-    /// 
-    ///  id = "id" } Using `TODO import`, import EMR Severless applications using the `id`. For exampleconsole % TODO import aws_emrserverless_application.example id
+    /// ```sh
+    ///  $ pulumi import aws:emrserverless/application:Application example id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:emrserverless/application:Application")]
     public partial class Application : global::Pulumi.CustomResource

--- a/sdk/dotnet/GameLift/GameServerGroup.cs
+++ b/sdk/dotnet/GameLift/GameServerGroup.cs
@@ -172,11 +172,11 @@ namespace Pulumi.Aws.GameLift
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import GameLift Game Server Group using the `name`. For exampleterraform import {
+    /// Using `pulumi import`, import GameLift Game Server Group using the `name`. For example:
     /// 
-    ///  to = aws_gamelift_game_server_group.example
-    /// 
-    ///  id = "example" } Using `TODO import`, import GameLift Game Server Group using the `name`. For exampleconsole % TODO import aws_gamelift_game_server_group.example example
+    /// ```sh
+    ///  $ pulumi import aws:gamelift/gameServerGroup:GameServerGroup example example
+    /// ```
     /// </summary>
     [AwsResourceType("aws:gamelift/gameServerGroup:GameServerGroup")]
     public partial class GameServerGroup : global::Pulumi.CustomResource

--- a/sdk/dotnet/Glue/DevEndpoint.cs
+++ b/sdk/dotnet/Glue/DevEndpoint.cs
@@ -70,11 +70,11 @@ namespace Pulumi.Aws.Glue
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import a Glue Development Endpoint using the `name`. For exampleterraform import {
+    /// Using `pulumi import`, import a Glue Development Endpoint using the `name`. For example:
     /// 
-    ///  to = aws_glue_dev_endpoint.example
-    /// 
-    ///  id = "foo" } Using `TODO import`, import a Glue Development Endpoint using the `name`. For exampleconsole % TODO import aws_glue_dev_endpoint.example foo
+    /// ```sh
+    ///  $ pulumi import aws:glue/devEndpoint:DevEndpoint example foo
+    /// ```
     /// </summary>
     [AwsResourceType("aws:glue/devEndpoint:DevEndpoint")]
     public partial class DevEndpoint : global::Pulumi.CustomResource

--- a/sdk/dotnet/Iam/GroupPolicyAttachment.cs
+++ b/sdk/dotnet/Iam/GroupPolicyAttachment.cs
@@ -43,11 +43,11 @@ namespace Pulumi.Aws.Iam
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleterraform import {
+    /// Using `pulumi import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For example:
     /// 
-    ///  to = aws_iam_group_policy_attachment.test-attach
-    /// 
-    ///  id = "test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+    /// ```sh
+    ///  $ pulumi import aws:iam/groupPolicyAttachment:GroupPolicyAttachment test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+    /// ```
     /// </summary>
     [AwsResourceType("aws:iam/groupPolicyAttachment:GroupPolicyAttachment")]
     public partial class GroupPolicyAttachment : global::Pulumi.CustomResource

--- a/sdk/dotnet/Iam/RolePolicyAttachment.cs
+++ b/sdk/dotnet/Iam/RolePolicyAttachment.cs
@@ -93,11 +93,11 @@ namespace Pulumi.Aws.Iam
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleterraform import {
+    /// Using `pulumi import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
     /// 
-    ///  to = aws_iam_role_policy_attachment.test-attach
-    /// 
-    ///  id = "test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+    /// ```sh
+    ///  $ pulumi import aws:iam/rolePolicyAttachment:RolePolicyAttachment test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+    /// ```
     /// </summary>
     [AwsResourceType("aws:iam/rolePolicyAttachment:RolePolicyAttachment")]
     public partial class RolePolicyAttachment : global::Pulumi.CustomResource

--- a/sdk/dotnet/Iam/UserPolicyAttachment.cs
+++ b/sdk/dotnet/Iam/UserPolicyAttachment.cs
@@ -43,11 +43,11 @@ namespace Pulumi.Aws.Iam
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleterraform import {
+    /// Using `pulumi import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For example:
     /// 
-    ///  to = aws_iam_user_policy_attachment.test-attach
-    /// 
-    ///  id = "test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+    /// ```sh
+    ///  $ pulumi import aws:iam/userPolicyAttachment:UserPolicyAttachment test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+    /// ```
     /// </summary>
     [AwsResourceType("aws:iam/userPolicyAttachment:UserPolicyAttachment")]
     public partial class UserPolicyAttachment : global::Pulumi.CustomResource

--- a/sdk/dotnet/Lex/V2modelsBot.cs
+++ b/sdk/dotnet/Lex/V2modelsBot.cs
@@ -41,11 +41,11 @@ namespace Pulumi.Aws.Lex
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Lex V2 Models Bot using the `example_id_arg`. For exampleterraform import {
+    /// Using `pulumi import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
     /// 
-    ///  to = aws_lexv2models_bot.example
-    /// 
-    ///  id = "bot-id-12345678" } Using `TODO import`, import Lex V2 Models Bot using the `example_id_arg`. For exampleconsole % TODO import aws_lexv2models_bot.example bot-id-12345678
+    /// ```sh
+    ///  $ pulumi import aws:lex/v2modelsBot:V2modelsBot example bot-id-12345678
+    /// ```
     /// </summary>
     [AwsResourceType("aws:lex/v2modelsBot:V2modelsBot")]
     public partial class V2modelsBot : global::Pulumi.CustomResource

--- a/sdk/dotnet/LicenseManager/Association.cs
+++ b/sdk/dotnet/LicenseManager/Association.cs
@@ -66,11 +66,11 @@ namespace Pulumi.Aws.LicenseManager
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import license configurations using `resource_arn,license_configuration_arn`. For exampleterraform import {
+    /// Using `pulumi import`, import license configurations using `resource_arn,license_configuration_arn`. For example:
     /// 
-    ///  to = aws_licensemanager_association.example
-    /// 
-    ///  id = "arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using `resource_arn,license_configuration_arn`. For exampleconsole % TODO import aws_licensemanager_association.example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+    /// ```sh
+    ///  $ pulumi import aws:licensemanager/association:Association example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+    /// ```
     /// </summary>
     [AwsResourceType("aws:licensemanager/association:Association")]
     public partial class Association : global::Pulumi.CustomResource

--- a/sdk/dotnet/LicenseManager/LicenseConfiguration.cs
+++ b/sdk/dotnet/LicenseManager/LicenseConfiguration.cs
@@ -56,11 +56,11 @@ namespace Pulumi.Aws.LicenseManager
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import license configurations using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import license configurations using the `id`. For example:
     /// 
-    ///  to = aws_licensemanager_license_configuration.example
-    /// 
-    ///  id = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using the `id`. For exampleconsole % TODO import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+    /// ```sh
+    ///  $ pulumi import aws:licensemanager/licenseConfiguration:LicenseConfiguration example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+    /// ```
     /// </summary>
     [AwsResourceType("aws:licensemanager/licenseConfiguration:LicenseConfiguration")]
     public partial class LicenseConfiguration : global::Pulumi.CustomResource

--- a/sdk/dotnet/Msk/ClusterPolicy.cs
+++ b/sdk/dotnet/Msk/ClusterPolicy.cs
@@ -67,11 +67,11 @@ namespace Pulumi.Aws.Msk
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Managed Streaming for Kafka Cluster Policy using the `cluster_arn. For exampleterraform import {
+    /// Using `pulumi import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For example:
     /// 
-    ///  to = aws_msk_cluster_policy.example
-    /// 
-    ///  id = "arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3" } Using `TODO import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For exampleconsole % TODO import aws_msk_cluster_policy.example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+    /// ```sh
+    ///  $ pulumi import aws:msk/clusterPolicy:ClusterPolicy example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+    /// ```
     /// </summary>
     [AwsResourceType("aws:msk/clusterPolicy:ClusterPolicy")]
     public partial class ClusterPolicy : global::Pulumi.CustomResource

--- a/sdk/dotnet/Msk/VpcConnection.cs
+++ b/sdk/dotnet/Msk/VpcConnection.cs
@@ -39,11 +39,11 @@ namespace Pulumi.Aws.Msk
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import MSK configurations using the configuration ARN. For exampleterraform import {
+    /// Using `pulumi import`, import MSK configurations using the configuration ARN. For example:
     /// 
-    ///  to = aws_msk_vpc_connection.example
-    /// 
-    ///  id = "arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2" } Using `TODO import`, import MSK configurations using the configuration ARN. For exampleconsole % TODO import aws_msk_vpc_connection.example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+    /// ```sh
+    ///  $ pulumi import aws:msk/vpcConnection:VpcConnection example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+    /// ```
     /// </summary>
     [AwsResourceType("aws:msk/vpcConnection:VpcConnection")]
     public partial class VpcConnection : global::Pulumi.CustomResource

--- a/sdk/dotnet/OpenSearch/VpcEndpoint.cs
+++ b/sdk/dotnet/OpenSearch/VpcEndpoint.cs
@@ -46,11 +46,11 @@ namespace Pulumi.Aws.OpenSearch
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import OpenSearch VPC endpoint connections using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import OpenSearch VPC endpoint connections using the `id`. For example:
     /// 
-    ///  to = aws_opensearch_vpc_endpoint_connection.example
-    /// 
-    ///  id = "endpoint-id" } Using `TODO import`, import OpenSearch VPC endpoint connections using the `id`. For exampleconsole % TODO import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+    /// ```sh
+    ///  $ pulumi import aws:opensearch/vpcEndpoint:VpcEndpoint example endpoint-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:opensearch/vpcEndpoint:VpcEndpoint")]
     public partial class VpcEndpoint : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/AdmChannel.cs
+++ b/sdk/dotnet/Pinpoint/AdmChannel.cs
@@ -38,11 +38,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint ADM Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint ADM Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_adm_channel.channel
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint ADM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_adm_channel.channel application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/admChannel:AdmChannel channel application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/admChannel:AdmChannel")]
     public partial class AdmChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/ApnsChannel.cs
+++ b/sdk/dotnet/Pinpoint/ApnsChannel.cs
@@ -38,11 +38,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint APNs Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_apns_channel.apns
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint APNs Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_channel.apns application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/apnsChannel:ApnsChannel apns application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/apnsChannel:ApnsChannel")]
     public partial class ApnsChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/ApnsSandboxChannel.cs
+++ b/sdk/dotnet/Pinpoint/ApnsSandboxChannel.cs
@@ -38,11 +38,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_apns_sandbox_channel.apns_sandbox
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_sandbox_channel.apns_sandbox application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel apns_sandbox application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel")]
     public partial class ApnsSandboxChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/ApnsVoipChannel.cs
+++ b/sdk/dotnet/Pinpoint/ApnsVoipChannel.cs
@@ -38,11 +38,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint APNs VoIP Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_apns_voip_channel.apns_voip
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_channel.apns_voip application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/apnsVoipChannel:ApnsVoipChannel apns_voip application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/apnsVoipChannel:ApnsVoipChannel")]
     public partial class ApnsVoipChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/ApnsVoipSandboxChannel.cs
+++ b/sdk/dotnet/Pinpoint/ApnsVoipSandboxChannel.cs
@@ -38,11 +38,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel apns_voip_sandbox application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel")]
     public partial class ApnsVoipSandboxChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/App.cs
+++ b/sdk/dotnet/Pinpoint/App.cs
@@ -40,11 +40,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint App using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint App using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_app.name
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint App using the `application-id`. For exampleconsole % TODO import aws_pinpoint_app.name application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/app:App name application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/app:App")]
     public partial class App : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/BaiduChannel.cs
+++ b/sdk/dotnet/Pinpoint/BaiduChannel.cs
@@ -37,11 +37,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint Baidu Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint Baidu Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_baidu_channel.channel
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint Baidu Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_baidu_channel.channel application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/baiduChannel:BaiduChannel channel application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/baiduChannel:BaiduChannel")]
     public partial class BaiduChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/EmailChannel.cs
+++ b/sdk/dotnet/Pinpoint/EmailChannel.cs
@@ -98,11 +98,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint Email Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint Email Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_email_channel.email
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint Email Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_email_channel.email application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/emailChannel:EmailChannel email application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/emailChannel:EmailChannel")]
     public partial class EmailChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/EventStream.cs
+++ b/sdk/dotnet/Pinpoint/EventStream.cs
@@ -98,11 +98,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint Event Stream using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint Event Stream using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_event_stream.stream
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint Event Stream using the `application-id`. For exampleconsole % TODO import aws_pinpoint_event_stream.stream application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/eventStream:EventStream stream application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/eventStream:EventStream")]
     public partial class EventStream : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/GcmChannel.cs
+++ b/sdk/dotnet/Pinpoint/GcmChannel.cs
@@ -36,11 +36,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Pinpoint GCM Channel using the `application-id`. For exampleterraform import {
+    /// Using `pulumi import`, import Pinpoint GCM Channel using the `application-id`. For example:
     /// 
-    ///  to = aws_pinpoint_gcm_channel.gcm
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import Pinpoint GCM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_gcm_channel.gcm application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/gcmChannel:GcmChannel gcm application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/gcmChannel:GcmChannel")]
     public partial class GcmChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Pinpoint/SmsChannel.cs
+++ b/sdk/dotnet/Pinpoint/SmsChannel.cs
@@ -34,11 +34,11 @@ namespace Pulumi.Aws.Pinpoint
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import the Pinpoint SMS Channel using the `application_id`. For exampleterraform import {
+    /// Using `pulumi import`, import the Pinpoint SMS Channel using the `application_id`. For example:
     /// 
-    ///  to = aws_pinpoint_sms_channel.sms
-    /// 
-    ///  id = "application-id" } Using `TODO import`, import the Pinpoint SMS Channel using the `application_id`. For exampleconsole % TODO import aws_pinpoint_sms_channel.sms application-id
+    /// ```sh
+    ///  $ pulumi import aws:pinpoint/smsChannel:SmsChannel sms application-id
+    /// ```
     /// </summary>
     [AwsResourceType("aws:pinpoint/smsChannel:SmsChannel")]
     public partial class SmsChannel : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ram/PrincipalAssociation.cs
+++ b/sdk/dotnet/Ram/PrincipalAssociation.cs
@@ -67,11 +67,11 @@ namespace Pulumi.Aws.Ram
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleterraform import {
+    /// Using `pulumi import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For example:
     /// 
-    ///  to = aws_ram_principal_association.example
-    /// 
-    ///  id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012" } Using `TODO import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleconsole % TODO import aws_ram_principal_association.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+    /// ```sh
+    ///  $ pulumi import aws:ram/principalAssociation:PrincipalAssociation example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ram/principalAssociation:PrincipalAssociation")]
     public partial class PrincipalAssociation : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ram/ResourceShare.cs
+++ b/sdk/dotnet/Ram/ResourceShare.cs
@@ -36,11 +36,11 @@ namespace Pulumi.Aws.Ram
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import resource shares using the `arn` of the resource share. For exampleterraform import {
+    /// Using `pulumi import`, import resource shares using the `arn` of the resource share. For example:
     /// 
-    ///  to = aws_ram_resource_share.example
-    /// 
-    ///  id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12" } Using `TODO import`, import resource shares using the `arn` of the resource share. For exampleconsole % TODO import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+    /// ```sh
+    ///  $ pulumi import aws:ram/resourceShare:ResourceShare example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ram/resourceShare:ResourceShare")]
     public partial class ResourceShare : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ram/ResourceShareAccepter.cs
+++ b/sdk/dotnet/Ram/ResourceShareAccepter.cs
@@ -64,11 +64,11 @@ namespace Pulumi.Aws.Ram
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import resource share accepters using the resource share ARN. For exampleterraform import {
+    /// Using `pulumi import`, import resource share accepters using the resource share ARN. For example:
     /// 
-    ///  to = aws_ram_resource_share_accepter.example
-    /// 
-    ///  id = "arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767" } Using `TODO import`, import resource share accepters using the resource share ARN. For exampleconsole % TODO import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+    /// ```sh
+    ///  $ pulumi import aws:ram/resourceShareAccepter:ResourceShareAccepter example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ram/resourceShareAccepter:ResourceShareAccepter")]
     public partial class ResourceShareAccepter : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ram/SharingWithOrganization.cs
+++ b/sdk/dotnet/Ram/SharingWithOrganization.cs
@@ -31,11 +31,11 @@ namespace Pulumi.Aws.Ram
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import the resource using the current AWS account ID. For exampleterraform import {
+    /// Using `pulumi import`, import the resource using the current AWS account ID. For example:
     /// 
-    ///  to = aws_ram_sharing_with_organization.example
-    /// 
-    ///  id = "123456789012" } Using `TODO import`, import the resource using the current AWS account ID. For exampleconsole % TODO import aws_ram_sharing_with_organization.example 123456789012
+    /// ```sh
+    ///  $ pulumi import aws:ram/sharingWithOrganization:SharingWithOrganization example 123456789012
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ram/sharingWithOrganization:SharingWithOrganization")]
     public partial class SharingWithOrganization : global::Pulumi.CustomResource

--- a/sdk/dotnet/Rds/ClusterParameterGroup.cs
+++ b/sdk/dotnet/Rds/ClusterParameterGroup.cs
@@ -49,11 +49,11 @@ namespace Pulumi.Aws.Rds
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import RDS Cluster Parameter Groups using the `name`. For exampleterraform import {
+    /// Using `pulumi import`, import RDS Cluster Parameter Groups using the `name`. For example:
     /// 
-    ///  to = aws_rds_cluster_parameter_group.cluster_pg
-    /// 
-    ///  id = "production-pg-1" } Using `TODO import`, import RDS Cluster Parameter Groups using the `name`. For exampleconsole % TODO import aws_rds_cluster_parameter_group.cluster_pg production-pg-1
+    /// ```sh
+    ///  $ pulumi import aws:rds/clusterParameterGroup:ClusterParameterGroup cluster_pg production-pg-1
+    /// ```
     /// </summary>
     [AwsResourceType("aws:rds/clusterParameterGroup:ClusterParameterGroup")]
     public partial class ClusterParameterGroup : global::Pulumi.CustomResource

--- a/sdk/dotnet/Rds/CustomDbEngineVersion.cs
+++ b/sdk/dotnet/Rds/CustomDbEngineVersion.cs
@@ -141,11 +141,11 @@ namespace Pulumi.Aws.Rds
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleterraform import {
+    /// Using `pulumi import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For example:
     /// 
-    ///  to = aws_rds_custom_db_engine_version.example
-    /// 
-    ///  id = "custom-oracle-ee-cdb:19.cdb_cev1" } Using `TODO import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleconsole % TODO import aws_rds_custom_db_engine_version.example custom-oracle-ee-cdb:19.cdb_cev1
+    /// ```sh
+    ///  $ pulumi import aws:rds/customDbEngineVersion:CustomDbEngineVersion example custom-oracle-ee-cdb:19.cdb_cev1
+    /// ```
     /// </summary>
     [AwsResourceType("aws:rds/customDbEngineVersion:CustomDbEngineVersion")]
     public partial class CustomDbEngineVersion : global::Pulumi.CustomResource

--- a/sdk/dotnet/Rds/InstanceAutomatedBackupsReplication.cs
+++ b/sdk/dotnet/Rds/InstanceAutomatedBackupsReplication.cs
@@ -105,11 +105,11 @@ namespace Pulumi.Aws.Rds
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import RDS instance automated backups replication using the `arn`. For exampleterraform import {
+    /// Using `pulumi import`, import RDS instance automated backups replication using the `arn`. For example:
     /// 
-    ///  to = aws_db_instance_automated_backups_replication.default
-    /// 
-    ///  id = "arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my" } Using `TODO import`, import RDS instance automated backups replication using the `arn`. For exampleconsole % TODO import aws_db_instance_automated_backups_replication.default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+    /// ```sh
+    ///  $ pulumi import aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+    /// ```
     /// </summary>
     [AwsResourceType("aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication")]
     public partial class InstanceAutomatedBackupsReplication : global::Pulumi.CustomResource

--- a/sdk/dotnet/Route53/ResolverFirewallConfig.cs
+++ b/sdk/dotnet/Route53/ResolverFirewallConfig.cs
@@ -40,11 +40,11 @@ namespace Pulumi.Aws.Route53
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleterraform import {
+    /// Using `pulumi import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For example:
     /// 
-    ///  to = aws_route53_resolver_firewall_config.example
-    /// 
-    ///  id = "rdsc-be1866ecc1683e95" } Using `TODO import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleconsole % TODO import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+    /// ```sh
+    ///  $ pulumi import aws:route53/resolverFirewallConfig:ResolverFirewallConfig example rdsc-be1866ecc1683e95
+    /// ```
     /// </summary>
     [AwsResourceType("aws:route53/resolverFirewallConfig:ResolverFirewallConfig")]
     public partial class ResolverFirewallConfig : global::Pulumi.CustomResource

--- a/sdk/dotnet/Route53/ResolverFirewallDomainList.cs
+++ b/sdk/dotnet/Route53/ResolverFirewallDomainList.cs
@@ -29,15 +29,13 @@ namespace Pulumi.Aws.Route53
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import
+    /// Using `pulumi import`, import
     /// 
-    /// Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleterraform import {
+    /// Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For example:
     /// 
-    ///  to = aws_route53_resolver_firewall_domain_list.example
-    /// 
-    ///  id = "rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
-    /// 
-    /// Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleconsole % TODO import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+    /// ```sh
+    ///  $ pulumi import aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList example rslvr-fdl-0123456789abcdef
+    /// ```
     /// </summary>
     [AwsResourceType("aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList")]
     public partial class ResolverFirewallDomainList : global::Pulumi.CustomResource

--- a/sdk/dotnet/Route53/ResolverFirewallRule.cs
+++ b/sdk/dotnet/Route53/ResolverFirewallRule.cs
@@ -53,15 +53,13 @@ namespace Pulumi.Aws.Route53
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import
+    /// Using `pulumi import`, import
     /// 
-    /// Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleterraform import {
+    /// Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For example:
     /// 
-    ///  to = aws_route53_resolver_firewall_rule.example
-    /// 
-    ///  id = "rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
-    /// 
-    /// Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleconsole % TODO import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+    /// ```sh
+    ///  $ pulumi import aws:route53/resolverFirewallRule:ResolverFirewallRule example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+    /// ```
     /// </summary>
     [AwsResourceType("aws:route53/resolverFirewallRule:ResolverFirewallRule")]
     public partial class ResolverFirewallRule : global::Pulumi.CustomResource

--- a/sdk/dotnet/Route53/ResolverFirewallRuleGroup.cs
+++ b/sdk/dotnet/Route53/ResolverFirewallRuleGroup.cs
@@ -29,15 +29,13 @@ namespace Pulumi.Aws.Route53
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import
+    /// Using `pulumi import`, import
     /// 
-    /// Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleterraform import {
+    /// Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For example:
     /// 
-    ///  to = aws_route53_resolver_firewall_rule_group.example
-    /// 
-    ///  id = "rslvr-frg-0123456789abcdef" } Using `TODO import`, import
-    /// 
-    /// Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+    /// ```sh
+    ///  $ pulumi import aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup example rslvr-frg-0123456789abcdef
+    /// ```
     /// </summary>
     [AwsResourceType("aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup")]
     public partial class ResolverFirewallRuleGroup : global::Pulumi.CustomResource

--- a/sdk/dotnet/Route53/ResolverFirewallRuleGroupAssociation.cs
+++ b/sdk/dotnet/Route53/ResolverFirewallRuleGroupAssociation.cs
@@ -36,11 +36,11 @@ namespace Pulumi.Aws.Route53
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleterraform import {
+    /// Using `pulumi import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For example:
     /// 
-    ///  to = aws_route53_resolver_firewall_rule_group_association.example
-    /// 
-    ///  id = "rslvr-frgassoc-0123456789abcdef" } Using `TODO import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+    /// ```sh
+    ///  $ pulumi import aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation example rslvr-frgassoc-0123456789abcdef
+    /// ```
     /// </summary>
     [AwsResourceType("aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation")]
     public partial class ResolverFirewallRuleGroupAssociation : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/Account.cs
+++ b/sdk/dotnet/SecurityHub/Account.cs
@@ -31,11 +31,11 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+    /// Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
     /// 
-    ///  to = aws_securityhub_account.example
-    /// 
-    ///  id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_account.example 123456789012
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/account:Account example 123456789012
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/account:Account")]
     public partial class Account : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/FindingAggregator.cs
+++ b/sdk/dotnet/SecurityHub/FindingAggregator.cs
@@ -107,11 +107,11 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub finding aggregator using the `arn`. For exampleterraform import {
+    /// Using `pulumi import`, import an existing Security Hub finding aggregator using the `arn`. For example:
     /// 
-    ///  to = aws_securityhub_finding_aggregator.example
-    /// 
-    ///  id = "arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456" } Using `TODO import`, import an existing Security Hub finding aggregator using the `arn`. For exampleconsole % TODO import aws_securityhub_finding_aggregator.example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/findingAggregator:FindingAggregator example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/findingAggregator:FindingAggregator")]
     public partial class FindingAggregator : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/InviteAccepter.cs
+++ b/sdk/dotnet/SecurityHub/InviteAccepter.cs
@@ -57,11 +57,11 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Security Hub invite acceptance using the account ID. For exampleterraform import {
+    /// Using `pulumi import`, import Security Hub invite acceptance using the account ID. For example:
     /// 
-    ///  to = aws_securityhub_invite_accepter.example
-    /// 
-    ///  id = "123456789012" } Using `TODO import`, import Security Hub invite acceptance using the account ID. For exampleconsole % TODO import aws_securityhub_invite_accepter.example 123456789012
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/inviteAccepter:InviteAccepter example 123456789012
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/inviteAccepter:InviteAccepter")]
     public partial class InviteAccepter : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/Member.cs
+++ b/sdk/dotnet/SecurityHub/Member.cs
@@ -42,11 +42,11 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Security Hub members using their account ID. For exampleterraform import {
+    /// Using `pulumi import`, import Security Hub members using their account ID. For example:
     /// 
-    ///  to = aws_securityhub_member.example
-    /// 
-    ///  id = "123456789012" } Using `TODO import`, import Security Hub members using their account ID. For exampleconsole % TODO import aws_securityhub_member.example 123456789012
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/member:Member example 123456789012
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/member:Member")]
     public partial class Member : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/OrganizationConfiguration.cs
+++ b/sdk/dotnet/SecurityHub/OrganizationConfiguration.cs
@@ -56,11 +56,11 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+    /// Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
     /// 
-    ///  to = aws_securityhub_organization_configuration.example
-    /// 
-    ///  id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_organization_configuration.example 123456789012
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/organizationConfiguration:OrganizationConfiguration example 123456789012
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/organizationConfiguration:OrganizationConfiguration")]
     public partial class OrganizationConfiguration : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/ProductSubscription.cs
+++ b/sdk/dotnet/SecurityHub/ProductSubscription.cs
@@ -42,11 +42,11 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Security Hub product subscriptions using `product_arn,arn`. For exampleterraform import {
+    /// Using `pulumi import`, import Security Hub product subscriptions using `product_arn,arn`. For example:
     /// 
-    ///  to = aws_securityhub_product_subscription.example
-    /// 
-    ///  id = "arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement" } Using `TODO import`, import Security Hub product subscriptions using `product_arn,arn`. For exampleconsole % TODO import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/productSubscription:ProductSubscription example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/productSubscription:ProductSubscription")]
     public partial class ProductSubscription : global::Pulumi.CustomResource

--- a/sdk/dotnet/SecurityHub/StandardsSubscription.cs
+++ b/sdk/dotnet/SecurityHub/StandardsSubscription.cs
@@ -53,19 +53,17 @@ namespace Pulumi.Aws.SecurityHub
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Security Hub standards subscriptions using the standards subscription ARN. For exampleterraform import {
+    /// Using `pulumi import`, import Security Hub standards subscriptions using the standards subscription ARN. For example:
     /// 
-    ///  to = aws_securityhub_standards_subscription.cis
-    /// 
-    ///  id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0" } terraform import {
-    /// 
-    ///  to = aws_securityhub_standards_subscription.pci_321
-    /// 
-    ///  id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1" } terraform import {
-    /// 
-    ///  to = aws_securityhub_standards_subscription.nist_800_53_rev_5
-    /// 
-    ///  id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0" } Using `TODO import`, import Security Hub standards subscriptions using the standards subscription ARN. For exampleconsole % TODO import aws_securityhub_standards_subscription.cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0 console % TODO import aws_securityhub_standards_subscription.pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1 console % TODO import aws_securityhub_standards_subscription.nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+    /// ```sh
+    ///  $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0
+    /// ```
+    /// ```sh
+    /// $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1
+    /// ```
+    /// ```sh
+    /// $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+    /// ```
     /// </summary>
     [AwsResourceType("aws:securityhub/standardsSubscription:StandardsSubscription")]
     public partial class StandardsSubscription : global::Pulumi.CustomResource

--- a/sdk/dotnet/ServiceCatalog/PrincipalPortfolioAssociation.cs
+++ b/sdk/dotnet/ServiceCatalog/PrincipalPortfolioAssociation.cs
@@ -34,9 +34,7 @@ namespace Pulumi.Aws.ServiceCatalog
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
-    /// 
-    /// Using `TODO import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
+    /// Using `pulumi import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
     /// 
     /// ```sh
     ///  $ pulumi import aws:servicecatalog/principalPortfolioAssociation:PrincipalPortfolioAssociation example en,arn:aws:iam::123456789012:user/Eleanor,port-68656c6c6f,IAM

--- a/sdk/dotnet/ServiceQuotas/Template.cs
+++ b/sdk/dotnet/ServiceQuotas/Template.cs
@@ -38,11 +38,11 @@ namespace Pulumi.Aws.ServiceQuotas
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Service Quotas Template using the `example_id_arg`. For exampleterraform import {
+    /// Using `pulumi import`, import Service Quotas Template using the `id`. For example:
     /// 
-    ///  to = aws_servicequotas_template.example
-    /// 
-    ///  id = "us-east-1,L-2ACBD22F,lambda" } Using `TODO import`, import Service Quotas Template using the `id`. For exampleconsole % TODO import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+    /// ```sh
+    ///  $ pulumi import aws:servicequotas/template:Template example us-east-1,L-2ACBD22F,lambda
+    /// ```
     /// </summary>
     [AwsResourceType("aws:servicequotas/template:Template")]
     public partial class Template : global::Pulumi.CustomResource

--- a/sdk/dotnet/Ses/IdentityNotificationTopic.cs
+++ b/sdk/dotnet/Ses/IdentityNotificationTopic.cs
@@ -35,11 +35,11 @@ namespace Pulumi.Aws.Ses
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleterraform import {
+    /// Using `pulumi import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For example:
     /// 
-    ///  to = aws_ses_identity_notification_topic.test
-    /// 
-    ///  id = "example.com|Bounce" } Using `TODO import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleconsole % TODO import aws_ses_identity_notification_topic.test 'example.com|Bounce'
+    /// ```sh
+    ///  $ pulumi import aws:ses/identityNotificationTopic:IdentityNotificationTopic test 'example.com|Bounce'
+    /// ```
     /// </summary>
     [AwsResourceType("aws:ses/identityNotificationTopic:IdentityNotificationTopic")]
     public partial class IdentityNotificationTopic : global::Pulumi.CustomResource

--- a/sdk/dotnet/SesV2/AccountVdmAttributes.cs
+++ b/sdk/dotnet/SesV2/AccountVdmAttributes.cs
@@ -41,11 +41,11 @@ namespace Pulumi.Aws.SesV2
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleterraform import {
+    /// Using `pulumi import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For example:
     /// 
-    ///  to = aws_sesv2_account_vdm_attributes.example
-    /// 
-    ///  id = "ses-account-vdm-attributes" } Using `TODO import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleconsole % TODO import aws_sesv2_account_vdm_attributes.example ses-account-vdm-attributes
+    /// ```sh
+    ///  $ pulumi import aws:sesv2/accountVdmAttributes:AccountVdmAttributes example ses-account-vdm-attributes
+    /// ```
     /// </summary>
     [AwsResourceType("aws:sesv2/accountVdmAttributes:AccountVdmAttributes")]
     public partial class AccountVdmAttributes : global::Pulumi.CustomResource

--- a/sdk/dotnet/VerifiedAccess/InstanceTrustProviderAttachment.cs
+++ b/sdk/dotnet/VerifiedAccess/InstanceTrustProviderAttachment.cs
@@ -46,11 +46,11 @@ namespace Pulumi.Aws.VerifiedAccess
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleterraform import {
+    /// Using `pulumi import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For example:
     /// 
-    ///  to = aws_verifiedaccess_instance_trust_provider_attachment.example
-    /// 
-    ///  id = "vai-1234567890abcdef0/vatp-8012925589" } Using `TODO import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleconsole % TODO import aws_verifiedaccess_instance_trust_provider_attachment.example vai-1234567890abcdef0/vatp-8012925589
+    /// ```sh
+    ///  $ pulumi import aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment example vai-1234567890abcdef0/vatp-8012925589
+    /// ```
     /// </summary>
     [AwsResourceType("aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment")]
     public partial class InstanceTrustProviderAttachment : global::Pulumi.CustomResource

--- a/sdk/dotnet/VerifiedAccess/TrustProvider.cs
+++ b/sdk/dotnet/VerifiedAccess/TrustProvider.cs
@@ -34,13 +34,13 @@ namespace Pulumi.Aws.VerifiedAccess
     /// 
     /// ## Import
     /// 
-    /// In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For exampleterraform import {
+    /// Using `pulumi import`, import Transfer Workflows using the
     /// 
-    ///  to = aws_verifiedaccess_trust_provider.example
+    /// `id`. For example:
     /// 
-    ///  id = "vatp-8012925589" } Using `TODO import`, import Transfer Workflows using the
-    /// 
-    /// `id`. For exampleconsole % TODO import aws_verifiedaccess_trust_provider.example vatp-8012925589
+    /// ```sh
+    ///  $ pulumi import aws:verifiedaccess/trustProvider:TrustProvider example vatp-8012925589
+    /// ```
     /// </summary>
     [AwsResourceType("aws:verifiedaccess/trustProvider:TrustProvider")]
     public partial class TrustProvider : global::Pulumi.CustomResource

--- a/sdk/go/aws/apigateway/apiKey.go
+++ b/sdk/go/aws/apigateway/apiKey.go
@@ -42,11 +42,13 @@ import (
 //
 // ## Import
 //
-// terraform import {
+// Using `pulumi import`, import API Gateway Keys using the `id`. For example:
 //
-//	to = aws_api_gateway_api_key.example
+// ```sh
 //
-//	id = "8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk" } Using `pulumi import`, import API Gateway Keys using the `id`. For exampleconsole % TODO import aws_api_gateway_api_key.example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+//	$ pulumi import aws:apigateway/apiKey:ApiKey example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+//
+// ```
 type ApiKey struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/apigateway/response.go
+++ b/sdk/go/aws/apigateway/response.go
@@ -55,11 +55,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleterraform import {
+// Using `pulumi import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For example:
 //
-//	to = aws_api_gateway_gateway_response.example
+// ```sh
 //
-//	id = "12345abcde/UNAUTHORIZED" } Using `TODO import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleconsole % TODO import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+//	$ pulumi import aws:apigateway/response:Response example 12345abcde/UNAUTHORIZED
+//
+// ```
 type Response struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cfg/aggregateAuthorization.go
+++ b/sdk/go/aws/cfg/aggregateAuthorization.go
@@ -44,11 +44,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Config aggregate authorizations using `account_id:region`. For exampleterraform import {
+// Using `pulumi import`, import Config aggregate authorizations using `account_id:region`. For example:
 //
-//	to = aws_config_aggregate_authorization.example
+// ```sh
 //
-//	id = "123456789012:us-east-1" } Using `TODO import`, import Config aggregate authorizations using `account_id:region`. For exampleconsole % TODO import aws_config_aggregate_authorization.example 123456789012:us-east-1
+//	$ pulumi import aws:cfg/aggregateAuthorization:AggregateAuthorization example 123456789012:us-east-1
+//
+// ```
 type AggregateAuthorization struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cleanrooms/configuredTable.go
+++ b/sdk/go/aws/cleanrooms/configuredTable.go
@@ -57,11 +57,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_cleanrooms_configured_table` using the `id`. For exampleterraform import {
+// Using `pulumi import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
 //
-//	to = aws_cleanrooms_configured_table.table
+// ```sh
 //
-//	id = "1234abcd-12ab-34cd-56ef-1234567890ab" } Using `TODO import`, import `aws_cleanrooms_configured_table` using the `id`. For exampleconsole % TODO import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+//	$ pulumi import aws:cleanrooms/configuredTable:ConfiguredTable table 1234abcd-12ab-34cd-56ef-1234567890ab
+//
+// ```
 type ConfiguredTable struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cloud9/environmentMembership.go
+++ b/sdk/go/aws/cloud9/environmentMembership.go
@@ -56,11 +56,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Cloud9 environment membership using the `environment-id#user-arn`. For exampleterraform import {
+// Using `pulumi import`, import Cloud9 environment membership using the `environment-id#user-arn`. For example:
 //
-//	to = aws_cloud9_environment_membership.test
+// ```sh
 //
-//	id = "environment-id#user-arn" } Using `TODO import`, import Cloud9 environment membership using the `environment-id#user-arn`. For exampleconsole % TODO import aws_cloud9_environment_membership.test environment-id#user-arn
+//	$ pulumi import aws:cloud9/environmentMembership:EnvironmentMembership test environment-id#user-arn
+//
+// ```
 type EnvironmentMembership struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cloudformation/stackSet.go
+++ b/sdk/go/aws/cloudformation/stackSet.go
@@ -144,7 +144,7 @@ import (
 //
 // ```
 //
-//	Using `TODO import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
+//	Using `pulumi import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
 //
 // ```sh
 //

--- a/sdk/go/aws/cloudformation/stackSetInstance.go
+++ b/sdk/go/aws/cloudformation/stackSetInstance.go
@@ -150,13 +150,11 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
-//
 // Import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
 //
 // Import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
 //
-// Using `TODO import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
+// Using `pulumi import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
 //
 // ```sh
 //
@@ -164,7 +162,7 @@ import (
 //
 // ```
 //
-//	Using `TODO import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
+//	Using `pulumi import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
 //
 // ```sh
 //
@@ -172,7 +170,7 @@ import (
 //
 // ```
 //
-//	Using `TODO import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
+//	Using `pulumi import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
 //
 // ```sh
 //

--- a/sdk/go/aws/cloudfront/continuousDeploymentPolicy.go
+++ b/sdk/go/aws/cloudfront/continuousDeploymentPolicy.go
@@ -149,11 +149,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CloudFront Continuous Deployment Policy using the `id`. For exampleterraform import {
+// Using `pulumi import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
 //
-//	to = aws_cloudfront_continuous_deployment_policy.example
+// ```sh
 //
-//	id = "abcd-1234" } Using `TODO import`, import CloudFront Continuous Deployment Policy using the `id`. For exampleconsole % TODO import aws_cloudfront_continuous_deployment_policy.example abcd-1234
+//	$ pulumi import aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy example abcd-1234
+//
+// ```
 type ContinuousDeploymentPolicy struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codecatalyst/project.go
+++ b/sdk/go/aws/codecatalyst/project.go
@@ -46,11 +46,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Project using the `example_id_arg`. For exampleterraform import {
+// Using `pulumi import`, import CodeCatalyst Project using the `example_id_arg`. For example:
 //
-//	to = aws_codecatalyst_project.example
+// ```sh
 //
-//	id = "project-id-12345678" } Using `TODO import`, import CodeCatalyst Project using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_project.example project-id-12345678
+//	$ pulumi import aws:codecatalyst/project:Project example project-id-12345678
+//
+// ```
 type Project struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codecatalyst/sourceRepository.go
+++ b/sdk/go/aws/codecatalyst/sourceRepository.go
@@ -45,11 +45,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Source Repository using the `example_id_arg`. For exampleterraform import {
+// Using `pulumi import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
 //
-//	to = aws_codecatalyst_source_repository.example
+// ```sh
 //
-//	id = "source_repository-id-12345678" } Using `TODO import`, import CodeCatalyst Source Repository using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_source_repository.example source_repository-id-12345678
+//	$ pulumi import aws:codecatalyst/sourceRepository:SourceRepository example source_repository-id-12345678
+//
+// ```
 type SourceRepository struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codecommit/repository.go
+++ b/sdk/go/aws/codecommit/repository.go
@@ -44,9 +44,7 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodeCommit repository using repository name. For example:
-//
-// Using `TODO import`, import CodeCommit repository using repository name. For example:
+// Using `pulumi import`, import CodeCommit repository using repository name. For example:
 //
 // ```sh
 //

--- a/sdk/go/aws/codepipeline/pipeline.go
+++ b/sdk/go/aws/codepipeline/pipeline.go
@@ -222,11 +222,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodePipelines using the name. For exampleterraform import {
+// Using `pulumi import`, import CodePipelines using the name. For example:
 //
-//	to = aws_codepipeline.foo
+// ```sh
 //
-//	id = "example" } Using `TODO import`, import CodePipelines using the name. For exampleconsole % TODO import aws_codepipeline.foo example
+//	$ pulumi import aws:codepipeline/pipeline:Pipeline foo example
+//
+// ```
 type Pipeline struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codepipeline/webhook.go
+++ b/sdk/go/aws/codepipeline/webhook.go
@@ -127,11 +127,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodePipeline Webhooks using their ARN. For exampleterraform import {
+// Using `pulumi import`, import CodePipeline Webhooks using their ARN. For example:
 //
-//	to = aws_codepipeline_webhook.example
+// ```sh
 //
-//	id = "arn:aws:codepipeline:us-west-2:123456789012:webhook:example" } Using `TODO import`, import CodePipeline Webhooks using their ARN. For exampleconsole % TODO import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+//	$ pulumi import aws:codepipeline/webhook:Webhook example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+//
+// ```
 type Webhook struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codestarconnections/connection.go
+++ b/sdk/go/aws/codestarconnections/connection.go
@@ -88,11 +88,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodeStar connections using the ARN. For exampleterraform import {
+// Using `pulumi import`, import CodeStar connections using the ARN. For example:
 //
-//	to = aws_codestarconnections_connection.test-connection
+// ```sh
 //
-//	id = "arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar connections using the ARN. For exampleconsole % TODO import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+//	$ pulumi import aws:codestarconnections/connection:Connection test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+//
+// ```
 type Connection struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codestarconnections/host.go
+++ b/sdk/go/aws/codestarconnections/host.go
@@ -46,11 +46,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodeStar Host using the ARN. For exampleterraform import {
+// Using `pulumi import`, import CodeStar Host using the ARN. For example:
 //
-//	to = aws_codestarconnections_host.example-host
+// ```sh
 //
-//	id = "arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar Host using the ARN. For exampleconsole % TODO import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+//	$ pulumi import aws:codestarconnections/host:Host example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+//
+// ```
 type Host struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/codestarnotifications/notificationRule.go
+++ b/sdk/go/aws/codestarnotifications/notificationRule.go
@@ -94,11 +94,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import CodeStar notification rule using the ARN. For exampleterraform import {
+// Using `pulumi import`, import CodeStar notification rule using the ARN. For example:
 //
-//	to = aws_codestarnotifications_notification_rule.foo
+// ```sh
 //
-//	id = "arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b" } Using `TODO import`, import CodeStar notification rule using the ARN. For exampleconsole % TODO import aws_codestarnotifications_notification_rule.foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+//	$ pulumi import aws:codestarnotifications/notificationRule:NotificationRule foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+//
+// ```
 type NotificationRule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cognito/identityPool.go
+++ b/sdk/go/aws/cognito/identityPool.go
@@ -84,11 +84,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool using its ID. For exampleterraform import {
+// Using `pulumi import`, import Cognito Identity Pool using its ID. For example:
 //
-//	to = aws_cognito_identity_pool.mypool
+// ```sh
 //
-//	id = "us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3" } Using `TODO import`, import Cognito Identity Pool using its ID. For exampleconsole % TODO import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+//	$ pulumi import aws:cognito/identityPool:IdentityPool mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+//
+// ```
 type IdentityPool struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cognito/identityPoolProviderPrincipalTag.go
+++ b/sdk/go/aws/cognito/identityPoolProviderPrincipalTag.go
@@ -17,11 +17,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleterraform import {
+// Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For example:
 //
-//	to = aws_cognito_identity_pool_provider_principal_tag.example
+// ```sh
 //
-//	id = "us-west-2_abc123:CorpAD" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleconsole % TODO import aws_cognito_identity_pool_provider_principal_tag.example us-west-2_abc123:CorpAD
+//	$ pulumi import aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag example us-west-2_abc123:CorpAD
+//
+// ```
 type IdentityPoolProviderPrincipalTag struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cognito/identityPoolRoleAttachment.go
+++ b/sdk/go/aws/cognito/identityPoolRoleAttachment.go
@@ -17,11 +17,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleterraform import {
+// Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For example:
 //
-//	to = aws_cognito_identity_pool_roles_attachment.example
+// ```sh
 //
-//	id = "us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleconsole % TODO import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+//	$ pulumi import aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+//
+// ```
 type IdentityPoolRoleAttachment struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/cognito/userPool.go
+++ b/sdk/go/aws/cognito/userPool.go
@@ -111,11 +111,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Cognito User Pools using the `id`. For exampleterraform import {
+// Using `pulumi import`, import Cognito User Pools using the `id`. For example:
 //
-//	to = aws_cognito_user_pool.pool
+// ```sh
 //
-//	id = "us-west-2_abc123" } Using `TODO import`, import Cognito User Pools using the `id`. For exampleconsole % TODO import aws_cognito_user_pool.pool us-west-2_abc123
+//	$ pulumi import aws:cognito/userPool:UserPool pool us-west-2_abc123
+//
+// ```
 type UserPool struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/connect/botAssociation.go
+++ b/sdk/go/aws/connect/botAssociation.go
@@ -130,11 +130,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleterraform import {
+// Using `pulumi import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For example:
 //
-//	to = aws_connect_bot_association.example
+// ```sh
 //
-//	id = "aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2" } Using `TODO import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleconsole % TODO import aws_connect_bot_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+//	$ pulumi import aws:connect/botAssociation:BotAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+//
+// ```
 type BotAssociation struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/connect/lambdaFunctionAssociation.go
+++ b/sdk/go/aws/connect/lambdaFunctionAssociation.go
@@ -45,11 +45,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleterraform import {
+// Using `pulumi import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For example:
 //
-//	to = aws_connect_lambda_function_association.example
+// ```sh
 //
-//	id = "aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example" } Using `TODO import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleconsole % TODO import aws_connect_lambda_function_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+//	$ pulumi import aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+//
+// ```
 type LambdaFunctionAssociation struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/datasync/locationAzureBlob.go
+++ b/sdk/go/aws/datasync/locationAzureBlob.go
@@ -52,11 +52,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleterraform import {
+// Using `pulumi import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For example:
 //
-//	to = aws_datasync_location_azure_blob.example
+// ```sh
 //
-//	id = "arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567" } Using `TODO import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleconsole % TODO import aws_datasync_location_azure_blob.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+//	$ pulumi import aws:datasync/locationAzureBlob:LocationAzureBlob example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+//
+// ```
 type LocationAzureBlob struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/datasync/locationFsxOntapFileSystem.go
+++ b/sdk/go/aws/datasync/locationFsxOntapFileSystem.go
@@ -19,11 +19,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleterraform import {
+// Using `pulumi import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For example:
 //
-//	to = aws_datasync_location_fsx_ontap_file_system.example
+// ```sh
 //
-//	id = "arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123" } Using `TODO import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleconsole % TODO import aws_datasync_location_fsx_ontap_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+//	$ pulumi import aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+//
+// ```
 type LocationFsxOntapFileSystem struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/directconnect/gatewayAssociationProposal.go
+++ b/sdk/go/aws/directconnect/gatewayAssociationProposal.go
@@ -49,7 +49,7 @@ import (
 //
 // Using a proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`:
 //
-// __With `TODO import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
+// __With `pulumi import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
 //
 // Using a proposal ID:
 //

--- a/sdk/go/aws/dlm/lifecyclePolicy.go
+++ b/sdk/go/aws/dlm/lifecyclePolicy.go
@@ -90,11 +90,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import DLM lifecycle policies using their policy ID. For exampleterraform import {
+// Using `pulumi import`, import DLM lifecycle policies using their policy ID. For example:
 //
-//	to = aws_dlm_lifecycle_policy.example
+// ```sh
 //
-//	id = "policy-abcdef12345678901" } Using `TODO import`, import DLM lifecycle policies using their policy ID. For exampleconsole % TODO import aws_dlm_lifecycle_policy.example policy-abcdef12345678901
+//	$ pulumi import aws:dlm/lifecyclePolicy:LifecyclePolicy example policy-abcdef12345678901
+//
+// ```
 type LifecyclePolicy struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/dms/replicationConfig.go
+++ b/sdk/go/aws/dms/replicationConfig.go
@@ -57,11 +57,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import replication configs using the `arn`. For exampleterraform import {
+// Using `pulumi import`, import a replication config using the `arn`. For example:
 //
-//	to = aws_dms_replication_config.example
+// ```sh
 //
-//	id = "arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI" } Using `TODO import`, import a replication config using the `arn`. For exampleconsole % TODO import aws_dms_replication_config.example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+//	$ pulumi import aws:dms/replicationConfig:ReplicationConfig example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+//
+// ```
 type ReplicationConfig struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ec2/networkInterface.go
+++ b/sdk/go/aws/ec2/networkInterface.go
@@ -71,11 +71,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Network Interfaces using the `id`. For exampleterraform import {
+// Using `pulumi import`, import Network Interfaces using the `id`. For example:
 //
-//	to = aws_network_interface.test
+// ```sh
 //
-//	id = "eni-e5aa89a3" } Using `TODO import`, import Network Interfaces using the `id`. For exampleconsole % TODO import aws_network_interface.test eni-e5aa89a3
+//	$ pulumi import aws:ec2/networkInterface:NetworkInterface test eni-e5aa89a3
+//
+// ```
 type NetworkInterface struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ec2/vpcIpamPoolCidr.go
+++ b/sdk/go/aws/ec2/vpcIpamPoolCidr.go
@@ -22,11 +22,17 @@ import (
 //
 // ## Import
 //
-// terraform import {
+// __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
 //
-//	to = aws_vpc_ipam_pool_cidr.example
+// Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For example:
 //
-//	id = "172.20.0.0/24_ipam-pool-0e634f5a1517cccdc" } Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For exampleconsole % TODO import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+// __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
+//
+// ```sh
+//
+//	$ pulumi import aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+//
+// ```
 type VpcIpamPoolCidr struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/emrcontainers/jobTemplate.go
+++ b/sdk/go/aws/emrcontainers/jobTemplate.go
@@ -52,11 +52,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import EKS job templates using the `id`. For exampleterraform import {
+// Using `pulumi import`, import EKS job templates using the `id`. For example:
 //
-//	to = aws_emrcontainers_job_template.example
+// ```sh
 //
-//	id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS job templates using the `id`. For exampleconsole % TODO import aws_emrcontainers_job_template.example a1b2c3d4e5f6g7h8i9j10k11l
+//	$ pulumi import aws:emrcontainers/jobTemplate:JobTemplate example a1b2c3d4e5f6g7h8i9j10k11l
+//
+// ```
 type JobTemplate struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/emrcontainers/virtualCluster.go
+++ b/sdk/go/aws/emrcontainers/virtualCluster.go
@@ -52,11 +52,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import EKS Clusters using the `id`. For exampleterraform import {
+// Using `pulumi import`, import EKS Clusters using the `id`. For example:
 //
-//	to = aws_emrcontainers_virtual_cluster.example
+// ```sh
 //
-//	id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS Clusters using the `id`. For exampleconsole % TODO import aws_emrcontainers_virtual_cluster.example a1b2c3d4e5f6g7h8i9j10k11l
+//	$ pulumi import aws:emrcontainers/virtualCluster:VirtualCluster example a1b2c3d4e5f6g7h8i9j10k11l
+//
+// ```
 type VirtualCluster struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/emrserverless/application.go
+++ b/sdk/go/aws/emrserverless/application.go
@@ -113,11 +113,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import EMR Severless applications using the `id`. For exampleterraform import {
+// Using `pulumi import`, import EMR Severless applications using the `id`. For example:
 //
-//	to = aws_emrserverless_application.example
+// ```sh
 //
-//	id = "id" } Using `TODO import`, import EMR Severless applications using the `id`. For exampleconsole % TODO import aws_emrserverless_application.example id
+//	$ pulumi import aws:emrserverless/application:Application example id
+//
+// ```
 type Application struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/gamelift/gameServerGroup.go
+++ b/sdk/go/aws/gamelift/gameServerGroup.go
@@ -180,11 +180,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import GameLift Game Server Group using the `name`. For exampleterraform import {
+// Using `pulumi import`, import GameLift Game Server Group using the `name`. For example:
 //
-//	to = aws_gamelift_game_server_group.example
+// ```sh
 //
-//	id = "example" } Using `TODO import`, import GameLift Game Server Group using the `name`. For exampleconsole % TODO import aws_gamelift_game_server_group.example example
+//	$ pulumi import aws:gamelift/gameServerGroup:GameServerGroup example example
+//
+// ```
 type GameServerGroup struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/glue/devEndpoint.go
+++ b/sdk/go/aws/glue/devEndpoint.go
@@ -79,11 +79,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import a Glue Development Endpoint using the `name`. For exampleterraform import {
+// Using `pulumi import`, import a Glue Development Endpoint using the `name`. For example:
 //
-//	to = aws_glue_dev_endpoint.example
+// ```sh
 //
-//	id = "foo" } Using `TODO import`, import a Glue Development Endpoint using the `name`. For exampleconsole % TODO import aws_glue_dev_endpoint.example foo
+//	$ pulumi import aws:glue/devEndpoint:DevEndpoint example foo
+//
+// ```
 type DevEndpoint struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/iam/groupPolicyAttachment.go
+++ b/sdk/go/aws/iam/groupPolicyAttachment.go
@@ -57,11 +57,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleterraform import {
+// Using `pulumi import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For example:
 //
-//	to = aws_iam_group_policy_attachment.test-attach
+// ```sh
 //
-//	id = "test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+//	$ pulumi import aws:iam/groupPolicyAttachment:GroupPolicyAttachment test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+//
+// ```
 type GroupPolicyAttachment struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/iam/rolePolicyAttachment.go
+++ b/sdk/go/aws/iam/rolePolicyAttachment.go
@@ -98,11 +98,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleterraform import {
+// Using `pulumi import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
 //
-//	to = aws_iam_role_policy_attachment.test-attach
+// ```sh
 //
-//	id = "test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+//	$ pulumi import aws:iam/rolePolicyAttachment:RolePolicyAttachment test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+//
+// ```
 type RolePolicyAttachment struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/iam/userPolicyAttachment.go
+++ b/sdk/go/aws/iam/userPolicyAttachment.go
@@ -57,11 +57,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleterraform import {
+// Using `pulumi import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For example:
 //
-//	to = aws_iam_user_policy_attachment.test-attach
+// ```sh
 //
-//	id = "test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+//	$ pulumi import aws:iam/userPolicyAttachment:UserPolicyAttachment test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+//
+// ```
 type UserPolicyAttachment struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/lex/v2modelsBot.go
+++ b/sdk/go/aws/lex/v2modelsBot.go
@@ -50,11 +50,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Lex V2 Models Bot using the `example_id_arg`. For exampleterraform import {
+// Using `pulumi import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
 //
-//	to = aws_lexv2models_bot.example
+// ```sh
 //
-//	id = "bot-id-12345678" } Using `TODO import`, import Lex V2 Models Bot using the `example_id_arg`. For exampleconsole % TODO import aws_lexv2models_bot.example bot-id-12345678
+//	$ pulumi import aws:lex/v2modelsBot:V2modelsBot example bot-id-12345678
+//
+// ```
 type V2modelsBot struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/licensemanager/association.go
+++ b/sdk/go/aws/licensemanager/association.go
@@ -77,11 +77,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import license configurations using `resource_arn,license_configuration_arn`. For exampleterraform import {
+// Using `pulumi import`, import license configurations using `resource_arn,license_configuration_arn`. For example:
 //
-//	to = aws_licensemanager_association.example
+// ```sh
 //
-//	id = "arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using `resource_arn,license_configuration_arn`. For exampleconsole % TODO import aws_licensemanager_association.example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+//	$ pulumi import aws:licensemanager/association:Association example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+//
+// ```
 type Association struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/licensemanager/licenseConfiguration.go
+++ b/sdk/go/aws/licensemanager/licenseConfiguration.go
@@ -65,11 +65,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import license configurations using the `id`. For exampleterraform import {
+// Using `pulumi import`, import license configurations using the `id`. For example:
 //
-//	to = aws_licensemanager_license_configuration.example
+// ```sh
 //
-//	id = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using the `id`. For exampleconsole % TODO import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+//	$ pulumi import aws:licensemanager/licenseConfiguration:LicenseConfiguration example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+//
+// ```
 type LicenseConfiguration struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/msk/clusterPolicy.go
+++ b/sdk/go/aws/msk/clusterPolicy.go
@@ -80,11 +80,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Managed Streaming for Kafka Cluster Policy using the `cluster_arn. For exampleterraform import {
+// Using `pulumi import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For example:
 //
-//	to = aws_msk_cluster_policy.example
+// ```sh
 //
-//	id = "arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3" } Using `TODO import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For exampleconsole % TODO import aws_msk_cluster_policy.example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+//	$ pulumi import aws:msk/clusterPolicy:ClusterPolicy example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+//
+// ```
 type ClusterPolicy struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/msk/vpcConnection.go
+++ b/sdk/go/aws/msk/vpcConnection.go
@@ -61,11 +61,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import MSK configurations using the configuration ARN. For exampleterraform import {
+// Using `pulumi import`, import MSK configurations using the configuration ARN. For example:
 //
-//	to = aws_msk_vpc_connection.example
+// ```sh
 //
-//	id = "arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2" } Using `TODO import`, import MSK configurations using the configuration ARN. For exampleconsole % TODO import aws_msk_vpc_connection.example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+//	$ pulumi import aws:msk/vpcConnection:VpcConnection example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+//
+// ```
 type VpcConnection struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/opensearch/vpcEndpoint.go
+++ b/sdk/go/aws/opensearch/vpcEndpoint.go
@@ -54,11 +54,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import OpenSearch VPC endpoint connections using the `id`. For exampleterraform import {
+// Using `pulumi import`, import OpenSearch VPC endpoint connections using the `id`. For example:
 //
-//	to = aws_opensearch_vpc_endpoint_connection.example
+// ```sh
 //
-//	id = "endpoint-id" } Using `TODO import`, import OpenSearch VPC endpoint connections using the `id`. For exampleconsole % TODO import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+//	$ pulumi import aws:opensearch/vpcEndpoint:VpcEndpoint example endpoint-id
+//
+// ```
 type VpcEndpoint struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/admChannel.go
+++ b/sdk/go/aws/pinpoint/admChannel.go
@@ -51,11 +51,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint ADM Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint ADM Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_adm_channel.channel
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint ADM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_adm_channel.channel application-id
+//	$ pulumi import aws:pinpoint/admChannel:AdmChannel channel application-id
+//
+// ```
 type AdmChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/apnsChannel.go
+++ b/sdk/go/aws/pinpoint/apnsChannel.go
@@ -60,11 +60,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint APNs Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_apns_channel.apns
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint APNs Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_channel.apns application-id
+//	$ pulumi import aws:pinpoint/apnsChannel:ApnsChannel apns application-id
+//
+// ```
 type ApnsChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/apnsSandboxChannel.go
+++ b/sdk/go/aws/pinpoint/apnsSandboxChannel.go
@@ -60,11 +60,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_apns_sandbox_channel.apns_sandbox
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_sandbox_channel.apns_sandbox application-id
+//	$ pulumi import aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel apns_sandbox application-id
+//
+// ```
 type ApnsSandboxChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/apnsVoipChannel.go
+++ b/sdk/go/aws/pinpoint/apnsVoipChannel.go
@@ -60,11 +60,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint APNs VoIP Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_apns_voip_channel.apns_voip
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_channel.apns_voip application-id
+//	$ pulumi import aws:pinpoint/apnsVoipChannel:ApnsVoipChannel apns_voip application-id
+//
+// ```
 type ApnsVoipChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/apnsVoipSandboxChannel.go
+++ b/sdk/go/aws/pinpoint/apnsVoipSandboxChannel.go
@@ -60,11 +60,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+//	$ pulumi import aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel apns_voip_sandbox application-id
+//
+// ```
 type ApnsVoipSandboxChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/app.go
+++ b/sdk/go/aws/pinpoint/app.go
@@ -48,11 +48,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint App using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint App using the `application-id`. For example:
 //
-//	to = aws_pinpoint_app.name
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint App using the `application-id`. For exampleconsole % TODO import aws_pinpoint_app.name application-id
+//	$ pulumi import aws:pinpoint/app:App name application-id
+//
+// ```
 type App struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/baiduChannel.go
+++ b/sdk/go/aws/pinpoint/baiduChannel.go
@@ -50,11 +50,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint Baidu Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint Baidu Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_baidu_channel.channel
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint Baidu Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_baidu_channel.channel application-id
+//	$ pulumi import aws:pinpoint/baiduChannel:BaiduChannel channel application-id
+//
+// ```
 type BaiduChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/emailChannel.go
+++ b/sdk/go/aws/pinpoint/emailChannel.go
@@ -108,11 +108,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint Email Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint Email Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_email_channel.email
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint Email Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_email_channel.email application-id
+//	$ pulumi import aws:pinpoint/emailChannel:EmailChannel email application-id
+//
+// ```
 type EmailChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/eventStream.go
+++ b/sdk/go/aws/pinpoint/eventStream.go
@@ -108,11 +108,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint Event Stream using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint Event Stream using the `application-id`. For example:
 //
-//	to = aws_pinpoint_event_stream.stream
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint Event Stream using the `application-id`. For exampleconsole % TODO import aws_pinpoint_event_stream.stream application-id
+//	$ pulumi import aws:pinpoint/eventStream:EventStream stream application-id
+//
+// ```
 type EventStream struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/gcmChannel.go
+++ b/sdk/go/aws/pinpoint/gcmChannel.go
@@ -49,11 +49,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Pinpoint GCM Channel using the `application-id`. For exampleterraform import {
+// Using `pulumi import`, import Pinpoint GCM Channel using the `application-id`. For example:
 //
-//	to = aws_pinpoint_gcm_channel.gcm
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import Pinpoint GCM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_gcm_channel.gcm application-id
+//	$ pulumi import aws:pinpoint/gcmChannel:GcmChannel gcm application-id
+//
+// ```
 type GcmChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/pinpoint/smsChannel.go
+++ b/sdk/go/aws/pinpoint/smsChannel.go
@@ -47,11 +47,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import the Pinpoint SMS Channel using the `application_id`. For exampleterraform import {
+// Using `pulumi import`, import the Pinpoint SMS Channel using the `application_id`. For example:
 //
-//	to = aws_pinpoint_sms_channel.sms
+// ```sh
 //
-//	id = "application-id" } Using `TODO import`, import the Pinpoint SMS Channel using the `application_id`. For exampleconsole % TODO import aws_pinpoint_sms_channel.sms application-id
+//	$ pulumi import aws:pinpoint/smsChannel:SmsChannel sms application-id
+//
+// ```
 type SmsChannel struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ram/principalAssociation.go
+++ b/sdk/go/aws/ram/principalAssociation.go
@@ -87,11 +87,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleterraform import {
+// Using `pulumi import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For example:
 //
-//	to = aws_ram_principal_association.example
+// ```sh
 //
-//	id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012" } Using `TODO import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleconsole % TODO import aws_ram_principal_association.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+//	$ pulumi import aws:ram/principalAssociation:PrincipalAssociation example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+//
+// ```
 type PrincipalAssociation struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ram/resourceShare.go
+++ b/sdk/go/aws/ram/resourceShare.go
@@ -45,11 +45,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import resource shares using the `arn` of the resource share. For exampleterraform import {
+// Using `pulumi import`, import resource shares using the `arn` of the resource share. For example:
 //
-//	to = aws_ram_resource_share.example
+// ```sh
 //
-//	id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12" } Using `TODO import`, import resource shares using the `arn` of the resource share. For exampleconsole % TODO import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+//	$ pulumi import aws:ram/resourceShare:ResourceShare example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+//
+// ```
 type ResourceShare struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ram/resourceShareAccepter.go
+++ b/sdk/go/aws/ram/resourceShareAccepter.go
@@ -74,11 +74,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import resource share accepters using the resource share ARN. For exampleterraform import {
+// Using `pulumi import`, import resource share accepters using the resource share ARN. For example:
 //
-//	to = aws_ram_resource_share_accepter.example
+// ```sh
 //
-//	id = "arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767" } Using `TODO import`, import resource share accepters using the resource share ARN. For exampleconsole % TODO import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+//	$ pulumi import aws:ram/resourceShareAccepter:ResourceShareAccepter example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+//
+// ```
 type ResourceShareAccepter struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ram/sharingWithOrganization.go
+++ b/sdk/go/aws/ram/sharingWithOrganization.go
@@ -42,11 +42,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import the resource using the current AWS account ID. For exampleterraform import {
+// Using `pulumi import`, import the resource using the current AWS account ID. For example:
 //
-//	to = aws_ram_sharing_with_organization.example
+// ```sh
 //
-//	id = "123456789012" } Using `TODO import`, import the resource using the current AWS account ID. For exampleconsole % TODO import aws_ram_sharing_with_organization.example 123456789012
+//	$ pulumi import aws:ram/sharingWithOrganization:SharingWithOrganization example 123456789012
+//
+// ```
 type SharingWithOrganization struct {
 	pulumi.CustomResourceState
 }

--- a/sdk/go/aws/rds/clusterParameterGroup.go
+++ b/sdk/go/aws/rds/clusterParameterGroup.go
@@ -57,11 +57,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import RDS Cluster Parameter Groups using the `name`. For exampleterraform import {
+// Using `pulumi import`, import RDS Cluster Parameter Groups using the `name`. For example:
 //
-//	to = aws_rds_cluster_parameter_group.cluster_pg
+// ```sh
 //
-//	id = "production-pg-1" } Using `TODO import`, import RDS Cluster Parameter Groups using the `name`. For exampleconsole % TODO import aws_rds_cluster_parameter_group.cluster_pg production-pg-1
+//	$ pulumi import aws:rds/clusterParameterGroup:ClusterParameterGroup cluster_pg production-pg-1
+//
+// ```
 type ClusterParameterGroup struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/rds/customDbEngineVersion.go
+++ b/sdk/go/aws/rds/customDbEngineVersion.go
@@ -178,11 +178,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleterraform import {
+// Using `pulumi import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For example:
 //
-//	to = aws_rds_custom_db_engine_version.example
+// ```sh
 //
-//	id = "custom-oracle-ee-cdb:19.cdb_cev1" } Using `TODO import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleconsole % TODO import aws_rds_custom_db_engine_version.example custom-oracle-ee-cdb:19.cdb_cev1
+//	$ pulumi import aws:rds/customDbEngineVersion:CustomDbEngineVersion example custom-oracle-ee-cdb:19.cdb_cev1
+//
+// ```
 type CustomDbEngineVersion struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/rds/instanceAutomatedBackupsReplication.go
+++ b/sdk/go/aws/rds/instanceAutomatedBackupsReplication.go
@@ -131,11 +131,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import RDS instance automated backups replication using the `arn`. For exampleterraform import {
+// Using `pulumi import`, import RDS instance automated backups replication using the `arn`. For example:
 //
-//	to = aws_db_instance_automated_backups_replication.default
+// ```sh
 //
-//	id = "arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my" } Using `TODO import`, import RDS instance automated backups replication using the `arn`. For exampleconsole % TODO import aws_db_instance_automated_backups_replication.default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+//	$ pulumi import aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+//
+// ```
 type InstanceAutomatedBackupsReplication struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/route53/resolverFirewallConfig.go
+++ b/sdk/go/aws/route53/resolverFirewallConfig.go
@@ -53,11 +53,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleterraform import {
+// Using `pulumi import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For example:
 //
-//	to = aws_route53_resolver_firewall_config.example
+// ```sh
 //
-//	id = "rdsc-be1866ecc1683e95" } Using `TODO import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleconsole % TODO import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+//	$ pulumi import aws:route53/resolverFirewallConfig:ResolverFirewallConfig example rdsc-be1866ecc1683e95
+//
+// ```
 type ResolverFirewallConfig struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/route53/resolverFirewallDomainList.go
+++ b/sdk/go/aws/route53/resolverFirewallDomainList.go
@@ -40,15 +40,15 @@ import (
 //
 // ## Import
 //
-// # In TODO v1.5.0 and later, use an `import` block to import
+// # Using `pulumi import`, import
 //
-// Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleterraform import {
+// Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For example:
 //
-//	to = aws_route53_resolver_firewall_domain_list.example
+// ```sh
 //
-//	id = "rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
+//	$ pulumi import aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList example rslvr-fdl-0123456789abcdef
 //
-// Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleconsole % TODO import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+// ```
 type ResolverFirewallDomainList struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/route53/resolverFirewallRule.go
+++ b/sdk/go/aws/route53/resolverFirewallRule.go
@@ -65,15 +65,15 @@ import (
 //
 // ## Import
 //
-// # In TODO v1.5.0 and later, use an `import` block to import
+// # Using `pulumi import`, import
 //
-// Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleterraform import {
+// Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For example:
 //
-//	to = aws_route53_resolver_firewall_rule.example
+// ```sh
 //
-//	id = "rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
+//	$ pulumi import aws:route53/resolverFirewallRule:ResolverFirewallRule example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
 //
-// Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleconsole % TODO import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+// ```
 type ResolverFirewallRule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/route53/resolverFirewallRuleGroup.go
+++ b/sdk/go/aws/route53/resolverFirewallRuleGroup.go
@@ -40,15 +40,15 @@ import (
 //
 // ## Import
 //
-// # In TODO v1.5.0 and later, use an `import` block to import
+// # Using `pulumi import`, import
 //
-// Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleterraform import {
+// Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For example:
 //
-//	to = aws_route53_resolver_firewall_rule_group.example
+// ```sh
 //
-//	id = "rslvr-frg-0123456789abcdef" } Using `TODO import`, import
+//	$ pulumi import aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup example rslvr-frg-0123456789abcdef
 //
-// Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+// ```
 type ResolverFirewallRuleGroup struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/route53/resolverFirewallRuleGroupAssociation.go
+++ b/sdk/go/aws/route53/resolverFirewallRuleGroupAssociation.go
@@ -49,11 +49,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleterraform import {
+// Using `pulumi import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For example:
 //
-//	to = aws_route53_resolver_firewall_rule_group_association.example
+// ```sh
 //
-//	id = "rslvr-frgassoc-0123456789abcdef" } Using `TODO import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+//	$ pulumi import aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation example rslvr-frgassoc-0123456789abcdef
+//
+// ```
 type ResolverFirewallRuleGroupAssociation struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/account.go
+++ b/sdk/go/aws/securityhub/account.go
@@ -42,11 +42,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+// Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
 //
-//	to = aws_securityhub_account.example
+// ```sh
 //
-//	id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_account.example 123456789012
+//	$ pulumi import aws:securityhub/account:Account example 123456789012
+//
+// ```
 type Account struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/findingAggregator.go
+++ b/sdk/go/aws/securityhub/findingAggregator.go
@@ -126,11 +126,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub finding aggregator using the `arn`. For exampleterraform import {
+// Using `pulumi import`, import an existing Security Hub finding aggregator using the `arn`. For example:
 //
-//	to = aws_securityhub_finding_aggregator.example
+// ```sh
 //
-//	id = "arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456" } Using `TODO import`, import an existing Security Hub finding aggregator using the `arn`. For exampleconsole % TODO import aws_securityhub_finding_aggregator.example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+//	$ pulumi import aws:securityhub/findingAggregator:FindingAggregator example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+//
+// ```
 type FindingAggregator struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/inviteAccepter.go
+++ b/sdk/go/aws/securityhub/inviteAccepter.go
@@ -63,11 +63,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Security Hub invite acceptance using the account ID. For exampleterraform import {
+// Using `pulumi import`, import Security Hub invite acceptance using the account ID. For example:
 //
-//	to = aws_securityhub_invite_accepter.example
+// ```sh
 //
-//	id = "123456789012" } Using `TODO import`, import Security Hub invite acceptance using the account ID. For exampleconsole % TODO import aws_securityhub_invite_accepter.example 123456789012
+//	$ pulumi import aws:securityhub/inviteAccepter:InviteAccepter example 123456789012
+//
+// ```
 type InviteAccepter struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/member.go
+++ b/sdk/go/aws/securityhub/member.go
@@ -51,11 +51,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Security Hub members using their account ID. For exampleterraform import {
+// Using `pulumi import`, import Security Hub members using their account ID. For example:
 //
-//	to = aws_securityhub_member.example
+// ```sh
 //
-//	id = "123456789012" } Using `TODO import`, import Security Hub members using their account ID. For exampleconsole % TODO import aws_securityhub_member.example 123456789012
+//	$ pulumi import aws:securityhub/member:Member example 123456789012
+//
+// ```
 type Member struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/organizationConfiguration.go
+++ b/sdk/go/aws/securityhub/organizationConfiguration.go
@@ -65,11 +65,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+// Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
 //
-//	to = aws_securityhub_organization_configuration.example
+// ```sh
 //
-//	id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_organization_configuration.example 123456789012
+//	$ pulumi import aws:securityhub/organizationConfiguration:OrganizationConfiguration example 123456789012
+//
+// ```
 type OrganizationConfiguration struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/productSubscription.go
+++ b/sdk/go/aws/securityhub/productSubscription.go
@@ -56,11 +56,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Security Hub product subscriptions using `product_arn,arn`. For exampleterraform import {
+// Using `pulumi import`, import Security Hub product subscriptions using `product_arn,arn`. For example:
 //
-//	to = aws_securityhub_product_subscription.example
+// ```sh
 //
-//	id = "arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement" } Using `TODO import`, import Security Hub product subscriptions using `product_arn,arn`. For exampleconsole % TODO import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+//	$ pulumi import aws:securityhub/productSubscription:ProductSubscription example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+//
+// ```
 type ProductSubscription struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/securityhub/standardsSubscription.go
+++ b/sdk/go/aws/securityhub/standardsSubscription.go
@@ -64,19 +64,19 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Security Hub standards subscriptions using the standards subscription ARN. For exampleterraform import {
+// Using `pulumi import`, import Security Hub standards subscriptions using the standards subscription ARN. For example:
 //
-//	to = aws_securityhub_standards_subscription.cis
+// ```sh
 //
-//	id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0" } terraform import {
+//	$ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0
 //
-//	to = aws_securityhub_standards_subscription.pci_321
-//
-//	id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1" } terraform import {
-//
-//	to = aws_securityhub_standards_subscription.nist_800_53_rev_5
-//
-//	id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0" } Using `TODO import`, import Security Hub standards subscriptions using the standards subscription ARN. For exampleconsole % TODO import aws_securityhub_standards_subscription.cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0 console % TODO import aws_securityhub_standards_subscription.pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1 console % TODO import aws_securityhub_standards_subscription.nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+// ```
+// ```sh
+// $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1
+// ```
+// ```sh
+// $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+// ```
 type StandardsSubscription struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/servicecatalog/principalPortfolioAssociation.go
+++ b/sdk/go/aws/servicecatalog/principalPortfolioAssociation.go
@@ -45,9 +45,7 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
-//
-// Using `TODO import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
+// Using `pulumi import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
 //
 // ```sh
 //

--- a/sdk/go/aws/servicequotas/template.go
+++ b/sdk/go/aws/servicequotas/template.go
@@ -49,11 +49,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Service Quotas Template using the `example_id_arg`. For exampleterraform import {
+// Using `pulumi import`, import Service Quotas Template using the `id`. For example:
 //
-//	to = aws_servicequotas_template.example
+// ```sh
 //
-//	id = "us-east-1,L-2ACBD22F,lambda" } Using `TODO import`, import Service Quotas Template using the `id`. For exampleconsole % TODO import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+//	$ pulumi import aws:servicequotas/template:Template example us-east-1,L-2ACBD22F,lambda
+//
+// ```
 type Template struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/ses/identityNotificationTopic.go
+++ b/sdk/go/aws/ses/identityNotificationTopic.go
@@ -46,11 +46,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleterraform import {
+// Using `pulumi import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For example:
 //
-//	to = aws_ses_identity_notification_topic.test
+// ```sh
 //
-//	id = "example.com|Bounce" } Using `TODO import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleconsole % TODO import aws_ses_identity_notification_topic.test 'example.com|Bounce'
+//	$ pulumi import aws:ses/identityNotificationTopic:IdentityNotificationTopic test 'example.com|Bounce'
+//
+// ```
 type IdentityNotificationTopic struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/sesv2/accountVdmAttributes.go
+++ b/sdk/go/aws/sesv2/accountVdmAttributes.go
@@ -50,11 +50,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleterraform import {
+// Using `pulumi import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For example:
 //
-//	to = aws_sesv2_account_vdm_attributes.example
+// ```sh
 //
-//	id = "ses-account-vdm-attributes" } Using `TODO import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleconsole % TODO import aws_sesv2_account_vdm_attributes.example ses-account-vdm-attributes
+//	$ pulumi import aws:sesv2/accountVdmAttributes:AccountVdmAttributes example ses-account-vdm-attributes
+//
+// ```
 type AccountVdmAttributes struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/verifiedaccess/instanceTrustProviderAttachment.go
+++ b/sdk/go/aws/verifiedaccess/instanceTrustProviderAttachment.go
@@ -59,11 +59,13 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleterraform import {
+// Using `pulumi import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For example:
 //
-//	to = aws_verifiedaccess_instance_trust_provider_attachment.example
+// ```sh
 //
-//	id = "vai-1234567890abcdef0/vatp-8012925589" } Using `TODO import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleconsole % TODO import aws_verifiedaccess_instance_trust_provider_attachment.example vai-1234567890abcdef0/vatp-8012925589
+//	$ pulumi import aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment example vai-1234567890abcdef0/vatp-8012925589
+//
+// ```
 type InstanceTrustProviderAttachment struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/verifiedaccess/trustProvider.go
+++ b/sdk/go/aws/verifiedaccess/trustProvider.go
@@ -45,13 +45,15 @@ import (
 //
 // ## Import
 //
-// In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For exampleterraform import {
+// # Using `pulumi import`, import Transfer Workflows using the
 //
-//	to = aws_verifiedaccess_trust_provider.example
+// `id`. For example:
 //
-//	id = "vatp-8012925589" } Using `TODO import`, import Transfer Workflows using the
+// ```sh
 //
-// `id`. For exampleconsole % TODO import aws_verifiedaccess_trust_provider.example vatp-8012925589
+//	$ pulumi import aws:verifiedaccess/trustProvider:TrustProvider example vatp-8012925589
+//
+// ```
 type TrustProvider struct {
 	pulumi.CustomResourceState
 

--- a/sdk/java/src/main/java/com/pulumi/aws/apigateway/ApiKey.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/apigateway/ApiKey.java
@@ -51,11 +51,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * terraform import {
+ * Using `pulumi import`, import API Gateway Keys using the `id`. For example:
  * 
- *  to = aws_api_gateway_api_key.example
- * 
- *  id = &#34;8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk&#34; } Using `pulumi import`, import API Gateway Keys using the `id`. For exampleconsole % TODO import aws_api_gateway_api_key.example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+ * ```sh
+ *  $ pulumi import aws:apigateway/apiKey:ApiKey example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+ * ```
  * 
  */
 @ResourceType(type="aws:apigateway/apiKey:ApiKey")

--- a/sdk/java/src/main/java/com/pulumi/aws/apigateway/Response.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/apigateway/Response.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleterraform import {
+ * Using `pulumi import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For example:
  * 
- *  to = aws_api_gateway_gateway_response.example
- * 
- *  id = &#34;12345abcde/UNAUTHORIZED&#34; } Using `TODO import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleconsole % TODO import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+ * ```sh
+ *  $ pulumi import aws:apigateway/response:Response example 12345abcde/UNAUTHORIZED
+ * ```
  * 
  */
 @ResourceType(type="aws:apigateway/response:Response")

--- a/sdk/java/src/main/java/com/pulumi/aws/cfg/AggregateAuthorization.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cfg/AggregateAuthorization.java
@@ -52,11 +52,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Config aggregate authorizations using `account_id:region`. For exampleterraform import {
+ * Using `pulumi import`, import Config aggregate authorizations using `account_id:region`. For example:
  * 
- *  to = aws_config_aggregate_authorization.example
- * 
- *  id = &#34;123456789012:us-east-1&#34; } Using `TODO import`, import Config aggregate authorizations using `account_id:region`. For exampleconsole % TODO import aws_config_aggregate_authorization.example 123456789012:us-east-1
+ * ```sh
+ *  $ pulumi import aws:cfg/aggregateAuthorization:AggregateAuthorization example 123456789012:us-east-1
+ * ```
  * 
  */
 @ResourceType(type="aws:cfg/aggregateAuthorization:AggregateAuthorization")

--- a/sdk/java/src/main/java/com/pulumi/aws/cleanrooms/ConfiguredTable.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cleanrooms/ConfiguredTable.java
@@ -64,11 +64,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_cleanrooms_configured_table` using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
  * 
- *  to = aws_cleanrooms_configured_table.table
- * 
- *  id = &#34;1234abcd-12ab-34cd-56ef-1234567890ab&#34; } Using `TODO import`, import `aws_cleanrooms_configured_table` using the `id`. For exampleconsole % TODO import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+ * ```sh
+ *  $ pulumi import aws:cleanrooms/configuredTable:ConfiguredTable table 1234abcd-12ab-34cd-56ef-1234567890ab
+ * ```
  * 
  */
 @ResourceType(type="aws:cleanrooms/configuredTable:ConfiguredTable")

--- a/sdk/java/src/main/java/com/pulumi/aws/cloud9/EnvironmentMembership.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloud9/EnvironmentMembership.java
@@ -59,11 +59,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Cloud9 environment membership using the `environment-id#user-arn`. For exampleterraform import {
+ * Using `pulumi import`, import Cloud9 environment membership using the `environment-id#user-arn`. For example:
  * 
- *  to = aws_cloud9_environment_membership.test
- * 
- *  id = &#34;environment-id#user-arn&#34; } Using `TODO import`, import Cloud9 environment membership using the `environment-id#user-arn`. For exampleconsole % TODO import aws_cloud9_environment_membership.test environment-id#user-arn
+ * ```sh
+ *  $ pulumi import aws:cloud9/environmentMembership:EnvironmentMembership test environment-id#user-arn
+ * ```
  * 
  */
 @ResourceType(type="aws:cloud9/environmentMembership:EnvironmentMembership")

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudformation/StackSet.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudformation/StackSet.java
@@ -125,7 +125,7 @@ import javax.annotation.Nullable;
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSet:StackSet example example
  * ```
- *  Using `TODO import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
+ *  Using `pulumi import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
  * 
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSet:StackSet example example,DELEGATED_ADMIN

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudformation/StackSetInstance.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudformation/StackSetInstance.java
@@ -156,23 +156,21 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
- * 
  * Import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
  * 
  * Import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
  * 
- * Using `TODO import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
+ * Using `pulumi import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
  * 
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,123456789012,us-east-1
  * ```
- *  Using `TODO import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
+ *  Using `pulumi import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
  * 
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1
  * ```
- *  Using `TODO import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
+ *  Using `pulumi import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
  * 
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1,DELEGATED_ADMIN

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/ContinuousDeploymentPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/ContinuousDeploymentPolicy.java
@@ -168,11 +168,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CloudFront Continuous Deployment Policy using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
  * 
- *  to = aws_cloudfront_continuous_deployment_policy.example
- * 
- *  id = &#34;abcd-1234&#34; } Using `TODO import`, import CloudFront Continuous Deployment Policy using the `id`. For exampleconsole % TODO import aws_cloudfront_continuous_deployment_policy.example abcd-1234
+ * ```sh
+ *  $ pulumi import aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy example abcd-1234
+ * ```
  * 
  */
 @ResourceType(type="aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy")

--- a/sdk/java/src/main/java/com/pulumi/aws/codecatalyst/Project.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codecatalyst/Project.java
@@ -52,11 +52,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Project using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import CodeCatalyst Project using the `example_id_arg`. For example:
  * 
- *  to = aws_codecatalyst_project.example
- * 
- *  id = &#34;project-id-12345678&#34; } Using `TODO import`, import CodeCatalyst Project using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_project.example project-id-12345678
+ * ```sh
+ *  $ pulumi import aws:codecatalyst/project:Project example project-id-12345678
+ * ```
  * 
  */
 @ResourceType(type="aws:codecatalyst/project:Project")

--- a/sdk/java/src/main/java/com/pulumi/aws/codecatalyst/SourceRepository.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codecatalyst/SourceRepository.java
@@ -51,11 +51,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Source Repository using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
  * 
- *  to = aws_codecatalyst_source_repository.example
- * 
- *  id = &#34;source_repository-id-12345678&#34; } Using `TODO import`, import CodeCatalyst Source Repository using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_source_repository.example source_repository-id-12345678
+ * ```sh
+ *  $ pulumi import aws:codecatalyst/sourceRepository:SourceRepository example source_repository-id-12345678
+ * ```
  * 
  */
 @ResourceType(type="aws:codecatalyst/sourceRepository:SourceRepository")

--- a/sdk/java/src/main/java/com/pulumi/aws/codecommit/Repository.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codecommit/Repository.java
@@ -52,9 +52,7 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodeCommit repository using repository name. For example:
- * 
- * Using `TODO import`, import CodeCommit repository using repository name. For example:
+ * Using `pulumi import`, import CodeCommit repository using repository name. For example:
  * 
  * ```sh
  *  $ pulumi import aws:codecommit/repository:Repository imported ExistingRepo

--- a/sdk/java/src/main/java/com/pulumi/aws/codepipeline/Pipeline.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codepipeline/Pipeline.java
@@ -188,11 +188,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodePipelines using the name. For exampleterraform import {
+ * Using `pulumi import`, import CodePipelines using the name. For example:
  * 
- *  to = aws_codepipeline.foo
- * 
- *  id = &#34;example&#34; } Using `TODO import`, import CodePipelines using the name. For exampleconsole % TODO import aws_codepipeline.foo example
+ * ```sh
+ *  $ pulumi import aws:codepipeline/pipeline:Pipeline foo example
+ * ```
  * 
  */
 @ResourceType(type="aws:codepipeline/pipeline:Pipeline")

--- a/sdk/java/src/main/java/com/pulumi/aws/codepipeline/Webhook.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codepipeline/Webhook.java
@@ -126,11 +126,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodePipeline Webhooks using their ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodePipeline Webhooks using their ARN. For example:
  * 
- *  to = aws_codepipeline_webhook.example
- * 
- *  id = &#34;arn:aws:codepipeline:us-west-2:123456789012:webhook:example&#34; } Using `TODO import`, import CodePipeline Webhooks using their ARN. For exampleconsole % TODO import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+ * ```sh
+ *  $ pulumi import aws:codepipeline/webhook:Webhook example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+ * ```
  * 
  */
 @ResourceType(type="aws:codepipeline/webhook:Webhook")

--- a/sdk/java/src/main/java/com/pulumi/aws/codestarconnections/Connection.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codestarconnections/Connection.java
@@ -87,11 +87,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodeStar connections using the ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodeStar connections using the ARN. For example:
  * 
- *  to = aws_codestarconnections_connection.test-connection
- * 
- *  id = &#34;arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448&#34; } Using `TODO import`, import CodeStar connections using the ARN. For exampleconsole % TODO import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```sh
+ *  $ pulumi import aws:codestarconnections/connection:Connection test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```
  * 
  */
 @ResourceType(type="aws:codestarconnections/connection:Connection")

--- a/sdk/java/src/main/java/com/pulumi/aws/codestarconnections/Host.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codestarconnections/Host.java
@@ -53,11 +53,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodeStar Host using the ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodeStar Host using the ARN. For example:
  * 
- *  to = aws_codestarconnections_host.example-host
- * 
- *  id = &#34;arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448&#34; } Using `TODO import`, import CodeStar Host using the ARN. For exampleconsole % TODO import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```sh
+ *  $ pulumi import aws:codestarconnections/host:Host example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```
  * 
  */
 @ResourceType(type="aws:codestarconnections/host:Host")

--- a/sdk/java/src/main/java/com/pulumi/aws/codestarnotifications/NotificationRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/codestarnotifications/NotificationRule.java
@@ -87,11 +87,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import CodeStar notification rule using the ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodeStar notification rule using the ARN. For example:
  * 
- *  to = aws_codestarnotifications_notification_rule.foo
- * 
- *  id = &#34;arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b&#34; } Using `TODO import`, import CodeStar notification rule using the ARN. For exampleconsole % TODO import aws_codestarnotifications_notification_rule.foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+ * ```sh
+ *  $ pulumi import aws:codestarnotifications/notificationRule:NotificationRule foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+ * ```
  * 
  */
 @ResourceType(type="aws:codestarnotifications/notificationRule:NotificationRule")

--- a/sdk/java/src/main/java/com/pulumi/aws/cognito/IdentityPool.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cognito/IdentityPool.java
@@ -79,11 +79,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool using its ID. For exampleterraform import {
+ * Using `pulumi import`, import Cognito Identity Pool using its ID. For example:
  * 
- *  to = aws_cognito_identity_pool.mypool
- * 
- *  id = &#34;us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3&#34; } Using `TODO import`, import Cognito Identity Pool using its ID. For exampleconsole % TODO import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+ * ```sh
+ *  $ pulumi import aws:cognito/identityPool:IdentityPool mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+ * ```
  * 
  */
 @ResourceType(type="aws:cognito/identityPool:IdentityPool")

--- a/sdk/java/src/main/java/com/pulumi/aws/cognito/IdentityPoolProviderPrincipalTag.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cognito/IdentityPoolProviderPrincipalTag.java
@@ -21,11 +21,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleterraform import {
+ * Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For example:
  * 
- *  to = aws_cognito_identity_pool_provider_principal_tag.example
- * 
- *  id = &#34;us-west-2_abc123:CorpAD&#34; } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleconsole % TODO import aws_cognito_identity_pool_provider_principal_tag.example us-west-2_abc123:CorpAD
+ * ```sh
+ *  $ pulumi import aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag example us-west-2_abc123:CorpAD
+ * ```
  * 
  */
 @ResourceType(type="aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag")

--- a/sdk/java/src/main/java/com/pulumi/aws/cognito/IdentityPoolRoleAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cognito/IdentityPoolRoleAttachment.java
@@ -22,11 +22,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleterraform import {
+ * Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For example:
  * 
- *  to = aws_cognito_identity_pool_roles_attachment.example
- * 
- *  id = &#34;us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42&#34; } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleconsole % TODO import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+ * ```sh
+ *  $ pulumi import aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+ * ```
  * 
  */
 @ResourceType(type="aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment")

--- a/sdk/java/src/main/java/com/pulumi/aws/cognito/UserPool.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cognito/UserPool.java
@@ -143,11 +143,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Cognito User Pools using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import Cognito User Pools using the `id`. For example:
  * 
- *  to = aws_cognito_user_pool.pool
- * 
- *  id = &#34;us-west-2_abc123&#34; } Using `TODO import`, import Cognito User Pools using the `id`. For exampleconsole % TODO import aws_cognito_user_pool.pool us-west-2_abc123
+ * ```sh
+ *  $ pulumi import aws:cognito/userPool:UserPool pool us-west-2_abc123
+ * ```
  * 
  */
 @ResourceType(type="aws:cognito/userPool:UserPool")

--- a/sdk/java/src/main/java/com/pulumi/aws/connect/BotAssociation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/connect/BotAssociation.java
@@ -136,11 +136,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleterraform import {
+ * Using `pulumi import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For example:
  * 
- *  to = aws_connect_bot_association.example
- * 
- *  id = &#34;aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2&#34; } Using `TODO import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleconsole % TODO import aws_connect_bot_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+ * ```sh
+ *  $ pulumi import aws:connect/botAssociation:BotAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+ * ```
  * 
  */
 @ResourceType(type="aws:connect/botAssociation:BotAssociation")

--- a/sdk/java/src/main/java/com/pulumi/aws/connect/LambdaFunctionAssociation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/connect/LambdaFunctionAssociation.java
@@ -50,11 +50,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleterraform import {
+ * Using `pulumi import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For example:
  * 
- *  to = aws_connect_lambda_function_association.example
- * 
- *  id = &#34;aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example&#34; } Using `TODO import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleconsole % TODO import aws_connect_lambda_function_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+ * ```sh
+ *  $ pulumi import aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+ * ```
  * 
  */
 @ResourceType(type="aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation")

--- a/sdk/java/src/main/java/com/pulumi/aws/datasync/LocationAzureBlob.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/datasync/LocationAzureBlob.java
@@ -60,11 +60,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleterraform import {
+ * Using `pulumi import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For example:
  * 
- *  to = aws_datasync_location_azure_blob.example
- * 
- *  id = &#34;arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567&#34; } Using `TODO import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleconsole % TODO import aws_datasync_location_azure_blob.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+ * ```sh
+ *  $ pulumi import aws:datasync/locationAzureBlob:LocationAzureBlob example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+ * ```
  * 
  */
 @ResourceType(type="aws:datasync/locationAzureBlob:LocationAzureBlob")

--- a/sdk/java/src/main/java/com/pulumi/aws/datasync/LocationFsxOntapFileSystem.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/datasync/LocationFsxOntapFileSystem.java
@@ -66,11 +66,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleterraform import {
+ * Using `pulumi import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For example:
  * 
- *  to = aws_datasync_location_fsx_ontap_file_system.example
- * 
- *  id = &#34;arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123&#34; } Using `TODO import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleconsole % TODO import aws_datasync_location_fsx_ontap_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+ * ```sh
+ *  $ pulumi import aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+ * ```
  * 
  */
 @ResourceType(type="aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem")

--- a/sdk/java/src/main/java/com/pulumi/aws/directconnect/GatewayAssociationProposal.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/directconnect/GatewayAssociationProposal.java
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
  * 
  * Using a proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`:
  * 
- * __With `TODO import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
+ * __With `pulumi import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
  * 
  * Using a proposal ID:
  * 

--- a/sdk/java/src/main/java/com/pulumi/aws/dlm/LifecyclePolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/dlm/LifecyclePolicy.java
@@ -282,11 +282,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import DLM lifecycle policies using their policy ID. For exampleterraform import {
+ * Using `pulumi import`, import DLM lifecycle policies using their policy ID. For example:
  * 
- *  to = aws_dlm_lifecycle_policy.example
- * 
- *  id = &#34;policy-abcdef12345678901&#34; } Using `TODO import`, import DLM lifecycle policies using their policy ID. For exampleconsole % TODO import aws_dlm_lifecycle_policy.example policy-abcdef12345678901
+ * ```sh
+ *  $ pulumi import aws:dlm/lifecyclePolicy:LifecyclePolicy example policy-abcdef12345678901
+ * ```
  * 
  */
 @ResourceType(type="aws:dlm/lifecyclePolicy:LifecyclePolicy")

--- a/sdk/java/src/main/java/com/pulumi/aws/dms/ReplicationConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/dms/ReplicationConfig.java
@@ -72,11 +72,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import replication configs using the `arn`. For exampleterraform import {
+ * Using `pulumi import`, import a replication config using the `arn`. For example:
  * 
- *  to = aws_dms_replication_config.example
- * 
- *  id = &#34;arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI&#34; } Using `TODO import`, import a replication config using the `arn`. For exampleconsole % TODO import aws_dms_replication_config.example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+ * ```sh
+ *  $ pulumi import aws:dms/replicationConfig:ReplicationConfig example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+ * ```
  * 
  */
 @ResourceType(type="aws:dms/replicationConfig:ReplicationConfig")

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkInterface.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkInterface.java
@@ -77,11 +77,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Network Interfaces using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import Network Interfaces using the `id`. For example:
  * 
- *  to = aws_network_interface.test
- * 
- *  id = &#34;eni-e5aa89a3&#34; } Using `TODO import`, import Network Interfaces using the `id`. For exampleconsole % TODO import aws_network_interface.test eni-e5aa89a3
+ * ```sh
+ *  $ pulumi import aws:ec2/networkInterface:NetworkInterface test eni-e5aa89a3
+ * ```
  * 
  */
 @ResourceType(type="aws:ec2/networkInterface:NetworkInterface")

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/VpcIpamPoolCidr.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/VpcIpamPoolCidr.java
@@ -141,11 +141,15 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * terraform import {
+ * __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
  * 
- *  to = aws_vpc_ipam_pool_cidr.example
+ * Using `pulumi import`, import IPAMs using the `&lt;cidr&gt;_&lt;ipam-pool-id&gt;`. For example:
  * 
- *  id = &#34;172.20.0.0/24_ipam-pool-0e634f5a1517cccdc&#34; } Using `pulumi import`, import IPAMs using the `&lt;cidr&gt;_&lt;ipam-pool-id&gt;`. For exampleconsole % TODO import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+ * __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
+ * 
+ * ```sh
+ *  $ pulumi import aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+ * ```
  * 
  */
 @ResourceType(type="aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr")

--- a/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/JobTemplate.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/JobTemplate.java
@@ -64,11 +64,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import EKS job templates using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import EKS job templates using the `id`. For example:
  * 
- *  to = aws_emrcontainers_job_template.example
- * 
- *  id = &#34;a1b2c3d4e5f6g7h8i9j10k11l&#34; } Using `TODO import`, import EKS job templates using the `id`. For exampleconsole % TODO import aws_emrcontainers_job_template.example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```sh
+ *  $ pulumi import aws:emrcontainers/jobTemplate:JobTemplate example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```
  * 
  */
 @ResourceType(type="aws:emrcontainers/jobTemplate:JobTemplate")

--- a/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/VirtualCluster.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/emrcontainers/VirtualCluster.java
@@ -64,11 +64,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import EKS Clusters using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import EKS Clusters using the `id`. For example:
  * 
- *  to = aws_emrcontainers_virtual_cluster.example
- * 
- *  id = &#34;a1b2c3d4e5f6g7h8i9j10k11l&#34; } Using `TODO import`, import EKS Clusters using the `id`. For exampleconsole % TODO import aws_emrcontainers_virtual_cluster.example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```sh
+ *  $ pulumi import aws:emrcontainers/virtualCluster:VirtualCluster example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```
  * 
  */
 @ResourceType(type="aws:emrcontainers/virtualCluster:VirtualCluster")

--- a/sdk/java/src/main/java/com/pulumi/aws/emrserverless/Application.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/emrserverless/Application.java
@@ -137,11 +137,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import EMR Severless applications using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import EMR Severless applications using the `id`. For example:
  * 
- *  to = aws_emrserverless_application.example
- * 
- *  id = &#34;id&#34; } Using `TODO import`, import EMR Severless applications using the `id`. For exampleconsole % TODO import aws_emrserverless_application.example id
+ * ```sh
+ *  $ pulumi import aws:emrserverless/application:Application example id
+ * ```
  * 
  */
 @ResourceType(type="aws:emrserverless/application:Application")

--- a/sdk/java/src/main/java/com/pulumi/aws/gamelift/GameServerGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/gamelift/GameServerGroup.java
@@ -193,11 +193,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import GameLift Game Server Group using the `name`. For exampleterraform import {
+ * Using `pulumi import`, import GameLift Game Server Group using the `name`. For example:
  * 
- *  to = aws_gamelift_game_server_group.example
- * 
- *  id = &#34;example&#34; } Using `TODO import`, import GameLift Game Server Group using the `name`. For exampleconsole % TODO import aws_gamelift_game_server_group.example example
+ * ```sh
+ *  $ pulumi import aws:gamelift/gameServerGroup:GameServerGroup example example
+ * ```
  * 
  */
 @ResourceType(type="aws:gamelift/gameServerGroup:GameServerGroup")

--- a/sdk/java/src/main/java/com/pulumi/aws/glue/DevEndpoint.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/glue/DevEndpoint.java
@@ -79,11 +79,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import a Glue Development Endpoint using the `name`. For exampleterraform import {
+ * Using `pulumi import`, import a Glue Development Endpoint using the `name`. For example:
  * 
- *  to = aws_glue_dev_endpoint.example
- * 
- *  id = &#34;foo&#34; } Using `TODO import`, import a Glue Development Endpoint using the `name`. For exampleconsole % TODO import aws_glue_dev_endpoint.example foo
+ * ```sh
+ *  $ pulumi import aws:glue/devEndpoint:DevEndpoint example foo
+ * ```
  * 
  */
 @ResourceType(type="aws:glue/devEndpoint:DevEndpoint")

--- a/sdk/java/src/main/java/com/pulumi/aws/iam/GroupPolicyAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/iam/GroupPolicyAttachment.java
@@ -61,11 +61,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleterraform import {
+ * Using `pulumi import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For example:
  * 
- *  to = aws_iam_group_policy_attachment.test-attach
- * 
- *  id = &#34;test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy&#34; } Using `TODO import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```sh
+ *  $ pulumi import aws:iam/groupPolicyAttachment:GroupPolicyAttachment test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```
  * 
  */
 @ResourceType(type="aws:iam/groupPolicyAttachment:GroupPolicyAttachment")

--- a/sdk/java/src/main/java/com/pulumi/aws/iam/RolePolicyAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/iam/RolePolicyAttachment.java
@@ -87,11 +87,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleterraform import {
+ * Using `pulumi import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
  * 
- *  to = aws_iam_role_policy_attachment.test-attach
- * 
- *  id = &#34;test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy&#34; } Using `TODO import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```sh
+ *  $ pulumi import aws:iam/rolePolicyAttachment:RolePolicyAttachment test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```
  * 
  */
 @ResourceType(type="aws:iam/rolePolicyAttachment:RolePolicyAttachment")

--- a/sdk/java/src/main/java/com/pulumi/aws/iam/UserPolicyAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/iam/UserPolicyAttachment.java
@@ -61,11 +61,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleterraform import {
+ * Using `pulumi import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For example:
  * 
- *  to = aws_iam_user_policy_attachment.test-attach
- * 
- *  id = &#34;test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy&#34; } Using `TODO import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```sh
+ *  $ pulumi import aws:iam/userPolicyAttachment:UserPolicyAttachment test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```
  * 
  */
 @ResourceType(type="aws:iam/userPolicyAttachment:UserPolicyAttachment")

--- a/sdk/java/src/main/java/com/pulumi/aws/lex/V2modelsBot.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lex/V2modelsBot.java
@@ -61,11 +61,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Lex V2 Models Bot using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
  * 
- *  to = aws_lexv2models_bot.example
- * 
- *  id = &#34;bot-id-12345678&#34; } Using `TODO import`, import Lex V2 Models Bot using the `example_id_arg`. For exampleconsole % TODO import aws_lexv2models_bot.example bot-id-12345678
+ * ```sh
+ *  $ pulumi import aws:lex/v2modelsBot:V2modelsBot example bot-id-12345678
+ * ```
  * 
  */
 @ResourceType(type="aws:lex/v2modelsBot:V2modelsBot")

--- a/sdk/java/src/main/java/com/pulumi/aws/licensemanager/Association.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/licensemanager/Association.java
@@ -75,11 +75,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import license configurations using `resource_arn,license_configuration_arn`. For exampleterraform import {
+ * Using `pulumi import`, import license configurations using `resource_arn,license_configuration_arn`. For example:
  * 
- *  to = aws_licensemanager_association.example
- * 
- *  id = &#34;arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef&#34; } Using `TODO import`, import license configurations using `resource_arn,license_configuration_arn`. For exampleconsole % TODO import aws_licensemanager_association.example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:licensemanager/association:Association example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```
  * 
  */
 @ResourceType(type="aws:licensemanager/association:Association")

--- a/sdk/java/src/main/java/com/pulumi/aws/licensemanager/LicenseConfiguration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/licensemanager/LicenseConfiguration.java
@@ -71,11 +71,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import license configurations using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import license configurations using the `id`. For example:
  * 
- *  to = aws_licensemanager_license_configuration.example
- * 
- *  id = &#34;arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef&#34; } Using `TODO import`, import license configurations using the `id`. For exampleconsole % TODO import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:licensemanager/licenseConfiguration:LicenseConfiguration example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```
  * 
  */
 @ResourceType(type="aws:licensemanager/licenseConfiguration:LicenseConfiguration")

--- a/sdk/java/src/main/java/com/pulumi/aws/msk/ClusterPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/msk/ClusterPolicy.java
@@ -75,11 +75,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Managed Streaming for Kafka Cluster Policy using the `cluster_arn. For exampleterraform import {
+ * Using `pulumi import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For example:
  * 
- *  to = aws_msk_cluster_policy.example
- * 
- *  id = &#34;arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3&#34; } Using `TODO import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For exampleconsole % TODO import aws_msk_cluster_policy.example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+ * ```sh
+ *  $ pulumi import aws:msk/clusterPolicy:ClusterPolicy example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+ * ```
  * 
  */
 @ResourceType(type="aws:msk/clusterPolicy:ClusterPolicy")

--- a/sdk/java/src/main/java/com/pulumi/aws/msk/VpcConnection.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/msk/VpcConnection.java
@@ -55,11 +55,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import MSK configurations using the configuration ARN. For exampleterraform import {
+ * Using `pulumi import`, import MSK configurations using the configuration ARN. For example:
  * 
- *  to = aws_msk_vpc_connection.example
- * 
- *  id = &#34;arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2&#34; } Using `TODO import`, import MSK configurations using the configuration ARN. For exampleconsole % TODO import aws_msk_vpc_connection.example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+ * ```sh
+ *  $ pulumi import aws:msk/vpcConnection:VpcConnection example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+ * ```
  * 
  */
 @ResourceType(type="aws:msk/vpcConnection:VpcConnection")

--- a/sdk/java/src/main/java/com/pulumi/aws/opensearch/VpcEndpoint.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/opensearch/VpcEndpoint.java
@@ -59,11 +59,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import OpenSearch VPC endpoint connections using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import OpenSearch VPC endpoint connections using the `id`. For example:
  * 
- *  to = aws_opensearch_vpc_endpoint_connection.example
- * 
- *  id = &#34;endpoint-id&#34; } Using `TODO import`, import OpenSearch VPC endpoint connections using the `id`. For exampleconsole % TODO import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+ * ```sh
+ *  $ pulumi import aws:opensearch/vpcEndpoint:VpcEndpoint example endpoint-id
+ * ```
  * 
  */
 @ResourceType(type="aws:opensearch/vpcEndpoint:VpcEndpoint")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/AdmChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/AdmChannel.java
@@ -58,11 +58,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint ADM Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint ADM Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_adm_channel.channel
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint ADM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_adm_channel.channel application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/admChannel:AdmChannel channel application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/admChannel:AdmChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsChannel.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_apns_channel.apns
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint APNs Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_channel.apns application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsChannel:ApnsChannel apns application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/apnsChannel:ApnsChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsSandboxChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsSandboxChannel.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_apns_sandbox_channel.apns_sandbox
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_sandbox_channel.apns_sandbox application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel apns_sandbox application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsVoipChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsVoipChannel.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs VoIP Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_apns_voip_channel.apns_voip
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint APNs VoIP Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_channel.apns_voip application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsVoipChannel:ApnsVoipChannel apns_voip application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/apnsVoipChannel:ApnsVoipChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsVoipSandboxChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/ApnsVoipSandboxChannel.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel apns_voip_sandbox application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/App.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/App.java
@@ -62,11 +62,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint App using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint App using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_app.name
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint App using the `application-id`. For exampleconsole % TODO import aws_pinpoint_app.name application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/app:App name application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/app:App")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/BaiduChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/BaiduChannel.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint Baidu Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint Baidu Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_baidu_channel.channel
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint Baidu Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_baidu_channel.channel application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/baiduChannel:BaiduChannel channel application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/baiduChannel:BaiduChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/EmailChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/EmailChannel.java
@@ -98,11 +98,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint Email Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint Email Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_email_channel.email
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint Email Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_email_channel.email application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/emailChannel:EmailChannel email application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/emailChannel:EmailChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/EventStream.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/EventStream.java
@@ -95,11 +95,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint Event Stream using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint Event Stream using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_event_stream.stream
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint Event Stream using the `application-id`. For exampleconsole % TODO import aws_pinpoint_event_stream.stream application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/eventStream:EventStream stream application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/eventStream:EventStream")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/GcmChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/GcmChannel.java
@@ -56,11 +56,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint GCM Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint GCM Channel using the `application-id`. For example:
  * 
- *  to = aws_pinpoint_gcm_channel.gcm
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import Pinpoint GCM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_gcm_channel.gcm application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/gcmChannel:GcmChannel gcm application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/gcmChannel:GcmChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/pinpoint/SmsChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/pinpoint/SmsChannel.java
@@ -54,11 +54,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import the Pinpoint SMS Channel using the `application_id`. For exampleterraform import {
+ * Using `pulumi import`, import the Pinpoint SMS Channel using the `application_id`. For example:
  * 
- *  to = aws_pinpoint_sms_channel.sms
- * 
- *  id = &#34;application-id&#34; } Using `TODO import`, import the Pinpoint SMS Channel using the `application_id`. For exampleconsole % TODO import aws_pinpoint_sms_channel.sms application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/smsChannel:SmsChannel sms application-id
+ * ```
  * 
  */
 @ResourceType(type="aws:pinpoint/smsChannel:SmsChannel")

--- a/sdk/java/src/main/java/com/pulumi/aws/ram/PrincipalAssociation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ram/PrincipalAssociation.java
@@ -96,11 +96,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleterraform import {
+ * Using `pulumi import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For example:
  * 
- *  to = aws_ram_principal_association.example
- * 
- *  id = &#34;arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012&#34; } Using `TODO import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleconsole % TODO import aws_ram_principal_association.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+ * ```sh
+ *  $ pulumi import aws:ram/principalAssociation:PrincipalAssociation example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+ * ```
  * 
  */
 @ResourceType(type="aws:ram/principalAssociation:PrincipalAssociation")

--- a/sdk/java/src/main/java/com/pulumi/aws/ram/ResourceShare.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ram/ResourceShare.java
@@ -53,11 +53,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import resource shares using the `arn` of the resource share. For exampleterraform import {
+ * Using `pulumi import`, import resource shares using the `arn` of the resource share. For example:
  * 
- *  to = aws_ram_resource_share.example
- * 
- *  id = &#34;arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12&#34; } Using `TODO import`, import resource shares using the `arn` of the resource share. For exampleconsole % TODO import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+ * ```sh
+ *  $ pulumi import aws:ram/resourceShare:ResourceShare example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+ * ```
  * 
  */
 @ResourceType(type="aws:ram/resourceShare:ResourceShare")

--- a/sdk/java/src/main/java/com/pulumi/aws/ram/ResourceShareAccepter.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ram/ResourceShareAccepter.java
@@ -82,11 +82,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import resource share accepters using the resource share ARN. For exampleterraform import {
+ * Using `pulumi import`, import resource share accepters using the resource share ARN. For example:
  * 
- *  to = aws_ram_resource_share_accepter.example
- * 
- *  id = &#34;arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767&#34; } Using `TODO import`, import resource share accepters using the resource share ARN. For exampleconsole % TODO import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+ * ```sh
+ *  $ pulumi import aws:ram/resourceShareAccepter:ResourceShareAccepter example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+ * ```
  * 
  */
 @ResourceType(type="aws:ram/resourceShareAccepter:ResourceShareAccepter")

--- a/sdk/java/src/main/java/com/pulumi/aws/ram/SharingWithOrganization.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ram/SharingWithOrganization.java
@@ -45,11 +45,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import the resource using the current AWS account ID. For exampleterraform import {
+ * Using `pulumi import`, import the resource using the current AWS account ID. For example:
  * 
- *  to = aws_ram_sharing_with_organization.example
- * 
- *  id = &#34;123456789012&#34; } Using `TODO import`, import the resource using the current AWS account ID. For exampleconsole % TODO import aws_ram_sharing_with_organization.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:ram/sharingWithOrganization:SharingWithOrganization example 123456789012
+ * ```
  * 
  */
 @ResourceType(type="aws:ram/sharingWithOrganization:SharingWithOrganization")

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/ClusterParameterGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/ClusterParameterGroup.java
@@ -66,11 +66,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import RDS Cluster Parameter Groups using the `name`. For exampleterraform import {
+ * Using `pulumi import`, import RDS Cluster Parameter Groups using the `name`. For example:
  * 
- *  to = aws_rds_cluster_parameter_group.cluster_pg
- * 
- *  id = &#34;production-pg-1&#34; } Using `TODO import`, import RDS Cluster Parameter Groups using the `name`. For exampleconsole % TODO import aws_rds_cluster_parameter_group.cluster_pg production-pg-1
+ * ```sh
+ *  $ pulumi import aws:rds/clusterParameterGroup:ClusterParameterGroup cluster_pg production-pg-1
+ * ```
  * 
  */
 @ResourceType(type="aws:rds/clusterParameterGroup:ClusterParameterGroup")

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/CustomDbEngineVersion.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/CustomDbEngineVersion.java
@@ -186,11 +186,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleterraform import {
+ * Using `pulumi import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For example:
  * 
- *  to = aws_rds_custom_db_engine_version.example
- * 
- *  id = &#34;custom-oracle-ee-cdb:19.cdb_cev1&#34; } Using `TODO import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleconsole % TODO import aws_rds_custom_db_engine_version.example custom-oracle-ee-cdb:19.cdb_cev1
+ * ```sh
+ *  $ pulumi import aws:rds/customDbEngineVersion:CustomDbEngineVersion example custom-oracle-ee-cdb:19.cdb_cev1
+ * ```
  * 
  */
 @ResourceType(type="aws:rds/customDbEngineVersion:CustomDbEngineVersion")

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/InstanceAutomatedBackupsReplication.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/InstanceAutomatedBackupsReplication.java
@@ -149,11 +149,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import RDS instance automated backups replication using the `arn`. For exampleterraform import {
+ * Using `pulumi import`, import RDS instance automated backups replication using the `arn`. For example:
  * 
- *  to = aws_db_instance_automated_backups_replication.default
- * 
- *  id = &#34;arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my&#34; } Using `TODO import`, import RDS instance automated backups replication using the `arn`. For exampleconsole % TODO import aws_db_instance_automated_backups_replication.default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+ * ```sh
+ *  $ pulumi import aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+ * ```
  * 
  */
 @ResourceType(type="aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication")

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallConfig.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleterraform import {
+ * Using `pulumi import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For example:
  * 
- *  to = aws_route53_resolver_firewall_config.example
- * 
- *  id = &#34;rdsc-be1866ecc1683e95&#34; } Using `TODO import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleconsole % TODO import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallConfig:ResolverFirewallConfig example rdsc-be1866ecc1683e95
+ * ```
  * 
  */
 @ResourceType(type="aws:route53/resolverFirewallConfig:ResolverFirewallConfig")

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallDomainList.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallDomainList.java
@@ -48,15 +48,13 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import
+ * Using `pulumi import`, import
  * 
- * Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleterraform import {
+ * Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For example:
  * 
- *  to = aws_route53_resolver_firewall_domain_list.example
- * 
- *  id = &#34;rslvr-fdl-0123456789abcdef&#34; } Using `TODO import`, import
- * 
- * Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleconsole % TODO import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList example rslvr-fdl-0123456789abcdef
+ * ```
  * 
  */
 @ResourceType(type="aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList")

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallRule.java
@@ -70,15 +70,13 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import
+ * Using `pulumi import`, import
  * 
- * Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by &#39;:&#39;. For exampleterraform import {
+ * Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by &#39;:&#39;. For example:
  * 
- *  to = aws_route53_resolver_firewall_rule.example
- * 
- *  id = &#34;rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef&#34; } Using `TODO import`, import
- * 
- * Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by &#39;:&#39;. For exampleconsole % TODO import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallRule:ResolverFirewallRule example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+ * ```
  * 
  */
 @ResourceType(type="aws:route53/resolverFirewallRule:ResolverFirewallRule")

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallRuleGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallRuleGroup.java
@@ -48,15 +48,13 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import
+ * Using `pulumi import`, import
  * 
- * Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleterraform import {
+ * Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For example:
  * 
- *  to = aws_route53_resolver_firewall_rule_group.example
- * 
- *  id = &#34;rslvr-frg-0123456789abcdef&#34; } Using `TODO import`, import
- * 
- * Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup example rslvr-frg-0123456789abcdef
+ * ```
  * 
  */
 @ResourceType(type="aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup")

--- a/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallRuleGroupAssociation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/route53/ResolverFirewallRuleGroupAssociation.java
@@ -57,11 +57,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleterraform import {
+ * Using `pulumi import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For example:
  * 
- *  to = aws_route53_resolver_firewall_rule_group_association.example
- * 
- *  id = &#34;rslvr-frgassoc-0123456789abcdef&#34; } Using `TODO import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation example rslvr-frgassoc-0123456789abcdef
+ * ```
  * 
  */
 @ResourceType(type="aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/Account.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/Account.java
@@ -49,11 +49,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+ * Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
  * 
- *  to = aws_securityhub_account.example
- * 
- *  id = &#34;123456789012&#34; } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_account.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/account:Account example 123456789012
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/account:Account")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/FindingAggregator.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/FindingAggregator.java
@@ -139,11 +139,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub finding aggregator using the `arn`. For exampleterraform import {
+ * Using `pulumi import`, import an existing Security Hub finding aggregator using the `arn`. For example:
  * 
- *  to = aws_securityhub_finding_aggregator.example
- * 
- *  id = &#34;arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456&#34; } Using `TODO import`, import an existing Security Hub finding aggregator using the `arn`. For exampleconsole % TODO import aws_securityhub_finding_aggregator.example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+ * ```sh
+ *  $ pulumi import aws:securityhub/findingAggregator:FindingAggregator example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/findingAggregator:FindingAggregator")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/InviteAccepter.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/InviteAccepter.java
@@ -70,11 +70,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub invite acceptance using the account ID. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub invite acceptance using the account ID. For example:
  * 
- *  to = aws_securityhub_invite_accepter.example
- * 
- *  id = &#34;123456789012&#34; } Using `TODO import`, import Security Hub invite acceptance using the account ID. For exampleconsole % TODO import aws_securityhub_invite_accepter.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/inviteAccepter:InviteAccepter example 123456789012
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/inviteAccepter:InviteAccepter")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/Member.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/Member.java
@@ -58,11 +58,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub members using their account ID. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub members using their account ID. For example:
  * 
- *  to = aws_securityhub_member.example
- * 
- *  id = &#34;123456789012&#34; } Using `TODO import`, import Security Hub members using their account ID. For exampleconsole % TODO import aws_securityhub_member.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/member:Member example 123456789012
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/member:Member")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/OrganizationConfiguration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/OrganizationConfiguration.java
@@ -69,11 +69,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+ * Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
  * 
- *  to = aws_securityhub_organization_configuration.example
- * 
- *  id = &#34;123456789012&#34; } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_organization_configuration.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/organizationConfiguration:OrganizationConfiguration example 123456789012
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/organizationConfiguration:OrganizationConfiguration")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/ProductSubscription.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/ProductSubscription.java
@@ -58,11 +58,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub product subscriptions using `product_arn,arn`. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub product subscriptions using `product_arn,arn`. For example:
  * 
- *  to = aws_securityhub_product_subscription.example
- * 
- *  id = &#34;arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement&#34; } Using `TODO import`, import Security Hub product subscriptions using `product_arn,arn`. For exampleconsole % TODO import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+ * ```sh
+ *  $ pulumi import aws:securityhub/productSubscription:ProductSubscription example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/productSubscription:ProductSubscription")

--- a/sdk/java/src/main/java/com/pulumi/aws/securityhub/StandardsSubscription.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/securityhub/StandardsSubscription.java
@@ -64,19 +64,17 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub standards subscriptions using the standards subscription ARN. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub standards subscriptions using the standards subscription ARN. For example:
  * 
- *  to = aws_securityhub_standards_subscription.cis
- * 
- *  id = &#34;arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0&#34; } terraform import {
- * 
- *  to = aws_securityhub_standards_subscription.pci_321
- * 
- *  id = &#34;arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1&#34; } terraform import {
- * 
- *  to = aws_securityhub_standards_subscription.nist_800_53_rev_5
- * 
- *  id = &#34;arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0&#34; } Using `TODO import`, import Security Hub standards subscriptions using the standards subscription ARN. For exampleconsole % TODO import aws_securityhub_standards_subscription.cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0 console % TODO import aws_securityhub_standards_subscription.pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1 console % TODO import aws_securityhub_standards_subscription.nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+ * ```sh
+ *  $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0
+ * ```
+ * ```sh
+ * $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1
+ * ```
+ * ```sh
+ * $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+ * ```
  * 
  */
 @ResourceType(type="aws:securityhub/standardsSubscription:StandardsSubscription")

--- a/sdk/java/src/main/java/com/pulumi/aws/servicecatalog/PrincipalPortfolioAssociation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/servicecatalog/PrincipalPortfolioAssociation.java
@@ -51,9 +51,7 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
- * 
- * Using `TODO import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
+ * Using `pulumi import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
  * 
  * ```sh
  *  $ pulumi import aws:servicecatalog/principalPortfolioAssociation:PrincipalPortfolioAssociation example en,arn:aws:iam::123456789012:user/Eleanor,port-68656c6c6f,IAM

--- a/sdk/java/src/main/java/com/pulumi/aws/servicequotas/Template.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/servicequotas/Template.java
@@ -56,11 +56,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Service Quotas Template using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import Service Quotas Template using the `id`. For example:
  * 
- *  to = aws_servicequotas_template.example
- * 
- *  id = &#34;us-east-1,L-2ACBD22F,lambda&#34; } Using `TODO import`, import Service Quotas Template using the `id`. For exampleconsole % TODO import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+ * ```sh
+ *  $ pulumi import aws:servicequotas/template:Template example us-east-1,L-2ACBD22F,lambda
+ * ```
  * 
  */
 @ResourceType(type="aws:servicequotas/template:Template")

--- a/sdk/java/src/main/java/com/pulumi/aws/ses/IdentityNotificationTopic.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ses/IdentityNotificationTopic.java
@@ -53,11 +53,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleterraform import {
+ * Using `pulumi import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For example:
  * 
- *  to = aws_ses_identity_notification_topic.test
- * 
- *  id = &#34;example.com|Bounce&#34; } Using `TODO import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleconsole % TODO import aws_ses_identity_notification_topic.test &#39;example.com|Bounce&#39;
+ * ```sh
+ *  $ pulumi import aws:ses/identityNotificationTopic:IdentityNotificationTopic test &#39;example.com|Bounce&#39;
+ * ```
  * 
  */
 @ResourceType(type="aws:ses/identityNotificationTopic:IdentityNotificationTopic")

--- a/sdk/java/src/main/java/com/pulumi/aws/sesv2/AccountVdmAttributes.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/sesv2/AccountVdmAttributes.java
@@ -59,11 +59,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleterraform import {
+ * Using `pulumi import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For example:
  * 
- *  to = aws_sesv2_account_vdm_attributes.example
- * 
- *  id = &#34;ses-account-vdm-attributes&#34; } Using `TODO import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleconsole % TODO import aws_sesv2_account_vdm_attributes.example ses-account-vdm-attributes
+ * ```sh
+ *  $ pulumi import aws:sesv2/accountVdmAttributes:AccountVdmAttributes example ses-account-vdm-attributes
+ * ```
  * 
  */
 @ResourceType(type="aws:sesv2/accountVdmAttributes:AccountVdmAttributes")

--- a/sdk/java/src/main/java/com/pulumi/aws/verifiedaccess/InstanceTrustProviderAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/verifiedaccess/InstanceTrustProviderAttachment.java
@@ -64,11 +64,11 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleterraform import {
+ * Using `pulumi import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For example:
  * 
- *  to = aws_verifiedaccess_instance_trust_provider_attachment.example
- * 
- *  id = &#34;vai-1234567890abcdef0/vatp-8012925589&#34; } Using `TODO import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleconsole % TODO import aws_verifiedaccess_instance_trust_provider_attachment.example vai-1234567890abcdef0/vatp-8012925589
+ * ```sh
+ *  $ pulumi import aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment example vai-1234567890abcdef0/vatp-8012925589
+ * ```
  * 
  */
 @ResourceType(type="aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment")

--- a/sdk/java/src/main/java/com/pulumi/aws/verifiedaccess/TrustProvider.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/verifiedaccess/TrustProvider.java
@@ -55,13 +55,13 @@ import javax.annotation.Nullable;
  * 
  * ## Import
  * 
- * In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import Transfer Workflows using the
  * 
- *  to = aws_verifiedaccess_trust_provider.example
+ * `id`. For example:
  * 
- *  id = &#34;vatp-8012925589&#34; } Using `TODO import`, import Transfer Workflows using the
- * 
- * `id`. For exampleconsole % TODO import aws_verifiedaccess_trust_provider.example vatp-8012925589
+ * ```sh
+ *  $ pulumi import aws:verifiedaccess/trustProvider:TrustProvider example vatp-8012925589
+ * ```
  * 
  */
 @ResourceType(type="aws:verifiedaccess/trustProvider:TrustProvider")

--- a/sdk/nodejs/apigateway/apiKey.ts
+++ b/sdk/nodejs/apigateway/apiKey.ts
@@ -20,11 +20,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * terraform import {
+ * Using `pulumi import`, import API Gateway Keys using the `id`. For example:
  *
- *  to = aws_api_gateway_api_key.example
- *
- *  id = "8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk" } Using `pulumi import`, import API Gateway Keys using the `id`. For exampleconsole % TODO import aws_api_gateway_api_key.example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+ * ```sh
+ *  $ pulumi import aws:apigateway/apiKey:ApiKey example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+ * ```
  */
 export class ApiKey extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/apigateway/response.ts
+++ b/sdk/nodejs/apigateway/response.ts
@@ -29,11 +29,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleterraform import {
+ * Using `pulumi import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For example:
  *
- *  to = aws_api_gateway_gateway_response.example
- *
- *  id = "12345abcde/UNAUTHORIZED" } Using `TODO import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleconsole % TODO import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+ * ```sh
+ *  $ pulumi import aws:apigateway/response:Response example 12345abcde/UNAUTHORIZED
+ * ```
  */
 export class Response extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cfg/aggregateAuthorization.ts
+++ b/sdk/nodejs/cfg/aggregateAuthorization.ts
@@ -21,11 +21,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Config aggregate authorizations using `account_id:region`. For exampleterraform import {
+ * Using `pulumi import`, import Config aggregate authorizations using `account_id:region`. For example:
  *
- *  to = aws_config_aggregate_authorization.example
- *
- *  id = "123456789012:us-east-1" } Using `TODO import`, import Config aggregate authorizations using `account_id:region`. For exampleconsole % TODO import aws_config_aggregate_authorization.example 123456789012:us-east-1
+ * ```sh
+ *  $ pulumi import aws:cfg/aggregateAuthorization:AggregateAuthorization example 123456789012:us-east-1
+ * ```
  */
 export class AggregateAuthorization extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cleanrooms/configuredTable.ts
+++ b/sdk/nodejs/cleanrooms/configuredTable.ts
@@ -37,11 +37,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_cleanrooms_configured_table` using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
  *
- *  to = aws_cleanrooms_configured_table.table
- *
- *  id = "1234abcd-12ab-34cd-56ef-1234567890ab" } Using `TODO import`, import `aws_cleanrooms_configured_table` using the `id`. For exampleconsole % TODO import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+ * ```sh
+ *  $ pulumi import aws:cleanrooms/configuredTable:ConfiguredTable table 1234abcd-12ab-34cd-56ef-1234567890ab
+ * ```
  */
 export class ConfiguredTable extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cloud9/environmentMembership.ts
+++ b/sdk/nodejs/cloud9/environmentMembership.ts
@@ -24,11 +24,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Cloud9 environment membership using the `environment-id#user-arn`. For exampleterraform import {
+ * Using `pulumi import`, import Cloud9 environment membership using the `environment-id#user-arn`. For example:
  *
- *  to = aws_cloud9_environment_membership.test
- *
- *  id = "environment-id#user-arn" } Using `TODO import`, import Cloud9 environment membership using the `environment-id#user-arn`. For exampleconsole % TODO import aws_cloud9_environment_membership.test environment-id#user-arn
+ * ```sh
+ *  $ pulumi import aws:cloud9/environmentMembership:EnvironmentMembership test environment-id#user-arn
+ * ```
  */
 export class EnvironmentMembership extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cloudformation/stackSet.ts
+++ b/sdk/nodejs/cloudformation/stackSet.ts
@@ -82,7 +82,7 @@ import * as utilities from "../utilities";
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSet:StackSet example example
  * ```
- *  Using `TODO import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
+ *  Using `pulumi import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
  *
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSet:StackSet example example,DELEGATED_ADMIN

--- a/sdk/nodejs/cloudformation/stackSetInstance.ts
+++ b/sdk/nodejs/cloudformation/stackSetInstance.ts
@@ -77,23 +77,21 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
- *
  * Import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
  *
  * Import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
  *
- * Using `TODO import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
+ * Using `pulumi import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
  *
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,123456789012,us-east-1
  * ```
- *  Using `TODO import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
+ *  Using `pulumi import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
  *
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1
  * ```
- *  Using `TODO import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
+ *  Using `pulumi import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
  *
  * ```sh
  *  $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1,DELEGATED_ADMIN

--- a/sdk/nodejs/cloudfront/continuousDeploymentPolicy.ts
+++ b/sdk/nodejs/cloudfront/continuousDeploymentPolicy.ts
@@ -89,11 +89,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CloudFront Continuous Deployment Policy using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
  *
- *  to = aws_cloudfront_continuous_deployment_policy.example
- *
- *  id = "abcd-1234" } Using `TODO import`, import CloudFront Continuous Deployment Policy using the `id`. For exampleconsole % TODO import aws_cloudfront_continuous_deployment_policy.example abcd-1234
+ * ```sh
+ *  $ pulumi import aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy example abcd-1234
+ * ```
  */
 export class ContinuousDeploymentPolicy extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codecatalyst/project.ts
+++ b/sdk/nodejs/codecatalyst/project.ts
@@ -23,11 +23,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Project using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import CodeCatalyst Project using the `example_id_arg`. For example:
  *
- *  to = aws_codecatalyst_project.example
- *
- *  id = "project-id-12345678" } Using `TODO import`, import CodeCatalyst Project using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_project.example project-id-12345678
+ * ```sh
+ *  $ pulumi import aws:codecatalyst/project:Project example project-id-12345678
+ * ```
  */
 export class Project extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codecatalyst/sourceRepository.ts
+++ b/sdk/nodejs/codecatalyst/sourceRepository.ts
@@ -22,11 +22,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Source Repository using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
  *
- *  to = aws_codecatalyst_source_repository.example
- *
- *  id = "source_repository-id-12345678" } Using `TODO import`, import CodeCatalyst Source Repository using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_source_repository.example source_repository-id-12345678
+ * ```sh
+ *  $ pulumi import aws:codecatalyst/sourceRepository:SourceRepository example source_repository-id-12345678
+ * ```
  */
 export class SourceRepository extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codecommit/repository.ts
+++ b/sdk/nodejs/codecommit/repository.ts
@@ -21,9 +21,7 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodeCommit repository using repository name. For example:
- *
- * Using `TODO import`, import CodeCommit repository using repository name. For example:
+ * Using `pulumi import`, import CodeCommit repository using repository name. For example:
  *
  * ```sh
  *  $ pulumi import aws:codecommit/repository:Repository imported ExistingRepo

--- a/sdk/nodejs/codepipeline/pipeline.ts
+++ b/sdk/nodejs/codepipeline/pipeline.ts
@@ -137,11 +137,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodePipelines using the name. For exampleterraform import {
+ * Using `pulumi import`, import CodePipelines using the name. For example:
  *
- *  to = aws_codepipeline.foo
- *
- *  id = "example" } Using `TODO import`, import CodePipelines using the name. For exampleconsole % TODO import aws_codepipeline.foo example
+ * ```sh
+ *  $ pulumi import aws:codepipeline/pipeline:Pipeline foo example
+ * ```
  */
 export class Pipeline extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codepipeline/webhook.ts
+++ b/sdk/nodejs/codepipeline/webhook.ts
@@ -88,11 +88,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodePipeline Webhooks using their ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodePipeline Webhooks using their ARN. For example:
  *
- *  to = aws_codepipeline_webhook.example
- *
- *  id = "arn:aws:codepipeline:us-west-2:123456789012:webhook:example" } Using `TODO import`, import CodePipeline Webhooks using their ARN. For exampleconsole % TODO import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+ * ```sh
+ *  $ pulumi import aws:codepipeline/webhook:Webhook example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+ * ```
  */
 export class Webhook extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codestarconnections/connection.ts
+++ b/sdk/nodejs/codestarconnections/connection.ts
@@ -50,11 +50,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodeStar connections using the ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodeStar connections using the ARN. For example:
  *
- *  to = aws_codestarconnections_connection.test-connection
- *
- *  id = "arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar connections using the ARN. For exampleconsole % TODO import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```sh
+ *  $ pulumi import aws:codestarconnections/connection:Connection test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```
  */
 export class Connection extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codestarconnections/host.ts
+++ b/sdk/nodejs/codestarconnections/host.ts
@@ -26,11 +26,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodeStar Host using the ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodeStar Host using the ARN. For example:
  *
- *  to = aws_codestarconnections_host.example-host
- *
- *  id = "arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar Host using the ARN. For exampleconsole % TODO import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```sh
+ *  $ pulumi import aws:codestarconnections/host:Host example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+ * ```
  */
 export class Host extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/codestarnotifications/notificationRule.ts
+++ b/sdk/nodejs/codestarnotifications/notificationRule.ts
@@ -44,11 +44,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import CodeStar notification rule using the ARN. For exampleterraform import {
+ * Using `pulumi import`, import CodeStar notification rule using the ARN. For example:
  *
- *  to = aws_codestarnotifications_notification_rule.foo
- *
- *  id = "arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b" } Using `TODO import`, import CodeStar notification rule using the ARN. For exampleconsole % TODO import aws_codestarnotifications_notification_rule.foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+ * ```sh
+ *  $ pulumi import aws:codestarnotifications/notificationRule:NotificationRule foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+ * ```
  */
 export class NotificationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cognito/identityPool.ts
+++ b/sdk/nodejs/cognito/identityPool.ts
@@ -45,11 +45,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool using its ID. For exampleterraform import {
+ * Using `pulumi import`, import Cognito Identity Pool using its ID. For example:
  *
- *  to = aws_cognito_identity_pool.mypool
- *
- *  id = "us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3" } Using `TODO import`, import Cognito Identity Pool using its ID. For exampleconsole % TODO import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+ * ```sh
+ *  $ pulumi import aws:cognito/identityPool:IdentityPool mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+ * ```
  */
 export class IdentityPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cognito/identityPoolProviderPrincipalTag.ts
+++ b/sdk/nodejs/cognito/identityPoolProviderPrincipalTag.ts
@@ -9,11 +9,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleterraform import {
+ * Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For example:
  *
- *  to = aws_cognito_identity_pool_provider_principal_tag.example
- *
- *  id = "us-west-2_abc123:CorpAD" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleconsole % TODO import aws_cognito_identity_pool_provider_principal_tag.example us-west-2_abc123:CorpAD
+ * ```sh
+ *  $ pulumi import aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag example us-west-2_abc123:CorpAD
+ * ```
  */
 export class IdentityPoolProviderPrincipalTag extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cognito/identityPoolRoleAttachment.ts
+++ b/sdk/nodejs/cognito/identityPoolRoleAttachment.ts
@@ -12,11 +12,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleterraform import {
+ * Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For example:
  *
- *  to = aws_cognito_identity_pool_roles_attachment.example
- *
- *  id = "us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleconsole % TODO import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+ * ```sh
+ *  $ pulumi import aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+ * ```
  */
 export class IdentityPoolRoleAttachment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cognito/userPool.ts
+++ b/sdk/nodejs/cognito/userPool.ts
@@ -61,11 +61,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Cognito User Pools using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import Cognito User Pools using the `id`. For example:
  *
- *  to = aws_cognito_user_pool.pool
- *
- *  id = "us-west-2_abc123" } Using `TODO import`, import Cognito User Pools using the `id`. For exampleconsole % TODO import aws_cognito_user_pool.pool us-west-2_abc123
+ * ```sh
+ *  $ pulumi import aws:cognito/userPool:UserPool pool us-west-2_abc123
+ * ```
  */
 export class UserPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/connect/botAssociation.ts
+++ b/sdk/nodejs/connect/botAssociation.ts
@@ -76,11 +76,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleterraform import {
+ * Using `pulumi import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For example:
  *
- *  to = aws_connect_bot_association.example
- *
- *  id = "aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2" } Using `TODO import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleconsole % TODO import aws_connect_bot_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+ * ```sh
+ *  $ pulumi import aws:connect/botAssociation:BotAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+ * ```
  */
 export class BotAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/connect/lambdaFunctionAssociation.ts
+++ b/sdk/nodejs/connect/lambdaFunctionAssociation.ts
@@ -22,11 +22,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleterraform import {
+ * Using `pulumi import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For example:
  *
- *  to = aws_connect_lambda_function_association.example
- *
- *  id = "aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example" } Using `TODO import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleconsole % TODO import aws_connect_lambda_function_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+ * ```sh
+ *  $ pulumi import aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+ * ```
  */
 export class LambdaFunctionAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/datasync/locationAzureBlob.ts
+++ b/sdk/nodejs/datasync/locationAzureBlob.ts
@@ -30,11 +30,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleterraform import {
+ * Using `pulumi import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For example:
  *
- *  to = aws_datasync_location_azure_blob.example
- *
- *  id = "arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567" } Using `TODO import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleconsole % TODO import aws_datasync_location_azure_blob.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+ * ```sh
+ *  $ pulumi import aws:datasync/locationAzureBlob:LocationAzureBlob example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+ * ```
  */
 export class LocationAzureBlob extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/datasync/locationFsxOntapFileSystem.ts
+++ b/sdk/nodejs/datasync/locationFsxOntapFileSystem.ts
@@ -14,11 +14,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleterraform import {
+ * Using `pulumi import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For example:
  *
- *  to = aws_datasync_location_fsx_ontap_file_system.example
- *
- *  id = "arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123" } Using `TODO import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleconsole % TODO import aws_datasync_location_fsx_ontap_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+ * ```sh
+ *  $ pulumi import aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+ * ```
  */
 export class LocationFsxOntapFileSystem extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/directconnect/gatewayAssociationProposal.ts
+++ b/sdk/nodejs/directconnect/gatewayAssociationProposal.ts
@@ -26,7 +26,7 @@ import * as utilities from "../utilities";
  *
  * Using a proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`:
  *
- * __With `TODO import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
+ * __With `pulumi import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
  *
  * Using a proposal ID:
  *

--- a/sdk/nodejs/dlm/lifecyclePolicy.ts
+++ b/sdk/nodejs/dlm/lifecyclePolicy.ts
@@ -55,11 +55,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import DLM lifecycle policies using their policy ID. For exampleterraform import {
+ * Using `pulumi import`, import DLM lifecycle policies using their policy ID. For example:
  *
- *  to = aws_dlm_lifecycle_policy.example
- *
- *  id = "policy-abcdef12345678901" } Using `TODO import`, import DLM lifecycle policies using their policy ID. For exampleconsole % TODO import aws_dlm_lifecycle_policy.example policy-abcdef12345678901
+ * ```sh
+ *  $ pulumi import aws:dlm/lifecyclePolicy:LifecyclePolicy example policy-abcdef12345678901
+ * ```
  */
 export class LifecyclePolicy extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dms/replicationConfig.ts
+++ b/sdk/nodejs/dms/replicationConfig.ts
@@ -40,11 +40,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import replication configs using the `arn`. For exampleterraform import {
+ * Using `pulumi import`, import a replication config using the `arn`. For example:
  *
- *  to = aws_dms_replication_config.example
- *
- *  id = "arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI" } Using `TODO import`, import a replication config using the `arn`. For exampleconsole % TODO import aws_dms_replication_config.example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+ * ```sh
+ *  $ pulumi import aws:dms/replicationConfig:ReplicationConfig example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+ * ```
  */
 export class ReplicationConfig extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ec2/networkInterface.ts
+++ b/sdk/nodejs/ec2/networkInterface.ts
@@ -45,11 +45,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Network Interfaces using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import Network Interfaces using the `id`. For example:
  *
- *  to = aws_network_interface.test
- *
- *  id = "eni-e5aa89a3" } Using `TODO import`, import Network Interfaces using the `id`. For exampleconsole % TODO import aws_network_interface.test eni-e5aa89a3
+ * ```sh
+ *  $ pulumi import aws:ec2/networkInterface:NetworkInterface test eni-e5aa89a3
+ * ```
  */
 export class NetworkInterface extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ec2/vpcIpamPoolCidr.ts
+++ b/sdk/nodejs/ec2/vpcIpamPoolCidr.ts
@@ -17,11 +17,15 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * terraform import {
+ * __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
  *
- *  to = aws_vpc_ipam_pool_cidr.example
+ * Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For example:
  *
- *  id = "172.20.0.0/24_ipam-pool-0e634f5a1517cccdc" } Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For exampleconsole % TODO import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+ * __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
+ *
+ * ```sh
+ *  $ pulumi import aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+ * ```
  */
 export class VpcIpamPoolCidr extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/emrcontainers/jobTemplate.ts
+++ b/sdk/nodejs/emrcontainers/jobTemplate.ts
@@ -30,11 +30,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import EKS job templates using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import EKS job templates using the `id`. For example:
  *
- *  to = aws_emrcontainers_job_template.example
- *
- *  id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS job templates using the `id`. For exampleconsole % TODO import aws_emrcontainers_job_template.example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```sh
+ *  $ pulumi import aws:emrcontainers/jobTemplate:JobTemplate example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```
  */
 export class JobTemplate extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/emrcontainers/virtualCluster.ts
+++ b/sdk/nodejs/emrcontainers/virtualCluster.ts
@@ -30,11 +30,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import EKS Clusters using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import EKS Clusters using the `id`. For example:
  *
- *  to = aws_emrcontainers_virtual_cluster.example
- *
- *  id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS Clusters using the `id`. For exampleconsole % TODO import aws_emrcontainers_virtual_cluster.example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```sh
+ *  $ pulumi import aws:emrcontainers/virtualCluster:VirtualCluster example a1b2c3d4e5f6g7h8i9j10k11l
+ * ```
  */
 export class VirtualCluster extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/emrserverless/application.ts
+++ b/sdk/nodejs/emrserverless/application.ts
@@ -61,11 +61,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import EMR Severless applications using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import EMR Severless applications using the `id`. For example:
  *
- *  to = aws_emrserverless_application.example
- *
- *  id = "id" } Using `TODO import`, import EMR Severless applications using the `id`. For exampleconsole % TODO import aws_emrserverless_application.example id
+ * ```sh
+ *  $ pulumi import aws:emrserverless/application:Application example id
+ * ```
  */
 export class Application extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/gamelift/gameServerGroup.ts
+++ b/sdk/nodejs/gamelift/gameServerGroup.ts
@@ -110,11 +110,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import GameLift Game Server Group using the `name`. For exampleterraform import {
+ * Using `pulumi import`, import GameLift Game Server Group using the `name`. For example:
  *
- *  to = aws_gamelift_game_server_group.example
- *
- *  id = "example" } Using `TODO import`, import GameLift Game Server Group using the `name`. For exampleconsole % TODO import aws_gamelift_game_server_group.example example
+ * ```sh
+ *  $ pulumi import aws:gamelift/gameServerGroup:GameServerGroup example example
+ * ```
  */
 export class GameServerGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/glue/devEndpoint.ts
+++ b/sdk/nodejs/glue/devEndpoint.ts
@@ -34,11 +34,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import a Glue Development Endpoint using the `name`. For exampleterraform import {
+ * Using `pulumi import`, import a Glue Development Endpoint using the `name`. For example:
  *
- *  to = aws_glue_dev_endpoint.example
- *
- *  id = "foo" } Using `TODO import`, import a Glue Development Endpoint using the `name`. For exampleconsole % TODO import aws_glue_dev_endpoint.example foo
+ * ```sh
+ *  $ pulumi import aws:glue/devEndpoint:DevEndpoint example foo
+ * ```
  */
 export class DevEndpoint extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/iam/groupPolicyAttachment.ts
+++ b/sdk/nodejs/iam/groupPolicyAttachment.ts
@@ -31,11 +31,11 @@ import {Group} from "./index";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleterraform import {
+ * Using `pulumi import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For example:
  *
- *  to = aws_iam_group_policy_attachment.test-attach
- *
- *  id = "test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```sh
+ *  $ pulumi import aws:iam/groupPolicyAttachment:GroupPolicyAttachment test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```
  */
 export class GroupPolicyAttachment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/iam/rolePolicyAttachment.ts
+++ b/sdk/nodejs/iam/rolePolicyAttachment.ts
@@ -50,11 +50,11 @@ import {Role} from "./index";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleterraform import {
+ * Using `pulumi import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
  *
- *  to = aws_iam_role_policy_attachment.test-attach
- *
- *  id = "test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```sh
+ *  $ pulumi import aws:iam/rolePolicyAttachment:RolePolicyAttachment test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```
  */
 export class RolePolicyAttachment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/iam/userPolicyAttachment.ts
+++ b/sdk/nodejs/iam/userPolicyAttachment.ts
@@ -31,11 +31,11 @@ import {User} from "./index";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleterraform import {
+ * Using `pulumi import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For example:
  *
- *  to = aws_iam_user_policy_attachment.test-attach
- *
- *  id = "test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```sh
+ *  $ pulumi import aws:iam/userPolicyAttachment:UserPolicyAttachment test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+ * ```
  */
 export class UserPolicyAttachment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lex/v2modelsBot.ts
+++ b/sdk/nodejs/lex/v2modelsBot.ts
@@ -28,11 +28,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Lex V2 Models Bot using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
  *
- *  to = aws_lexv2models_bot.example
- *
- *  id = "bot-id-12345678" } Using `TODO import`, import Lex V2 Models Bot using the `example_id_arg`. For exampleconsole % TODO import aws_lexv2models_bot.example bot-id-12345678
+ * ```sh
+ *  $ pulumi import aws:lex/v2modelsBot:V2modelsBot example bot-id-12345678
+ * ```
  */
 export class V2modelsBot extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/licensemanager/association.ts
+++ b/sdk/nodejs/licensemanager/association.ts
@@ -36,11 +36,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import license configurations using `resource_arn,license_configuration_arn`. For exampleterraform import {
+ * Using `pulumi import`, import license configurations using `resource_arn,license_configuration_arn`. For example:
  *
- *  to = aws_licensemanager_association.example
- *
- *  id = "arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using `resource_arn,license_configuration_arn`. For exampleconsole % TODO import aws_licensemanager_association.example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:licensemanager/association:Association example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```
  */
 export class Association extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/licensemanager/licenseConfiguration.ts
+++ b/sdk/nodejs/licensemanager/licenseConfiguration.ts
@@ -40,11 +40,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import license configurations using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import license configurations using the `id`. For example:
  *
- *  to = aws_licensemanager_license_configuration.example
- *
- *  id = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using the `id`. For exampleconsole % TODO import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:licensemanager/licenseConfiguration:LicenseConfiguration example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+ * ```
  */
 export class LicenseConfiguration extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/msk/clusterPolicy.ts
+++ b/sdk/nodejs/msk/clusterPolicy.ts
@@ -40,11 +40,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Managed Streaming for Kafka Cluster Policy using the `cluster_arn. For exampleterraform import {
+ * Using `pulumi import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For example:
  *
- *  to = aws_msk_cluster_policy.example
- *
- *  id = "arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3" } Using `TODO import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For exampleconsole % TODO import aws_msk_cluster_policy.example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+ * ```sh
+ *  $ pulumi import aws:msk/clusterPolicy:ClusterPolicy example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+ * ```
  */
 export class ClusterPolicy extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/msk/vpcConnection.ts
+++ b/sdk/nodejs/msk/vpcConnection.ts
@@ -24,11 +24,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import MSK configurations using the configuration ARN. For exampleterraform import {
+ * Using `pulumi import`, import MSK configurations using the configuration ARN. For example:
  *
- *  to = aws_msk_vpc_connection.example
- *
- *  id = "arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2" } Using `TODO import`, import MSK configurations using the configuration ARN. For exampleconsole % TODO import aws_msk_vpc_connection.example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+ * ```sh
+ *  $ pulumi import aws:msk/vpcConnection:VpcConnection example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+ * ```
  */
 export class VpcConnection extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/opensearch/vpcEndpoint.ts
+++ b/sdk/nodejs/opensearch/vpcEndpoint.ts
@@ -34,11 +34,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import OpenSearch VPC endpoint connections using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import OpenSearch VPC endpoint connections using the `id`. For example:
  *
- *  to = aws_opensearch_vpc_endpoint_connection.example
- *
- *  id = "endpoint-id" } Using `TODO import`, import OpenSearch VPC endpoint connections using the `id`. For exampleconsole % TODO import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+ * ```sh
+ *  $ pulumi import aws:opensearch/vpcEndpoint:VpcEndpoint example endpoint-id
+ * ```
  */
 export class VpcEndpoint extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/admChannel.ts
+++ b/sdk/nodejs/pinpoint/admChannel.ts
@@ -25,11 +25,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint ADM Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint ADM Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_adm_channel.channel
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint ADM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_adm_channel.channel application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/admChannel:AdmChannel channel application-id
+ * ```
  */
 export class AdmChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/apnsChannel.ts
+++ b/sdk/nodejs/pinpoint/apnsChannel.ts
@@ -25,11 +25,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_apns_channel.apns
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint APNs Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_channel.apns application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsChannel:ApnsChannel apns application-id
+ * ```
  */
 export class ApnsChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/apnsSandboxChannel.ts
+++ b/sdk/nodejs/pinpoint/apnsSandboxChannel.ts
@@ -25,11 +25,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_apns_sandbox_channel.apns_sandbox
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_sandbox_channel.apns_sandbox application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel apns_sandbox application-id
+ * ```
  */
 export class ApnsSandboxChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/apnsVoipChannel.ts
+++ b/sdk/nodejs/pinpoint/apnsVoipChannel.ts
@@ -25,11 +25,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs VoIP Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_apns_voip_channel.apns_voip
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_channel.apns_voip application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsVoipChannel:ApnsVoipChannel apns_voip application-id
+ * ```
  */
 export class ApnsVoipChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/apnsVoipSandboxChannel.ts
+++ b/sdk/nodejs/pinpoint/apnsVoipSandboxChannel.ts
@@ -25,11 +25,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel apns_voip_sandbox application-id
+ * ```
  */
 export class ApnsVoipSandboxChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/app.ts
+++ b/sdk/nodejs/pinpoint/app.ts
@@ -29,11 +29,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint App using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint App using the `application-id`. For example:
  *
- *  to = aws_pinpoint_app.name
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint App using the `application-id`. For exampleconsole % TODO import aws_pinpoint_app.name application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/app:App name application-id
+ * ```
  */
 export class App extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/baiduChannel.ts
+++ b/sdk/nodejs/pinpoint/baiduChannel.ts
@@ -24,11 +24,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint Baidu Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint Baidu Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_baidu_channel.channel
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint Baidu Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_baidu_channel.channel application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/baiduChannel:BaiduChannel channel application-id
+ * ```
  */
 export class BaiduChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/emailChannel.ts
+++ b/sdk/nodejs/pinpoint/emailChannel.ts
@@ -49,11 +49,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint Email Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint Email Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_email_channel.email
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint Email Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_email_channel.email application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/emailChannel:EmailChannel email application-id
+ * ```
  */
 export class EmailChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/eventStream.ts
+++ b/sdk/nodejs/pinpoint/eventStream.ts
@@ -49,11 +49,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint Event Stream using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint Event Stream using the `application-id`. For example:
  *
- *  to = aws_pinpoint_event_stream.stream
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint Event Stream using the `application-id`. For exampleconsole % TODO import aws_pinpoint_event_stream.stream application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/eventStream:EventStream stream application-id
+ * ```
  */
 export class EventStream extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/gcmChannel.ts
+++ b/sdk/nodejs/pinpoint/gcmChannel.ts
@@ -23,11 +23,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Pinpoint GCM Channel using the `application-id`. For exampleterraform import {
+ * Using `pulumi import`, import Pinpoint GCM Channel using the `application-id`. For example:
  *
- *  to = aws_pinpoint_gcm_channel.gcm
- *
- *  id = "application-id" } Using `TODO import`, import Pinpoint GCM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_gcm_channel.gcm application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/gcmChannel:GcmChannel gcm application-id
+ * ```
  */
 export class GcmChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/pinpoint/smsChannel.ts
+++ b/sdk/nodejs/pinpoint/smsChannel.ts
@@ -19,11 +19,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import the Pinpoint SMS Channel using the `application_id`. For exampleterraform import {
+ * Using `pulumi import`, import the Pinpoint SMS Channel using the `application_id`. For example:
  *
- *  to = aws_pinpoint_sms_channel.sms
- *
- *  id = "application-id" } Using `TODO import`, import the Pinpoint SMS Channel using the `application_id`. For exampleconsole % TODO import aws_pinpoint_sms_channel.sms application-id
+ * ```sh
+ *  $ pulumi import aws:pinpoint/smsChannel:SmsChannel sms application-id
+ * ```
  */
 export class SmsChannel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ram/principalAssociation.ts
+++ b/sdk/nodejs/ram/principalAssociation.ts
@@ -44,11 +44,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleterraform import {
+ * Using `pulumi import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For example:
  *
- *  to = aws_ram_principal_association.example
- *
- *  id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012" } Using `TODO import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleconsole % TODO import aws_ram_principal_association.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+ * ```sh
+ *  $ pulumi import aws:ram/principalAssociation:PrincipalAssociation example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+ * ```
  */
 export class PrincipalAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ram/resourceShare.ts
+++ b/sdk/nodejs/ram/resourceShare.ts
@@ -23,11 +23,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import resource shares using the `arn` of the resource share. For exampleterraform import {
+ * Using `pulumi import`, import resource shares using the `arn` of the resource share. For example:
  *
- *  to = aws_ram_resource_share.example
- *
- *  id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12" } Using `TODO import`, import resource shares using the `arn` of the resource share. For exampleconsole % TODO import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+ * ```sh
+ *  $ pulumi import aws:ram/resourceShare:ResourceShare example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+ * ```
  */
 export class ResourceShare extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ram/resourceShareAccepter.ts
+++ b/sdk/nodejs/ram/resourceShareAccepter.ts
@@ -38,11 +38,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import resource share accepters using the resource share ARN. For exampleterraform import {
+ * Using `pulumi import`, import resource share accepters using the resource share ARN. For example:
  *
- *  to = aws_ram_resource_share_accepter.example
- *
- *  id = "arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767" } Using `TODO import`, import resource share accepters using the resource share ARN. For exampleconsole % TODO import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+ * ```sh
+ *  $ pulumi import aws:ram/resourceShareAccepter:ResourceShareAccepter example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+ * ```
  */
 export class ResourceShareAccepter extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ram/sharingWithOrganization.ts
+++ b/sdk/nodejs/ram/sharingWithOrganization.ts
@@ -20,11 +20,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import the resource using the current AWS account ID. For exampleterraform import {
+ * Using `pulumi import`, import the resource using the current AWS account ID. For example:
  *
- *  to = aws_ram_sharing_with_organization.example
- *
- *  id = "123456789012" } Using `TODO import`, import the resource using the current AWS account ID. For exampleconsole % TODO import aws_ram_sharing_with_organization.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:ram/sharingWithOrganization:SharingWithOrganization example 123456789012
+ * ```
  */
 export class SharingWithOrganization extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/rds/clusterParameterGroup.ts
+++ b/sdk/nodejs/rds/clusterParameterGroup.ts
@@ -37,11 +37,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import RDS Cluster Parameter Groups using the `name`. For exampleterraform import {
+ * Using `pulumi import`, import RDS Cluster Parameter Groups using the `name`. For example:
  *
- *  to = aws_rds_cluster_parameter_group.cluster_pg
- *
- *  id = "production-pg-1" } Using `TODO import`, import RDS Cluster Parameter Groups using the `name`. For exampleconsole % TODO import aws_rds_cluster_parameter_group.cluster_pg production-pg-1
+ * ```sh
+ *  $ pulumi import aws:rds/clusterParameterGroup:ClusterParameterGroup cluster_pg production-pg-1
+ * ```
  */
 export class ClusterParameterGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/rds/customDbEngineVersion.ts
+++ b/sdk/nodejs/rds/customDbEngineVersion.ts
@@ -93,11 +93,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleterraform import {
+ * Using `pulumi import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For example:
  *
- *  to = aws_rds_custom_db_engine_version.example
- *
- *  id = "custom-oracle-ee-cdb:19.cdb_cev1" } Using `TODO import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleconsole % TODO import aws_rds_custom_db_engine_version.example custom-oracle-ee-cdb:19.cdb_cev1
+ * ```sh
+ *  $ pulumi import aws:rds/customDbEngineVersion:CustomDbEngineVersion example custom-oracle-ee-cdb:19.cdb_cev1
+ * ```
  */
 export class CustomDbEngineVersion extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/rds/instanceAutomatedBackupsReplication.ts
+++ b/sdk/nodejs/rds/instanceAutomatedBackupsReplication.ts
@@ -67,11 +67,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import RDS instance automated backups replication using the `arn`. For exampleterraform import {
+ * Using `pulumi import`, import RDS instance automated backups replication using the `arn`. For example:
  *
- *  to = aws_db_instance_automated_backups_replication.default
- *
- *  id = "arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my" } Using `TODO import`, import RDS instance automated backups replication using the `arn`. For exampleconsole % TODO import aws_db_instance_automated_backups_replication.default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+ * ```sh
+ *  $ pulumi import aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+ * ```
  */
 export class InstanceAutomatedBackupsReplication extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/route53/resolverFirewallConfig.ts
+++ b/sdk/nodejs/route53/resolverFirewallConfig.ts
@@ -26,11 +26,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleterraform import {
+ * Using `pulumi import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For example:
  *
- *  to = aws_route53_resolver_firewall_config.example
- *
- *  id = "rdsc-be1866ecc1683e95" } Using `TODO import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleconsole % TODO import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallConfig:ResolverFirewallConfig example rdsc-be1866ecc1683e95
+ * ```
  */
 export class ResolverFirewallConfig extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/route53/resolverFirewallDomainList.ts
+++ b/sdk/nodejs/route53/resolverFirewallDomainList.ts
@@ -18,15 +18,13 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import
+ * Using `pulumi import`, import
  *
- * Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleterraform import {
+ * Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For example:
  *
- *  to = aws_route53_resolver_firewall_domain_list.example
- *
- *  id = "rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
- *
- * Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleconsole % TODO import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList example rslvr-fdl-0123456789abcdef
+ * ```
  */
 export class ResolverFirewallDomainList extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/route53/resolverFirewallRule.ts
+++ b/sdk/nodejs/route53/resolverFirewallRule.ts
@@ -32,15 +32,13 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import
+ * Using `pulumi import`, import
  *
- * Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleterraform import {
+ * Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For example:
  *
- *  to = aws_route53_resolver_firewall_rule.example
- *
- *  id = "rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
- *
- * Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleconsole % TODO import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallRule:ResolverFirewallRule example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+ * ```
  */
 export class ResolverFirewallRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/route53/resolverFirewallRuleGroup.ts
+++ b/sdk/nodejs/route53/resolverFirewallRuleGroup.ts
@@ -18,15 +18,13 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import
+ * Using `pulumi import`, import
  *
- * Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleterraform import {
+ * Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For example:
  *
- *  to = aws_route53_resolver_firewall_rule_group.example
- *
- *  id = "rslvr-frg-0123456789abcdef" } Using `TODO import`, import
- *
- * Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup example rslvr-frg-0123456789abcdef
+ * ```
  */
 export class ResolverFirewallRuleGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/route53/resolverFirewallRuleGroupAssociation.ts
+++ b/sdk/nodejs/route53/resolverFirewallRuleGroupAssociation.ts
@@ -23,11 +23,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleterraform import {
+ * Using `pulumi import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For example:
  *
- *  to = aws_route53_resolver_firewall_rule_group_association.example
- *
- *  id = "rslvr-frgassoc-0123456789abcdef" } Using `TODO import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+ * ```sh
+ *  $ pulumi import aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation example rslvr-frgassoc-0123456789abcdef
+ * ```
  */
 export class ResolverFirewallRuleGroupAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/account.ts
+++ b/sdk/nodejs/securityhub/account.ts
@@ -20,11 +20,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+ * Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
  *
- *  to = aws_securityhub_account.example
- *
- *  id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_account.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/account:Account example 123456789012
+ * ```
  */
 export class Account extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/findingAggregator.ts
+++ b/sdk/nodejs/securityhub/findingAggregator.ts
@@ -62,11 +62,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub finding aggregator using the `arn`. For exampleterraform import {
+ * Using `pulumi import`, import an existing Security Hub finding aggregator using the `arn`. For example:
  *
- *  to = aws_securityhub_finding_aggregator.example
- *
- *  id = "arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456" } Using `TODO import`, import an existing Security Hub finding aggregator using the `arn`. For exampleconsole % TODO import aws_securityhub_finding_aggregator.example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+ * ```sh
+ *  $ pulumi import aws:securityhub/findingAggregator:FindingAggregator example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+ * ```
  */
 export class FindingAggregator extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/inviteAccepter.ts
+++ b/sdk/nodejs/securityhub/inviteAccepter.ts
@@ -32,11 +32,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub invite acceptance using the account ID. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub invite acceptance using the account ID. For example:
  *
- *  to = aws_securityhub_invite_accepter.example
- *
- *  id = "123456789012" } Using `TODO import`, import Security Hub invite acceptance using the account ID. For exampleconsole % TODO import aws_securityhub_invite_accepter.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/inviteAccepter:InviteAccepter example 123456789012
+ * ```
  */
 export class InviteAccepter extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/member.ts
+++ b/sdk/nodejs/securityhub/member.ts
@@ -25,11 +25,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub members using their account ID. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub members using their account ID. For example:
  *
- *  to = aws_securityhub_member.example
- *
- *  id = "123456789012" } Using `TODO import`, import Security Hub members using their account ID. For exampleconsole % TODO import aws_securityhub_member.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/member:Member example 123456789012
+ * ```
  */
 export class Member extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/organizationConfiguration.ts
+++ b/sdk/nodejs/securityhub/organizationConfiguration.ts
@@ -29,11 +29,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+ * Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
  *
- *  to = aws_securityhub_organization_configuration.example
- *
- *  id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_organization_configuration.example 123456789012
+ * ```sh
+ *  $ pulumi import aws:securityhub/organizationConfiguration:OrganizationConfiguration example 123456789012
+ * ```
  */
 export class OrganizationConfiguration extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/productSubscription.ts
+++ b/sdk/nodejs/securityhub/productSubscription.ts
@@ -22,11 +22,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub product subscriptions using `product_arn,arn`. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub product subscriptions using `product_arn,arn`. For example:
  *
- *  to = aws_securityhub_product_subscription.example
- *
- *  id = "arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement" } Using `TODO import`, import Security Hub product subscriptions using `product_arn,arn`. For exampleconsole % TODO import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+ * ```sh
+ *  $ pulumi import aws:securityhub/productSubscription:ProductSubscription example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+ * ```
  */
 export class ProductSubscription extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securityhub/standardsSubscription.ts
+++ b/sdk/nodejs/securityhub/standardsSubscription.ts
@@ -25,19 +25,17 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Security Hub standards subscriptions using the standards subscription ARN. For exampleterraform import {
+ * Using `pulumi import`, import Security Hub standards subscriptions using the standards subscription ARN. For example:
  *
- *  to = aws_securityhub_standards_subscription.cis
- *
- *  id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0" } terraform import {
- *
- *  to = aws_securityhub_standards_subscription.pci_321
- *
- *  id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1" } terraform import {
- *
- *  to = aws_securityhub_standards_subscription.nist_800_53_rev_5
- *
- *  id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0" } Using `TODO import`, import Security Hub standards subscriptions using the standards subscription ARN. For exampleconsole % TODO import aws_securityhub_standards_subscription.cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0 console % TODO import aws_securityhub_standards_subscription.pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1 console % TODO import aws_securityhub_standards_subscription.nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+ * ```sh
+ *  $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0
+ * ```
+ * ```sh
+ * $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1
+ * ```
+ * ```sh
+ * $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+ * ```
  */
 export class StandardsSubscription extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/servicecatalog/principalPortfolioAssociation.ts
+++ b/sdk/nodejs/servicecatalog/principalPortfolioAssociation.ts
@@ -22,9 +22,7 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
- *
- * Using `TODO import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
+ * Using `pulumi import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
  *
  * ```sh
  *  $ pulumi import aws:servicecatalog/principalPortfolioAssociation:PrincipalPortfolioAssociation example en,arn:aws:iam::123456789012:user/Eleanor,port-68656c6c6f,IAM

--- a/sdk/nodejs/servicequotas/template.ts
+++ b/sdk/nodejs/servicequotas/template.ts
@@ -26,11 +26,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Service Quotas Template using the `example_id_arg`. For exampleterraform import {
+ * Using `pulumi import`, import Service Quotas Template using the `id`. For example:
  *
- *  to = aws_servicequotas_template.example
- *
- *  id = "us-east-1,L-2ACBD22F,lambda" } Using `TODO import`, import Service Quotas Template using the `id`. For exampleconsole % TODO import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+ * ```sh
+ *  $ pulumi import aws:servicequotas/template:Template example us-east-1,L-2ACBD22F,lambda
+ * ```
  */
 export class Template extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ses/identityNotificationTopic.ts
+++ b/sdk/nodejs/ses/identityNotificationTopic.ts
@@ -23,11 +23,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleterraform import {
+ * Using `pulumi import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For example:
  *
- *  to = aws_ses_identity_notification_topic.test
- *
- *  id = "example.com|Bounce" } Using `TODO import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleconsole % TODO import aws_ses_identity_notification_topic.test 'example.com|Bounce'
+ * ```sh
+ *  $ pulumi import aws:ses/identityNotificationTopic:IdentityNotificationTopic test 'example.com|Bounce'
+ * ```
  */
 export class IdentityNotificationTopic extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/sesv2/accountVdmAttributes.ts
+++ b/sdk/nodejs/sesv2/accountVdmAttributes.ts
@@ -30,11 +30,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleterraform import {
+ * Using `pulumi import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For example:
  *
- *  to = aws_sesv2_account_vdm_attributes.example
- *
- *  id = "ses-account-vdm-attributes" } Using `TODO import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleconsole % TODO import aws_sesv2_account_vdm_attributes.example ses-account-vdm-attributes
+ * ```sh
+ *  $ pulumi import aws:sesv2/accountVdmAttributes:AccountVdmAttributes example ses-account-vdm-attributes
+ * ```
  */
 export class AccountVdmAttributes extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/verifiedaccess/instanceTrustProviderAttachment.ts
+++ b/sdk/nodejs/verifiedaccess/instanceTrustProviderAttachment.ts
@@ -30,11 +30,11 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleterraform import {
+ * Using `pulumi import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For example:
  *
- *  to = aws_verifiedaccess_instance_trust_provider_attachment.example
- *
- *  id = "vai-1234567890abcdef0/vatp-8012925589" } Using `TODO import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleconsole % TODO import aws_verifiedaccess_instance_trust_provider_attachment.example vai-1234567890abcdef0/vatp-8012925589
+ * ```sh
+ *  $ pulumi import aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment example vai-1234567890abcdef0/vatp-8012925589
+ * ```
  */
 export class InstanceTrustProviderAttachment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/verifiedaccess/trustProvider.ts
+++ b/sdk/nodejs/verifiedaccess/trustProvider.ts
@@ -25,13 +25,13 @@ import * as utilities from "../utilities";
  *
  * ## Import
  *
- * In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For exampleterraform import {
+ * Using `pulumi import`, import Transfer Workflows using the
  *
- *  to = aws_verifiedaccess_trust_provider.example
+ * `id`. For example:
  *
- *  id = "vatp-8012925589" } Using `TODO import`, import Transfer Workflows using the
- *
- * `id`. For exampleconsole % TODO import aws_verifiedaccess_trust_provider.example vatp-8012925589
+ * ```sh
+ *  $ pulumi import aws:verifiedaccess/trustProvider:TrustProvider example vatp-8012925589
+ * ```
  */
 export class TrustProvider extends pulumi.CustomResource {
     /**

--- a/sdk/python/pulumi_aws/apigateway/api_key.py
+++ b/sdk/python/pulumi_aws/apigateway/api_key.py
@@ -321,11 +321,11 @@ class ApiKey(pulumi.CustomResource):
 
         ## Import
 
-        terraform import {
+        Using `pulumi import`, import API Gateway Keys using the `id`. For example:
 
-         to = aws_api_gateway_api_key.example
-
-         id = "8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk" } Using `pulumi import`, import API Gateway Keys using the `id`. For exampleconsole % TODO import aws_api_gateway_api_key.example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+        ```sh
+         $ pulumi import aws:apigateway/apiKey:ApiKey example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -358,11 +358,11 @@ class ApiKey(pulumi.CustomResource):
 
         ## Import
 
-        terraform import {
+        Using `pulumi import`, import API Gateway Keys using the `id`. For example:
 
-         to = aws_api_gateway_api_key.example
-
-         id = "8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk" } Using `pulumi import`, import API Gateway Keys using the `id`. For exampleconsole % TODO import aws_api_gateway_api_key.example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+        ```sh
+         $ pulumi import aws:apigateway/apiKey:ApiKey example 8bklk8bl1k3sB38D9B3l0enyWT8c09B30lkq0blk
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApiKeyArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/apigateway/response.py
+++ b/sdk/python/pulumi_aws/apigateway/response.py
@@ -220,11 +220,11 @@ class Response(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleterraform import {
+        Using `pulumi import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For example:
 
-         to = aws_api_gateway_gateway_response.example
-
-         id = "12345abcde/UNAUTHORIZED" } Using `TODO import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleconsole % TODO import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+        ```sh
+         $ pulumi import aws:apigateway/response:Response example 12345abcde/UNAUTHORIZED
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -264,11 +264,11 @@ class Response(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleterraform import {
+        Using `pulumi import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For example:
 
-         to = aws_api_gateway_gateway_response.example
-
-         id = "12345abcde/UNAUTHORIZED" } Using `TODO import`, import `aws_api_gateway_gateway_response` using `REST-API-ID/RESPONSE-TYPE`. For exampleconsole % TODO import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+        ```sh
+         $ pulumi import aws:apigateway/response:Response example 12345abcde/UNAUTHORIZED
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResponseArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cfg/aggregate_authorization.py
+++ b/sdk/python/pulumi_aws/cfg/aggregate_authorization.py
@@ -184,11 +184,11 @@ class AggregateAuthorization(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Config aggregate authorizations using `account_id:region`. For exampleterraform import {
+        Using `pulumi import`, import Config aggregate authorizations using `account_id:region`. For example:
 
-         to = aws_config_aggregate_authorization.example
-
-         id = "123456789012:us-east-1" } Using `TODO import`, import Config aggregate authorizations using `account_id:region`. For exampleconsole % TODO import aws_config_aggregate_authorization.example 123456789012:us-east-1
+        ```sh
+         $ pulumi import aws:cfg/aggregateAuthorization:AggregateAuthorization example 123456789012:us-east-1
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -218,11 +218,11 @@ class AggregateAuthorization(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Config aggregate authorizations using `account_id:region`. For exampleterraform import {
+        Using `pulumi import`, import Config aggregate authorizations using `account_id:region`. For example:
 
-         to = aws_config_aggregate_authorization.example
-
-         id = "123456789012:us-east-1" } Using `TODO import`, import Config aggregate authorizations using `account_id:region`. For exampleconsole % TODO import aws_config_aggregate_authorization.example 123456789012:us-east-1
+        ```sh
+         $ pulumi import aws:cfg/aggregateAuthorization:AggregateAuthorization example 123456789012:us-east-1
+        ```
 
         :param str resource_name: The name of the resource.
         :param AggregateAuthorizationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cleanrooms/configured_table.py
+++ b/sdk/python/pulumi_aws/cleanrooms/configured_table.py
@@ -333,11 +333,11 @@ class ConfiguredTable(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_cleanrooms_configured_table` using the `id`. For exampleterraform import {
+        Using `pulumi import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
 
-         to = aws_cleanrooms_configured_table.table
-
-         id = "1234abcd-12ab-34cd-56ef-1234567890ab" } Using `TODO import`, import `aws_cleanrooms_configured_table` using the `id`. For exampleconsole % TODO import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+        ```sh
+         $ pulumi import aws:cleanrooms/configuredTable:ConfiguredTable table 1234abcd-12ab-34cd-56ef-1234567890ab
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -385,11 +385,11 @@ class ConfiguredTable(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_cleanrooms_configured_table` using the `id`. For exampleterraform import {
+        Using `pulumi import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
 
-         to = aws_cleanrooms_configured_table.table
-
-         id = "1234abcd-12ab-34cd-56ef-1234567890ab" } Using `TODO import`, import `aws_cleanrooms_configured_table` using the `id`. For exampleconsole % TODO import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+        ```sh
+         $ pulumi import aws:cleanrooms/configuredTable:ConfiguredTable table 1234abcd-12ab-34cd-56ef-1234567890ab
+        ```
 
         :param str resource_name: The name of the resource.
         :param ConfiguredTableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cloud9/environment_membership.py
+++ b/sdk/python/pulumi_aws/cloud9/environment_membership.py
@@ -164,11 +164,11 @@ class EnvironmentMembership(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cloud9 environment membership using the `environment-id#user-arn`. For exampleterraform import {
+        Using `pulumi import`, import Cloud9 environment membership using the `environment-id#user-arn`. For example:
 
-         to = aws_cloud9_environment_membership.test
-
-         id = "environment-id#user-arn" } Using `TODO import`, import Cloud9 environment membership using the `environment-id#user-arn`. For exampleconsole % TODO import aws_cloud9_environment_membership.test environment-id#user-arn
+        ```sh
+         $ pulumi import aws:cloud9/environmentMembership:EnvironmentMembership test environment-id#user-arn
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -201,11 +201,11 @@ class EnvironmentMembership(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cloud9 environment membership using the `environment-id#user-arn`. For exampleterraform import {
+        Using `pulumi import`, import Cloud9 environment membership using the `environment-id#user-arn`. For example:
 
-         to = aws_cloud9_environment_membership.test
-
-         id = "environment-id#user-arn" } Using `TODO import`, import Cloud9 environment membership using the `environment-id#user-arn`. For exampleconsole % TODO import aws_cloud9_environment_membership.test environment-id#user-arn
+        ```sh
+         $ pulumi import aws:cloud9/environmentMembership:EnvironmentMembership test environment-id#user-arn
+        ```
 
         :param str resource_name: The name of the resource.
         :param EnvironmentMembershipArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cloudformation/stack_set.py
+++ b/sdk/python/pulumi_aws/cloudformation/stack_set.py
@@ -621,7 +621,7 @@ class StackSet(pulumi.CustomResource):
         ```sh
          $ pulumi import aws:cloudformation/stackSet:StackSet example example
         ```
-         Using `TODO import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
+         Using `pulumi import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSet:StackSet example example,DELEGATED_ADMIN
@@ -720,7 +720,7 @@ class StackSet(pulumi.CustomResource):
         ```sh
          $ pulumi import aws:cloudformation/stackSet:StackSet example example
         ```
-         Using `TODO import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
+         Using `pulumi import`, import CloudFormation StackSets when acting a delegated administrator in a member account using the `name` and `call_as` values separated by a comma (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSet:StackSet example example,DELEGATED_ADMIN

--- a/sdk/python/pulumi_aws/cloudformation/stack_set_instance.py
+++ b/sdk/python/pulumi_aws/cloudformation/stack_set_instance.py
@@ -409,23 +409,21 @@ class StackSetInstance(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
-
         Import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
 
         Import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
 
-        Using `TODO import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
+        Using `pulumi import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,123456789012,us-east-1
         ```
-         Using `TODO import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
+         Using `pulumi import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1
         ```
-         Using `TODO import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
+         Using `pulumi import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1,DELEGATED_ADMIN
@@ -511,23 +509,21 @@ class StackSetInstance(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
-
         Import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
 
         Import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
 
-        Using `TODO import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
+        Using `pulumi import`, import CloudFormation StackSet Instances that target an AWS Account ID using the StackSet name, target AWS account ID, and target AWS Region separated by commas (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,123456789012,us-east-1
         ```
-         Using `TODO import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
+         Using `pulumi import`, import CloudFormation StackSet Instances that target AWS Organizational Units using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS Region separated by commas (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1
         ```
-         Using `TODO import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
+         Using `pulumi import`, import CloudFormation StackSet Instances when acting a delegated administrator in a member account using the StackSet name, target AWS account ID or slash (`/`) separated list of organizational unit IDs, target AWS Region and `call_as` value separated by commas (`,`). For example:
 
         ```sh
          $ pulumi import aws:cloudformation/stackSetInstance:StackSetInstance example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1,DELEGATED_ADMIN

--- a/sdk/python/pulumi_aws/cloudfront/continuous_deployment_policy.py
+++ b/sdk/python/pulumi_aws/cloudfront/continuous_deployment_policy.py
@@ -242,11 +242,11 @@ class ContinuousDeploymentPolicy(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CloudFront Continuous Deployment Policy using the `id`. For exampleterraform import {
+        Using `pulumi import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
 
-         to = aws_cloudfront_continuous_deployment_policy.example
-
-         id = "abcd-1234" } Using `TODO import`, import CloudFront Continuous Deployment Policy using the `id`. For exampleconsole % TODO import aws_cloudfront_continuous_deployment_policy.example abcd-1234
+        ```sh
+         $ pulumi import aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy example abcd-1234
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -337,11 +337,11 @@ class ContinuousDeploymentPolicy(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CloudFront Continuous Deployment Policy using the `id`. For exampleterraform import {
+        Using `pulumi import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
 
-         to = aws_cloudfront_continuous_deployment_policy.example
-
-         id = "abcd-1234" } Using `TODO import`, import CloudFront Continuous Deployment Policy using the `id`. For exampleconsole % TODO import aws_cloudfront_continuous_deployment_policy.example abcd-1234
+        ```sh
+         $ pulumi import aws:cloudfront/continuousDeploymentPolicy:ContinuousDeploymentPolicy example abcd-1234
+        ```
 
         :param str resource_name: The name of the resource.
         :param ContinuousDeploymentPolicyArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codecatalyst/project.py
+++ b/sdk/python/pulumi_aws/codecatalyst/project.py
@@ -172,11 +172,11 @@ class Project(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Project using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import CodeCatalyst Project using the `example_id_arg`. For example:
 
-         to = aws_codecatalyst_project.example
-
-         id = "project-id-12345678" } Using `TODO import`, import CodeCatalyst Project using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_project.example project-id-12345678
+        ```sh
+         $ pulumi import aws:codecatalyst/project:Project example project-id-12345678
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -210,11 +210,11 @@ class Project(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Project using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import CodeCatalyst Project using the `example_id_arg`. For example:
 
-         to = aws_codecatalyst_project.example
-
-         id = "project-id-12345678" } Using `TODO import`, import CodeCatalyst Project using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_project.example project-id-12345678
+        ```sh
+         $ pulumi import aws:codecatalyst/project:Project example project-id-12345678
+        ```
 
         :param str resource_name: The name of the resource.
         :param ProjectArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codecatalyst/source_repository.py
+++ b/sdk/python/pulumi_aws/codecatalyst/source_repository.py
@@ -188,11 +188,11 @@ class SourceRepository(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Source Repository using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
 
-         to = aws_codecatalyst_source_repository.example
-
-         id = "source_repository-id-12345678" } Using `TODO import`, import CodeCatalyst Source Repository using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_source_repository.example source_repository-id-12345678
+        ```sh
+         $ pulumi import aws:codecatalyst/sourceRepository:SourceRepository example source_repository-id-12345678
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -226,11 +226,11 @@ class SourceRepository(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeCatalyst Source Repository using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
 
-         to = aws_codecatalyst_source_repository.example
-
-         id = "source_repository-id-12345678" } Using `TODO import`, import CodeCatalyst Source Repository using the `example_id_arg`. For exampleconsole % TODO import aws_codecatalyst_source_repository.example source_repository-id-12345678
+        ```sh
+         $ pulumi import aws:codecatalyst/sourceRepository:SourceRepository example source_repository-id-12345678
+        ```
 
         :param str resource_name: The name of the resource.
         :param SourceRepositoryArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codecommit/repository.py
+++ b/sdk/python/pulumi_aws/codecommit/repository.py
@@ -266,9 +266,7 @@ class Repository(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeCommit repository using repository name. For example:
-
-        Using `TODO import`, import CodeCommit repository using repository name. For example:
+        Using `pulumi import`, import CodeCommit repository using repository name. For example:
 
         ```sh
          $ pulumi import aws:codecommit/repository:Repository imported ExistingRepo
@@ -303,9 +301,7 @@ class Repository(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeCommit repository using repository name. For example:
-
-        Using `TODO import`, import CodeCommit repository using repository name. For example:
+        Using `pulumi import`, import CodeCommit repository using repository name. For example:
 
         ```sh
          $ pulumi import aws:codecommit/repository:Repository imported ExistingRepo

--- a/sdk/python/pulumi_aws/codepipeline/pipeline.py
+++ b/sdk/python/pulumi_aws/codepipeline/pipeline.py
@@ -356,11 +356,11 @@ class Pipeline(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodePipelines using the name. For exampleterraform import {
+        Using `pulumi import`, import CodePipelines using the name. For example:
 
-         to = aws_codepipeline.foo
-
-         id = "example" } Using `TODO import`, import CodePipelines using the name. For exampleconsole % TODO import aws_codepipeline.foo example
+        ```sh
+         $ pulumi import aws:codepipeline/pipeline:Pipeline foo example
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -497,11 +497,11 @@ class Pipeline(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodePipelines using the name. For exampleterraform import {
+        Using `pulumi import`, import CodePipelines using the name. For example:
 
-         to = aws_codepipeline.foo
-
-         id = "example" } Using `TODO import`, import CodePipelines using the name. For exampleconsole % TODO import aws_codepipeline.foo example
+        ```sh
+         $ pulumi import aws:codepipeline/pipeline:Pipeline foo example
+        ```
 
         :param str resource_name: The name of the resource.
         :param PipelineArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codepipeline/webhook.py
+++ b/sdk/python/pulumi_aws/codepipeline/webhook.py
@@ -394,11 +394,11 @@ class Webhook(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodePipeline Webhooks using their ARN. For exampleterraform import {
+        Using `pulumi import`, import CodePipeline Webhooks using their ARN. For example:
 
-         to = aws_codepipeline_webhook.example
-
-         id = "arn:aws:codepipeline:us-west-2:123456789012:webhook:example" } Using `TODO import`, import CodePipeline Webhooks using their ARN. For exampleconsole % TODO import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+        ```sh
+         $ pulumi import aws:codepipeline/webhook:Webhook example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -494,11 +494,11 @@ class Webhook(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodePipeline Webhooks using their ARN. For exampleterraform import {
+        Using `pulumi import`, import CodePipeline Webhooks using their ARN. For example:
 
-         to = aws_codepipeline_webhook.example
-
-         id = "arn:aws:codepipeline:us-west-2:123456789012:webhook:example" } Using `TODO import`, import CodePipeline Webhooks using their ARN. For exampleconsole % TODO import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+        ```sh
+         $ pulumi import aws:codepipeline/webhook:Webhook example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+        ```
 
         :param str resource_name: The name of the resource.
         :param WebhookArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codestarconnections/connection.py
+++ b/sdk/python/pulumi_aws/codestarconnections/connection.py
@@ -264,11 +264,11 @@ class Connection(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeStar connections using the ARN. For exampleterraform import {
+        Using `pulumi import`, import CodeStar connections using the ARN. For example:
 
-         to = aws_codestarconnections_connection.test-connection
-
-         id = "arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar connections using the ARN. For exampleconsole % TODO import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```sh
+         $ pulumi import aws:codestarconnections/connection:Connection test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -328,11 +328,11 @@ class Connection(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeStar connections using the ARN. For exampleterraform import {
+        Using `pulumi import`, import CodeStar connections using the ARN. For example:
 
-         to = aws_codestarconnections_connection.test-connection
-
-         id = "arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar connections using the ARN. For exampleconsole % TODO import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```sh
+         $ pulumi import aws:codestarconnections/connection:Connection test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```
 
         :param str resource_name: The name of the resource.
         :param ConnectionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codestarconnections/host.py
+++ b/sdk/python/pulumi_aws/codestarconnections/host.py
@@ -215,11 +215,11 @@ class Host(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeStar Host using the ARN. For exampleterraform import {
+        Using `pulumi import`, import CodeStar Host using the ARN. For example:
 
-         to = aws_codestarconnections_host.example-host
-
-         id = "arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar Host using the ARN. For exampleconsole % TODO import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```sh
+         $ pulumi import aws:codestarconnections/host:Host example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -252,11 +252,11 @@ class Host(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeStar Host using the ARN. For exampleterraform import {
+        Using `pulumi import`, import CodeStar Host using the ARN. For example:
 
-         to = aws_codestarconnections_host.example-host
-
-         id = "arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448" } Using `TODO import`, import CodeStar Host using the ARN. For exampleconsole % TODO import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```sh
+         $ pulumi import aws:codestarconnections/host:Host example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+        ```
 
         :param str resource_name: The name of the resource.
         :param HostArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/codestarnotifications/notification_rule.py
+++ b/sdk/python/pulumi_aws/codestarnotifications/notification_rule.py
@@ -338,11 +338,11 @@ class NotificationRule(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeStar notification rule using the ARN. For exampleterraform import {
+        Using `pulumi import`, import CodeStar notification rule using the ARN. For example:
 
-         to = aws_codestarnotifications_notification_rule.foo
-
-         id = "arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b" } Using `TODO import`, import CodeStar notification rule using the ARN. For exampleconsole % TODO import aws_codestarnotifications_notification_rule.foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+        ```sh
+         $ pulumi import aws:codestarnotifications/notificationRule:NotificationRule foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -394,11 +394,11 @@ class NotificationRule(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import CodeStar notification rule using the ARN. For exampleterraform import {
+        Using `pulumi import`, import CodeStar notification rule using the ARN. For example:
 
-         to = aws_codestarnotifications_notification_rule.foo
-
-         id = "arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b" } Using `TODO import`, import CodeStar notification rule using the ARN. For exampleconsole % TODO import aws_codestarnotifications_notification_rule.foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+        ```sh
+         $ pulumi import aws:codestarnotifications/notificationRule:NotificationRule foo arn:aws:codestar-notifications:us-west-1:0123456789:notificationrule/2cdc68a3-8f7c-4893-b6a5-45b362bd4f2b
+        ```
 
         :param str resource_name: The name of the resource.
         :param NotificationRuleArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cognito/identity_pool.py
+++ b/sdk/python/pulumi_aws/cognito/identity_pool.py
@@ -409,11 +409,11 @@ class IdentityPool(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool using its ID. For exampleterraform import {
+        Using `pulumi import`, import Cognito Identity Pool using its ID. For example:
 
-         to = aws_cognito_identity_pool.mypool
-
-         id = "us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3" } Using `TODO import`, import Cognito Identity Pool using its ID. For exampleconsole % TODO import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+        ```sh
+         $ pulumi import aws:cognito/identityPool:IdentityPool mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -470,11 +470,11 @@ class IdentityPool(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool using its ID. For exampleterraform import {
+        Using `pulumi import`, import Cognito Identity Pool using its ID. For example:
 
-         to = aws_cognito_identity_pool.mypool
-
-         id = "us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3" } Using `TODO import`, import Cognito Identity Pool using its ID. For exampleconsole % TODO import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+        ```sh
+         $ pulumi import aws:cognito/identityPool:IdentityPool mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
+        ```
 
         :param str resource_name: The name of the resource.
         :param IdentityPoolArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cognito/identity_pool_provider_principal_tag.py
+++ b/sdk/python/pulumi_aws/cognito/identity_pool_provider_principal_tag.py
@@ -168,11 +168,11 @@ class IdentityPoolProviderPrincipalTag(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleterraform import {
+        Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For example:
 
-         to = aws_cognito_identity_pool_provider_principal_tag.example
-
-         id = "us-west-2_abc123:CorpAD" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleconsole % TODO import aws_cognito_identity_pool_provider_principal_tag.example us-west-2_abc123:CorpAD
+        ```sh
+         $ pulumi import aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag example us-west-2_abc123:CorpAD
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -192,11 +192,11 @@ class IdentityPoolProviderPrincipalTag(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleterraform import {
+        Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For example:
 
-         to = aws_cognito_identity_pool_provider_principal_tag.example
-
-         id = "us-west-2_abc123:CorpAD" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID and provider name. For exampleconsole % TODO import aws_cognito_identity_pool_provider_principal_tag.example us-west-2_abc123:CorpAD
+        ```sh
+         $ pulumi import aws:cognito/identityPoolProviderPrincipalTag:IdentityPoolProviderPrincipalTag example us-west-2_abc123:CorpAD
+        ```
 
         :param str resource_name: The name of the resource.
         :param IdentityPoolProviderPrincipalTagArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cognito/identity_pool_role_attachment.py
+++ b/sdk/python/pulumi_aws/cognito/identity_pool_role_attachment.py
@@ -137,11 +137,11 @@ class IdentityPoolRoleAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleterraform import {
+        Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For example:
 
-         to = aws_cognito_identity_pool_roles_attachment.example
-
-         id = "us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleconsole % TODO import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+        ```sh
+         $ pulumi import aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -160,11 +160,11 @@ class IdentityPoolRoleAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleterraform import {
+        Using `pulumi import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For example:
 
-         to = aws_cognito_identity_pool_roles_attachment.example
-
-         id = "us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42" } Using `TODO import`, import Cognito Identity Pool Roles Attachment using the Identity Pool ID. For exampleconsole % TODO import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+        ```sh
+         $ pulumi import aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
+        ```
 
         :param str resource_name: The name of the resource.
         :param IdentityPoolRoleAttachmentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/cognito/user_pool.py
+++ b/sdk/python/pulumi_aws/cognito/user_pool.py
@@ -1022,11 +1022,11 @@ class UserPool(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito User Pools using the `id`. For exampleterraform import {
+        Using `pulumi import`, import Cognito User Pools using the `id`. For example:
 
-         to = aws_cognito_user_pool.pool
-
-         id = "us-west-2_abc123" } Using `TODO import`, import Cognito User Pools using the `id`. For exampleconsole % TODO import aws_cognito_user_pool.pool us-west-2_abc123
+        ```sh
+         $ pulumi import aws:cognito/userPool:UserPool pool us-west-2_abc123
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -1116,11 +1116,11 @@ class UserPool(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Cognito User Pools using the `id`. For exampleterraform import {
+        Using `pulumi import`, import Cognito User Pools using the `id`. For example:
 
-         to = aws_cognito_user_pool.pool
-
-         id = "us-west-2_abc123" } Using `TODO import`, import Cognito User Pools using the `id`. For exampleconsole % TODO import aws_cognito_user_pool.pool us-west-2_abc123
+        ```sh
+         $ pulumi import aws:cognito/userPool:UserPool pool us-west-2_abc123
+        ```
 
         :param str resource_name: The name of the resource.
         :param UserPoolArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/connect/bot_association.py
+++ b/sdk/python/pulumi_aws/connect/bot_association.py
@@ -164,11 +164,11 @@ class BotAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleterraform import {
+        Using `pulumi import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For example:
 
-         to = aws_connect_bot_association.example
-
-         id = "aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2" } Using `TODO import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleconsole % TODO import aws_connect_bot_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+        ```sh
+         $ pulumi import aws:connect/botAssociation:BotAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -246,11 +246,11 @@ class BotAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleterraform import {
+        Using `pulumi import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For example:
 
-         to = aws_connect_bot_association.example
-
-         id = "aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2" } Using `TODO import`, import `aws_connect_bot_association` using the Amazon Connect instance ID, Lex (V1) bot name, and Lex (V1) bot region separated by colons (`:`). For exampleconsole % TODO import aws_connect_bot_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+        ```sh
+         $ pulumi import aws:connect/botAssociation:BotAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111:Example:us-west-2
+        ```
 
         :param str resource_name: The name of the resource.
         :param BotAssociationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/connect/lambda_function_association.py
+++ b/sdk/python/pulumi_aws/connect/lambda_function_association.py
@@ -114,11 +114,11 @@ class LambdaFunctionAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleterraform import {
+        Using `pulumi import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For example:
 
-         to = aws_connect_lambda_function_association.example
-
-         id = "aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example" } Using `TODO import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleconsole % TODO import aws_connect_lambda_function_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+        ```sh
+         $ pulumi import aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -148,11 +148,11 @@ class LambdaFunctionAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleterraform import {
+        Using `pulumi import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For example:
 
-         to = aws_connect_lambda_function_association.example
-
-         id = "aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example" } Using `TODO import`, import `aws_connect_lambda_function_association` using the `instance_id` and `function_arn` separated by a comma (`,`). For exampleconsole % TODO import aws_connect_lambda_function_association.example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+        ```sh
+         $ pulumi import aws:connect/lambdaFunctionAssociation:LambdaFunctionAssociation example aaaaaaaa-bbbb-cccc-dddd-111111111111,arn:aws:lambda:us-west-2:123456789123:function:example
+        ```
 
         :param str resource_name: The name of the resource.
         :param LambdaFunctionAssociationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/datasync/location_azure_blob.py
+++ b/sdk/python/pulumi_aws/datasync/location_azure_blob.py
@@ -368,11 +368,11 @@ class LocationAzureBlob(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleterraform import {
+        Using `pulumi import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For example:
 
-         to = aws_datasync_location_azure_blob.example
-
-         id = "arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567" } Using `TODO import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleconsole % TODO import aws_datasync_location_azure_blob.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+        ```sh
+         $ pulumi import aws:datasync/locationAzureBlob:LocationAzureBlob example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -413,11 +413,11 @@ class LocationAzureBlob(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleterraform import {
+        Using `pulumi import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For example:
 
-         to = aws_datasync_location_azure_blob.example
-
-         id = "arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567" } Using `TODO import`, import `aws_datasync_location_azure_blob` using the Amazon Resource Name (ARN). For exampleconsole % TODO import aws_datasync_location_azure_blob.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+        ```sh
+         $ pulumi import aws:datasync/locationAzureBlob:LocationAzureBlob example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+        ```
 
         :param str resource_name: The name of the resource.
         :param LocationAzureBlobArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/datasync/location_fsx_ontap_file_system.py
+++ b/sdk/python/pulumi_aws/datasync/location_fsx_ontap_file_system.py
@@ -298,11 +298,11 @@ class LocationFsxOntapFileSystem(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleterraform import {
+        Using `pulumi import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For example:
 
-         to = aws_datasync_location_fsx_ontap_file_system.example
-
-         id = "arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123" } Using `TODO import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleconsole % TODO import aws_datasync_location_fsx_ontap_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+        ```sh
+         $ pulumi import aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -329,11 +329,11 @@ class LocationFsxOntapFileSystem(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleterraform import {
+        Using `pulumi import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For example:
 
-         to = aws_datasync_location_fsx_ontap_file_system.example
-
-         id = "arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123" } Using `TODO import`, import `aws_datasync_location_fsx_ontap_file_system` using the `DataSync-ARN#FSx-ontap-svm-ARN`. For exampleconsole % TODO import aws_datasync_location_fsx_ontap_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+        ```sh
+         $ pulumi import aws:datasync/locationFsxOntapFileSystem:LocationFsxOntapFileSystem example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:123456789012:storage-virtual-machine/svm-12345678abcdef123
+        ```
 
         :param str resource_name: The name of the resource.
         :param LocationFsxOntapFileSystemArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/directconnect/gateway_association_proposal.py
+++ b/sdk/python/pulumi_aws/directconnect/gateway_association_proposal.py
@@ -215,7 +215,7 @@ class GatewayAssociationProposal(pulumi.CustomResource):
 
         Using a proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`:
 
-        __With `TODO import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
+        __With `pulumi import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
 
         Using a proposal ID:
 
@@ -263,7 +263,7 @@ class GatewayAssociationProposal(pulumi.CustomResource):
 
         Using a proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`:
 
-        __With `TODO import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
+        __With `pulumi import`__, import Direct Connect Gateway Association Proposals using either a proposal ID or proposal ID, Direct Connect Gateway ID and associated gateway ID separated by `/`. For example:
 
         Using a proposal ID:
 

--- a/sdk/python/pulumi_aws/dlm/lifecycle_policy.py
+++ b/sdk/python/pulumi_aws/dlm/lifecycle_policy.py
@@ -279,11 +279,11 @@ class LifecyclePolicy(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import DLM lifecycle policies using their policy ID. For exampleterraform import {
+        Using `pulumi import`, import DLM lifecycle policies using their policy ID. For example:
 
-         to = aws_dlm_lifecycle_policy.example
-
-         id = "policy-abcdef12345678901" } Using `TODO import`, import DLM lifecycle policies using their policy ID. For exampleconsole % TODO import aws_dlm_lifecycle_policy.example policy-abcdef12345678901
+        ```sh
+         $ pulumi import aws:dlm/lifecyclePolicy:LifecyclePolicy example policy-abcdef12345678901
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -343,11 +343,11 @@ class LifecyclePolicy(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import DLM lifecycle policies using their policy ID. For exampleterraform import {
+        Using `pulumi import`, import DLM lifecycle policies using their policy ID. For example:
 
-         to = aws_dlm_lifecycle_policy.example
-
-         id = "policy-abcdef12345678901" } Using `TODO import`, import DLM lifecycle policies using their policy ID. For exampleconsole % TODO import aws_dlm_lifecycle_policy.example policy-abcdef12345678901
+        ```sh
+         $ pulumi import aws:dlm/lifecyclePolicy:LifecyclePolicy example policy-abcdef12345678901
+        ```
 
         :param str resource_name: The name of the resource.
         :param LifecyclePolicyArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/dms/replication_config.py
+++ b/sdk/python/pulumi_aws/dms/replication_config.py
@@ -462,11 +462,11 @@ class ReplicationConfig(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import replication configs using the `arn`. For exampleterraform import {
+        Using `pulumi import`, import a replication config using the `arn`. For example:
 
-         to = aws_dms_replication_config.example
-
-         id = "arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI" } Using `TODO import`, import a replication config using the `arn`. For exampleconsole % TODO import aws_dms_replication_config.example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+        ```sh
+         $ pulumi import aws:dms/replicationConfig:ReplicationConfig example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -520,11 +520,11 @@ class ReplicationConfig(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import replication configs using the `arn`. For exampleterraform import {
+        Using `pulumi import`, import a replication config using the `arn`. For example:
 
-         to = aws_dms_replication_config.example
-
-         id = "arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI" } Using `TODO import`, import a replication config using the `arn`. For exampleconsole % TODO import aws_dms_replication_config.example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+        ```sh
+         $ pulumi import aws:dms/replicationConfig:ReplicationConfig example arn:aws:dms:us-east-1:123456789012:replication-config:UX6OL6MHMMJKFFOXE3H7LLJCMEKBDUG4ZV7DRSI
+        ```
 
         :param str resource_name: The name of the resource.
         :param ReplicationConfigArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ec2/network_interface.py
+++ b/sdk/python/pulumi_aws/ec2/network_interface.py
@@ -829,11 +829,11 @@ class NetworkInterface(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Network Interfaces using the `id`. For exampleterraform import {
+        Using `pulumi import`, import Network Interfaces using the `id`. For example:
 
-         to = aws_network_interface.test
-
-         id = "eni-e5aa89a3" } Using `TODO import`, import Network Interfaces using the `id`. For exampleconsole % TODO import aws_network_interface.test eni-e5aa89a3
+        ```sh
+         $ pulumi import aws:ec2/networkInterface:NetworkInterface test eni-e5aa89a3
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -902,11 +902,11 @@ class NetworkInterface(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Network Interfaces using the `id`. For exampleterraform import {
+        Using `pulumi import`, import Network Interfaces using the `id`. For example:
 
-         to = aws_network_interface.test
-
-         id = "eni-e5aa89a3" } Using `TODO import`, import Network Interfaces using the `id`. For exampleconsole % TODO import aws_network_interface.test eni-e5aa89a3
+        ```sh
+         $ pulumi import aws:ec2/networkInterface:NetworkInterface test eni-e5aa89a3
+        ```
 
         :param str resource_name: The name of the resource.
         :param NetworkInterfaceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ec2/vpc_ipam_pool_cidr.py
+++ b/sdk/python/pulumi_aws/ec2/vpc_ipam_pool_cidr.py
@@ -192,11 +192,15 @@ class VpcIpamPoolCidr(pulumi.CustomResource):
 
         ## Import
 
-        terraform import {
+        __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
 
-         to = aws_vpc_ipam_pool_cidr.example
+        Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For example:
 
-         id = "172.20.0.0/24_ipam-pool-0e634f5a1517cccdc" } Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For exampleconsole % TODO import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+        __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
+
+        ```sh
+         $ pulumi import aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -221,11 +225,15 @@ class VpcIpamPoolCidr(pulumi.CustomResource):
 
         ## Import
 
-        terraform import {
+        __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
 
-         to = aws_vpc_ipam_pool_cidr.example
+        Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For example:
 
-         id = "172.20.0.0/24_ipam-pool-0e634f5a1517cccdc" } Using `pulumi import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For exampleconsole % TODO import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+        __NOTE:__ Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
+
+        ```sh
+         $ pulumi import aws:ec2/vpcIpamPoolCidr:VpcIpamPoolCidr example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
+        ```
 
         :param str resource_name: The name of the resource.
         :param VpcIpamPoolCidrArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/emrcontainers/job_template.py
+++ b/sdk/python/pulumi_aws/emrcontainers/job_template.py
@@ -227,11 +227,11 @@ class JobTemplate(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import EKS job templates using the `id`. For exampleterraform import {
+        Using `pulumi import`, import EKS job templates using the `id`. For example:
 
-         to = aws_emrcontainers_job_template.example
-
-         id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS job templates using the `id`. For exampleconsole % TODO import aws_emrcontainers_job_template.example a1b2c3d4e5f6g7h8i9j10k11l
+        ```sh
+         $ pulumi import aws:emrcontainers/jobTemplate:JobTemplate example a1b2c3d4e5f6g7h8i9j10k11l
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -269,11 +269,11 @@ class JobTemplate(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import EKS job templates using the `id`. For exampleterraform import {
+        Using `pulumi import`, import EKS job templates using the `id`. For example:
 
-         to = aws_emrcontainers_job_template.example
-
-         id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS job templates using the `id`. For exampleconsole % TODO import aws_emrcontainers_job_template.example a1b2c3d4e5f6g7h8i9j10k11l
+        ```sh
+         $ pulumi import aws:emrcontainers/jobTemplate:JobTemplate example a1b2c3d4e5f6g7h8i9j10k11l
+        ```
 
         :param str resource_name: The name of the resource.
         :param JobTemplateArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/emrcontainers/virtual_cluster.py
+++ b/sdk/python/pulumi_aws/emrcontainers/virtual_cluster.py
@@ -194,11 +194,11 @@ class VirtualCluster(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import EKS Clusters using the `id`. For exampleterraform import {
+        Using `pulumi import`, import EKS Clusters using the `id`. For example:
 
-         to = aws_emrcontainers_virtual_cluster.example
-
-         id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS Clusters using the `id`. For exampleconsole % TODO import aws_emrcontainers_virtual_cluster.example a1b2c3d4e5f6g7h8i9j10k11l
+        ```sh
+         $ pulumi import aws:emrcontainers/virtualCluster:VirtualCluster example a1b2c3d4e5f6g7h8i9j10k11l
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -235,11 +235,11 @@ class VirtualCluster(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import EKS Clusters using the `id`. For exampleterraform import {
+        Using `pulumi import`, import EKS Clusters using the `id`. For example:
 
-         to = aws_emrcontainers_virtual_cluster.example
-
-         id = "a1b2c3d4e5f6g7h8i9j10k11l" } Using `TODO import`, import EKS Clusters using the `id`. For exampleconsole % TODO import aws_emrcontainers_virtual_cluster.example a1b2c3d4e5f6g7h8i9j10k11l
+        ```sh
+         $ pulumi import aws:emrcontainers/virtualCluster:VirtualCluster example a1b2c3d4e5f6g7h8i9j10k11l
+        ```
 
         :param str resource_name: The name of the resource.
         :param VirtualClusterArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/emrserverless/application.py
+++ b/sdk/python/pulumi_aws/emrserverless/application.py
@@ -485,11 +485,11 @@ class Application(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import EMR Severless applications using the `id`. For exampleterraform import {
+        Using `pulumi import`, import EMR Severless applications using the `id`. For example:
 
-         to = aws_emrserverless_application.example
-
-         id = "id" } Using `TODO import`, import EMR Severless applications using the `id`. For exampleconsole % TODO import aws_emrserverless_application.example id
+        ```sh
+         $ pulumi import aws:emrserverless/application:Application example id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -562,11 +562,11 @@ class Application(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import EMR Severless applications using the `id`. For exampleterraform import {
+        Using `pulumi import`, import EMR Severless applications using the `id`. For example:
 
-         to = aws_emrserverless_application.example
-
-         id = "id" } Using `TODO import`, import EMR Severless applications using the `id`. For exampleconsole % TODO import aws_emrserverless_application.example id
+        ```sh
+         $ pulumi import aws:emrserverless/application:Application example id
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApplicationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/gamelift/game_server_group.py
+++ b/sdk/python/pulumi_aws/gamelift/game_server_group.py
@@ -554,11 +554,11 @@ class GameServerGroup(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import GameLift Game Server Group using the `name`. For exampleterraform import {
+        Using `pulumi import`, import GameLift Game Server Group using the `name`. For example:
 
-         to = aws_gamelift_game_server_group.example
-
-         id = "example" } Using `TODO import`, import GameLift Game Server Group using the `name`. For exampleconsole % TODO import aws_gamelift_game_server_group.example example
+        ```sh
+         $ pulumi import aws:gamelift/gameServerGroup:GameServerGroup example example
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -683,11 +683,11 @@ class GameServerGroup(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import GameLift Game Server Group using the `name`. For exampleterraform import {
+        Using `pulumi import`, import GameLift Game Server Group using the `name`. For example:
 
-         to = aws_gamelift_game_server_group.example
-
-         id = "example" } Using `TODO import`, import GameLift Game Server Group using the `name`. For exampleconsole % TODO import aws_gamelift_game_server_group.example example
+        ```sh
+         $ pulumi import aws:gamelift/gameServerGroup:GameServerGroup example example
+        ```
 
         :param str resource_name: The name of the resource.
         :param GameServerGroupArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/glue/dev_endpoint.py
+++ b/sdk/python/pulumi_aws/glue/dev_endpoint.py
@@ -720,11 +720,11 @@ class DevEndpoint(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import a Glue Development Endpoint using the `name`. For exampleterraform import {
+        Using `pulumi import`, import a Glue Development Endpoint using the `name`. For example:
 
-         to = aws_glue_dev_endpoint.example
-
-         id = "foo" } Using `TODO import`, import a Glue Development Endpoint using the `name`. For exampleconsole % TODO import aws_glue_dev_endpoint.example foo
+        ```sh
+         $ pulumi import aws:glue/devEndpoint:DevEndpoint example foo
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -777,11 +777,11 @@ class DevEndpoint(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import a Glue Development Endpoint using the `name`. For exampleterraform import {
+        Using `pulumi import`, import a Glue Development Endpoint using the `name`. For example:
 
-         to = aws_glue_dev_endpoint.example
-
-         id = "foo" } Using `TODO import`, import a Glue Development Endpoint using the `name`. For exampleconsole % TODO import aws_glue_dev_endpoint.example foo
+        ```sh
+         $ pulumi import aws:glue/devEndpoint:DevEndpoint example foo
+        ```
 
         :param str resource_name: The name of the resource.
         :param DevEndpointArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/iam/group_policy_attachment.py
+++ b/sdk/python/pulumi_aws/iam/group_policy_attachment.py
@@ -119,11 +119,11 @@ class GroupPolicyAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleterraform import {
+        Using `pulumi import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For example:
 
-         to = aws_iam_group_policy_attachment.test-attach
-
-         id = "test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```sh
+         $ pulumi import aws:iam/groupPolicyAttachment:GroupPolicyAttachment test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -158,11 +158,11 @@ class GroupPolicyAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleterraform import {
+        Using `pulumi import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For example:
 
-         to = aws_iam_group_policy_attachment.test-attach
-
-         id = "test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM group policy attachments using the group name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```sh
+         $ pulumi import aws:iam/groupPolicyAttachment:GroupPolicyAttachment test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```
 
         :param str resource_name: The name of the resource.
         :param GroupPolicyAttachmentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/iam/role_policy_attachment.py
+++ b/sdk/python/pulumi_aws/iam/role_policy_attachment.py
@@ -134,11 +134,11 @@ class RolePolicyAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleterraform import {
+        Using `pulumi import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
 
-         to = aws_iam_role_policy_attachment.test-attach
-
-         id = "test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```sh
+         $ pulumi import aws:iam/rolePolicyAttachment:RolePolicyAttachment test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -188,11 +188,11 @@ class RolePolicyAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleterraform import {
+        Using `pulumi import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
 
-         to = aws_iam_role_policy_attachment.test-attach
-
-         id = "test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```sh
+         $ pulumi import aws:iam/rolePolicyAttachment:RolePolicyAttachment test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```
 
         :param str resource_name: The name of the resource.
         :param RolePolicyAttachmentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/iam/user_policy_attachment.py
+++ b/sdk/python/pulumi_aws/iam/user_policy_attachment.py
@@ -119,11 +119,11 @@ class UserPolicyAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleterraform import {
+        Using `pulumi import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For example:
 
-         to = aws_iam_user_policy_attachment.test-attach
-
-         id = "test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```sh
+         $ pulumi import aws:iam/userPolicyAttachment:UserPolicyAttachment test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -158,11 +158,11 @@ class UserPolicyAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleterraform import {
+        Using `pulumi import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For example:
 
-         to = aws_iam_user_policy_attachment.test-attach
-
-         id = "test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy" } Using `TODO import`, import IAM user policy attachments using the user name and policy arn separated by `/`. For exampleconsole % TODO import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```sh
+         $ pulumi import aws:iam/userPolicyAttachment:UserPolicyAttachment test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+        ```
 
         :param str resource_name: The name of the resource.
         :param UserPolicyAttachmentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/lex/v2models_bot.py
+++ b/sdk/python/pulumi_aws/lex/v2models_bot.py
@@ -397,11 +397,11 @@ class V2modelsBot(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Lex V2 Models Bot using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
 
-         to = aws_lexv2models_bot.example
-
-         id = "bot-id-12345678" } Using `TODO import`, import Lex V2 Models Bot using the `example_id_arg`. For exampleconsole % TODO import aws_lexv2models_bot.example bot-id-12345678
+        ```sh
+         $ pulumi import aws:lex/v2modelsBot:V2modelsBot example bot-id-12345678
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -441,11 +441,11 @@ class V2modelsBot(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Lex V2 Models Bot using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
 
-         to = aws_lexv2models_bot.example
-
-         id = "bot-id-12345678" } Using `TODO import`, import Lex V2 Models Bot using the `example_id_arg`. For exampleconsole % TODO import aws_lexv2models_bot.example bot-id-12345678
+        ```sh
+         $ pulumi import aws:lex/v2modelsBot:V2modelsBot example bot-id-12345678
+        ```
 
         :param str resource_name: The name of the resource.
         :param V2modelsBotArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/licensemanager/association.py
+++ b/sdk/python/pulumi_aws/licensemanager/association.py
@@ -125,11 +125,11 @@ class Association(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import license configurations using `resource_arn,license_configuration_arn`. For exampleterraform import {
+        Using `pulumi import`, import license configurations using `resource_arn,license_configuration_arn`. For example:
 
-         to = aws_licensemanager_association.example
-
-         id = "arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using `resource_arn,license_configuration_arn`. For exampleconsole % TODO import aws_licensemanager_association.example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```sh
+         $ pulumi import aws:licensemanager/association:Association example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -170,11 +170,11 @@ class Association(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import license configurations using `resource_arn,license_configuration_arn`. For exampleterraform import {
+        Using `pulumi import`, import license configurations using `resource_arn,license_configuration_arn`. For example:
 
-         to = aws_licensemanager_association.example
-
-         id = "arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using `resource_arn,license_configuration_arn`. For exampleconsole % TODO import aws_licensemanager_association.example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```sh
+         $ pulumi import aws:licensemanager/association:Association example arn:aws:ec2:eu-west-1:123456789012:image/ami-123456789abcdef01,arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param AssociationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/licensemanager/license_configuration.py
+++ b/sdk/python/pulumi_aws/licensemanager/license_configuration.py
@@ -352,11 +352,11 @@ class LicenseConfiguration(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import license configurations using the `id`. For exampleterraform import {
+        Using `pulumi import`, import license configurations using the `id`. For example:
 
-         to = aws_licensemanager_license_configuration.example
-
-         id = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using the `id`. For exampleconsole % TODO import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```sh
+         $ pulumi import aws:licensemanager/licenseConfiguration:LicenseConfiguration example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -409,11 +409,11 @@ class LicenseConfiguration(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import license configurations using the `id`. For exampleterraform import {
+        Using `pulumi import`, import license configurations using the `id`. For example:
 
-         to = aws_licensemanager_license_configuration.example
-
-         id = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef" } Using `TODO import`, import license configurations using the `id`. For exampleconsole % TODO import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```sh
+         $ pulumi import aws:licensemanager/licenseConfiguration:LicenseConfiguration example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param LicenseConfigurationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/msk/cluster_policy.py
+++ b/sdk/python/pulumi_aws/msk/cluster_policy.py
@@ -145,11 +145,11 @@ class ClusterPolicy(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Managed Streaming for Kafka Cluster Policy using the `cluster_arn. For exampleterraform import {
+        Using `pulumi import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For example:
 
-         to = aws_msk_cluster_policy.example
-
-         id = "arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3" } Using `TODO import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For exampleconsole % TODO import aws_msk_cluster_policy.example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+        ```sh
+         $ pulumi import aws:msk/clusterPolicy:ClusterPolicy example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -198,11 +198,11 @@ class ClusterPolicy(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Managed Streaming for Kafka Cluster Policy using the `cluster_arn. For exampleterraform import {
+        Using `pulumi import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For example:
 
-         to = aws_msk_cluster_policy.example
-
-         id = "arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3" } Using `TODO import`, import Managed Streaming for Kafka Cluster Policy using the `cluster_arn`. For exampleconsole % TODO import aws_msk_cluster_policy.example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+        ```sh
+         $ pulumi import aws:msk/clusterPolicy:ClusterPolicy example arn:aws:kafka:us-west-2:123456789012:cluster/example/279c0212-d057-4dba-9aa9-1c4e5a25bfc7-3
+        ```
 
         :param str resource_name: The name of the resource.
         :param ClusterPolicyArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/msk/vpc_connection.py
+++ b/sdk/python/pulumi_aws/msk/vpc_connection.py
@@ -283,11 +283,11 @@ class VpcConnection(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import MSK configurations using the configuration ARN. For exampleterraform import {
+        Using `pulumi import`, import MSK configurations using the configuration ARN. For example:
 
-         to = aws_msk_vpc_connection.example
-
-         id = "arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2" } Using `TODO import`, import MSK configurations using the configuration ARN. For exampleconsole % TODO import aws_msk_vpc_connection.example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+        ```sh
+         $ pulumi import aws:msk/vpcConnection:VpcConnection example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -323,11 +323,11 @@ class VpcConnection(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import MSK configurations using the configuration ARN. For exampleterraform import {
+        Using `pulumi import`, import MSK configurations using the configuration ARN. For example:
 
-         to = aws_msk_vpc_connection.example
-
-         id = "arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2" } Using `TODO import`, import MSK configurations using the configuration ARN. For exampleconsole % TODO import aws_msk_vpc_connection.example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+        ```sh
+         $ pulumi import aws:msk/vpcConnection:VpcConnection example arn:aws:kafka:eu-west-2:123456789012:vpc-connection/123456789012/example/38173259-79cd-4ee8-87f3-682ea6023f48-2
+        ```
 
         :param str resource_name: The name of the resource.
         :param VpcConnectionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/opensearch/vpc_endpoint.py
+++ b/sdk/python/pulumi_aws/opensearch/vpc_endpoint.py
@@ -141,11 +141,11 @@ class VpcEndpoint(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import OpenSearch VPC endpoint connections using the `id`. For exampleterraform import {
+        Using `pulumi import`, import OpenSearch VPC endpoint connections using the `id`. For example:
 
-         to = aws_opensearch_vpc_endpoint_connection.example
-
-         id = "endpoint-id" } Using `TODO import`, import OpenSearch VPC endpoint connections using the `id`. For exampleconsole % TODO import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+        ```sh
+         $ pulumi import aws:opensearch/vpcEndpoint:VpcEndpoint example endpoint-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -184,11 +184,11 @@ class VpcEndpoint(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import OpenSearch VPC endpoint connections using the `id`. For exampleterraform import {
+        Using `pulumi import`, import OpenSearch VPC endpoint connections using the `id`. For example:
 
-         to = aws_opensearch_vpc_endpoint_connection.example
-
-         id = "endpoint-id" } Using `TODO import`, import OpenSearch VPC endpoint connections using the `id`. For exampleconsole % TODO import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+        ```sh
+         $ pulumi import aws:opensearch/vpcEndpoint:VpcEndpoint example endpoint-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param VpcEndpointArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/adm_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/adm_channel.py
@@ -182,11 +182,11 @@ class AdmChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint ADM Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint ADM Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_adm_channel.channel
-
-         id = "application-id" } Using `TODO import`, import Pinpoint ADM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_adm_channel.channel application-id
+        ```sh
+         $ pulumi import aws:pinpoint/admChannel:AdmChannel channel application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -221,11 +221,11 @@ class AdmChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint ADM Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint ADM Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_adm_channel.channel
-
-         id = "application-id" } Using `TODO import`, import Pinpoint ADM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_adm_channel.channel application-id
+        ```sh
+         $ pulumi import aws:pinpoint/admChannel:AdmChannel channel application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param AdmChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/apns_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/apns_channel.py
@@ -384,11 +384,11 @@ class ApnsChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_channel.apns
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_channel.apns application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsChannel:ApnsChannel apns application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -436,11 +436,11 @@ class ApnsChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_channel.apns
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_channel.apns application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsChannel:ApnsChannel apns application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApnsChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/apns_sandbox_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/apns_sandbox_channel.py
@@ -384,11 +384,11 @@ class ApnsSandboxChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_sandbox_channel.apns_sandbox
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_sandbox_channel.apns_sandbox application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel apns_sandbox application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -436,11 +436,11 @@ class ApnsSandboxChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_sandbox_channel.apns_sandbox
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_sandbox_channel.apns_sandbox application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsSandboxChannel:ApnsSandboxChannel apns_sandbox application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApnsSandboxChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/apns_voip_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/apns_voip_channel.py
@@ -384,11 +384,11 @@ class ApnsVoipChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs VoIP Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_voip_channel.apns_voip
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_channel.apns_voip application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsVoipChannel:ApnsVoipChannel apns_voip application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -436,11 +436,11 @@ class ApnsVoipChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs VoIP Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_voip_channel.apns_voip
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_channel.apns_voip application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsVoipChannel:ApnsVoipChannel apns_voip application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApnsVoipChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/apns_voip_sandbox_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/apns_voip_sandbox_channel.py
@@ -384,11 +384,11 @@ class ApnsVoipSandboxChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel apns_voip_sandbox application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -436,11 +436,11 @@ class ApnsVoipSandboxChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox
-
-         id = "application-id" } Using `TODO import`, import Pinpoint APNs VoIP Sandbox Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+        ```sh
+         $ pulumi import aws:pinpoint/apnsVoipSandboxChannel:ApnsVoipSandboxChannel apns_voip_sandbox application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApnsVoipSandboxChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/app.py
+++ b/sdk/python/pulumi_aws/pinpoint/app.py
@@ -308,11 +308,11 @@ class App(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint App using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint App using the `application-id`. For example:
 
-         to = aws_pinpoint_app.name
-
-         id = "application-id" } Using `TODO import`, import Pinpoint App using the `application-id`. For exampleconsole % TODO import aws_pinpoint_app.name application-id
+        ```sh
+         $ pulumi import aws:pinpoint/app:App name application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -350,11 +350,11 @@ class App(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint App using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint App using the `application-id`. For example:
 
-         to = aws_pinpoint_app.name
-
-         id = "application-id" } Using `TODO import`, import Pinpoint App using the `application-id`. For exampleconsole % TODO import aws_pinpoint_app.name application-id
+        ```sh
+         $ pulumi import aws:pinpoint/app:App name application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param AppArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/baidu_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/baidu_channel.py
@@ -181,11 +181,11 @@ class BaiduChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint Baidu Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint Baidu Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_baidu_channel.channel
-
-         id = "application-id" } Using `TODO import`, import Pinpoint Baidu Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_baidu_channel.channel application-id
+        ```sh
+         $ pulumi import aws:pinpoint/baiduChannel:BaiduChannel channel application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -219,11 +219,11 @@ class BaiduChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint Baidu Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint Baidu Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_baidu_channel.channel
-
-         id = "application-id" } Using `TODO import`, import Pinpoint Baidu Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_baidu_channel.channel application-id
+        ```sh
+         $ pulumi import aws:pinpoint/baiduChannel:BaiduChannel channel application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param BaiduChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/email_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/email_channel.py
@@ -283,11 +283,11 @@ class EmailChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint Email Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint Email Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_email_channel.email
-
-         id = "application-id" } Using `TODO import`, import Pinpoint Email Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_email_channel.email application-id
+        ```sh
+         $ pulumi import aws:pinpoint/emailChannel:EmailChannel email application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -343,11 +343,11 @@ class EmailChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint Email Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint Email Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_email_channel.email
-
-         id = "application-id" } Using `TODO import`, import Pinpoint Email Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_email_channel.email application-id
+        ```sh
+         $ pulumi import aws:pinpoint/emailChannel:EmailChannel email application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param EmailChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/event_stream.py
+++ b/sdk/python/pulumi_aws/pinpoint/event_stream.py
@@ -168,11 +168,11 @@ class EventStream(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint Event Stream using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint Event Stream using the `application-id`. For example:
 
-         to = aws_pinpoint_event_stream.stream
-
-         id = "application-id" } Using `TODO import`, import Pinpoint Event Stream using the `application-id`. For exampleconsole % TODO import aws_pinpoint_event_stream.stream application-id
+        ```sh
+         $ pulumi import aws:pinpoint/eventStream:EventStream stream application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -225,11 +225,11 @@ class EventStream(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint Event Stream using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint Event Stream using the `application-id`. For example:
 
-         to = aws_pinpoint_event_stream.stream
-
-         id = "application-id" } Using `TODO import`, import Pinpoint Event Stream using the `application-id`. For exampleconsole % TODO import aws_pinpoint_event_stream.stream application-id
+        ```sh
+         $ pulumi import aws:pinpoint/eventStream:EventStream stream application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param EventStreamArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/gcm_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/gcm_channel.py
@@ -148,11 +148,11 @@ class GcmChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint GCM Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint GCM Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_gcm_channel.gcm
-
-         id = "application-id" } Using `TODO import`, import Pinpoint GCM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_gcm_channel.gcm application-id
+        ```sh
+         $ pulumi import aws:pinpoint/gcmChannel:GcmChannel gcm application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -184,11 +184,11 @@ class GcmChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Pinpoint GCM Channel using the `application-id`. For exampleterraform import {
+        Using `pulumi import`, import Pinpoint GCM Channel using the `application-id`. For example:
 
-         to = aws_pinpoint_gcm_channel.gcm
-
-         id = "application-id" } Using `TODO import`, import Pinpoint GCM Channel using the `application-id`. For exampleconsole % TODO import aws_pinpoint_gcm_channel.gcm application-id
+        ```sh
+         $ pulumi import aws:pinpoint/gcmChannel:GcmChannel gcm application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param GcmChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/pinpoint/sms_channel.py
+++ b/sdk/python/pulumi_aws/pinpoint/sms_channel.py
@@ -211,11 +211,11 @@ class SmsChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import the Pinpoint SMS Channel using the `application_id`. For exampleterraform import {
+        Using `pulumi import`, import the Pinpoint SMS Channel using the `application_id`. For example:
 
-         to = aws_pinpoint_sms_channel.sms
-
-         id = "application-id" } Using `TODO import`, import the Pinpoint SMS Channel using the `application_id`. For exampleconsole % TODO import aws_pinpoint_sms_channel.sms application-id
+        ```sh
+         $ pulumi import aws:pinpoint/smsChannel:SmsChannel sms application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -245,11 +245,11 @@ class SmsChannel(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import the Pinpoint SMS Channel using the `application_id`. For exampleterraform import {
+        Using `pulumi import`, import the Pinpoint SMS Channel using the `application_id`. For example:
 
-         to = aws_pinpoint_sms_channel.sms
-
-         id = "application-id" } Using `TODO import`, import the Pinpoint SMS Channel using the `application_id`. For exampleconsole % TODO import aws_pinpoint_sms_channel.sms application-id
+        ```sh
+         $ pulumi import aws:pinpoint/smsChannel:SmsChannel sms application-id
+        ```
 
         :param str resource_name: The name of the resource.
         :param SmsChannelArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ram/principal_association.py
+++ b/sdk/python/pulumi_aws/ram/principal_association.py
@@ -135,11 +135,11 @@ class PrincipalAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleterraform import {
+        Using `pulumi import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For example:
 
-         to = aws_ram_principal_association.example
-
-         id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012" } Using `TODO import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleconsole % TODO import aws_ram_principal_association.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+        ```sh
+         $ pulumi import aws:ram/principalAssociation:PrincipalAssociation example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -190,11 +190,11 @@ class PrincipalAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleterraform import {
+        Using `pulumi import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For example:
 
-         to = aws_ram_principal_association.example
-
-         id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012" } Using `TODO import`, import RAM Principal Associations using their Resource Share ARN and the `principal` separated by a comma. For exampleconsole % TODO import aws_ram_principal_association.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+        ```sh
+         $ pulumi import aws:ram/principalAssociation:PrincipalAssociation example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12,123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param PrincipalAssociationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ram/resource_share.py
+++ b/sdk/python/pulumi_aws/ram/resource_share.py
@@ -221,11 +221,11 @@ class ResourceShare(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import resource shares using the `arn` of the resource share. For exampleterraform import {
+        Using `pulumi import`, import resource shares using the `arn` of the resource share. For example:
 
-         to = aws_ram_resource_share.example
-
-         id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12" } Using `TODO import`, import resource shares using the `arn` of the resource share. For exampleconsole % TODO import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+        ```sh
+         $ pulumi import aws:ram/resourceShare:ResourceShare example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -258,11 +258,11 @@ class ResourceShare(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import resource shares using the `arn` of the resource share. For exampleterraform import {
+        Using `pulumi import`, import resource shares using the `arn` of the resource share. For example:
 
-         to = aws_ram_resource_share.example
-
-         id = "arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12" } Using `TODO import`, import resource shares using the `arn` of the resource share. For exampleconsole % TODO import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+        ```sh
+         $ pulumi import aws:ram/resourceShare:ResourceShare example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResourceShareArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ram/resource_share_accepter.py
+++ b/sdk/python/pulumi_aws/ram/resource_share_accepter.py
@@ -207,11 +207,11 @@ class ResourceShareAccepter(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import resource share accepters using the resource share ARN. For exampleterraform import {
+        Using `pulumi import`, import resource share accepters using the resource share ARN. For example:
 
-         to = aws_ram_resource_share_accepter.example
-
-         id = "arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767" } Using `TODO import`, import resource share accepters using the resource share ARN. For exampleconsole % TODO import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+        ```sh
+         $ pulumi import aws:ram/resourceShareAccepter:ResourceShareAccepter example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -253,11 +253,11 @@ class ResourceShareAccepter(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import resource share accepters using the resource share ARN. For exampleterraform import {
+        Using `pulumi import`, import resource share accepters using the resource share ARN. For example:
 
-         to = aws_ram_resource_share_accepter.example
-
-         id = "arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767" } Using `TODO import`, import resource share accepters using the resource share ARN. For exampleconsole % TODO import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+        ```sh
+         $ pulumi import aws:ram/resourceShareAccepter:ResourceShareAccepter example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResourceShareAccepterArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ram/sharing_with_organization.py
+++ b/sdk/python/pulumi_aws/ram/sharing_with_organization.py
@@ -42,11 +42,11 @@ class SharingWithOrganization(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import the resource using the current AWS account ID. For exampleterraform import {
+        Using `pulumi import`, import the resource using the current AWS account ID. For example:
 
-         to = aws_ram_sharing_with_organization.example
-
-         id = "123456789012" } Using `TODO import`, import the resource using the current AWS account ID. For exampleconsole % TODO import aws_ram_sharing_with_organization.example 123456789012
+        ```sh
+         $ pulumi import aws:ram/sharingWithOrganization:SharingWithOrganization example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -73,11 +73,11 @@ class SharingWithOrganization(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import the resource using the current AWS account ID. For exampleterraform import {
+        Using `pulumi import`, import the resource using the current AWS account ID. For example:
 
-         to = aws_ram_sharing_with_organization.example
-
-         id = "123456789012" } Using `TODO import`, import the resource using the current AWS account ID. For exampleconsole % TODO import aws_ram_sharing_with_organization.example 123456789012
+        ```sh
+         $ pulumi import aws:ram/sharingWithOrganization:SharingWithOrganization example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param SharingWithOrganizationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/rds/cluster_parameter_group.py
+++ b/sdk/python/pulumi_aws/rds/cluster_parameter_group.py
@@ -303,11 +303,11 @@ class ClusterParameterGroup(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import RDS Cluster Parameter Groups using the `name`. For exampleterraform import {
+        Using `pulumi import`, import RDS Cluster Parameter Groups using the `name`. For example:
 
-         to = aws_rds_cluster_parameter_group.cluster_pg
-
-         id = "production-pg-1" } Using `TODO import`, import RDS Cluster Parameter Groups using the `name`. For exampleconsole % TODO import aws_rds_cluster_parameter_group.cluster_pg production-pg-1
+        ```sh
+         $ pulumi import aws:rds/clusterParameterGroup:ClusterParameterGroup cluster_pg production-pg-1
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -353,11 +353,11 @@ class ClusterParameterGroup(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import RDS Cluster Parameter Groups using the `name`. For exampleterraform import {
+        Using `pulumi import`, import RDS Cluster Parameter Groups using the `name`. For example:
 
-         to = aws_rds_cluster_parameter_group.cluster_pg
-
-         id = "production-pg-1" } Using `TODO import`, import RDS Cluster Parameter Groups using the `name`. For exampleconsole % TODO import aws_rds_cluster_parameter_group.cluster_pg production-pg-1
+        ```sh
+         $ pulumi import aws:rds/clusterParameterGroup:ClusterParameterGroup cluster_pg production-pg-1
+        ```
 
         :param str resource_name: The name of the resource.
         :param ClusterParameterGroupArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/rds/custom_db_engine_version.py
+++ b/sdk/python/pulumi_aws/rds/custom_db_engine_version.py
@@ -629,11 +629,11 @@ class CustomDbEngineVersion(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleterraform import {
+        Using `pulumi import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For example:
 
-         to = aws_rds_custom_db_engine_version.example
-
-         id = "custom-oracle-ee-cdb:19.cdb_cev1" } Using `TODO import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleconsole % TODO import aws_rds_custom_db_engine_version.example custom-oracle-ee-cdb:19.cdb_cev1
+        ```sh
+         $ pulumi import aws:rds/customDbEngineVersion:CustomDbEngineVersion example custom-oracle-ee-cdb:19.cdb_cev1
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -740,11 +740,11 @@ class CustomDbEngineVersion(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleterraform import {
+        Using `pulumi import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For example:
 
-         to = aws_rds_custom_db_engine_version.example
-
-         id = "custom-oracle-ee-cdb:19.cdb_cev1" } Using `TODO import`, import custom engine versions for Amazon RDS custom using the `engine` and `engine_version` separated by a colon (`:`). For exampleconsole % TODO import aws_rds_custom_db_engine_version.example custom-oracle-ee-cdb:19.cdb_cev1
+        ```sh
+         $ pulumi import aws:rds/customDbEngineVersion:CustomDbEngineVersion example custom-oracle-ee-cdb:19.cdb_cev1
+        ```
 
         :param str resource_name: The name of the resource.
         :param CustomDbEngineVersionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/rds/instance_automated_backups_replication.py
+++ b/sdk/python/pulumi_aws/rds/instance_automated_backups_replication.py
@@ -221,11 +221,11 @@ class InstanceAutomatedBackupsReplication(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import RDS instance automated backups replication using the `arn`. For exampleterraform import {
+        Using `pulumi import`, import RDS instance automated backups replication using the `arn`. For example:
 
-         to = aws_db_instance_automated_backups_replication.default
-
-         id = "arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my" } Using `TODO import`, import RDS instance automated backups replication using the `arn`. For exampleconsole % TODO import aws_db_instance_automated_backups_replication.default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+        ```sh
+         $ pulumi import aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -297,11 +297,11 @@ class InstanceAutomatedBackupsReplication(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import RDS instance automated backups replication using the `arn`. For exampleterraform import {
+        Using `pulumi import`, import RDS instance automated backups replication using the `arn`. For example:
 
-         to = aws_db_instance_automated_backups_replication.default
-
-         id = "arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my" } Using `TODO import`, import RDS instance automated backups replication using the `arn`. For exampleconsole % TODO import aws_db_instance_automated_backups_replication.default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+        ```sh
+         $ pulumi import aws:rds/instanceAutomatedBackupsReplication:InstanceAutomatedBackupsReplication default arn:aws:rds:us-east-1:123456789012:auto-backup:ab-faaa2mgdj1vmp4xflr7yhsrmtbtob7ltrzzz2my
+        ```
 
         :param str resource_name: The name of the resource.
         :param InstanceAutomatedBackupsReplicationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/route53/resolver_firewall_config.py
+++ b/sdk/python/pulumi_aws/route53/resolver_firewall_config.py
@@ -134,11 +134,11 @@ class ResolverFirewallConfig(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleterraform import {
+        Using `pulumi import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For example:
 
-         to = aws_route53_resolver_firewall_config.example
-
-         id = "rdsc-be1866ecc1683e95" } Using `TODO import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleconsole % TODO import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallConfig:ResolverFirewallConfig example rdsc-be1866ecc1683e95
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -171,11 +171,11 @@ class ResolverFirewallConfig(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleterraform import {
+        Using `pulumi import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For example:
 
-         to = aws_route53_resolver_firewall_config.example
-
-         id = "rdsc-be1866ecc1683e95" } Using `TODO import`, import Route 53 Resolver DNS Firewall configs using the Route 53 Resolver DNS Firewall config ID. For exampleconsole % TODO import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallConfig:ResolverFirewallConfig example rdsc-be1866ecc1683e95
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResolverFirewallConfigArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/route53/resolver_firewall_domain_list.py
+++ b/sdk/python/pulumi_aws/route53/resolver_firewall_domain_list.py
@@ -184,15 +184,13 @@ class ResolverFirewallDomainList(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import
+        Using `pulumi import`, import
 
-        Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleterraform import {
+        Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For example:
 
-         to = aws_route53_resolver_firewall_domain_list.example
-
-         id = "rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
-
-        Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleconsole % TODO import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList example rslvr-fdl-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -220,15 +218,13 @@ class ResolverFirewallDomainList(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import
+        Using `pulumi import`, import
 
-        Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleterraform import {
+        Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For example:
 
-         to = aws_route53_resolver_firewall_domain_list.example
-
-         id = "rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
-
-        Route 53 Resolver DNS Firewall domain lists using the Route 53 Resolver DNS Firewall domain list ID. For exampleconsole % TODO import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallDomainList:ResolverFirewallDomainList example rslvr-fdl-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResolverFirewallDomainListArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/route53/resolver_firewall_rule.py
+++ b/sdk/python/pulumi_aws/route53/resolver_firewall_rule.py
@@ -352,15 +352,13 @@ class ResolverFirewallRule(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import
+        Using `pulumi import`, import
 
-        Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleterraform import {
+        Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For example:
 
-         to = aws_route53_resolver_firewall_rule.example
-
-         id = "rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
-
-        Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleconsole % TODO import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallRule:ResolverFirewallRule example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -406,15 +404,13 @@ class ResolverFirewallRule(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import
+        Using `pulumi import`, import
 
-        Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleterraform import {
+        Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For example:
 
-         to = aws_route53_resolver_firewall_rule.example
-
-         id = "rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef" } Using `TODO import`, import
-
-        Route 53 Resolver DNS Firewall rules using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':'. For exampleconsole % TODO import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallRule:ResolverFirewallRule example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResolverFirewallRuleArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/route53/resolver_firewall_rule_group.py
+++ b/sdk/python/pulumi_aws/route53/resolver_firewall_rule_group.py
@@ -183,15 +183,13 @@ class ResolverFirewallRuleGroup(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import
+        Using `pulumi import`, import
 
-        Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleterraform import {
+        Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For example:
 
-         to = aws_route53_resolver_firewall_rule_group.example
-
-         id = "rslvr-frg-0123456789abcdef" } Using `TODO import`, import
-
-        Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup example rslvr-frg-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -218,15 +216,13 @@ class ResolverFirewallRuleGroup(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import
+        Using `pulumi import`, import
 
-        Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleterraform import {
+        Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For example:
 
-         to = aws_route53_resolver_firewall_rule_group.example
-
-         id = "rslvr-frg-0123456789abcdef" } Using `TODO import`, import
-
-        Route 53 Resolver DNS Firewall rule groups using the Route 53 Resolver DNS Firewall rule group ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallRuleGroup:ResolverFirewallRuleGroup example rslvr-frg-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResolverFirewallRuleGroupArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/route53/resolver_firewall_rule_group_association.py
+++ b/sdk/python/pulumi_aws/route53/resolver_firewall_rule_group_association.py
@@ -284,11 +284,11 @@ class ResolverFirewallRuleGroupAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleterraform import {
+        Using `pulumi import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For example:
 
-         to = aws_route53_resolver_firewall_rule_group_association.example
-
-         id = "rslvr-frgassoc-0123456789abcdef" } Using `TODO import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation example rslvr-frgassoc-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -323,11 +323,11 @@ class ResolverFirewallRuleGroupAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleterraform import {
+        Using `pulumi import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For example:
 
-         to = aws_route53_resolver_firewall_rule_group_association.example
-
-         id = "rslvr-frgassoc-0123456789abcdef" } Using `TODO import`, import Route 53 Resolver DNS Firewall rule group associations using the Route 53 Resolver DNS Firewall rule group association ID. For exampleconsole % TODO import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+        ```sh
+         $ pulumi import aws:route53/resolverFirewallRuleGroupAssociation:ResolverFirewallRuleGroupAssociation example rslvr-frgassoc-0123456789abcdef
+        ```
 
         :param str resource_name: The name of the resource.
         :param ResolverFirewallRuleGroupAssociationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/account.py
+++ b/sdk/python/pulumi_aws/securityhub/account.py
@@ -164,11 +164,11 @@ class Account(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+        Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
 
-         to = aws_securityhub_account.example
-
-         id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_account.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/account:Account example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -198,11 +198,11 @@ class Account(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+        Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
 
-         to = aws_securityhub_account.example
-
-         id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_account.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/account:Account example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param AccountArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/finding_aggregator.py
+++ b/sdk/python/pulumi_aws/securityhub/finding_aggregator.py
@@ -151,11 +151,11 @@ class FindingAggregator(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub finding aggregator using the `arn`. For exampleterraform import {
+        Using `pulumi import`, import an existing Security Hub finding aggregator using the `arn`. For example:
 
-         to = aws_securityhub_finding_aggregator.example
-
-         id = "arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456" } Using `TODO import`, import an existing Security Hub finding aggregator using the `arn`. For exampleconsole % TODO import aws_securityhub_finding_aggregator.example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+        ```sh
+         $ pulumi import aws:securityhub/findingAggregator:FindingAggregator example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -221,11 +221,11 @@ class FindingAggregator(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub finding aggregator using the `arn`. For exampleterraform import {
+        Using `pulumi import`, import an existing Security Hub finding aggregator using the `arn`. For example:
 
-         to = aws_securityhub_finding_aggregator.example
-
-         id = "arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456" } Using `TODO import`, import an existing Security Hub finding aggregator using the `arn`. For exampleconsole % TODO import aws_securityhub_finding_aggregator.example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+        ```sh
+         $ pulumi import aws:securityhub/findingAggregator:FindingAggregator example arn:aws:securityhub:eu-west-1:123456789098:finding-aggregator/abcd1234-abcd-1234-1234-abcdef123456
+        ```
 
         :param str resource_name: The name of the resource.
         :param FindingAggregatorArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/invite_accepter.py
+++ b/sdk/python/pulumi_aws/securityhub/invite_accepter.py
@@ -105,11 +105,11 @@ class InviteAccepter(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub invite acceptance using the account ID. For exampleterraform import {
+        Using `pulumi import`, import Security Hub invite acceptance using the account ID. For example:
 
-         to = aws_securityhub_invite_accepter.example
-
-         id = "123456789012" } Using `TODO import`, import Security Hub invite acceptance using the account ID. For exampleconsole % TODO import aws_securityhub_invite_accepter.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/inviteAccepter:InviteAccepter example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -145,11 +145,11 @@ class InviteAccepter(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub invite acceptance using the account ID. For exampleterraform import {
+        Using `pulumi import`, import Security Hub invite acceptance using the account ID. For example:
 
-         to = aws_securityhub_invite_accepter.example
-
-         id = "123456789012" } Using `TODO import`, import Security Hub invite acceptance using the account ID. For exampleconsole % TODO import aws_securityhub_invite_accepter.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/inviteAccepter:InviteAccepter example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param InviteAccepterArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/member.py
+++ b/sdk/python/pulumi_aws/securityhub/member.py
@@ -182,11 +182,11 @@ class Member(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub members using their account ID. For exampleterraform import {
+        Using `pulumi import`, import Security Hub members using their account ID. For example:
 
-         to = aws_securityhub_member.example
-
-         id = "123456789012" } Using `TODO import`, import Security Hub members using their account ID. For exampleconsole % TODO import aws_securityhub_member.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/member:Member example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -219,11 +219,11 @@ class Member(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub members using their account ID. For exampleterraform import {
+        Using `pulumi import`, import Security Hub members using their account ID. For example:
 
-         to = aws_securityhub_member.example
-
-         id = "123456789012" } Using `TODO import`, import Security Hub members using their account ID. For exampleconsole % TODO import aws_securityhub_member.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/member:Member example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param MemberArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/organization_configuration.py
+++ b/sdk/python/pulumi_aws/securityhub/organization_configuration.py
@@ -121,11 +121,11 @@ class OrganizationConfiguration(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+        Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
 
-         to = aws_securityhub_organization_configuration.example
-
-         id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_organization_configuration.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/organizationConfiguration:OrganizationConfiguration example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -161,11 +161,11 @@ class OrganizationConfiguration(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import an existing Security Hub enabled account using the AWS account ID. For exampleterraform import {
+        Using `pulumi import`, import an existing Security Hub enabled account using the AWS account ID. For example:
 
-         to = aws_securityhub_organization_configuration.example
-
-         id = "123456789012" } Using `TODO import`, import an existing Security Hub enabled account using the AWS account ID. For exampleconsole % TODO import aws_securityhub_organization_configuration.example 123456789012
+        ```sh
+         $ pulumi import aws:securityhub/organizationConfiguration:OrganizationConfiguration example 123456789012
+        ```
 
         :param str resource_name: The name of the resource.
         :param OrganizationConfigurationArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/product_subscription.py
+++ b/sdk/python/pulumi_aws/securityhub/product_subscription.py
@@ -250,11 +250,11 @@ class ProductSubscription(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub product subscriptions using `product_arn,arn`. For exampleterraform import {
+        Using `pulumi import`, import Security Hub product subscriptions using `product_arn,arn`. For example:
 
-         to = aws_securityhub_product_subscription.example
-
-         id = "arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement" } Using `TODO import`, import Security Hub product subscriptions using `product_arn,arn`. For exampleconsole % TODO import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+        ```sh
+         $ pulumi import aws:securityhub/productSubscription:ProductSubscription example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -321,11 +321,11 @@ class ProductSubscription(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub product subscriptions using `product_arn,arn`. For exampleterraform import {
+        Using `pulumi import`, import Security Hub product subscriptions using `product_arn,arn`. For example:
 
-         to = aws_securityhub_product_subscription.example
-
-         id = "arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement" } Using `TODO import`, import Security Hub product subscriptions using `product_arn,arn`. For exampleconsole % TODO import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+        ```sh
+         $ pulumi import aws:securityhub/productSubscription:ProductSubscription example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
+        ```
 
         :param str resource_name: The name of the resource.
         :param ProductSubscriptionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/securityhub/standards_subscription.py
+++ b/sdk/python/pulumi_aws/securityhub/standards_subscription.py
@@ -124,19 +124,17 @@ class StandardsSubscription(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub standards subscriptions using the standards subscription ARN. For exampleterraform import {
+        Using `pulumi import`, import Security Hub standards subscriptions using the standards subscription ARN. For example:
 
-         to = aws_securityhub_standards_subscription.cis
-
-         id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0" } terraform import {
-
-         to = aws_securityhub_standards_subscription.pci_321
-
-         id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1" } terraform import {
-
-         to = aws_securityhub_standards_subscription.nist_800_53_rev_5
-
-         id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0" } Using `TODO import`, import Security Hub standards subscriptions using the standards subscription ARN. For exampleconsole % TODO import aws_securityhub_standards_subscription.cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0 console % TODO import aws_securityhub_standards_subscription.pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1 console % TODO import aws_securityhub_standards_subscription.nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+        ```sh
+         $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0
+        ```
+        ```sh
+        $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1
+        ```
+        ```sh
+        $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -177,19 +175,17 @@ class StandardsSubscription(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Security Hub standards subscriptions using the standards subscription ARN. For exampleterraform import {
+        Using `pulumi import`, import Security Hub standards subscriptions using the standards subscription ARN. For example:
 
-         to = aws_securityhub_standards_subscription.cis
-
-         id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0" } terraform import {
-
-         to = aws_securityhub_standards_subscription.pci_321
-
-         id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1" } terraform import {
-
-         to = aws_securityhub_standards_subscription.nist_800_53_rev_5
-
-         id = "arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0" } Using `TODO import`, import Security Hub standards subscriptions using the standards subscription ARN. For exampleconsole % TODO import aws_securityhub_standards_subscription.cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0 console % TODO import aws_securityhub_standards_subscription.pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1 console % TODO import aws_securityhub_standards_subscription.nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+        ```sh
+         $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription cis arn:aws:securityhub:eu-west-1:123456789012:subscription/cis-aws-foundations-benchmark/v/1.2.0
+        ```
+        ```sh
+        $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription pci_321 arn:aws:securityhub:eu-west-1:123456789012:subscription/pci-dss/v/3.2.1
+        ```
+        ```sh
+        $ pulumi import aws:securityhub/standardsSubscription:StandardsSubscription nist_800_53_rev_5 arn:aws:securityhub:eu-west-1:123456789012:subscription/nist-800-53/v/5.0.0
+        ```
 
         :param str resource_name: The name of the resource.
         :param StandardsSubscriptionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/servicecatalog/principal_portfolio_association.py
+++ b/sdk/python/pulumi_aws/servicecatalog/principal_portfolio_association.py
@@ -188,9 +188,7 @@ class PrincipalPortfolioAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
-
-        Using `TODO import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
+        Using `pulumi import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
 
         ```sh
          $ pulumi import aws:servicecatalog/principalPortfolioAssociation:PrincipalPortfolioAssociation example en,arn:aws:iam::123456789012:user/Eleanor,port-68656c6c6f,IAM
@@ -228,9 +226,7 @@ class PrincipalPortfolioAssociation(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
-
-        Using `TODO import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
+        Using `pulumi import`, import `aws_servicecatalog_principal_portfolio_association` using `accept_language`, `principal_arn`, `portfolio_id`, and `principal_type` separated by a comma. For example:
 
         ```sh
          $ pulumi import aws:servicecatalog/principalPortfolioAssociation:PrincipalPortfolioAssociation example en,arn:aws:iam::123456789012:user/Eleanor,port-68656c6c6f,IAM

--- a/sdk/python/pulumi_aws/servicequotas/template.py
+++ b/sdk/python/pulumi_aws/servicequotas/template.py
@@ -246,11 +246,11 @@ class Template(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Service Quotas Template using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import Service Quotas Template using the `id`. For example:
 
-         to = aws_servicequotas_template.example
-
-         id = "us-east-1,L-2ACBD22F,lambda" } Using `TODO import`, import Service Quotas Template using the `id`. For exampleconsole % TODO import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+        ```sh
+         $ pulumi import aws:servicequotas/template:Template example us-east-1,L-2ACBD22F,lambda
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -286,11 +286,11 @@ class Template(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Service Quotas Template using the `example_id_arg`. For exampleterraform import {
+        Using `pulumi import`, import Service Quotas Template using the `id`. For example:
 
-         to = aws_servicequotas_template.example
-
-         id = "us-east-1,L-2ACBD22F,lambda" } Using `TODO import`, import Service Quotas Template using the `id`. For exampleconsole % TODO import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+        ```sh
+         $ pulumi import aws:servicequotas/template:Template example us-east-1,L-2ACBD22F,lambda
+        ```
 
         :param str resource_name: The name of the resource.
         :param TemplateArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/ses/identity_notification_topic.py
+++ b/sdk/python/pulumi_aws/ses/identity_notification_topic.py
@@ -181,11 +181,11 @@ class IdentityNotificationTopic(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleterraform import {
+        Using `pulumi import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For example:
 
-         to = aws_ses_identity_notification_topic.test
-
-         id = "example.com|Bounce" } Using `TODO import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleconsole % TODO import aws_ses_identity_notification_topic.test 'example.com|Bounce'
+        ```sh
+         $ pulumi import aws:ses/identityNotificationTopic:IdentityNotificationTopic test 'example.com|Bounce'
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -218,11 +218,11 @@ class IdentityNotificationTopic(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleterraform import {
+        Using `pulumi import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For example:
 
-         to = aws_ses_identity_notification_topic.test
-
-         id = "example.com|Bounce" } Using `TODO import`, import Identity Notification Topics using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type. For exampleconsole % TODO import aws_ses_identity_notification_topic.test 'example.com|Bounce'
+        ```sh
+         $ pulumi import aws:ses/identityNotificationTopic:IdentityNotificationTopic test 'example.com|Bounce'
+        ```
 
         :param str resource_name: The name of the resource.
         :param IdentityNotificationTopicArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/sesv2/account_vdm_attributes.py
+++ b/sdk/python/pulumi_aws/sesv2/account_vdm_attributes.py
@@ -163,11 +163,11 @@ class AccountVdmAttributes(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleterraform import {
+        Using `pulumi import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For example:
 
-         to = aws_sesv2_account_vdm_attributes.example
-
-         id = "ses-account-vdm-attributes" } Using `TODO import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleconsole % TODO import aws_sesv2_account_vdm_attributes.example ses-account-vdm-attributes
+        ```sh
+         $ pulumi import aws:sesv2/accountVdmAttributes:AccountVdmAttributes example ses-account-vdm-attributes
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -205,11 +205,11 @@ class AccountVdmAttributes(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleterraform import {
+        Using `pulumi import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For example:
 
-         to = aws_sesv2_account_vdm_attributes.example
-
-         id = "ses-account-vdm-attributes" } Using `TODO import`, import SESv2 (Simple Email V2) Account VDM Attributes using the word `ses-account-vdm-attributes`. For exampleconsole % TODO import aws_sesv2_account_vdm_attributes.example ses-account-vdm-attributes
+        ```sh
+         $ pulumi import aws:sesv2/accountVdmAttributes:AccountVdmAttributes example ses-account-vdm-attributes
+        ```
 
         :param str resource_name: The name of the resource.
         :param AccountVdmAttributesArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/verifiedaccess/instance_trust_provider_attachment.py
+++ b/sdk/python/pulumi_aws/verifiedaccess/instance_trust_provider_attachment.py
@@ -121,11 +121,11 @@ class InstanceTrustProviderAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleterraform import {
+        Using `pulumi import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For example:
 
-         to = aws_verifiedaccess_instance_trust_provider_attachment.example
-
-         id = "vai-1234567890abcdef0/vatp-8012925589" } Using `TODO import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleconsole % TODO import aws_verifiedaccess_instance_trust_provider_attachment.example vai-1234567890abcdef0/vatp-8012925589
+        ```sh
+         $ pulumi import aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment example vai-1234567890abcdef0/vatp-8012925589
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -162,11 +162,11 @@ class InstanceTrustProviderAttachment(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleterraform import {
+        Using `pulumi import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For example:
 
-         to = aws_verifiedaccess_instance_trust_provider_attachment.example
-
-         id = "vai-1234567890abcdef0/vatp-8012925589" } Using `TODO import`, import Verified Access Instance Trust Provider Attachments using the `verifiedaccess_instance_id` and `verifiedaccess_trust_provider_id` separated by a forward slash (`/`). For exampleconsole % TODO import aws_verifiedaccess_instance_trust_provider_attachment.example vai-1234567890abcdef0/vatp-8012925589
+        ```sh
+         $ pulumi import aws:verifiedaccess/instanceTrustProviderAttachment:InstanceTrustProviderAttachment example vai-1234567890abcdef0/vatp-8012925589
+        ```
 
         :param str resource_name: The name of the resource.
         :param InstanceTrustProviderAttachmentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_aws/verifiedaccess/trust_provider.py
+++ b/sdk/python/pulumi_aws/verifiedaccess/trust_provider.py
@@ -340,13 +340,13 @@ class TrustProvider(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For exampleterraform import {
+        Using `pulumi import`, import Transfer Workflows using the
 
-         to = aws_verifiedaccess_trust_provider.example
+        `id`. For example:
 
-         id = "vatp-8012925589" } Using `TODO import`, import Transfer Workflows using the
-
-        `id`. For exampleconsole % TODO import aws_verifiedaccess_trust_provider.example vatp-8012925589
+        ```sh
+         $ pulumi import aws:verifiedaccess/trustProvider:TrustProvider example vatp-8012925589
+        ```
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -384,13 +384,13 @@ class TrustProvider(pulumi.CustomResource):
 
         ## Import
 
-        In TODO v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For exampleterraform import {
+        Using `pulumi import`, import Transfer Workflows using the
 
-         to = aws_verifiedaccess_trust_provider.example
+        `id`. For example:
 
-         id = "vatp-8012925589" } Using `TODO import`, import Transfer Workflows using the
-
-        `id`. For exampleconsole % TODO import aws_verifiedaccess_trust_provider.example vatp-8012925589
+        ```sh
+         $ pulumi import aws:verifiedaccess/trustProvider:TrustProvider example vatp-8012925589
+        ```
 
         :param str resource_name: The name of the resource.
         :param TrustProviderArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
As an immediate fix to #2871 imports and a general quality improvement, this PR applies a programatic fix to imports.

The best way to review in by commit:
- fc4d4126e526944d02678fef99a247d555983c3e is the hand authored fix, with tests.
- 3930135e6728afa3f084071831f6823c537a9166 realizes the effect of `make tfgen`.
- ade94ea050d748837e48f22e889398c8f64adc6f applies `make build_sdks`.