### PR TITLE
Build bridge on SDK runners

### DIFF
--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   upgrade_provider:
     name: upgrade-provider
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Call upgrade provider action
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.8


### PR DESCRIPTION
This PR is a manual run of `make ci-mgmt` to apply SDK-build capable runners to the Upgrade Bridge workflow.

~Will follow this up with either a ticket or a PR in ci-mgmt, because we should be applying the CI config every time we update workflows, and either there's a bug, or a missing implementation here.~

Looks like we're just behind in updating the Workflows: https://github.com/pulumi/pulumi-aws/pull/2889/files

Prereq for fixing #2848.
