### PR TITLE
Add text to inform users about ESC on creds error

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -617,7 +617,10 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	if _, _, diag := awsbase.GetAwsConfig(context.Background(), config); diag != nil && diag.HasError() {
 		return fmt.Errorf("unable to validate AWS credentials. \n"+
 			"Details: %s\n"+
-			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n", formatDiags(diag))
+			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n\n"+
+			"NEW: You can use Pulumi ESC to set up dynamic credentials with AWS OIDC to ensure the "+
+			"correct and valid credentials are used.\nLearn more: "+
+			"https://www.pulumi.com/docs/pulumi-cloud/esc/environments/", formatDiags(diag))
 	}
 
 	return nil

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -620,7 +620,7 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n\n"+
 			"NEW: You can use Pulumi ESC to set up dynamic credentials with AWS OIDC to ensure the "+
 			"correct and valid credentials are used.\nLearn more: "+
-			"https://www.pulumi.com/docs/pulumi-cloud/esc/environments/", formatDiags(diag))
+			"https://www.pulumi.com/blog/esc-env-run-aws/", formatDiags(diag))
 	}
 
 	return nil


### PR DESCRIPTION
Part of https://github.com/pulumi/marketing/issues/816

This PR adds some text to current text emitted when a user hits a credentials to let them know about ESC and that they can configure their AWS creds with ESC. When I was testing this locally I noticed the error emitted twice (same with a warning about using the aws plugin from my path) so not sure if that is expected with local dev. 

Example output: 

<img width="1344" alt="promote-esc-on-error-aws" src="https://github.com/pulumi/pulumi-aws/assets/15146337/d6b93272-c697-4f68-a533-477181d6d6ce">
