### PR TITLE
Remove additional code for making tagsAll secret

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -7182,10 +7182,6 @@ $ pulumi import aws:networkfirewall/resourcePolicy:ResourcePolicy example arn:aw
 		contract.Assertf(prov.Resources[key].TransformOutputs == nil,
 			"prov.Resources[key].TransformOutputs==nil")
 
-		// TODO[pulumi/pulumi-terraform-bridge#1380] this should not be necessary once 1380
-		// is fixed since marking tags_all as Secret should achieve the same effect
-		prov.Resources[key].TransformOutputs = ensureTagsAllSecret
-
 		return true
 	})
 

--- a/provider/tags.go
+++ b/provider/tags.go
@@ -123,16 +123,3 @@ func mergeTags(
 		return resource.NewNullProperty(), nil
 	}
 }
-
-// Ensures that a tagsAll property, if present is marked secret. This works around deeper issues
-// where bridged providers opt out of being sent secret bits and leave it to Pulumi CLI to handle
-// secret propagation, however the mechanism lacks enough information to appreciate that tagsAll
-// depends on tags can can propagate secret material across these two properties.
-func ensureTagsAllSecret(ctx context.Context, props resource.PropertyMap) (resource.PropertyMap, error) {
-	if _, ok := props["tagsAll"]; !ok || props["tagsAll"].IsSecret() {
-		return props, nil
-	}
-	copy := props.Copy()
-	copy["tagsAll"] = resource.MakeSecret(props["tagsAll"])
-	return copy, nil
-}


### PR DESCRIPTION
Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/1380

It seems that the issue which this code originally addressed is no longer there.

More details here: https://github.com/pulumi/pulumi-terraform-bridge/issues/1380#issuecomment-1785590797

Let me know if I have overlooked something in my tests but I failed to reproduce the behaviour which was originally reported.