### PR TITLE
Do not set DestroyOnCleanup for matrix tests

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -165,8 +165,7 @@ func (st tagsState) validateTransitionTo(t *testing.T, st2 tagsState) {
 			"state1":     st.serialize(t),
 			"state2":     st2.serialize(t),
 		},
-		Quick:            true,
-		DestroyOnCleanup: true,
+		Quick: true,
 	})
 }
 

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -83,7 +83,6 @@ func TestTagsCombinationsGo(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			tc.s1.validateTransitionTo(t, tc.s2)
 		})
 	}
@@ -128,7 +127,6 @@ func TestRandomTagsCombinationsGo(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
-			t.Parallel()
 			i := rand.Intn(len(states))
 			j := rand.Intn(len(states))
 			state1, state2 := states[i], states[j]


### PR DESCRIPTION
Generic CI failures with "The maximum number of VPCs has been reached”  point to large number of VPCs.

```
	// Destroy on cleanup defers stack destruction until the test cleanup step, rather than after
	// program test execution. This is useful for more realistic stack reference testing, allowing one
	// project and stack to be stood up and a second to be run before the first is destroyed.
	//
	// Implies NoParallel because we expect that another caller to ProgramTest will set that

```

One problem here is that a matrix-style test that tries 100 random combinations of VPC+Bucket should not be setting DestroyOnCleanup.