### PR TITLE
Update ESC suggestion to non-blog content

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -609,7 +609,8 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 			"Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`. \n\n"+
 			"NEW: You can use Pulumi ESC to set up dynamic credentials with AWS OIDC to ensure the "+
 			"correct and valid credentials are used.\nLearn more: "+
-			"https://www.pulumi.com/blog/esc-env-run-aws/", formatDiags(diag))
+			"https://www.pulumi.com/registry/packages/aws/installation-configuration/#dynamically-generate-credentials",
+			formatDiags(diag))
 	}
 
 	return nil


### PR DESCRIPTION
Point users to the new official reference content at https://www.pulumi.com/registry/packages/aws/installation-configuration/#dynamically-generate-credentials instead.