### PR TITLE
Correct CloudFront documentation

### DIFF
--- a/sdk/dotnet/CloudFront/Distribution.cs
+++ b/sdk/dotnet/CloudFront/Distribution.cs
@@ -400,7 +400,7 @@ namespace Pulumi.Aws.CloudFront
         public Output<string> DomainName { get; private set; } = null!;
 
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// Whether the distribution is enabled.
         /// </summary>
         [Output("enabled")]
         public Output<bool> Enabled { get; private set; } = null!;
@@ -636,7 +636,7 @@ namespace Pulumi.Aws.CloudFront
         public Input<string>? DefaultRootObject { get; set; }
 
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// Whether the distribution is enabled.
         /// </summary>
         [Input("enabled", required: true)]
         public Input<bool> Enabled { get; set; } = null!;
@@ -824,7 +824,7 @@ namespace Pulumi.Aws.CloudFront
         public Input<string>? DomainName { get; set; }
 
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// Whether the distribution is enabled.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupArgs.cs
+++ b/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.CloudFront.Inputs
     public sealed class DistributionTrustedKeyGroupArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupGetArgs.cs
+++ b/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.CloudFront.Inputs
     public sealed class DistributionTrustedKeyGroupGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Inputs/DistributionTrustedSignerGetArgs.cs
+++ b/sdk/dotnet/CloudFront/Inputs/DistributionTrustedSignerGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.CloudFront.Inputs
     public sealed class DistributionTrustedSignerGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Outputs/DistributionTrustedKeyGroup.cs
+++ b/sdk/dotnet/CloudFront/Outputs/DistributionTrustedKeyGroup.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.CloudFront.Outputs
     public sealed class DistributionTrustedKeyGroup
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         /// </summary>
         public readonly bool? Enabled;
         /// <summary>

--- a/sdk/dotnet/CloudFront/Outputs/DistributionTrustedSigner.cs
+++ b/sdk/dotnet/CloudFront/Outputs/DistributionTrustedSigner.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.CloudFront.Outputs
     public sealed class DistributionTrustedSigner
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         /// </summary>
         public readonly bool? Enabled;
         /// <summary>

--- a/sdk/go/aws/cloudfront/distribution.go
+++ b/sdk/go/aws/cloudfront/distribution.go
@@ -340,7 +340,7 @@ type Distribution struct {
 	DefaultRootObject pulumi.StringPtrOutput `pulumi:"defaultRootObject"`
 	// DNS domain name of either the S3 bucket, or web site of your custom origin.
 	DomainName pulumi.StringOutput `pulumi:"domainName"`
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled pulumi.BoolOutput `pulumi:"enabled"`
 	// Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
 	Etag pulumi.StringOutput `pulumi:"etag"`
@@ -457,7 +457,7 @@ type distributionState struct {
 	DefaultRootObject *string `pulumi:"defaultRootObject"`
 	// DNS domain name of either the S3 bucket, or web site of your custom origin.
 	DomainName *string `pulumi:"domainName"`
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled *bool `pulumi:"enabled"`
 	// Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
 	Etag *string `pulumi:"etag"`
@@ -526,7 +526,7 @@ type DistributionState struct {
 	DefaultRootObject pulumi.StringPtrInput
 	// DNS domain name of either the S3 bucket, or web site of your custom origin.
 	DomainName pulumi.StringPtrInput
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled pulumi.BoolPtrInput
 	// Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
 	Etag pulumi.StringPtrInput
@@ -593,7 +593,7 @@ type distributionArgs struct {
 	DefaultCacheBehavior DistributionDefaultCacheBehavior `pulumi:"defaultCacheBehavior"`
 	// Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 	DefaultRootObject *string `pulumi:"defaultRootObject"`
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled bool `pulumi:"enabled"`
 	// Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
 	HttpVersion *string `pulumi:"httpVersion"`
@@ -639,7 +639,7 @@ type DistributionArgs struct {
 	DefaultCacheBehavior DistributionDefaultCacheBehaviorInput
 	// Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 	DefaultRootObject pulumi.StringPtrInput
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled pulumi.BoolInput
 	// Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
 	HttpVersion pulumi.StringPtrInput
@@ -803,7 +803,7 @@ func (o DistributionOutput) DomainName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Distribution) pulumi.StringOutput { return v.DomainName }).(pulumi.StringOutput)
 }
 
-// Whether Origin Shield is enabled.
+// Whether the distribution is enabled.
 func (o DistributionOutput) Enabled() pulumi.BoolOutput {
 	return o.ApplyT(func(v *Distribution) pulumi.BoolOutput { return v.Enabled }).(pulumi.BoolOutput)
 }

--- a/sdk/go/aws/cloudfront/pulumiTypes.go
+++ b/sdk/go/aws/cloudfront/pulumiTypes.go
@@ -5499,7 +5499,7 @@ func (o DistributionRestrictionsGeoRestrictionPtrOutput) RestrictionType() pulum
 }
 
 type DistributionTrustedKeyGroup struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
 	Enabled *bool `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items []DistributionTrustedKeyGroupItem `pulumi:"items"`
@@ -5517,7 +5517,7 @@ type DistributionTrustedKeyGroupInput interface {
 }
 
 type DistributionTrustedKeyGroupArgs struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
 	Enabled pulumi.BoolPtrInput `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items DistributionTrustedKeyGroupItemArrayInput `pulumi:"items"`
@@ -5574,7 +5574,7 @@ func (o DistributionTrustedKeyGroupOutput) ToDistributionTrustedKeyGroupOutputWi
 	return o
 }
 
-// Whether Origin Shield is enabled.
+// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
 func (o DistributionTrustedKeyGroupOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v DistributionTrustedKeyGroup) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
 }
@@ -5711,7 +5711,7 @@ func (o DistributionTrustedKeyGroupItemArrayOutput) Index(i pulumi.IntInput) Dis
 }
 
 type DistributionTrustedSigner struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
 	Enabled *bool `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items []DistributionTrustedSignerItem `pulumi:"items"`
@@ -5729,7 +5729,7 @@ type DistributionTrustedSignerInput interface {
 }
 
 type DistributionTrustedSignerArgs struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
 	Enabled pulumi.BoolPtrInput `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items DistributionTrustedSignerItemArrayInput `pulumi:"items"`
@@ -5786,7 +5786,7 @@ func (o DistributionTrustedSignerOutput) ToDistributionTrustedSignerOutputWithCo
 	return o
 }
 
-// Whether Origin Shield is enabled.
+// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
 func (o DistributionTrustedSignerOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v DistributionTrustedSigner) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/Distribution.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/Distribution.java
@@ -474,14 +474,14 @@ public class Distribution extends com.pulumi.resources.CustomResource {
         return this.domainName;
     }
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      * 
      */
     @Export(name="enabled", refs={Boolean.class}, tree="[0]")
     private Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return Whether the distribution is enabled.
      * 
      */
     public Output<Boolean> enabled() {

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/DistributionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/DistributionArgs.java
@@ -117,14 +117,14 @@ public final class DistributionArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      * 
      */
     @Import(name="enabled", required=true)
     private Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return Whether the distribution is enabled.
      * 
      */
     public Output<Boolean> enabled() {
@@ -532,7 +532,7 @@ public final class DistributionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 
@@ -543,7 +543,7 @@ public final class DistributionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionState.java
@@ -165,14 +165,14 @@ public final class DistributionState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      * 
      */
     @Import(name="enabled")
     private @Nullable Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return Whether the distribution is enabled.
      * 
      */
     public Optional<Output<Boolean>> enabled() {
@@ -782,7 +782,7 @@ public final class DistributionState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 
@@ -793,7 +793,7 @@ public final class DistributionState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedKeyGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedKeyGroupArgs.java
@@ -18,14 +18,14 @@ public final class DistributionTrustedKeyGroupArgs extends com.pulumi.resources.
     public static final DistributionTrustedKeyGroupArgs Empty = new DistributionTrustedKeyGroupArgs();
 
     /**
-     * Whether Origin Shield is enabled.
+     * This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     @Import(name="enabled")
     private @Nullable Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     public Optional<Output<Boolean>> enabled() {
@@ -73,7 +73,7 @@ public final class DistributionTrustedKeyGroupArgs extends com.pulumi.resources.
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          * 
          * @return builder
          * 
@@ -84,7 +84,7 @@ public final class DistributionTrustedKeyGroupArgs extends com.pulumi.resources.
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedSignerArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedSignerArgs.java
@@ -18,14 +18,14 @@ public final class DistributionTrustedSignerArgs extends com.pulumi.resources.Re
     public static final DistributionTrustedSignerArgs Empty = new DistributionTrustedSignerArgs();
 
     /**
-     * Whether Origin Shield is enabled.
+     * This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     @Import(name="enabled")
     private @Nullable Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     public Optional<Output<Boolean>> enabled() {
@@ -73,7 +73,7 @@ public final class DistributionTrustedSignerArgs extends com.pulumi.resources.Re
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          * 
          * @return builder
          * 
@@ -84,7 +84,7 @@ public final class DistributionTrustedSignerArgs extends com.pulumi.resources.Re
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedKeyGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedKeyGroup.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class DistributionTrustedKeyGroup {
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     private @Nullable Boolean enabled;
@@ -26,7 +26,7 @@ public final class DistributionTrustedKeyGroup {
 
     private DistributionTrustedKeyGroup() {}
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     public Optional<Boolean> enabled() {

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedSigner.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedSigner.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class DistributionTrustedSigner {
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     private @Nullable Boolean enabled;
@@ -26,7 +26,7 @@ public final class DistributionTrustedSigner {
 
     private DistributionTrustedSigner() {}
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     public Optional<Boolean> enabled() {

--- a/sdk/nodejs/cloudfront/distribution.ts
+++ b/sdk/nodejs/cloudfront/distribution.ts
@@ -319,7 +319,7 @@ export class Distribution extends pulumi.CustomResource {
      */
     public /*out*/ readonly domainName!: pulumi.Output<string>;
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      */
     public readonly enabled!: pulumi.Output<boolean>;
     /**
@@ -556,7 +556,7 @@ export interface DistributionState {
      */
     domainName?: pulumi.Input<string>;
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      */
     enabled?: pulumi.Input<boolean>;
     /**
@@ -680,7 +680,7 @@ export interface DistributionArgs {
      */
     defaultRootObject?: pulumi.Input<string>;
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      */
     enabled: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -10329,7 +10329,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedKeyGroup {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          */
         enabled?: pulumi.Input<boolean>;
         /**
@@ -10351,7 +10351,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedSigner {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          */
         enabled?: pulumi.Input<boolean>;
         /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -11860,7 +11860,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedKeyGroup {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          */
         enabled: boolean;
         /**
@@ -11882,7 +11882,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedSigner {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          */
         enabled: boolean;
         /**

--- a/sdk/python/pulumi_aws/cloudfront/_inputs.py
+++ b/sdk/python/pulumi_aws/cloudfront/_inputs.py
@@ -2213,7 +2213,7 @@ class DistributionTrustedKeyGroupArgs:
                  enabled: Optional[pulumi.Input[bool]] = None,
                  items: Optional[pulumi.Input[Sequence[pulumi.Input['DistributionTrustedKeyGroupItemArgs']]]] = None):
         """
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         :param pulumi.Input[Sequence[pulumi.Input['DistributionTrustedKeyGroupItemArgs']]] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2225,7 +2225,7 @@ class DistributionTrustedKeyGroupArgs:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 
@@ -2291,7 +2291,7 @@ class DistributionTrustedSignerArgs:
                  enabled: Optional[pulumi.Input[bool]] = None,
                  items: Optional[pulumi.Input[Sequence[pulumi.Input['DistributionTrustedSignerItemArgs']]]] = None):
         """
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         :param pulumi.Input[Sequence[pulumi.Input['DistributionTrustedSignerItemArgs']]] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2303,7 +2303,7 @@ class DistributionTrustedSignerArgs:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 

--- a/sdk/python/pulumi_aws/cloudfront/distribution.py
+++ b/sdk/python/pulumi_aws/cloudfront/distribution.py
@@ -40,7 +40,7 @@ class DistributionArgs:
         """
         The set of arguments for constructing a Distribution resource.
         :param pulumi.Input['DistributionDefaultCacheBehaviorArgs'] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[Sequence[pulumi.Input['DistributionOriginArgs']]] origins: One or more origins for this distribution (multiples allowed).
         :param pulumi.Input['DistributionRestrictionsArgs'] restrictions: The restriction configuration for this distribution (maximum one).
         :param pulumi.Input['DistributionViewerCertificateArgs'] viewer_certificate: The SSL configuration for this distribution (maximum one).
@@ -115,7 +115,7 @@ class DistributionArgs:
     @pulumi.getter
     def enabled(self) -> pulumi.Input[bool]:
         """
-        Whether Origin Shield is enabled.
+        Whether the distribution is enabled.
         """
         return pulumi.get(self, "enabled")
 
@@ -398,7 +398,7 @@ class _DistributionState:
         :param pulumi.Input['DistributionDefaultCacheBehaviorArgs'] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
         :param pulumi.Input[str] default_root_object: Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
         :param pulumi.Input[str] domain_name: DNS domain name of either the S3 bucket, or web site of your custom origin.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[str] etag: Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
         :param pulumi.Input[str] hosted_zone_id: CloudFront Route 53 zone ID that can be used to route an [Alias Resource Record Set](http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html) to. This attribute is simply an alias for the zone ID `Z2FDTNDATAQYW2`.
         :param pulumi.Input[str] http_version: Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
@@ -602,7 +602,7 @@ class _DistributionState:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
-        Whether Origin Shield is enabled.
+        Whether the distribution is enabled.
         """
         return pulumi.get(self, "enabled")
 
@@ -1156,7 +1156,7 @@ class Distribution(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DistributionCustomErrorResponseArgs']]]] custom_error_responses: One or more custom error response elements (multiples allowed).
         :param pulumi.Input[pulumi.InputType['DistributionDefaultCacheBehaviorArgs']] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
         :param pulumi.Input[str] default_root_object: Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[str] http_version: Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
         :param pulumi.Input[bool] is_ipv6_enabled: Whether the IPv6 is enabled for the distribution.
         :param pulumi.Input[pulumi.InputType['DistributionLoggingConfigArgs']] logging_config: The logging configuration that controls how logs are written to your distribution (maximum one).
@@ -1568,7 +1568,7 @@ class Distribution(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['DistributionDefaultCacheBehaviorArgs']] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
         :param pulumi.Input[str] default_root_object: Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
         :param pulumi.Input[str] domain_name: DNS domain name of either the S3 bucket, or web site of your custom origin.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[str] etag: Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
         :param pulumi.Input[str] hosted_zone_id: CloudFront Route 53 zone ID that can be used to route an [Alias Resource Record Set](http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html) to. This attribute is simply an alias for the zone ID `Z2FDTNDATAQYW2`.
         :param pulumi.Input[str] http_version: Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
@@ -1706,7 +1706,7 @@ class Distribution(pulumi.CustomResource):
     @pulumi.getter
     def enabled(self) -> pulumi.Output[bool]:
         """
-        Whether Origin Shield is enabled.
+        Whether the distribution is enabled.
         """
         return pulumi.get(self, "enabled")
 

--- a/sdk/python/pulumi_aws/cloudfront/outputs.py
+++ b/sdk/python/pulumi_aws/cloudfront/outputs.py
@@ -2370,7 +2370,7 @@ class DistributionTrustedKeyGroup(dict):
                  enabled: Optional[bool] = None,
                  items: Optional[Sequence['outputs.DistributionTrustedKeyGroupItem']] = None):
         """
-        :param bool enabled: Whether Origin Shield is enabled.
+        :param bool enabled: This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         :param Sequence['DistributionTrustedKeyGroupItemArgs'] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2382,7 +2382,7 @@ class DistributionTrustedKeyGroup(dict):
     @pulumi.getter
     def enabled(self) -> Optional[bool]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 
@@ -2451,7 +2451,7 @@ class DistributionTrustedSigner(dict):
                  enabled: Optional[bool] = None,
                  items: Optional[Sequence['outputs.DistributionTrustedSignerItem']] = None):
         """
-        :param bool enabled: Whether Origin Shield is enabled.
+        :param bool enabled: This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         :param Sequence['DistributionTrustedSignerItemArgs'] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2463,7 +2463,7 @@ class DistributionTrustedSigner(dict):
     @pulumi.getter
     def enabled(self) -> Optional[bool]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 


### PR DESCRIPTION
Fixes CloudFront documentation accross SDKs for enabled, trusted sgner and trusted key group.

I took comments from [TrustedSigners](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_TrustedSigners.html) and [TrustedKeyGroups](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_TrustedKeyGroups.html) API reference, feel free to edit it as per your conventions.