### PR TITLE
Correct CloudFront functions available runtimes

### DIFF
--- a/sdk/dotnet/CloudFront/Distribution.cs
+++ b/sdk/dotnet/CloudFront/Distribution.cs
@@ -400,7 +400,7 @@ namespace Pulumi.Aws.CloudFront
         public Output<string> DomainName { get; private set; } = null!;
 
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// Whether the distribution is enabled.
         /// </summary>
         [Output("enabled")]
         public Output<bool> Enabled { get; private set; } = null!;
@@ -636,7 +636,7 @@ namespace Pulumi.Aws.CloudFront
         public Input<string>? DefaultRootObject { get; set; }
 
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// Whether the distribution is enabled.
         /// </summary>
         [Input("enabled", required: true)]
         public Input<bool> Enabled { get; set; } = null!;
@@ -824,7 +824,7 @@ namespace Pulumi.Aws.CloudFront
         public Input<string>? DomainName { get; set; }
 
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// Whether the distribution is enabled.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Function.cs
+++ b/sdk/dotnet/CloudFront/Function.cs
@@ -11,22 +11,22 @@ namespace Pulumi.Aws.CloudFront
 {
     /// <summary>
     /// Provides a CloudFront Function resource. With CloudFront Functions in Amazon CloudFront, you can write lightweight functions in JavaScript for high-scale, latency-sensitive CDN customizations.
-    /// 
+    ///
     /// See [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
-    /// 
+    ///
     /// &gt; **NOTE:** You cannot delete a function if it’s associated with a cache behavior. First, update your distributions to remove the function association from all cache behaviors, then delete the function.
-    /// 
+    ///
     /// ## Example Usage
     /// ### Basic Example
-    /// 
+    ///
     /// ```csharp
     /// using System.Collections.Generic;
     /// using System.IO;
     /// using System.Linq;
     /// using Pulumi;
     /// using Aws = Pulumi.Aws;
-    /// 
-    /// return await Deployment.RunAsync(() =&gt; 
+    ///
+    /// return await Deployment.RunAsync(() =&gt;
     /// {
     ///     var test = new Aws.CloudFront.Function("test", new()
     ///     {
@@ -35,14 +35,14 @@ namespace Pulumi.Aws.CloudFront
     ///         Publish = true,
     ///         Code = File.ReadAllText($"{path.Module}/function.js"),
     ///     });
-    /// 
+    ///
     /// });
     /// ```
-    /// 
+    ///
     /// ## Import
-    /// 
+    ///
     /// Using `pulumi import`, import CloudFront Functions using the `name`. For example:
-    /// 
+    ///
     /// ```sh
     ///  $ pulumi import aws:cloudfront/function:Function test my_test_function
     /// ```
@@ -93,8 +93,8 @@ namespace Pulumi.Aws.CloudFront
         public Output<bool?> Publish { get; private set; } = null!;
 
         /// <summary>
-        /// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-        /// 
+        /// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+        ///
         /// The following arguments are optional:
         /// </summary>
         [Output("runtime")]
@@ -177,8 +177,8 @@ namespace Pulumi.Aws.CloudFront
         public Input<bool>? Publish { get; set; }
 
         /// <summary>
-        /// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-        /// 
+        /// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+        ///
         /// The following arguments are optional:
         /// </summary>
         [Input("runtime", required: true)]
@@ -235,8 +235,8 @@ namespace Pulumi.Aws.CloudFront
         public Input<bool>? Publish { get; set; }
 
         /// <summary>
-        /// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-        /// 
+        /// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+        ///
         /// The following arguments are optional:
         /// </summary>
         [Input("runtime")]

--- a/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupArgs.cs
+++ b/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.CloudFront.Inputs
     public sealed class DistributionTrustedKeyGroupArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupGetArgs.cs
+++ b/sdk/dotnet/CloudFront/Inputs/DistributionTrustedKeyGroupGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.CloudFront.Inputs
     public sealed class DistributionTrustedKeyGroupGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Inputs/DistributionTrustedSignerGetArgs.cs
+++ b/sdk/dotnet/CloudFront/Inputs/DistributionTrustedSignerGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.CloudFront.Inputs
     public sealed class DistributionTrustedSignerGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/CloudFront/Outputs/DistributionTrustedKeyGroup.cs
+++ b/sdk/dotnet/CloudFront/Outputs/DistributionTrustedKeyGroup.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.CloudFront.Outputs
     public sealed class DistributionTrustedKeyGroup
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         /// </summary>
         public readonly bool? Enabled;
         /// <summary>

--- a/sdk/dotnet/CloudFront/Outputs/DistributionTrustedSigner.cs
+++ b/sdk/dotnet/CloudFront/Outputs/DistributionTrustedSigner.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.CloudFront.Outputs
     public sealed class DistributionTrustedSigner
     {
         /// <summary>
-        /// Whether Origin Shield is enabled.
+        /// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         /// </summary>
         public readonly bool? Enabled;
         /// <summary>

--- a/sdk/go/aws/cloudfront/distribution.go
+++ b/sdk/go/aws/cloudfront/distribution.go
@@ -340,7 +340,7 @@ type Distribution struct {
 	DefaultRootObject pulumi.StringPtrOutput `pulumi:"defaultRootObject"`
 	// DNS domain name of either the S3 bucket, or web site of your custom origin.
 	DomainName pulumi.StringOutput `pulumi:"domainName"`
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled pulumi.BoolOutput `pulumi:"enabled"`
 	// Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
 	Etag pulumi.StringOutput `pulumi:"etag"`
@@ -457,7 +457,7 @@ type distributionState struct {
 	DefaultRootObject *string `pulumi:"defaultRootObject"`
 	// DNS domain name of either the S3 bucket, or web site of your custom origin.
 	DomainName *string `pulumi:"domainName"`
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled *bool `pulumi:"enabled"`
 	// Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
 	Etag *string `pulumi:"etag"`
@@ -526,7 +526,7 @@ type DistributionState struct {
 	DefaultRootObject pulumi.StringPtrInput
 	// DNS domain name of either the S3 bucket, or web site of your custom origin.
 	DomainName pulumi.StringPtrInput
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled pulumi.BoolPtrInput
 	// Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
 	Etag pulumi.StringPtrInput
@@ -593,7 +593,7 @@ type distributionArgs struct {
 	DefaultCacheBehavior DistributionDefaultCacheBehavior `pulumi:"defaultCacheBehavior"`
 	// Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 	DefaultRootObject *string `pulumi:"defaultRootObject"`
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled bool `pulumi:"enabled"`
 	// Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
 	HttpVersion *string `pulumi:"httpVersion"`
@@ -639,7 +639,7 @@ type DistributionArgs struct {
 	DefaultCacheBehavior DistributionDefaultCacheBehaviorInput
 	// Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 	DefaultRootObject pulumi.StringPtrInput
-	// Whether Origin Shield is enabled.
+	// Whether the distribution is enabled.
 	Enabled pulumi.BoolInput
 	// Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
 	HttpVersion pulumi.StringPtrInput
@@ -803,7 +803,7 @@ func (o DistributionOutput) DomainName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Distribution) pulumi.StringOutput { return v.DomainName }).(pulumi.StringOutput)
 }
 
-// Whether Origin Shield is enabled.
+// Whether the distribution is enabled.
 func (o DistributionOutput) Enabled() pulumi.BoolOutput {
 	return o.ApplyT(func(v *Distribution) pulumi.BoolOutput { return v.Enabled }).(pulumi.BoolOutput)
 }

--- a/sdk/go/aws/cloudfront/function.go
+++ b/sdk/go/aws/cloudfront/function.go
@@ -85,7 +85,7 @@ type Function struct {
 	Name pulumi.StringOutput `pulumi:"name"`
 	// Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
 	Publish pulumi.BoolPtrOutput `pulumi:"publish"`
-	// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+	// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 	//
 	// The following arguments are optional:
 	Runtime pulumi.StringOutput `pulumi:"runtime"`
@@ -143,7 +143,7 @@ type functionState struct {
 	Name *string `pulumi:"name"`
 	// Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
 	Publish *bool `pulumi:"publish"`
-	// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+	// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 	//
 	// The following arguments are optional:
 	Runtime *string `pulumi:"runtime"`
@@ -166,7 +166,7 @@ type FunctionState struct {
 	Name pulumi.StringPtrInput
 	// Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
 	Publish pulumi.BoolPtrInput
-	// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+	// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 	//
 	// The following arguments are optional:
 	Runtime pulumi.StringPtrInput
@@ -187,7 +187,7 @@ type functionArgs struct {
 	Name *string `pulumi:"name"`
 	// Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
 	Publish *bool `pulumi:"publish"`
-	// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+	// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 	//
 	// The following arguments are optional:
 	Runtime string `pulumi:"runtime"`
@@ -203,7 +203,7 @@ type FunctionArgs struct {
 	Name pulumi.StringPtrInput
 	// Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
 	Publish pulumi.BoolPtrInput
-	// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+	// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 	//
 	// The following arguments are optional:
 	Runtime pulumi.StringInput
@@ -331,7 +331,7 @@ func (o FunctionOutput) Publish() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Function) pulumi.BoolPtrOutput { return v.Publish }).(pulumi.BoolPtrOutput)
 }
 
-// Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+// Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 //
 // The following arguments are optional:
 func (o FunctionOutput) Runtime() pulumi.StringOutput {

--- a/sdk/go/aws/cloudfront/pulumiTypes.go
+++ b/sdk/go/aws/cloudfront/pulumiTypes.go
@@ -5499,7 +5499,7 @@ func (o DistributionRestrictionsGeoRestrictionPtrOutput) RestrictionType() pulum
 }
 
 type DistributionTrustedKeyGroup struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
 	Enabled *bool `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items []DistributionTrustedKeyGroupItem `pulumi:"items"`
@@ -5517,7 +5517,7 @@ type DistributionTrustedKeyGroupInput interface {
 }
 
 type DistributionTrustedKeyGroupArgs struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
 	Enabled pulumi.BoolPtrInput `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items DistributionTrustedKeyGroupItemArrayInput `pulumi:"items"`
@@ -5574,7 +5574,7 @@ func (o DistributionTrustedKeyGroupOutput) ToDistributionTrustedKeyGroupOutputWi
 	return o
 }
 
-// Whether Origin Shield is enabled.
+// This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
 func (o DistributionTrustedKeyGroupOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v DistributionTrustedKeyGroup) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
 }
@@ -5711,7 +5711,7 @@ func (o DistributionTrustedKeyGroupItemArrayOutput) Index(i pulumi.IntInput) Dis
 }
 
 type DistributionTrustedSigner struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
 	Enabled *bool `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items []DistributionTrustedSignerItem `pulumi:"items"`
@@ -5729,7 +5729,7 @@ type DistributionTrustedSignerInput interface {
 }
 
 type DistributionTrustedSignerArgs struct {
-	// Whether Origin Shield is enabled.
+	// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
 	Enabled pulumi.BoolPtrInput `pulumi:"enabled"`
 	// List of nested attributes for each trusted signer
 	Items DistributionTrustedSignerItemArrayInput `pulumi:"items"`
@@ -5786,7 +5786,7 @@ func (o DistributionTrustedSignerOutput) ToDistributionTrustedSignerOutputWithCo
 	return o
 }
 
-// Whether Origin Shield is enabled.
+// This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
 func (o DistributionTrustedSignerOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v DistributionTrustedSigner) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/Distribution.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/Distribution.java
@@ -474,14 +474,14 @@ public class Distribution extends com.pulumi.resources.CustomResource {
         return this.domainName;
     }
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      * 
      */
     @Export(name="enabled", refs={Boolean.class}, tree="[0]")
     private Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return Whether the distribution is enabled.
      * 
      */
     public Output<Boolean> enabled() {

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/DistributionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/DistributionArgs.java
@@ -117,14 +117,14 @@ public final class DistributionArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      * 
      */
     @Import(name="enabled", required=true)
     private Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return Whether the distribution is enabled.
      * 
      */
     public Output<Boolean> enabled() {
@@ -532,7 +532,7 @@ public final class DistributionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 
@@ -543,7 +543,7 @@ public final class DistributionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/Function.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/Function.java
@@ -17,16 +17,16 @@ import javax.annotation.Nullable;
 
 /**
  * Provides a CloudFront Function resource. With CloudFront Functions in Amazon CloudFront, you can write lightweight functions in JavaScript for high-scale, latency-sensitive CDN customizations.
- * 
+ *
  * See [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
- * 
+ *
  * &gt; **NOTE:** You cannot delete a function if it’s associated with a cache behavior. First, update your distributions to remove the function association from all cache behaviors, then delete the function.
- * 
+ *
  * ## Example Usage
  * ### Basic Example
  * ```java
  * package generated_program;
- * 
+ *
  * import com.pulumi.Context;
  * import com.pulumi.Pulumi;
  * import com.pulumi.core.Output;
@@ -38,161 +38,161 @@ import javax.annotation.Nullable;
  * import java.io.File;
  * import java.nio.file.Files;
  * import java.nio.file.Paths;
- * 
+ *
  * public class App {
  *     public static void main(String[] args) {
  *         Pulumi.run(App::stack);
  *     }
- * 
+ *
  *     public static void stack(Context ctx) {
- *         var test = new Function(&#34;test&#34;, FunctionArgs.builder()        
+ *         var test = new Function(&#34;test&#34;, FunctionArgs.builder()
  *             .runtime(&#34;cloudfront-js-1.0&#34;)
  *             .comment(&#34;my function&#34;)
  *             .publish(true)
  *             .code(Files.readString(Paths.get(String.format(&#34;%s/function.js&#34;, path.module()))))
  *             .build());
- * 
+ *
  *     }
  * }
  * ```
- * 
+ *
  * ## Import
- * 
+ *
  * Using `pulumi import`, import CloudFront Functions using the `name`. For example:
- * 
+ *
  * ```sh
  *  $ pulumi import aws:cloudfront/function:Function test my_test_function
  * ```
- * 
+ *
  */
 @ResourceType(type="aws:cloudfront/function:Function")
 public class Function extends com.pulumi.resources.CustomResource {
     /**
      * Amazon Resource Name (ARN) identifying your CloudFront Function.
-     * 
+     *
      */
     @Export(name="arn", refs={String.class}, tree="[0]")
     private Output<String> arn;
 
     /**
      * @return Amazon Resource Name (ARN) identifying your CloudFront Function.
-     * 
+     *
      */
     public Output<String> arn() {
         return this.arn;
     }
     /**
      * Source code of the function
-     * 
+     *
      */
     @Export(name="code", refs={String.class}, tree="[0]")
     private Output<String> code;
 
     /**
      * @return Source code of the function
-     * 
+     *
      */
     public Output<String> code() {
         return this.code;
     }
     /**
      * Comment.
-     * 
+     *
      */
     @Export(name="comment", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> comment;
 
     /**
      * @return Comment.
-     * 
+     *
      */
     public Output<Optional<String>> comment() {
         return Codegen.optional(this.comment);
     }
     /**
      * ETag hash of the function. This is the value for the `DEVELOPMENT` stage of the function.
-     * 
+     *
      */
     @Export(name="etag", refs={String.class}, tree="[0]")
     private Output<String> etag;
 
     /**
      * @return ETag hash of the function. This is the value for the `DEVELOPMENT` stage of the function.
-     * 
+     *
      */
     public Output<String> etag() {
         return this.etag;
     }
     /**
      * ETag hash of any `LIVE` stage of the function.
-     * 
+     *
      */
     @Export(name="liveStageEtag", refs={String.class}, tree="[0]")
     private Output<String> liveStageEtag;
 
     /**
      * @return ETag hash of any `LIVE` stage of the function.
-     * 
+     *
      */
     public Output<String> liveStageEtag() {
         return this.liveStageEtag;
     }
     /**
      * Unique name for your CloudFront Function.
-     * 
+     *
      */
     @Export(name="name", refs={String.class}, tree="[0]")
     private Output<String> name;
 
     /**
      * @return Unique name for your CloudFront Function.
-     * 
+     *
      */
     public Output<String> name() {
         return this.name;
     }
     /**
      * Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-     * 
+     *
      */
     @Export(name="publish", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> publish;
 
     /**
      * @return Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-     * 
+     *
      */
     public Output<Optional<Boolean>> publish() {
         return Codegen.optional(this.publish);
     }
     /**
-     * Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-     * 
+     * Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+     *
      * The following arguments are optional:
-     * 
+     *
      */
     @Export(name="runtime", refs={String.class}, tree="[0]")
     private Output<String> runtime;
 
     /**
-     * @return Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-     * 
+     * @return Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+     *
      * The following arguments are optional:
-     * 
+     *
      */
     public Output<String> runtime() {
         return this.runtime;
     }
     /**
      * Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
-     * 
+     *
      */
     @Export(name="status", refs={String.class}, tree="[0]")
     private Output<String> status;
 
     /**
      * @return Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
-     * 
+     *
      */
     public Output<String> status() {
         return this.status;

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/FunctionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/FunctionArgs.java
@@ -18,14 +18,14 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Source code of the function
-     * 
+     *
      */
     @Import(name="code", required=true)
     private Output<String> code;
 
     /**
      * @return Source code of the function
-     * 
+     *
      */
     public Output<String> code() {
         return this.code;
@@ -33,14 +33,14 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Comment.
-     * 
+     *
      */
     @Import(name="comment")
     private @Nullable Output<String> comment;
 
     /**
      * @return Comment.
-     * 
+     *
      */
     public Optional<Output<String>> comment() {
         return Optional.ofNullable(this.comment);
@@ -48,14 +48,14 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Unique name for your CloudFront Function.
-     * 
+     *
      */
     @Import(name="name")
     private @Nullable Output<String> name;
 
     /**
      * @return Unique name for your CloudFront Function.
-     * 
+     *
      */
     public Optional<Output<String>> name() {
         return Optional.ofNullable(this.name);
@@ -63,33 +63,33 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-     * 
+     *
      */
     @Import(name="publish")
     private @Nullable Output<Boolean> publish;
 
     /**
      * @return Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-     * 
+     *
      */
     public Optional<Output<Boolean>> publish() {
         return Optional.ofNullable(this.publish);
     }
 
     /**
-     * Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-     * 
+     * Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+     *
      * The following arguments are optional:
-     * 
+     *
      */
     @Import(name="runtime", required=true)
     private Output<String> runtime;
 
     /**
-     * @return Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-     * 
+     * @return Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+     *
      * The following arguments are optional:
-     * 
+     *
      */
     public Output<String> runtime() {
         return this.runtime;
@@ -125,9 +125,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param code Source code of the function
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder code(Output<String> code) {
             $.code = code;
@@ -136,9 +136,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param code Source code of the function
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder code(String code) {
             return code(Output.of(code));
@@ -146,9 +146,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param comment Comment.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder comment(@Nullable Output<String> comment) {
             $.comment = comment;
@@ -157,9 +157,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param comment Comment.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder comment(String comment) {
             return comment(Output.of(comment));
@@ -167,9 +167,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param name Unique name for your CloudFront Function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder name(@Nullable Output<String> name) {
             $.name = name;
@@ -178,9 +178,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param name Unique name for your CloudFront Function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder name(String name) {
             return name(Output.of(name));
@@ -188,9 +188,9 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param publish Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder publish(@Nullable Output<Boolean> publish) {
             $.publish = publish;
@@ -199,21 +199,21 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param publish Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder publish(Boolean publish) {
             return publish(Output.of(publish));
         }
 
         /**
-         * @param runtime Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-         * 
+         * @param runtime Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+         *
          * The following arguments are optional:
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder runtime(Output<String> runtime) {
             $.runtime = runtime;
@@ -221,12 +221,12 @@ public final class FunctionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param runtime Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-         * 
+         * @param runtime Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+         *
          * The following arguments are optional:
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder runtime(String runtime) {
             return runtime(Output.of(runtime));

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionState.java
@@ -165,14 +165,14 @@ public final class DistributionState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      * 
      */
     @Import(name="enabled")
     private @Nullable Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return Whether the distribution is enabled.
      * 
      */
     public Optional<Output<Boolean>> enabled() {
@@ -782,7 +782,7 @@ public final class DistributionState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 
@@ -793,7 +793,7 @@ public final class DistributionState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled Whether the distribution is enabled.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedKeyGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedKeyGroupArgs.java
@@ -18,14 +18,14 @@ public final class DistributionTrustedKeyGroupArgs extends com.pulumi.resources.
     public static final DistributionTrustedKeyGroupArgs Empty = new DistributionTrustedKeyGroupArgs();
 
     /**
-     * Whether Origin Shield is enabled.
+     * This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     @Import(name="enabled")
     private @Nullable Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     public Optional<Output<Boolean>> enabled() {
@@ -73,7 +73,7 @@ public final class DistributionTrustedKeyGroupArgs extends com.pulumi.resources.
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          * 
          * @return builder
          * 
@@ -84,7 +84,7 @@ public final class DistributionTrustedKeyGroupArgs extends com.pulumi.resources.
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedSignerArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/DistributionTrustedSignerArgs.java
@@ -18,14 +18,14 @@ public final class DistributionTrustedSignerArgs extends com.pulumi.resources.Re
     public static final DistributionTrustedSignerArgs Empty = new DistributionTrustedSignerArgs();
 
     /**
-     * Whether Origin Shield is enabled.
+     * This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     @Import(name="enabled")
     private @Nullable Output<Boolean> enabled;
 
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     public Optional<Output<Boolean>> enabled() {
@@ -73,7 +73,7 @@ public final class DistributionTrustedSignerArgs extends com.pulumi.resources.Re
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          * 
          * @return builder
          * 
@@ -84,7 +84,7 @@ public final class DistributionTrustedSignerArgs extends com.pulumi.resources.Re
         }
 
         /**
-         * @param enabled Whether Origin Shield is enabled.
+         * @param enabled This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/FunctionState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/inputs/FunctionState.java
@@ -18,14 +18,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Amazon Resource Name (ARN) identifying your CloudFront Function.
-     * 
+     *
      */
     @Import(name="arn")
     private @Nullable Output<String> arn;
 
     /**
      * @return Amazon Resource Name (ARN) identifying your CloudFront Function.
-     * 
+     *
      */
     public Optional<Output<String>> arn() {
         return Optional.ofNullable(this.arn);
@@ -33,14 +33,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Source code of the function
-     * 
+     *
      */
     @Import(name="code")
     private @Nullable Output<String> code;
 
     /**
      * @return Source code of the function
-     * 
+     *
      */
     public Optional<Output<String>> code() {
         return Optional.ofNullable(this.code);
@@ -48,14 +48,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Comment.
-     * 
+     *
      */
     @Import(name="comment")
     private @Nullable Output<String> comment;
 
     /**
      * @return Comment.
-     * 
+     *
      */
     public Optional<Output<String>> comment() {
         return Optional.ofNullable(this.comment);
@@ -63,14 +63,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * ETag hash of the function. This is the value for the `DEVELOPMENT` stage of the function.
-     * 
+     *
      */
     @Import(name="etag")
     private @Nullable Output<String> etag;
 
     /**
      * @return ETag hash of the function. This is the value for the `DEVELOPMENT` stage of the function.
-     * 
+     *
      */
     public Optional<Output<String>> etag() {
         return Optional.ofNullable(this.etag);
@@ -78,14 +78,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * ETag hash of any `LIVE` stage of the function.
-     * 
+     *
      */
     @Import(name="liveStageEtag")
     private @Nullable Output<String> liveStageEtag;
 
     /**
      * @return ETag hash of any `LIVE` stage of the function.
-     * 
+     *
      */
     public Optional<Output<String>> liveStageEtag() {
         return Optional.ofNullable(this.liveStageEtag);
@@ -93,14 +93,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Unique name for your CloudFront Function.
-     * 
+     *
      */
     @Import(name="name")
     private @Nullable Output<String> name;
 
     /**
      * @return Unique name for your CloudFront Function.
-     * 
+     *
      */
     public Optional<Output<String>> name() {
         return Optional.ofNullable(this.name);
@@ -108,33 +108,33 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-     * 
+     *
      */
     @Import(name="publish")
     private @Nullable Output<Boolean> publish;
 
     /**
      * @return Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-     * 
+     *
      */
     public Optional<Output<Boolean>> publish() {
         return Optional.ofNullable(this.publish);
     }
 
     /**
-     * Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-     * 
+     * Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+     *
      * The following arguments are optional:
-     * 
+     *
      */
     @Import(name="runtime")
     private @Nullable Output<String> runtime;
 
     /**
-     * @return Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-     * 
+     * @return Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+     *
      * The following arguments are optional:
-     * 
+     *
      */
     public Optional<Output<String>> runtime() {
         return Optional.ofNullable(this.runtime);
@@ -142,14 +142,14 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
-     * 
+     *
      */
     @Import(name="status")
     private @Nullable Output<String> status;
 
     /**
      * @return Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
-     * 
+     *
      */
     public Optional<Output<String>> status() {
         return Optional.ofNullable(this.status);
@@ -189,9 +189,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param arn Amazon Resource Name (ARN) identifying your CloudFront Function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder arn(@Nullable Output<String> arn) {
             $.arn = arn;
@@ -200,9 +200,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param arn Amazon Resource Name (ARN) identifying your CloudFront Function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder arn(String arn) {
             return arn(Output.of(arn));
@@ -210,9 +210,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param code Source code of the function
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder code(@Nullable Output<String> code) {
             $.code = code;
@@ -221,9 +221,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param code Source code of the function
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder code(String code) {
             return code(Output.of(code));
@@ -231,9 +231,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param comment Comment.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder comment(@Nullable Output<String> comment) {
             $.comment = comment;
@@ -242,9 +242,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param comment Comment.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder comment(String comment) {
             return comment(Output.of(comment));
@@ -252,9 +252,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param etag ETag hash of the function. This is the value for the `DEVELOPMENT` stage of the function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder etag(@Nullable Output<String> etag) {
             $.etag = etag;
@@ -263,9 +263,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param etag ETag hash of the function. This is the value for the `DEVELOPMENT` stage of the function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder etag(String etag) {
             return etag(Output.of(etag));
@@ -273,9 +273,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param liveStageEtag ETag hash of any `LIVE` stage of the function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder liveStageEtag(@Nullable Output<String> liveStageEtag) {
             $.liveStageEtag = liveStageEtag;
@@ -284,9 +284,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param liveStageEtag ETag hash of any `LIVE` stage of the function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder liveStageEtag(String liveStageEtag) {
             return liveStageEtag(Output.of(liveStageEtag));
@@ -294,9 +294,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param name Unique name for your CloudFront Function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder name(@Nullable Output<String> name) {
             $.name = name;
@@ -305,9 +305,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param name Unique name for your CloudFront Function.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder name(String name) {
             return name(Output.of(name));
@@ -315,9 +315,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param publish Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder publish(@Nullable Output<Boolean> publish) {
             $.publish = publish;
@@ -326,21 +326,21 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param publish Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder publish(Boolean publish) {
             return publish(Output.of(publish));
         }
 
         /**
-         * @param runtime Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-         * 
+         * @param runtime Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+         *
          * The following arguments are optional:
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder runtime(@Nullable Output<String> runtime) {
             $.runtime = runtime;
@@ -348,12 +348,12 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param runtime Identifier of the function&#39;s runtime. Currently only `cloudfront-js-1.0` is valid.
-         * 
+         * @param runtime Identifier of the function&#39;s runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+         *
          * The following arguments are optional:
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder runtime(String runtime) {
             return runtime(Output.of(runtime));
@@ -361,9 +361,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param status Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder status(@Nullable Output<String> status) {
             $.status = status;
@@ -372,9 +372,9 @@ public final class FunctionState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param status Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder status(String status) {
             return status(Output.of(status));

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedKeyGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedKeyGroup.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class DistributionTrustedKeyGroup {
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     private @Nullable Boolean enabled;
@@ -26,7 +26,7 @@ public final class DistributionTrustedKeyGroup {
 
     private DistributionTrustedKeyGroup() {}
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
      * 
      */
     public Optional<Boolean> enabled() {

--- a/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedSigner.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/cloudfront/outputs/DistributionTrustedSigner.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class DistributionTrustedSigner {
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     private @Nullable Boolean enabled;
@@ -26,7 +26,7 @@ public final class DistributionTrustedSigner {
 
     private DistributionTrustedSigner() {}
     /**
-     * @return Whether Origin Shield is enabled.
+     * @return This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
      * 
      */
     public Optional<Boolean> enabled() {

--- a/sdk/nodejs/cloudfront/distribution.ts
+++ b/sdk/nodejs/cloudfront/distribution.ts
@@ -319,7 +319,7 @@ export class Distribution extends pulumi.CustomResource {
      */
     public /*out*/ readonly domainName!: pulumi.Output<string>;
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      */
     public readonly enabled!: pulumi.Output<boolean>;
     /**
@@ -556,7 +556,7 @@ export interface DistributionState {
      */
     domainName?: pulumi.Input<string>;
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      */
     enabled?: pulumi.Input<boolean>;
     /**
@@ -680,7 +680,7 @@ export interface DistributionArgs {
      */
     defaultRootObject?: pulumi.Input<string>;
     /**
-     * Whether Origin Shield is enabled.
+     * Whether the distribution is enabled.
      */
     enabled: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/cloudfront/function.ts
+++ b/sdk/nodejs/cloudfront/function.ts
@@ -92,7 +92,7 @@ export class Function extends pulumi.CustomResource {
      */
     public readonly publish!: pulumi.Output<boolean | undefined>;
     /**
-     * Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+     * Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
      *
      * The following arguments are optional:
      */
@@ -180,7 +180,7 @@ export interface FunctionState {
      */
     publish?: pulumi.Input<boolean>;
     /**
-     * Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+     * Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
      *
      * The following arguments are optional:
      */
@@ -212,7 +212,7 @@ export interface FunctionArgs {
      */
     publish?: pulumi.Input<boolean>;
     /**
-     * Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+     * Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
      *
      * The following arguments are optional:
      */

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -10329,7 +10329,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedKeyGroup {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          */
         enabled?: pulumi.Input<boolean>;
         /**
@@ -10351,7 +10351,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedSigner {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          */
         enabled?: pulumi.Input<boolean>;
         /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -11860,7 +11860,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedKeyGroup {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
          */
         enabled: boolean;
         /**
@@ -11882,7 +11882,7 @@ export namespace cloudfront {
 
     export interface DistributionTrustedSigner {
         /**
-         * Whether Origin Shield is enabled.
+         * This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
          */
         enabled: boolean;
         /**

--- a/sdk/python/pulumi_aws/cloudfront/_inputs.py
+++ b/sdk/python/pulumi_aws/cloudfront/_inputs.py
@@ -2213,7 +2213,7 @@ class DistributionTrustedKeyGroupArgs:
                  enabled: Optional[pulumi.Input[bool]] = None,
                  items: Optional[pulumi.Input[Sequence[pulumi.Input['DistributionTrustedKeyGroupItemArgs']]]] = None):
         """
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         :param pulumi.Input[Sequence[pulumi.Input['DistributionTrustedKeyGroupItemArgs']]] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2225,7 +2225,7 @@ class DistributionTrustedKeyGroupArgs:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 
@@ -2291,7 +2291,7 @@ class DistributionTrustedSignerArgs:
                  enabled: Optional[pulumi.Input[bool]] = None,
                  items: Optional[pulumi.Input[Sequence[pulumi.Input['DistributionTrustedSignerItemArgs']]]] = None):
         """
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         :param pulumi.Input[Sequence[pulumi.Input['DistributionTrustedSignerItemArgs']]] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2303,7 +2303,7 @@ class DistributionTrustedSignerArgs:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 

--- a/sdk/python/pulumi_aws/cloudfront/distribution.py
+++ b/sdk/python/pulumi_aws/cloudfront/distribution.py
@@ -40,7 +40,7 @@ class DistributionArgs:
         """
         The set of arguments for constructing a Distribution resource.
         :param pulumi.Input['DistributionDefaultCacheBehaviorArgs'] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[Sequence[pulumi.Input['DistributionOriginArgs']]] origins: One or more origins for this distribution (multiples allowed).
         :param pulumi.Input['DistributionRestrictionsArgs'] restrictions: The restriction configuration for this distribution (maximum one).
         :param pulumi.Input['DistributionViewerCertificateArgs'] viewer_certificate: The SSL configuration for this distribution (maximum one).
@@ -115,7 +115,7 @@ class DistributionArgs:
     @pulumi.getter
     def enabled(self) -> pulumi.Input[bool]:
         """
-        Whether Origin Shield is enabled.
+        Whether the distribution is enabled.
         """
         return pulumi.get(self, "enabled")
 
@@ -398,7 +398,7 @@ class _DistributionState:
         :param pulumi.Input['DistributionDefaultCacheBehaviorArgs'] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
         :param pulumi.Input[str] default_root_object: Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
         :param pulumi.Input[str] domain_name: DNS domain name of either the S3 bucket, or web site of your custom origin.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[str] etag: Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
         :param pulumi.Input[str] hosted_zone_id: CloudFront Route 53 zone ID that can be used to route an [Alias Resource Record Set](http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html) to. This attribute is simply an alias for the zone ID `Z2FDTNDATAQYW2`.
         :param pulumi.Input[str] http_version: Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
@@ -602,7 +602,7 @@ class _DistributionState:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
-        Whether Origin Shield is enabled.
+        Whether the distribution is enabled.
         """
         return pulumi.get(self, "enabled")
 
@@ -1156,7 +1156,7 @@ class Distribution(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DistributionCustomErrorResponseArgs']]]] custom_error_responses: One or more custom error response elements (multiples allowed).
         :param pulumi.Input[pulumi.InputType['DistributionDefaultCacheBehaviorArgs']] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
         :param pulumi.Input[str] default_root_object: Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[str] http_version: Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
         :param pulumi.Input[bool] is_ipv6_enabled: Whether the IPv6 is enabled for the distribution.
         :param pulumi.Input[pulumi.InputType['DistributionLoggingConfigArgs']] logging_config: The logging configuration that controls how logs are written to your distribution (maximum one).
@@ -1568,7 +1568,7 @@ class Distribution(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['DistributionDefaultCacheBehaviorArgs']] default_cache_behavior: Default cache behavior for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
         :param pulumi.Input[str] default_root_object: Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
         :param pulumi.Input[str] domain_name: DNS domain name of either the S3 bucket, or web site of your custom origin.
-        :param pulumi.Input[bool] enabled: Whether Origin Shield is enabled.
+        :param pulumi.Input[bool] enabled: Whether the distribution is enabled.
         :param pulumi.Input[str] etag: Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
         :param pulumi.Input[str] hosted_zone_id: CloudFront Route 53 zone ID that can be used to route an [Alias Resource Record Set](http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html) to. This attribute is simply an alias for the zone ID `Z2FDTNDATAQYW2`.
         :param pulumi.Input[str] http_version: Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
@@ -1706,7 +1706,7 @@ class Distribution(pulumi.CustomResource):
     @pulumi.getter
     def enabled(self) -> pulumi.Output[bool]:
         """
-        Whether Origin Shield is enabled.
+        Whether the distribution is enabled.
         """
         return pulumi.get(self, "enabled")
 

--- a/sdk/python/pulumi_aws/cloudfront/function.py
+++ b/sdk/python/pulumi_aws/cloudfront/function.py
@@ -22,8 +22,8 @@ class FunctionArgs:
         """
         The set of arguments for constructing a Function resource.
         :param pulumi.Input[str] code: Source code of the function
-        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-               
+        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+
                The following arguments are optional:
         :param pulumi.Input[str] comment: Comment.
         :param pulumi.Input[str] name: Unique name for your CloudFront Function.
@@ -54,7 +54,7 @@ class FunctionArgs:
     @pulumi.getter
     def runtime(self) -> pulumi.Input[str]:
         """
-        Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+        Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 
         The following arguments are optional:
         """
@@ -122,8 +122,8 @@ class _FunctionState:
         :param pulumi.Input[str] live_stage_etag: ETag hash of any `LIVE` stage of the function.
         :param pulumi.Input[str] name: Unique name for your CloudFront Function.
         :param pulumi.Input[bool] publish: Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-               
+        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+
                The following arguments are optional:
         :param pulumi.Input[str] status: Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
         """
@@ -234,7 +234,7 @@ class _FunctionState:
     @pulumi.getter
     def runtime(self) -> Optional[pulumi.Input[str]]:
         """
-        Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+        Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 
         The following arguments are optional:
         """
@@ -303,8 +303,8 @@ class Function(pulumi.CustomResource):
         :param pulumi.Input[str] comment: Comment.
         :param pulumi.Input[str] name: Unique name for your CloudFront Function.
         :param pulumi.Input[bool] publish: Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-               
+        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+
                The following arguments are optional:
         """
         ...
@@ -417,8 +417,8 @@ class Function(pulumi.CustomResource):
         :param pulumi.Input[str] live_stage_etag: ETag hash of any `LIVE` stage of the function.
         :param pulumi.Input[str] name: Unique name for your CloudFront Function.
         :param pulumi.Input[bool] publish: Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
-               
+        :param pulumi.Input[str] runtime: Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
+
                The following arguments are optional:
         :param pulumi.Input[str] status: Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
         """
@@ -497,7 +497,7 @@ class Function(pulumi.CustomResource):
     @pulumi.getter
     def runtime(self) -> pulumi.Output[str]:
         """
-        Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+        Identifier of the function's runtime. Possible values are curently `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 
         The following arguments are optional:
         """

--- a/sdk/python/pulumi_aws/cloudfront/outputs.py
+++ b/sdk/python/pulumi_aws/cloudfront/outputs.py
@@ -2370,7 +2370,7 @@ class DistributionTrustedKeyGroup(dict):
                  enabled: Optional[bool] = None,
                  items: Optional[Sequence['outputs.DistributionTrustedKeyGroupItem']] = None):
         """
-        :param bool enabled: Whether Origin Shield is enabled.
+        :param bool enabled: This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         :param Sequence['DistributionTrustedKeyGroupItemArgs'] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2382,7 +2382,7 @@ class DistributionTrustedKeyGroup(dict):
     @pulumi.getter
     def enabled(self) -> Optional[bool]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the key groups in the list have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 
@@ -2451,7 +2451,7 @@ class DistributionTrustedSigner(dict):
                  enabled: Optional[bool] = None,
                  items: Optional[Sequence['outputs.DistributionTrustedSignerItem']] = None):
         """
-        :param bool enabled: Whether Origin Shield is enabled.
+        :param bool enabled: This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         :param Sequence['DistributionTrustedSignerItemArgs'] items: List of nested attributes for each trusted signer
         """
         if enabled is not None:
@@ -2463,7 +2463,7 @@ class DistributionTrustedSigner(dict):
     @pulumi.getter
     def enabled(self) -> Optional[bool]:
         """
-        Whether Origin Shield is enabled.
+        This field is true if any of the AWS accounts in the list are configured as trusted signers. If not, this field is false.
         """
         return pulumi.get(self, "enabled")
 


### PR DESCRIPTION
Correct CloudFront functions available runtimes as `cloudfront-js-2.0` is now available and works out of the box with Pulumi.
Branch is based on https://github.com/pulumi/pulumi-aws/pull/3045