### PR TITLE
Add assume role with web identity, expand assume role properties in creds validation

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -558,7 +558,18 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 			SessionName: stringValue(details.ObjectValue(), "sessionName", []string{}),
 		}
 		config.AssumeRole = &assumeRole
+	}
 
+	if details, ok := vars["assumeRoleWithWebIdentity"]; ok {
+		assumeRole := awsbase.AssumeRoleWithWebIdentity{
+			RoleARN:              stringValue(details.ObjectValue(), "roleArn", []string{}),
+			Policy:               stringValue(details.ObjectValue(), "policy", []string{}),
+			PolicyARNs:           arrayValue(details.ObjectValue(), "policyArns", []string{}),
+			SessionName:          stringValue(details.ObjectValue(), "sessionName", []string{}),
+			WebIdentityToken:     stringValue(details.ObjectValue(), "webIdentityToken", []string{}),
+			WebIdentityTokenFile: stringValue(details.ObjectValue(), "webIdentityTokenFile", []string{}),
+		}
+		config.AssumeRoleWithWebIdentity = &assumeRole
 	}
 
 	// By default `skipMetadataApiCheck` is true for Pulumi to speed operations

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -550,12 +550,14 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 	}
 
 	if details, ok := vars["assumeRole"]; ok {
-
 		assumeRole := awsbase.AssumeRole{
-			RoleARN:     stringValue(details.ObjectValue(), "roleArn", []string{}),
-			ExternalID:  stringValue(details.ObjectValue(), "externalId", []string{}),
-			Policy:      stringValue(details.ObjectValue(), "policy", []string{}),
-			SessionName: stringValue(details.ObjectValue(), "sessionName", []string{}),
+			RoleARN:           stringValue(details.ObjectValue(), "roleArn", []string{}),
+			ExternalID:        stringValue(details.ObjectValue(), "externalId", []string{}),
+			Policy:            stringValue(details.ObjectValue(), "policy", []string{}),
+			PolicyARNs:        arrayValue(details.ObjectValue(), "policyArns", []string{}),
+			SessionName:       stringValue(details.ObjectValue(), "sessionName", []string{}),
+			SourceIdentity:    stringValue(details.ObjectValue(), "sourceIdentity", []string{}),
+			TransitiveTagKeys: arrayValue(details.ObjectValue(), "transitiveTagKeys", []string{}),
 		}
 		config.AssumeRole = &assumeRole
 	}

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,27 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDuration(t *testing.T) {
+	for _, v := range []string{
+		"1",
+		"60",
+		"3600",
+		"86400",
+		"1s",
+		"60s",
+		"3600s",
+	} {
+		valid := resource.PropertyMap{
+			"durationSeconds": resource.NewStringProperty(v),
+		}
+		d, err := durationFromConfig(valid, "durationSeconds", []string{})
+		assert.NoError(t, err)
+		assert.True(t, d > 0)
+	}
+}


### PR DESCRIPTION
- Add `assumeRoleWithWebIdentity` to creds validation #2252
- Add most missing properties to assumeRole credentials check
- Add duration to supported assumeRole properties

Resolves ##2252

The supported properties of both `assumeRole` and `assumeRoleWithWebIdentity` should now match [the ones documented in the registry](https://www.pulumi.com/registry/packages/aws/installation-configuration/#configuration-options).

The remaining exception is `tags` where I wasn't sure about the correct conversion from `PropertyMap` to Go `map`.

I have an e2e test for `assumeRoleWithWebIdentity` in progress as part of #3074 but wanted to get this change out there.