### PR TITLE
Fix 3094: preview when provisioning SecurityGroup with unknown ingress

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,7 +5,7 @@ go 1.21.0
 require (
 	github.com/aws/aws-sdk-go v1.48.9
 	github.com/pulumi/pulumi-aws/provider/v6 v6.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.21.1-0.20231207205658-538570c1932f
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3
 	github.com/pulumi/pulumi/pkg/v3 v3.95.0
 	github.com/stretchr/testify v1.8.4
@@ -281,7 +281,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.6.1-0.20231111193429-44b746a5b3b5 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.0 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.1-0.20231207205658-538570c1932f // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20231130182140-6385710fcbc4 // indirect
 	github.com/pulumi/pulumi/sdk/v3 v3.95.0 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2384,12 +2384,12 @@ github.com/pulumi/esc v0.6.1-0.20231111193429-44b746a5b3b5 h1:1DJMji9F7XPea46bSu
 github.com/pulumi/esc v0.6.1-0.20231111193429-44b746a5b3b5/go.mod h1:Y6W21yUukvxS2NnS5ae1beMSPhMvj0xNAYcDqDHVj/g=
 github.com/pulumi/providertest v0.0.3 h1:DLcAvVGgeP4mHEi1Ftk5zTX9QHjcrO6u5w5GCZrF99s=
 github.com/pulumi/providertest v0.0.3/go.mod h1:kZYBA14iemv3X4G4xsBKaa72zVbn//IyL5HTYKpLuy0=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0 h1:rKL6YQh55C6BTElSzox6VyuDDhxu8zh59qlECe4wkIM=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0/go.mod h1:4XbozjoCh9lbGcUD5+83LrjAqzGPQGjya0lavqVq1sQ=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.21.1-0.20231207205658-538570c1932f h1:vYOnyhGczomd2iLb8judh5kLHdIqpIFYW/0yAH9LlgY=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.21.1-0.20231207205658-538570c1932f/go.mod h1:4XbozjoCh9lbGcUD5+83LrjAqzGPQGjya0lavqVq1sQ=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3 h1:bBWWeAtSPPYpKYlPZr2h0BiYgWQpHRIk0HO/MQmB+jc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3/go.mod h1:vAQ7DeddebQ7FHdRaSG6ijuS28FS9PC4j8Y9wUuue0c=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.0 h1:s8eN3V6wNZOHK14lSwlSOW1TMCN0epRBDYXnS+W/ZV8=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.0/go.mod h1:m+XOZQff8d64SLZTfI3VhDOtVhu9KTsjQIx9Thvc/MU=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.1-0.20231207205658-538570c1932f h1:D1oTquV5nYggSQuMOCjaxQX8BpfW54B+Y1MSTpu8wlg=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.1-0.20231207205658-538570c1932f/go.mod h1:m+XOZQff8d64SLZTfI3VhDOtVhu9KTsjQIx9Thvc/MU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20231130182140-6385710fcbc4 h1:8lK+vlRrnAxB6K3J2YIPAq50ETpvvWZ92vi66Hko/4o=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20231130182140-6385710fcbc4/go.mod h1:F/fzVS4Ksc4SPPLtMjGFRM9M76QtM1Rc0CYGnHCHEwU=
 github.com/pulumi/pulumi/pkg/v3 v3.95.0 h1:FBA0EmjRaqUgzleFMpLSAQUojXH2PyIVERzAm53p63U=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220923175450-ca71523cdc36
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pulumi/providertest v0.0.3
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.21.1-0.20231207205658-538570c1932f
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.1-0.20231207205658-538570c1932f
 	github.com/pulumi/pulumi/pkg/v3 v3.95.0
 	github.com/pulumi/pulumi/sdk/v3 v3.95.0
 	github.com/stretchr/testify v1.8.4

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2406,12 +2406,12 @@ github.com/pulumi/providertest v0.0.3 h1:DLcAvVGgeP4mHEi1Ftk5zTX9QHjcrO6u5w5GCZr
 github.com/pulumi/providertest v0.0.3/go.mod h1:kZYBA14iemv3X4G4xsBKaa72zVbn//IyL5HTYKpLuy0=
 github.com/pulumi/pulumi-java/pkg v0.9.8 h1:c8mYsalnRXA2Ibgvv6scefOn6mW1Vb0UT0mcDqjsivQ=
 github.com/pulumi/pulumi-java/pkg v0.9.8/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0 h1:rKL6YQh55C6BTElSzox6VyuDDhxu8zh59qlECe4wkIM=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0/go.mod h1:4XbozjoCh9lbGcUD5+83LrjAqzGPQGjya0lavqVq1sQ=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.21.1-0.20231207205658-538570c1932f h1:vYOnyhGczomd2iLb8judh5kLHdIqpIFYW/0yAH9LlgY=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.21.1-0.20231207205658-538570c1932f/go.mod h1:4XbozjoCh9lbGcUD5+83LrjAqzGPQGjya0lavqVq1sQ=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1/go.mod h1:7OeUPH8rpt5ipyj9EFcnXpuzQ8SHL0dyqdfa8nOacdk=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.0 h1:s8eN3V6wNZOHK14lSwlSOW1TMCN0epRBDYXnS+W/ZV8=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.0/go.mod h1:m+XOZQff8d64SLZTfI3VhDOtVhu9KTsjQIx9Thvc/MU=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.1-0.20231207205658-538570c1932f h1:D1oTquV5nYggSQuMOCjaxQX8BpfW54B+Y1MSTpu8wlg=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.67.1-0.20231207205658-538570c1932f/go.mod h1:m+XOZQff8d64SLZTfI3VhDOtVhu9KTsjQIx9Thvc/MU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20231130182140-6385710fcbc4 h1:8lK+vlRrnAxB6K3J2YIPAq50ETpvvWZ92vi66Hko/4o=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7-0.20231130182140-6385710fcbc4/go.mod h1:F/fzVS4Ksc4SPPLtMjGFRM9M76QtM1Rc0CYGnHCHEwU=
 github.com/pulumi/pulumi-yaml v1.4.3 h1:GO36c7FTl8If20Dn/w2Hi3huP7kmsO00KNaz3GJU0Ws=

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -58,6 +58,14 @@ func TestJobQueue(t *testing.T) {
 		}))
 }
 
+func TestRegress3094(t *testing.T) {
+	simpleNodeTest(t,
+		filepath.Join("test-programs", "regress-3094"),
+		providertest.WithSkippedUpgradeTestMode(providertest.UpgradeTestMode_Quick, "Not testing upgrades"),
+		providertest.WithSkippedUpgradeTestMode(providertest.UpgradeTestMode_PreviewOnly, "Not testing upgrades"),
+	)
+}
+
 func nodeTest(t *testing.T, dir string, opts ...providertest.Option) {
 	envRegion := getEnvRegion(t)
 	opts = append(opts,

--- a/provider/test-programs/regress-3094/.gitignore
+++ b/provider/test-programs/regress-3094/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/provider/test-programs/regress-3094/Pulumi.yaml
+++ b/provider/test-programs/regress-3094/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: regress-3094
+runtime: nodejs
+description: Reproduce AWS 3094

--- a/provider/test-programs/regress-3094/index.ts
+++ b/provider/test-programs/regress-3094/index.ts
@@ -1,0 +1,7 @@
+import * as aws from '@pulumi/aws';
+
+const myGroup = new aws.ec2.SecurityGroup('myGroup', {});
+
+new aws.ec2.SecurityGroup('myGroup2', {
+    ingress: myGroup.ingress,
+});

--- a/provider/test-programs/regress-3094/package.json
+++ b/provider/test-programs/regress-3094/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "regress-3094",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2"
+    }
+}

--- a/provider/test-programs/regress-3094/tsconfig.json
+++ b/provider/test-programs/regress-3094/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Fixes #3094. With these changes I can preview and up the repro program.

The actual fix is in https://github.com/pulumi/pulumi-terraform-bridge/pull/1558

All bridge changes (to confirm) - this is the only change: https://github.com/pulumi/pulumi-terraform-bridge/compare/v3.67.0...538570c1932f59b78ee6a2f0843ce6c04976131e