### PR TITLE
Relax sqs/queue upgrade test to permits Updates

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -28,7 +28,9 @@ func TestLogGroup(t *testing.T) {
 }
 
 func TestQueue(t *testing.T) {
-	nodeTest(t, filepath.Join("..", "examples", "queue"))
+	nodeTest(t, filepath.Join("..", "examples", "queue"),
+		providertest.WithSkippedUpgradeTestMode(providertest.UpgradeTestMode_Quick, "Prefer PreviewOnly"),
+		providertest.WithDiffValidation(providertest.NoReplacements()))
 }
 
 func TestRoute53(t *testing.T) {


### PR DESCRIPTION
The test will still fail if a Replace plan is generated for any of the resources. However Update plans are now tolerated. This helps pass on a new bridge update that creates an Update plan to compensate for schema changes in EventSourceMapping. See #3122 and #3092.