### PR TITLE
Stop embedding bridge-metadata.json

### DIFF
--- a/provider/cmd/pulumi-resource-aws/main.go
+++ b/provider/cmd/pulumi-resource-aws/main.go
@@ -29,6 +29,6 @@ var pulumiSchema []byte
 
 func main() {
 	ctx := context.Background()
-	info := aws.RuntimeProvider()
+	info := aws.Provider()
 	pf.MainWithMuxer(ctx, "aws", *info, pulumiSchema)
 }

--- a/provider/fast_test.go
+++ b/provider/fast_test.go
@@ -19,9 +19,3 @@ func BenchmarkProvider(b *testing.B) {
 		Provider()
 	}
 }
-
-func BenchmarkRuntimeProvider(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		RuntimeProvider()
-	}
-}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -711,7 +711,7 @@ var managedByPulumi = &tfbridge.DefaultInfo{Value: "Managed by Pulumi"}
 var runtimeMetadata []byte
 
 // Provider returns additional overlaid schema and metadata associated with the aws package.
-func RuntimeProvider() *tfbridge.ProviderInfo {
+func Provider() *tfbridge.ProviderInfo {
 	return ProviderFromMeta(tfbridge.NewProviderMetadata(runtimeMetadata))
 }
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -707,16 +707,8 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 // managedByPulumi is a default used for some managed resources, in the absence of something more meaningful.
 var managedByPulumi = &tfbridge.DefaultInfo{Value: "Managed by Pulumi"}
 
-//go:embed cmd/pulumi-resource-aws/bridge-metadata.json
-var metadata []byte
-
 //go:embed cmd/pulumi-resource-aws/runtime-bridge-metadata.json
 var runtimeMetadata []byte
-
-// Provider returns additional overlaid schema and metadata associated with the aws package.
-func Provider() *tfbridge.ProviderInfo {
-	return ProviderFromMeta(tfbridge.NewProviderMetadata(metadata))
-}
 
 // Provider returns additional overlaid schema and metadata associated with the aws package.
 func RuntimeProvider() *tfbridge.ProviderInfo {


### PR DESCRIPTION
At this point bridge-metadata.json is a compile-time only concern as it is not needed at runtime at all. This PR makes the change obvious and stops embedding it. This should help the binary size a bit, possibly to the tune of 30MB (uncompressed):

 31M    provider/cmd/pulumi-resource-aws/bridge-metadata.json
 88K    provider/cmd/pulumi-resource-aws/runtime-bridge-metadata.json

Only runtime-bridge-metadata.json is currently needed.