### PR TITLE
Unpin pulumi cli 3

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -33,11 +33,6 @@ runner:
   publish: pulumi-ubuntu-8core
   buildSdk: pulumi-ubuntu-8core
 actions:
-  setupPulumi:
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v4
-      with:
-        pulumi-version: v3.77.1
   preTest:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -168,7 +168,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -219,7 +219,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -309,7 +309,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -403,7 +403,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -159,7 +159,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -253,7 +253,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -162,7 +162,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -252,7 +252,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -328,7 +328,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -175,7 +175,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -265,7 +265,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -376,7 +376,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -184,7 +184,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -321,7 +321,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
       with:
-        pulumi-version: v3.77.1
+        pulumi-version: ^3
     - name: Setup Node
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
Before this change, we used an outdated Pulumi CLI version to test the provider against. With this change we start using the latest 3.x release like most other bridged providers. While it would be my preference to have it pinned and automatically updating via PRs to move toward [Hermetic Builds](https://github.com/pulumi/ci-mgmt/issues/738) that's more work and for now this change is a quick improvement.  