### PR TITLE
Fix failing tests because of missing amazon linux 1 AMI

### DIFF
--- a/examples/webserver-cs/Program.cs
+++ b/examples/webserver-cs/Program.cs
@@ -37,7 +37,7 @@ class Program
             {
                 MostRecent = true,
                 Owners = { "137112412989" },
-                Filters = { new Pulumi.Aws.Ec2.Inputs.GetAmiFilterArgs { Name = "name", Values = { "amzn-ami-hvm-*" } } },
+                Filters = { new Pulumi.Aws.Ec2.Inputs.GetAmiFilterArgs { Name = "name", Values = { "amzn2-ami-hvm-*" } } },
             });
 
 

--- a/examples/webserver-go/main.go
+++ b/examples/webserver-go/main.go
@@ -50,7 +50,7 @@ func main() {
 			Filters: []ec2.GetAmiFilter{
 				{
 					Name:   "name",
-					Values: []string{"amzn-ami-hvm-*-x86_64-ebs"},
+					Values: []string{"amzn2-ami-hvm-*-x86_64-ebs"},
 				},
 			},
 			Owners:     []string{"137112412989"},


### PR DESCRIPTION
Looks like amazon linux 1 reached end of life https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/ 

They probably removed the amis from search results.

This PR fixes the examples to use amazon linux 2