### PR TITLE
Remove VPC from tags test matrix

### DIFF
--- a/examples/tags-combinations-go/main.go
+++ b/examples/tags-combinations-go/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/appconfig"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
@@ -49,14 +48,6 @@ func main() {
 			return err
 		}
 
-		vpc, err := ec2.NewVpc(ctx, "mainvpc", &ec2.VpcArgs{
-			CidrBlock: pulumi.String("10.0.0.0/16"),
-			Tags:      tagsMap,
-		}, pulumi.Provider(p))
-		if err != nil {
-			return err
-		}
-
 		bucket, err := s3.NewBucketV2(ctx, "bucketv2", &s3.BucketV2Args{
 			Tags: tagsMap,
 		}, pulumi.Provider(p))
@@ -79,8 +70,6 @@ func main() {
 			return err
 		}
 
-		ctx.Export("vpc", exportTags(vpc.Tags))
-		ctx.Export("vpc-id", vpc.ID())
 		ctx.Export("bucket", exportTags(bucket.Tags))
 		ctx.Export("legacy-bucket", exportTags(legacyBucket.Tags))
 		ctx.Export("bucket-name", bucket.Bucket)

--- a/examples/tags-combinations-go/step1/main.go
+++ b/examples/tags-combinations-go/step1/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/appconfig"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
@@ -21,7 +20,7 @@ type state struct {
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		conf := config.New(ctx, "")
-		tagsState := conf.Require("state2")
+		tagsState := conf.Require("state1")
 
 		var s state
 
@@ -49,14 +48,6 @@ func main() {
 			return err
 		}
 
-		vpc, err := ec2.NewVpc(ctx, "mainvpc", &ec2.VpcArgs{
-			CidrBlock: pulumi.String("10.0.0.0/16"),
-			Tags:      tagsMap,
-		}, pulumi.Provider(p))
-		if err != nil {
-			return err
-		}
-
 		bucket, err := s3.NewBucketV2(ctx, "bucketv2", &s3.BucketV2Args{
 			Tags: tagsMap,
 		}, pulumi.Provider(p))
@@ -79,8 +70,6 @@ func main() {
 			return err
 		}
 
-		ctx.Export("vpc", exportTags(vpc.Tags))
-		ctx.Export("vpc-id", vpc.ID())
 		ctx.Export("bucket", exportTags(bucket.Tags))
 		ctx.Export("legacy-bucket", exportTags(legacyBucket.Tags))
 		ctx.Export("bucket-name", bucket.Bucket)

--- a/examples/tags-combinations-go/step1/main.go
+++ b/examples/tags-combinations-go/step1/main.go
@@ -20,7 +20,7 @@ type state struct {
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		conf := config.New(ctx, "")
-		tagsState := conf.Require("state1")
+		tagsState := conf.Require("state2")
 
 		var s state
 


### PR DESCRIPTION
Nothing that the TestRandomTagsCombinationsGo test periodically flakes up, as in https://github.com/pulumi/pulumi-aws/pull/3292  on testing VPC resources. I've not established the root cause but it appears to be that the VPCs allocated by independent test instances collide. This is probably just not a good resource to test tag correctness on and I think we're not losing much coverage by simply removing it. Buckets tests still test the SDKv2 based resources.

