### PR TITLE
Patch upstream doc to be an H3 and display as part of the Example Usage section

### DIFF
--- a/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
+++ b/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 16:49:08 +0000
-Subject: [PATCH 01/40] Add TagsSchemaTrulyComputed definition
+Subject: [PATCH 01/41] Add TagsSchemaTrulyComputed definition
 
 
 diff --git a/internal/tags/tags.go b/internal/tags/tags.go

--- a/patches/0002-Conns-user-agent.patch
+++ b/patches/0002-Conns-user-agent.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:03:31 +0000
-Subject: [PATCH 02/40] Conns user agent
+Subject: [PATCH 02/41] Conns user agent
 
 Replace the useragent used for AWS client connections with a
 Pulumi-flavoured one.

--- a/patches/0003-Add-S3-legacy-bucket-to-resources.patch
+++ b/patches/0003-Add-S3-legacy-bucket-to-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:05:11 +0000
-Subject: [PATCH 03/40] Add S3 legacy bucket to resources
+Subject: [PATCH 03/41] Add S3 legacy bucket to resources
 
 This preserves the old S3 Resource in the SDK, by duplicating the code
 as a new service (in internal/service/s3legacy), and making an explicit

--- a/patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
+++ b/patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Thu, 9 Mar 2023 09:47:49 -0600
-Subject: [PATCH 04/40] Marks SSE Configuration as Computed for Legacy S3
+Subject: [PATCH 04/41] Marks SSE Configuration as Computed for Legacy S3
  Bucket
 
 In January, AWS enabled SSE by default for all new S3 buckets.

--- a/patches/0005-De-deprecate-bucket_object.patch
+++ b/patches/0005-De-deprecate-bucket_object.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:06:11 +0000
-Subject: [PATCH 05/40] De-deprecate bucket_object
+Subject: [PATCH 05/41] De-deprecate bucket_object
 
 
 diff --git a/internal/service/s3/bucket_object.go b/internal/service/s3/bucket_object.go

--- a/patches/0006-Remove-lakeformation-catalog_resource-default.patch
+++ b/patches/0006-Remove-lakeformation-catalog_resource-default.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:08:23 +0000
-Subject: [PATCH 06/40] Remove lakeformation catalog_resource default
+Subject: [PATCH 06/41] Remove lakeformation catalog_resource default
 
 
 diff --git a/internal/service/lakeformation/permissions.go b/internal/service/lakeformation/permissions.go

--- a/patches/0007-Workaround-SSM-Parameter-tier-bug.patch
+++ b/patches/0007-Workaround-SSM-Parameter-tier-bug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:24:42 +0000
-Subject: [PATCH 07/40] Workaround SSM Parameter tier bug
+Subject: [PATCH 07/41] Workaround SSM Parameter tier bug
 
 - Disable "computed".
 - Disable diff suppression & counteractions

--- a/patches/0008-Add-EKS-cluster-certificate_authorities-plural.patch
+++ b/patches/0008-Add-EKS-cluster-certificate_authorities-plural.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:32:49 +0000
-Subject: [PATCH 08/40] Add EKS cluster certificate_authorities (plural)
+Subject: [PATCH 08/41] Add EKS cluster certificate_authorities (plural)
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0009-Workaround-Autoscaling-launch_configuration-associat.patch
+++ b/patches/0009-Workaround-Autoscaling-launch_configuration-associat.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:34:56 +0000
-Subject: [PATCH 09/40] Workaround Autoscaling launch_configuration
+Subject: [PATCH 09/41] Workaround Autoscaling launch_configuration
  associate_public_ip_address
 
 - Disable computation of property until fixed.

--- a/patches/0010-Add-ECR-credentials_data_source.patch
+++ b/patches/0010-Add-ECR-credentials_data_source.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:36:34 +0000
-Subject: [PATCH 10/40] Add ECR credentials_data_source
+Subject: [PATCH 10/41] Add ECR credentials_data_source
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0011-Add-custom-appautoscaling-examples.patch
+++ b/patches/0011-Add-custom-appautoscaling-examples.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Wed, 9 Nov 2022 17:37:35 +0000
-Subject: [PATCH 11/40] Add custom appautoscaling examples
+Subject: [PATCH 11/41] Add custom appautoscaling examples
 
 
 diff --git a/website/docs/r/appautoscaling_policy.html.markdown b/website/docs/r/appautoscaling_policy.html.markdown

--- a/patches/0012-Add-dedicated_host-docs.patch
+++ b/patches/0012-Add-dedicated_host-docs.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 10:08:05 +0000
-Subject: [PATCH 12/40] Add dedicated_host docs
+Subject: [PATCH 12/41] Add dedicated_host docs
 
 
 diff --git a/website/docs/d/dedicated_host.html.markdown b/website/docs/d/dedicated_host.html.markdown

--- a/patches/0013-Revert-WAF-schema-changes.patch
+++ b/patches/0013-Revert-WAF-schema-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 13:59:57 +0000
-Subject: [PATCH 13/40] Revert WAF schema changes
+Subject: [PATCH 13/41] Revert WAF schema changes
 
 - This causes far too many types to be generated downstream.
 

--- a/patches/0014-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
+++ b/patches/0014-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@gmail.com>
 Date: Thu, 1 Dec 2022 10:56:32 -0800
-Subject: [PATCH 14/40] Catch cty panic in new
+Subject: [PATCH 14/41] Catch cty panic in new
  resourceTopicSubscriptionCustomizeDiff.
 
 The root cause is not fully understood yet but this might unblock us.

--- a/patches/0015-add-matchmaking-configuration-72.patch
+++ b/patches/0015-add-matchmaking-configuration-72.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Lee Briggs <jaxxstorm@users.noreply.github.com>
 Date: Wed, 21 Dec 2022 12:23:59 -0800
-Subject: [PATCH 15/40] add matchmaking configuration (#72)
+Subject: [PATCH 15/41] add matchmaking configuration (#72)
 
 * add matchmaking configuration
 * add matchmaking rule set

--- a/patches/0016-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
+++ b/patches/0016-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Fri, 27 Jan 2023 09:37:43 -0600
-Subject: [PATCH 16/40] Reverts patches to S3BucketLegacy and GameLift
+Subject: [PATCH 16/41] Reverts patches to S3BucketLegacy and GameLift
 
 Previously, we were pulling along patches which removed a few simplifications
 to waiters in AWS GameLift, and a newer patch which plumbed through context.Context

--- a/patches/0017-Revert-Update-endpointHashIPAddress.patch
+++ b/patches/0017-Revert-Update-endpointHashIPAddress.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@pulumi.com>
 Date: Fri, 3 Feb 2023 17:31:18 -0800
-Subject: [PATCH 17/40] Revert "Update endpointHashIPAddress"
+Subject: [PATCH 17/41] Revert "Update endpointHashIPAddress"
 
 This reverts commit 2197a6c2c7a0ff306cec3432acb9f5680866f034.
 

--- a/patches/0018-Fixup-gamelift-context.patch
+++ b/patches/0018-Fixup-gamelift-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Thu, 9 Mar 2023 14:50:51 +0000
-Subject: [PATCH 18/40] Fixup gamelift context
+Subject: [PATCH 18/41] Fixup gamelift context
 
 
 diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go

--- a/patches/0019-Change-default-descriptions-to-Managed-by-Pulumi.patch
+++ b/patches/0019-Change-default-descriptions-to-Managed-by-Pulumi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 28 Feb 2023 15:19:24 +0000
-Subject: [PATCH 19/40] Change default descriptions to "Managed by Pulumi"
+Subject: [PATCH 19/41] Change default descriptions to "Managed by Pulumi"
 
 
 diff --git a/internal/service/apigateway/api_key.go b/internal/service/apigateway/api_key.go

--- a/patches/0020-remove-required-elements-from-schema-and-fix-tests-7.patch
+++ b/patches/0020-remove-required-elements-from-schema-and-fix-tests-7.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel.dbphoto@gmail.com>
 Date: Tue, 28 Mar 2023 19:54:00 +0100
-Subject: [PATCH 20/40] remove required elements from schema and fix tests
+Subject: [PATCH 20/41] remove required elements from schema and fix tests
  (#77)
 
 Co-authored-by: Lee Briggs <lee@leebriggs.co.uk>

--- a/patches/0021-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
+++ b/patches/0021-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 24 Apr 2023 10:36:36 -0400
-Subject: [PATCH 21/40] Temp remove cognito_identity_pool_roles_attachment
+Subject: [PATCH 21/41] Temp remove cognito_identity_pool_roles_attachment
  example beacuse of flaky translation
 
 

--- a/patches/0022-Fix-elbv2-target-group-read-to-workaround-2517.patch
+++ b/patches/0022-Fix-elbv2-target-group-read-to-workaround-2517.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 17:36:47 -0500
-Subject: [PATCH 22/40] Fix elbv2 target group read to workaround #2517
+Subject: [PATCH 22/41] Fix elbv2 target group read to workaround #2517
 
 
 diff --git a/internal/service/elbv2/target_group.go b/internal/service/elbv2/target_group.go

--- a/patches/0023-Fix-spurrious-json-diff-for-redrive_policy.patch
+++ b/patches/0023-Fix-spurrious-json-diff-for-redrive_policy.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ramon Quitales <ramon@pulumi.com>
 Date: Thu, 18 May 2023 15:21:33 -0700
-Subject: [PATCH 23/40] Fix spurrious json diff for redrive_policy
+Subject: [PATCH 23/41] Fix spurrious json diff for redrive_policy
 
 We need to normalize the json input to compare agasint the one stored
 in state.

--- a/patches/0024-Provide-context-to-conns.patch
+++ b/patches/0024-Provide-context-to-conns.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Mon, 10 Jul 2023 11:51:24 +0200
-Subject: [PATCH 24/40] Provide context to conns
+Subject: [PATCH 24/41] Provide context to conns
 
 
 diff --git a/internal/service/ecr/credentials_data_source.go b/internal/service/ecr/credentials_data_source.go

--- a/patches/0025-Match-the-tags-behavior-of-other-resources.patch
+++ b/patches/0025-Match-the-tags-behavior-of-other-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Wed, 2 Aug 2023 14:12:03 +0200
-Subject: [PATCH 25/40] Match the "tags" behavior of other resources
+Subject: [PATCH 25/41] Match the "tags" behavior of other resources
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0026-move-shim-logic-to-upstream-as-a-patch.patch
+++ b/patches/0026-move-shim-logic-to-upstream-as-a-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 6 Sep 2023 10:43:30 -0700
-Subject: [PATCH 26/40] move shim logic to upstream as a patch
+Subject: [PATCH 26/41] move shim logic to upstream as a patch
 
 
 diff --git a/shim/shim.go b/shim/shim.go

--- a/patches/0027-Restore-S3ConnURICleaningDisabled.patch
+++ b/patches/0027-Restore-S3ConnURICleaningDisabled.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 25 Sep 2023 15:22:30 -0400
-Subject: [PATCH 27/40] Restore S3ConnURICleaningDisabled
+Subject: [PATCH 27/41] Restore S3ConnURICleaningDisabled
 
 
 diff --git a/internal/conns/awsclient.go b/internal/conns/awsclient.go

--- a/patches/0028-Do-not-compute-tags_all-at-TF-level.patch
+++ b/patches/0028-Do-not-compute-tags_all-at-TF-level.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 6 Nov 2023 11:17:16 -0500
-Subject: [PATCH 28/40] Do not compute tags_all at TF level
+Subject: [PATCH 28/41] Do not compute tags_all at TF level
 
 
 diff --git a/internal/framework/base.go b/internal/framework/base.go

--- a/patches/0029-aws_eks_cluster-implement-default_addons_to_remove.patch
+++ b/patches/0029-aws_eks_cluster-implement-default_addons_to_remove.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 15 Nov 2023 11:53:09 -0500
-Subject: [PATCH 29/40] aws_eks_cluster: implement default_addons_to_remove
+Subject: [PATCH 29/41] aws_eks_cluster: implement default_addons_to_remove
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0030-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
+++ b/patches/0030-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 29 Nov 2023 17:23:09 -0500
-Subject: [PATCH 30/40] Fix markTagsAllNotComputedForResources to recognize
+Subject: [PATCH 30/41] Fix markTagsAllNotComputedForResources to recognize
  SchemaFunc
 
 

--- a/patches/0031-Optimize-startup-performance.patch
+++ b/patches/0031-Optimize-startup-performance.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 30 Nov 2023 14:28:37 -0500
-Subject: [PATCH 31/40] Optimize startup performance
+Subject: [PATCH 31/41] Optimize startup performance
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0032-Fix-job-queue-sdkv2-migration.patch
+++ b/patches/0032-Fix-job-queue-sdkv2-migration.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:41:21 -0500
-Subject: [PATCH 32/40] Fix job queue sdkv2 migration
+Subject: [PATCH 32/41] Fix job queue sdkv2 migration
 
 
 diff --git a/internal/service/batch/job_queue_schema.go b/internal/service/batch/job_queue_schema.go

--- a/patches/0033-DisableTagSchemaCheck-for-PF-provider.patch
+++ b/patches/0033-DisableTagSchemaCheck-for-PF-provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:44:25 -0500
-Subject: [PATCH 33/40] DisableTagSchemaCheck for PF provider
+Subject: [PATCH 33/41] DisableTagSchemaCheck for PF provider
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0034-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
+++ b/patches/0034-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:05:40 -0500
-Subject: [PATCH 34/40] Run scripts/patch_computed_only.sh to patch
+Subject: [PATCH 34/41] Run scripts/patch_computed_only.sh to patch
  eks/pod_identity_association and more
 
 

--- a/patches/0035-Fail-fast-when-PF-resources-are-dropped.patch
+++ b/patches/0035-Fail-fast-when-PF-resources-are-dropped.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:18:14 -0500
-Subject: [PATCH 35/40] Fail fast when PF resources are dropped
+Subject: [PATCH 35/41] Fail fast when PF resources are dropped
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0036-Fix-tags_all-Computed-for-PF-resources.patch
+++ b/patches/0036-Fix-tags_all-Computed-for-PF-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 7 Feb 2024 12:24:44 -0500
-Subject: [PATCH 36/40] Fix tags_all Computed for PF resources
+Subject: [PATCH 36/41] Fix tags_all Computed for PF resources
 
 
 diff --git a/internal/service/amp/scraper.go b/internal/service/amp/scraper.go

--- a/patches/0037-Disable-retry-for-KMS-access-denied-in-lambda.patch
+++ b/patches/0037-Disable-retry-for-KMS-access-denied-in-lambda.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 8 Jan 2024 16:58:44 -0500
-Subject: [PATCH 37/40] Disable retry for KMS access denied in lambda
+Subject: [PATCH 37/41] Disable retry for KMS access denied in lambda
 
 
 diff --git a/internal/service/lambda/service_package_extra.go b/internal/service/lambda/service_package_extra.go

--- a/patches/0038-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
+++ b/patches/0038-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 18:08:51 -0500
-Subject: [PATCH 38/40] Patch ACM retry to not retry after
+Subject: [PATCH 38/41] Patch ACM retry to not retry after
  LimitExceededException (#3290)
 
 

--- a/patches/0039-Restore-legacy-bucket.patch
+++ b/patches/0039-Restore-legacy-bucket.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 7 Feb 2024 12:08:03 -0500
-Subject: [PATCH 39/40] Restore legacy bucket
+Subject: [PATCH 39/41] Restore legacy bucket
 
 
 diff --git a/go.mod b/go.mod

--- a/patches/0040-Patch-osis_pipeline-tags-flags.patch
+++ b/patches/0040-Patch-osis_pipeline-tags-flags.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 9 Feb 2024 14:39:32 -0500
-Subject: [PATCH 40/40] Patch osis_pipeline tags flags
+Subject: [PATCH 40/41] Patch osis_pipeline tags flags
 
 
 diff --git a/internal/service/osis/pipeline.go b/internal/service/osis/pipeline.go

--- a/patches/0041-Include-CloudWatch-Logging-section-in-Lambda-Example.patch
+++ b/patches/0041-Include-CloudWatch-Logging-section-in-Lambda-Example.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: guineveresaenger <guinevere@pulumi.com>
+Date: Fri, 9 Feb 2024 15:25:41 -0800
+Subject: [PATCH 41/41] Include CloudWatch Logging section in Lambda Example
+
+
+diff --git a/website/docs/r/lambda_function.html.markdown b/website/docs/r/lambda_function.html.markdown
+index 29ab71f69f..212521e7e5 100644
+--- a/website/docs/r/lambda_function.html.markdown
++++ b/website/docs/r/lambda_function.html.markdown
+@@ -186,7 +186,7 @@ resource "aws_efs_access_point" "access_point_for_lambda" {
+ 
+ Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the [aws_lambda_function_event_invoke_config resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config).
+ 
+-## CloudWatch Logging and Permissions
++### CloudWatch Logging and Permissions
+ 
+ For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
+ 

--- a/sdk/dotnet/Lambda/Function.cs
+++ b/sdk/dotnet/Lambda/Function.cs
@@ -253,7 +253,7 @@ namespace Pulumi.Aws.Lambda
     /// ### Lambda retries
     /// 
     /// Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the aws.lambda.FunctionEventInvokeConfig resource.
-    /// ## CloudWatch Logging and Permissions
+    /// ### CloudWatch Logging and Permissions
     /// 
     /// For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
     /// 
@@ -325,7 +325,6 @@ namespace Pulumi.Aws.Lambda
     /// 
     /// });
     /// ```
-    /// 
     /// ## Specifying the Deployment Package
     /// 
     /// AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).

--- a/sdk/go/aws/lambda/function.go
+++ b/sdk/go/aws/lambda/function.go
@@ -265,7 +265,7 @@ import (
 // ### Lambda retries
 //
 // Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the lambda.FunctionEventInvokeConfig resource.
-// ## CloudWatch Logging and Permissions
+// ### CloudWatch Logging and Permissions
 //
 // For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
 //
@@ -344,7 +344,6 @@ import (
 //	}
 //
 // ```
-//
 // ## Specifying the Deployment Package
 //
 // AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).

--- a/sdk/java/src/main/java/com/pulumi/aws/lambda/Function.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lambda/Function.java
@@ -275,7 +275,7 @@ import javax.annotation.Nullable;
  * ### Lambda retries
  * 
  * Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the aws.lambda.FunctionEventInvokeConfig resource.
- * ## CloudWatch Logging and Permissions
+ * ### CloudWatch Logging and Permissions
  * 
  * For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
  * ```java
@@ -350,7 +350,6 @@ import javax.annotation.Nullable;
  *     }
  * }
  * ```
- * 
  * ## Specifying the Deployment Package
  * 
  * AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).

--- a/sdk/nodejs/lambda/function.ts
+++ b/sdk/nodejs/lambda/function.ts
@@ -147,7 +147,7 @@ import {ARN} from "..";
  * ### Lambda retries
  *
  * Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the aws.lambda.FunctionEventInvokeConfig resource.
- * ## CloudWatch Logging and Permissions
+ * ### CloudWatch Logging and Permissions
  *
  * For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
  *
@@ -189,7 +189,6 @@ import {ARN} from "..";
  *     ],
  * });
  * ```
- *
  * ## Specifying the Deployment Package
  *
  * AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).

--- a/sdk/python/pulumi_aws/lambda_/function.py
+++ b/sdk/python/pulumi_aws/lambda_/function.py
@@ -1452,7 +1452,7 @@ class Function(pulumi.CustomResource):
         ### Lambda retries
 
         Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the lambda.FunctionEventInvokeConfig resource.
-        ## CloudWatch Logging and Permissions
+        ### CloudWatch Logging and Permissions
 
         For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
 
@@ -1491,7 +1491,6 @@ class Function(pulumi.CustomResource):
                 example,
             ]))
         ```
-
         ## Specifying the Deployment Package
 
         AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
@@ -1678,7 +1677,7 @@ class Function(pulumi.CustomResource):
         ### Lambda retries
 
         Lambda Functions allow you to configure error handling for asynchronous invocation. The settings that it supports are `Maximum age of event` and `Retry attempts` as stated in [Lambda documentation for Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors). To configure these settings, refer to the lambda.FunctionEventInvokeConfig resource.
-        ## CloudWatch Logging and Permissions
+        ### CloudWatch Logging and Permissions
 
         For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
 
@@ -1717,7 +1716,6 @@ class Function(pulumi.CustomResource):
                 example,
             ]))
         ```
-
         ## Specifying the Deployment Package
 
         AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).


### PR DESCRIPTION
Partial and temporary hack for https://github.com/pulumi/pulumi-aws/issues/2624.
Adds a patch that rewrites the "CloudWatch Logging and Permission" section as a nested H3 example, which gets rid of the inline code display at the top of out [Lambda Function landing page](https://www.pulumi.com/registry/packages/aws/api-docs/lambda/function/). 

Note:
Elides display the incorrect "Lambda retries" section. A full fix for #2624 will address this and bring it back as the [description-only section that it is](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#lambda-retries).
This is a temporary hack and should be fully addressed via #2624, after which this patch should be removed.

The unrelated patch churn seems legitimate:
 - the deleted patch was included in an earlier patch 0036
 - the changed function title in 0022 is the patch anchor and does not affect our patch content.
---

Here's a screenshot of what the page should look like in the registry (please excuse the tiny image, but you can see the improvement)
<img width="863" alt="Screenshot 2024-02-09 at 11 14 59 AM" src="https://github.com/pulumi/pulumi-aws/assets/13116240/8395c58e-f3e6-4779-add1-567a39cc0a9e">

 


