### PR TITLE
Revert upstream changes triggering LB panic

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -538,6 +538,18 @@ func TestRegress2555(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestRegress3421(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+				Dir: "regress-3421",
+				SkipRefresh: true,
+			},
+		)
+	// Disable envRegion mangling
+	test.Config = nil
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	envRegion := getEnvRegion(t)
 	baseJS := integration.ProgramTestOptions{

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -586,6 +586,68 @@ func TestWrongStateMaxItemOneDiffProduced(t *testing.T) {
 	replay(t, repro)
 }
 
+// Regression test for https://github.com/pulumi/pulumi-aws/issues/3421
+func TestLBListenerCreatePanic(t *testing.T) {
+  replay(t, `[
+    {
+      "method": "/pulumirpc.ResourceProvider/Configure",
+      "request": {
+          "variables": {
+              "aws:config:region": "us-east-1",
+              "aws:config:skipCredentialsValidation": "false",
+              "aws:config:skipMetadataApiCheck": "true",
+              "aws:config:skipRegionValidation": "true"
+          },
+          "args": {
+              "region": "us-east-1",
+              "skipCredentialsValidation": "false",
+              "skipMetadataApiCheck": "true",
+              "skipRegionValidation": "true",
+              "version": "6.22.0"
+          },
+          "acceptSecrets": true,
+          "acceptResources": true,
+          "sendsOldInputs": true,
+          "sendsOldInputsToDelete": true
+      },
+      "response": {
+          "supportsPreview": true
+      },
+      "metadata": {
+          "kind": "resource",
+          "mode": "client",
+          "name": "aws"
+      }
+  },
+  {
+    "method": "/pulumirpc.ResourceProvider/Create",
+    "request": {
+        "urn": "urn:pulumi:dev::lb_panic::aws:lb/listener:Listener::payload-lb-listner-http",
+        "properties": {
+            "__defaults": [],
+            "defaultActions": [
+                {
+                    "__defaults": [],
+                    "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:616138583583:targetgroup/payload-tg-cae0e1a/92aa6f538c20f368",
+                    "type": "forward"
+                }
+            ],
+            "loadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:616138583583:loadbalancer/app/payload-lb-c49bc74/f9f2bdfb83b7984c",
+            "port": 80,
+            "protocol": "HTTP"
+        }
+    },
+    "errors": [
+        "rpc error: code = Unavailable desc = error reading from server: EOF"
+    ],
+    "metadata": {
+        "kind": "resource",
+        "mode": "client",
+        "name": "aws"
+    }
+}]`)
+}
+
 // A lot of tests do not currently refresh cleanly. The work to root cause each tests has not been
 // done yet but the common causes are listed here:
 //

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -586,68 +586,6 @@ func TestWrongStateMaxItemOneDiffProduced(t *testing.T) {
 	replay(t, repro)
 }
 
-// Regression test for https://github.com/pulumi/pulumi-aws/issues/3421
-func TestLBListenerCreatePanic(t *testing.T) {
-  replay(t, `[
-    {
-      "method": "/pulumirpc.ResourceProvider/Configure",
-      "request": {
-          "variables": {
-              "aws:config:region": "us-east-1",
-              "aws:config:skipCredentialsValidation": "false",
-              "aws:config:skipMetadataApiCheck": "true",
-              "aws:config:skipRegionValidation": "true"
-          },
-          "args": {
-              "region": "us-east-1",
-              "skipCredentialsValidation": "false",
-              "skipMetadataApiCheck": "true",
-              "skipRegionValidation": "true",
-              "version": "6.22.0"
-          },
-          "acceptSecrets": true,
-          "acceptResources": true,
-          "sendsOldInputs": true,
-          "sendsOldInputsToDelete": true
-      },
-      "response": {
-          "supportsPreview": true
-      },
-      "metadata": {
-          "kind": "resource",
-          "mode": "client",
-          "name": "aws"
-      }
-  },
-  {
-    "method": "/pulumirpc.ResourceProvider/Create",
-    "request": {
-        "urn": "urn:pulumi:dev::lb_panic::aws:lb/listener:Listener::payload-lb-listner-http",
-        "properties": {
-            "__defaults": [],
-            "defaultActions": [
-                {
-                    "__defaults": [],
-                    "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:616138583583:targetgroup/payload-tg-cae0e1a/92aa6f538c20f368",
-                    "type": "forward"
-                }
-            ],
-            "loadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:616138583583:loadbalancer/app/payload-lb-c49bc74/f9f2bdfb83b7984c",
-            "port": 80,
-            "protocol": "HTTP"
-        }
-    },
-    "errors": [
-        "rpc error: code = Unavailable desc = error reading from server: EOF"
-    ],
-    "metadata": {
-        "kind": "resource",
-        "mode": "client",
-        "name": "aws"
-    }
-}]`)
-}
-
 // A lot of tests do not currently refresh cleanly. The work to root cause each tests has not been
 // done yet but the common causes are listed here:
 //

--- a/examples/regress-3421/.gitignore
+++ b/examples/regress-3421/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/regress-3421/Pulumi.yaml
+++ b/examples/regress-3421/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: regress-3421
+runtime: nodejs
+description: A minimal AWS TypeScript Pulumi program
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/examples/regress-3421/index.ts
+++ b/examples/regress-3421/index.ts
@@ -1,0 +1,50 @@
+import * as aws from "@pulumi/aws";
+
+const vpc = new aws.ec2.Vpc("main", { cidrBlock: "10.0.0.0/16" });
+
+const currentRegion = aws.getRegion({})
+const subnet = new aws.ec2.Subnet("main", {
+    vpcId: vpc.id,
+    cidrBlock: "10.0.12.0/24",
+    availabilityZone: currentRegion.then(region => region.name + "a")
+});
+
+const subnet2 = new aws.ec2.Subnet("subnet2", {
+    vpcId: vpc.id,
+    cidrBlock: "10.0.5.0/24",
+    availabilityZone: currentRegion.then(region => region.name + "b")
+});
+
+const secGroup = new aws.ec2.SecurityGroup("allowTls", {
+    description: "Allow TLS inbound traffic and all outbound traffic",
+    vpcId: vpc.id,
+    tags: {
+        Name: "allow_tls",
+    },
+});
+
+const loadbalancer = new aws.lb.LoadBalancer("payload-lb", {
+    loadBalancerType: "application",
+    securityGroups: [secGroup.id],
+    subnets: [subnet.id, subnet2.id],
+    internal: true,
+});
+
+const targetGroup = new aws.lb.TargetGroup("payload-tg", {
+    port: 80,
+    protocol: "HTTP",
+    targetType: "ip",
+    vpcId: vpc.id,
+});
+
+new aws.lb.Listener("payload-lb-listner-http", {
+loadBalancerArn: loadbalancer.arn,
+port: 80,
+protocol: "HTTP",
+defaultActions: [
+    {
+    type: "forward",
+    targetGroupArn: targetGroup.arn,
+    },
+],
+});

--- a/examples/regress-3421/package.json
+++ b/examples/regress-3421/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "regress-3421",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2"
+    }
+}

--- a/examples/regress-3421/tsconfig.json
+++ b/examples/regress-3421/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/patches/0042-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
+++ b/patches/0042-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
@@ -1,0 +1,525 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Venelin <venelin@pulumi.com>
+Date: Wed, 14 Feb 2024 14:49:33 +0000
+Subject: [PATCH 42/43] Revert "Merge pull request #35678 from
+ hashicorp/b-elbv2-unexpected-diff"
+
+This reverts commit bfcae6ad3e8a226083f803b40e772e045ec78baa, reversing
+changes made to e6a44f239c54a63b87f63292ae64121d6ac166a6.
+
+diff --git a/.changelog/35678.txt b/.changelog/35678.txt
+deleted file mode 100644
+index 106f298c02..0000000000
+--- a/.changelog/35678.txt
++++ /dev/null
+@@ -1,7 +0,0 @@
+-```release-note:bug
+-resource/aws_lb_listener: Fixes unexpected diff when using `default_action` parameters which don't match the `type`.
+-```
+-
+-```release-note:bug
+-resource/aws_lb_listener_rule: Fixes unexpected diff when using `action` parameters which don't match the `type`.
+-```
+diff --git a/internal/service/elbv2/listener.go b/internal/service/elbv2/listener.go
+index 5b358cc768..159d62abf7 100644
+--- a/internal/service/elbv2/listener.go
++++ b/internal/service/elbv2/listener.go
+@@ -75,10 +75,9 @@ func ResourceListener() *schema.Resource {
+ 				Elem: &schema.Resource{
+ 					Schema: map[string]*schema.Schema{
+ 						"authenticate_cognito": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumAuthenticateCognito),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"authentication_request_extra_params": {
+@@ -124,10 +123,9 @@ func ResourceListener() *schema.Resource {
+ 							},
+ 						},
+ 						"authenticate_oidc": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumAuthenticateOidc),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"authentication_request_extra_params": {
+@@ -185,10 +183,9 @@ func ResourceListener() *schema.Resource {
+ 							},
+ 						},
+ 						"fixed_response": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumFixedResponse),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"content_type": {
+@@ -217,10 +214,11 @@ func ResourceListener() *schema.Resource {
+ 							},
+ 						},
+ 						"forward": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumForward),
+-							MaxItems:         1,
++							Type:                  schema.TypeList,
++							Optional:              true,
++							DiffSuppressOnRefresh: true,
++							DiffSuppressFunc:      diffSuppressMissingForward("default_action"),
++							MaxItems:              1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"target_group": {
+@@ -274,10 +272,9 @@ func ResourceListener() *schema.Resource {
+ 							ValidateFunc: validation.IntBetween(listenerActionOrderMin, listenerActionOrderMax),
+ 						},
+ 						"redirect": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumRedirect),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"host": {
+@@ -322,10 +319,9 @@ func ResourceListener() *schema.Resource {
+ 							},
+ 						},
+ 						"target_group_arn": {
+-							Type:             schema.TypeString,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumForward),
+-							ValidateFunc:     verify.ValidARN,
++							Type:         schema.TypeString,
++							Optional:     true,
++							ValidateFunc: verify.ValidARN,
+ 						},
+ 						"type": {
+ 							Type:             schema.TypeString,
+@@ -397,21 +393,6 @@ func ResourceListener() *schema.Resource {
+ 	}
+ }
+ 
+-func suppressIfDefaultActionTypeNot(t awstypes.ActionTypeEnum) schema.SchemaDiffSuppressFunc {
+-	return func(k, old, new string, d *schema.ResourceData) bool {
+-		take := 2
+-		i := strings.IndexFunc(k, func(r rune) bool {
+-			if r == '.' {
+-				take -= 1
+-				return take == 0
+-			}
+-			return false
+-		})
+-		at := k[:i+1] + "type"
+-		return awstypes.ActionTypeEnum(d.Get(at).(string)) != t
+-	}
+-}
+-
+ func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	var diags diag.Diagnostics
+ 	conn := meta.(*conns.AWSClient).ELBV2Client(ctx)
+diff --git a/internal/service/elbv2/listener_rule.go b/internal/service/elbv2/listener_rule.go
+index 3943c4e7dd..047ee68dee 100644
+--- a/internal/service/elbv2/listener_rule.go
++++ b/internal/service/elbv2/listener_rule.go
+@@ -10,7 +10,6 @@ import (
+ 	"log"
+ 	"sort"
+ 	"strconv"
+-	"strings"
+ 	"time"
+ 
+ 	"github.com/YakDriver/regexache"
+@@ -93,10 +92,9 @@ func ResourceListenerRule() *schema.Resource {
+ 						},
+ 
+ 						"target_group_arn": {
+-							Type:             schema.TypeString,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumForward),
+-							ValidateFunc:     verify.ValidARN,
++							Type:         schema.TypeString,
++							Optional:     true,
++							ValidateFunc: verify.ValidARN,
+ 						},
+ 
+ 						"forward": {
+@@ -153,10 +151,9 @@ func ResourceListenerRule() *schema.Resource {
+ 						},
+ 
+ 						"redirect": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumRedirect),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"host": {
+@@ -207,10 +204,9 @@ func ResourceListenerRule() *schema.Resource {
+ 						},
+ 
+ 						"fixed_response": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumFixedResponse),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"content_type": {
+@@ -242,10 +238,9 @@ func ResourceListenerRule() *schema.Resource {
+ 						},
+ 
+ 						"authenticate_cognito": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumAuthenticateCognito),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"authentication_request_extra_params": {
+@@ -292,10 +287,9 @@ func ResourceListenerRule() *schema.Resource {
+ 						},
+ 
+ 						"authenticate_oidc": {
+-							Type:             schema.TypeList,
+-							Optional:         true,
+-							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumAuthenticateOidc),
+-							MaxItems:         1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"authentication_request_extra_params": {
+@@ -487,21 +481,6 @@ func ResourceListenerRule() *schema.Resource {
+ 	}
+ }
+ 
+-func suppressIfActionTypeNot(t awstypes.ActionTypeEnum) schema.SchemaDiffSuppressFunc {
+-	return func(k, old, new string, d *schema.ResourceData) bool {
+-		take := 2
+-		i := strings.IndexFunc(k, func(r rune) bool {
+-			if r == '.' {
+-				take -= 1
+-				return take == 0
+-			}
+-			return false
+-		})
+-		at := k[:i+1] + "type"
+-		return awstypes.ActionTypeEnum(d.Get(at).(string)) != t
+-	}
+-}
+-
+ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+ 	var diags diag.Diagnostics
+ 	conn := meta.(*conns.AWSClient).ELBV2Client(ctx)
+diff --git a/internal/service/elbv2/listener_rule_test.go b/internal/service/elbv2/listener_rule_test.go
+index e5b9ec36b1..f28fc7c62c 100644
+--- a/internal/service/elbv2/listener_rule_test.go
++++ b/internal/service/elbv2/listener_rule_test.go
+@@ -1510,48 +1510,6 @@ func TestAccELBV2ListenerRule_EmptyAction(t *testing.T) {
+ 	}
+ }
+ 
+-func TestAccELBV2ListenerRule_redirectWithTargetGroupARN(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	lbName := fmt.Sprintf("testrule-redirect-%s", sdkacctest.RandString(14))
+-
+-	resourceName := "aws_lb_listener_rule.static"
+-	frontEndListenerResourceName := "aws_lb_listener.front_end"
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:   acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				ExternalProviders: map[string]resource.ExternalProvider{
+-					"aws": {
+-						Source:            "hashicorp/aws",
+-						VersionConstraint: "5.34.0",
+-					},
+-				},
+-				Config: testAccListenerRuleConfig_redirectWithTargetGroupARN(lbName),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
+-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "redirect"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.redirect.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-				Config:                   testAccListenerRuleConfig_redirectWithTargetGroupARN(lbName),
+-				PlanOnly:                 true,
+-				ExpectNonEmptyPlan:       false,
+-			},
+-		},
+-	})
+-}
+-
+ func TestAccELBV2ListenerRule_conditionAttributesCount(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	err_many := regexache.MustCompile("Only one of host_header, http_header, http_request_method, path_pattern, query_string or source_ip can be set in a condition block")
+@@ -4360,119 +4318,6 @@ resource "aws_security_group" "test" {
+ `, rName, action)
+ }
+ 
+-func testAccListenerRuleConfig_redirectWithTargetGroupARN(lbName string) string {
+-	return fmt.Sprintf(`
+-resource "aws_lb_listener_rule" "static" {
+-  listener_arn = aws_lb_listener.front_end.arn
+-  priority     = 100
+-
+-  action {
+-    type = "redirect"
+-
+-    redirect {
+-      port        = "443"
+-      protocol    = "HTTPS"
+-      status_code = "HTTP_301"
+-    }
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-
+-resource "aws_lb_listener" "front_end" {
+-  load_balancer_arn = aws_lb.alb_test.id
+-  protocol          = "HTTP"
+-  port              = "80"
+-
+-  default_action {
+-    type = "redirect"
+-
+-    redirect {
+-      port        = "443"
+-      protocol    = "HTTPS"
+-      status_code = "HTTP_301"
+-    }
+-  }
+-}
+-
+-resource "aws_lb" "alb_test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.alb_test.id]
+-  subnets         = aws_subnet.alb_test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-variable "subnets" {
+-  default = ["10.0.1.0/24", "10.0.2.0/24"]
+-  type    = list(string)
+-}
+-
+-data "aws_availability_zones" "available" {
+-  state = "available"
+-
+-  filter {
+-    name   = "opt-in-status"
+-    values = ["opt-in-not-required"]
+-  }
+-}
+-
+-resource "aws_vpc" "alb_test" {
+-  cidr_block = "10.0.0.0/16"
+-
+-  tags = {
+-    Name = "terraform-testacc-lb-listener-rule-redirect"
+-  }
+-}
+-
+-resource "aws_subnet" "alb_test" {
+-  count                   = 2
+-  vpc_id                  = aws_vpc.alb_test.id
+-  cidr_block              = element(var.subnets, count.index)
+-  map_public_ip_on_launch = true
+-  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
+-
+-  tags = {
+-    Name = "tf-acc-lb-listener-rule-redirect-${count.index}"
+-  }
+-}
+-
+-resource "aws_security_group" "alb_test" {
+-  name        = "allow_all_alb_test"
+-  description = "Used for ALB Testing"
+-  vpc_id      = aws_vpc.alb_test.id
+-
+-  ingress {
+-    from_port   = 0
+-    to_port     = 0
+-    protocol    = "-1"
+-    cidr_blocks = ["0.0.0.0/0"]
+-  }
+-
+-  egress {
+-    from_port   = 0
+-    to_port     = 0
+-    protocol    = "-1"
+-    cidr_blocks = ["0.0.0.0/0"]
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-`, lbName)
+-}
+-
+ func testAccListenerRuleConfig_condition_error(condition string) string {
+ 	return fmt.Sprintf(`
+ data "aws_partition" "current" {}
+diff --git a/internal/service/elbv2/listener_test.go b/internal/service/elbv2/listener_test.go
+index 0830e2b8ab..ce31802724 100644
+--- a/internal/service/elbv2/listener_test.go
++++ b/internal/service/elbv2/listener_test.go
+@@ -1636,48 +1636,6 @@ func TestAccELBV2Listener_EmptyDefaultAction(t *testing.T) {
+ 	}
+ }
+ 
+-func TestAccELBV2Listener_redirectWithTargetGroupARN(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:   acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		CheckDestroy: testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				ExternalProviders: map[string]resource.ExternalProvider{
+-					"aws": {
+-						Source:            "hashicorp/aws",
+-						VersionConstraint: "5.34.0",
+-					},
+-				},
+-				Config: testAccListenerConfig_redirectWithTargetGroupARN(rName),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "redirect"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-				Config:                   testAccListenerConfig_redirectWithTargetGroupARN(rName),
+-				PlanOnly:                 true,
+-				ExpectNonEmptyPlan:       false,
+-			},
+-		},
+-	})
+-}
+-
+ func testAccCheckListenerDefaultActionOrderDisappears(ctx context.Context, listener *awstypes.Listener, actionOrderToDelete int) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+ 		var newDefaultActions []awstypes.Action
+@@ -3748,60 +3706,3 @@ resource "aws_lb_target_group" "test" {
+ }
+ `, rName, action))
+ }
+-
+-func testAccListenerConfig_redirectWithTargetGroupARN(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTP"
+-  port              = "80"
+-
+-  default_action {
+-    target_group_arn = aws_lb_target_group.test.arn
+-    type             = "redirect"
+-
+-    redirect {
+-      port        = "443"
+-      protocol    = "HTTPS"
+-      status_code = "HTTP_301"
+-    }
+-  }
+-}
+-
+-resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test" {
+-  name     = %[1]q
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-`, rName))
+-}

--- a/patches/0043-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
+++ b/patches/0043-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
@@ -1,0 +1,4598 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Venelin <venelin@pulumi.com>
+Date: Wed, 14 Feb 2024 14:49:38 +0000
+Subject: [PATCH 43/43] Revert "Merge pull request #35671 from
+ hashicorp/b-lb-listener-stickiness-3"
+
+This reverts commit 32a681fcfcd8d78c5ac9e199384a980bb71c82ed, reversing
+changes made to 18afc65502825fcff19b8be8588836a66a96e06a.
+
+diff --git a/.changelog/35671.txt b/.changelog/35671.txt
+deleted file mode 100644
+index 7c9da01c62..0000000000
+--- a/.changelog/35671.txt
++++ /dev/null
+@@ -1,15 +0,0 @@
+-```release-note:bug
+-resource/aws_lb_listener: Was not storing `default_action[].forward` in state if only a single `target_group` was set.
+-```
+-
+-```release-note:bug
+-resource/aws_lb_listener_rule: Was not storing `action[].forward` in state if only a single `target_group` was set.
+-```
+-
+-```release-note:bug
+-resource/aws_lb_listener: Was incorrectly reporting conflicting `default_action[].target_group_arn` when `ignore_changes` was set.
+-```
+-
+-```release-note:bug
+-resource/aws_lb_listener_rule: Was incorrectly reporting conflicting `action[].target_group_arn` when `ignore_changes` was set.
+-```
+diff --git a/internal/service/elbv2/listener.go b/internal/service/elbv2/listener.go
+index 159d62abf7..dd0eaddc43 100644
+--- a/internal/service/elbv2/listener.go
++++ b/internal/service/elbv2/listener.go
+@@ -214,11 +214,9 @@ func ResourceListener() *schema.Resource {
+ 							},
+ 						},
+ 						"forward": {
+-							Type:                  schema.TypeList,
+-							Optional:              true,
+-							DiffSuppressOnRefresh: true,
+-							DiffSuppressFunc:      diffSuppressMissingForward("default_action"),
+-							MaxItems:              1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"target_group": {
+@@ -513,7 +511,7 @@ func resourceListenerRead(ctx context.Context, d *schema.ResourceData, meta inte
+ 	sort.Slice(listener.DefaultActions, func(i, j int) bool {
+ 		return aws.ToInt32(listener.DefaultActions[i].Order) < aws.ToInt32(listener.DefaultActions[j].Order)
+ 	})
+-	if err := d.Set("default_action", flattenLbListenerActions(d, "default_action", listener.DefaultActions)); err != nil {
++	if err := d.Set("default_action", flattenLbListenerActions(d, listener.DefaultActions)); err != nil {
+ 		return sdkdiag.AppendErrorf(diags, "setting default_action: %s", err)
+ 	}
+ 	d.Set("load_balancer_arn", listener.LoadBalancerArn)
+@@ -930,26 +928,20 @@ func expandLbListenerActionForwardConfigTargetGroupStickinessConfig(l []interfac
+ 		return nil
+ 	}
+ 
+-	// The Plugin SDK stores a `nil` returned by the API as a `0` in the state. This is a invalid value.
+-	var duration *int32
+-	if v := tfMap["duration"].(int); v > 0 {
+-		duration = aws.Int32(int32(v))
+-	}
+-
+ 	return &awstypes.TargetGroupStickinessConfig{
+ 		Enabled:         aws.Bool(tfMap["enabled"].(bool)),
+-		DurationSeconds: duration,
++		DurationSeconds: aws.Int32(int32(tfMap["duration"].(int))),
+ 	}
+ }
+ 
+-func flattenLbListenerActions(d *schema.ResourceData, attrName string, actions []awstypes.Action) []interface{} {
+-	if len(actions) == 0 {
++func flattenLbListenerActions(d *schema.ResourceData, Actions []awstypes.Action) []interface{} {
++	if len(Actions) == 0 {
+ 		return []interface{}{}
+ 	}
+ 
+ 	var vActions []interface{}
+ 
+-	for i, action := range actions {
++	for i, action := range Actions {
+ 		m := map[string]interface{}{
+ 			"type":  string(action.Type),
+ 			"order": aws.ToInt32(action.Order),
+@@ -957,7 +949,11 @@ func flattenLbListenerActions(d *schema.ResourceData, attrName string, actions [
+ 
+ 		switch action.Type {
+ 		case awstypes.ActionTypeEnumForward:
+-			flattenLbForwardAction(d, attrName, i, action, m)
++			if aws.ToString(action.TargetGroupArn) != "" {
++				m["target_group_arn"] = aws.ToString(action.TargetGroupArn)
++			} else {
++				m["forward"] = flattenLbListenerActionForwardConfig(action.ForwardConfig)
++			}
+ 
+ 		case awstypes.ActionTypeEnumRedirect:
+ 			m["redirect"] = flattenLbListenerActionRedirectConfig(action.RedirectConfig)
+@@ -972,7 +968,7 @@ func flattenLbListenerActions(d *schema.ResourceData, attrName string, actions [
+ 			// The LB API currently provides no way to read the ClientSecret
+ 			// Instead we passthrough the configuration value into the state
+ 			var clientSecret string
+-			if v, ok := d.GetOk(attrName + "." + strconv.Itoa(i) + ".authenticate_oidc.0.client_secret"); ok {
++			if v, ok := d.GetOk("default_action." + strconv.Itoa(i) + ".authenticate_oidc.0.client_secret"); ok {
+ 				clientSecret = v.(string)
+ 			}
+ 
+@@ -985,50 +981,6 @@ func flattenLbListenerActions(d *schema.ResourceData, attrName string, actions [
+ 	return vActions
+ }
+ 
+-func flattenLbForwardAction(d *schema.ResourceData, attrName string, i int, awsAction awstypes.Action, actionMap map[string]any) {
+-	// On create and update, we have a Config
+-	// On refresh, we have a populated State
+-	// On import, we have an empty State and empty Config
+-
+-	if rawConfig := d.GetRawConfig(); rawConfig.IsKnown() && !rawConfig.IsNull() {
+-		actions := rawConfig.GetAttr(attrName)
+-		flattenLbForwardActionOneOf(actions, i, awsAction, actionMap)
+-		return
+-	}
+-
+-	rawState := d.GetRawState()
+-	defaultActions := rawState.GetAttr(attrName)
+-
+-	if defaultActions.LengthInt() > 0 {
+-		flattenLbForwardActionOneOf(defaultActions, i, awsAction, actionMap)
+-		return
+-	}
+-
+-	flattenLbForwardActionBoth(awsAction, actionMap)
+-}
+-
+-func flattenLbForwardActionOneOf(actions cty.Value, i int, awsAction awstypes.Action, actionMap map[string]any) {
+-	if actions.IsKnown() && !actions.IsNull() {
+-		index := cty.NumberIntVal(int64(i))
+-		if actions.HasIndex(index).True() {
+-			action := actions.Index(index)
+-			if action.IsKnown() && !action.IsNull() {
+-				forward := action.GetAttr("forward")
+-				if forward.IsKnown() && forward.LengthInt() > 0 {
+-					actionMap["forward"] = flattenLbListenerActionForwardConfig(awsAction.ForwardConfig)
+-				} else {
+-					actionMap["target_group_arn"] = aws.ToString(awsAction.TargetGroupArn)
+-				}
+-			}
+-		}
+-	}
+-}
+-
+-func flattenLbForwardActionBoth(awsAction awstypes.Action, actionMap map[string]any) {
+-	actionMap["target_group_arn"] = aws.ToString(awsAction.TargetGroupArn)
+-	actionMap["forward"] = flattenLbListenerActionForwardConfig(awsAction.ForwardConfig)
+-}
+-
+ func flattenMutualAuthenticationAttributes(description *awstypes.MutualAuthenticationAttributes) []interface{} {
+ 	if description == nil {
+ 		return []interface{}{}
+@@ -1243,8 +1195,7 @@ func listenerActionPlantimeValidate(actionPath cty.Path, action cty.Value, diags
+ 		tga := action.GetAttr("target_group_arn")
+ 		f := action.GetAttr("forward")
+ 
+-		// If `ignore_changes` is set, even if there is no value in the configuration, the value in RawConfig is "" on refresh.
+-		if (tga.IsKnown() && !tga.IsNull() && tga.AsString() != "") && (f.IsKnown() && !f.IsNull() && f.LengthInt() > 0) {
++		if !tga.IsNull() && (!f.IsNull() && f.LengthInt() > 0) {
+ 			*diags = append(*diags, errs.NewAttributeErrorDiagnostic(actionPath,
+ 				"Invalid Attribute Combination",
+ 				fmt.Sprintf("Only one of %q or %q can be specified.",
+@@ -1370,15 +1321,3 @@ func listenerActionRuntimeValidate(actionPath cty.Path, action map[string]any, d
+ 		}
+ 	}
+ }
+-
+-func diffSuppressMissingForward(attrName string) schema.SchemaDiffSuppressFunc {
+-	return func(k, old, new string, d *schema.ResourceData) bool {
+-		if regexache.MustCompile(fmt.Sprintf(`^%s\.\d+\.forward\.#$`, attrName)).MatchString(k) {
+-			return old == "1" && new == "0"
+-		}
+-		if regexache.MustCompile(fmt.Sprintf(`^%s\.\d+\.forward\.\d+\.target_group\.#$`, attrName)).MatchString(k) {
+-			return old == "1" && new == "0"
+-		}
+-		return false
+-	}
+-}
+diff --git a/internal/service/elbv2/listener_certificate_test.go b/internal/service/elbv2/listener_certificate_test.go
+index 78cdb72825..c9dbc7909d 100644
+--- a/internal/service/elbv2/listener_certificate_test.go
++++ b/internal/service/elbv2/listener_certificate_test.go
+@@ -9,15 +9,14 @@ import (
+ 	"fmt"
+ 	"testing"
+ 
+-	"github.com/aws/aws-sdk-go-v2/aws"
+-	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+-	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/elbv2"
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+ 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+ 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+ 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+ 	tfelbv2 "github.com/hashicorp/terraform-provider-aws/internal/service/elbv2"
+ )
+ 
+@@ -212,21 +211,21 @@ func TestAccELBV2ListenerCertificate_disappears_Listener(t *testing.T) {
+ 
+ func testAccCheckListenerCertificateDestroy(ctx context.Context) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Conn(ctx)
+ 
+ 		for _, rs := range s.RootModule().Resources {
+ 			if rs.Type != "aws_lb_listener_certificate" {
+ 				continue
+ 			}
+ 
+-			input := &elasticloadbalancingv2.DescribeListenerCertificatesInput{
++			input := &elbv2.DescribeListenerCertificatesInput{
+ 				ListenerArn: aws.String(rs.Primary.Attributes["listener_arn"]),
+-				PageSize:    aws.Int32(400),
++				PageSize:    aws.Int64(400),
+ 			}
+ 
+-			resp, err := conn.DescribeListenerCertificates(ctx, input)
++			resp, err := conn.DescribeListenerCertificatesWithContext(ctx, input)
+ 			if err != nil {
+-				if errs.IsA[*awstypes.ListenerNotFoundException](err) {
++				if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeListenerNotFoundException) {
+ 					return nil
+ 				}
+ 				return err
+@@ -234,11 +233,11 @@ func testAccCheckListenerCertificateDestroy(ctx context.Context) resource.TestCh
+ 
+ 			for _, cert := range resp.Certificates {
+ 				// We only care about additional certificates.
+-				if aws.ToBool(cert.IsDefault) {
++				if aws.BoolValue(cert.IsDefault) {
+ 					continue
+ 				}
+ 
+-				if aws.ToString(cert.CertificateArn) == rs.Primary.Attributes["certificate_arn"] {
++				if aws.StringValue(cert.CertificateArn) == rs.Primary.Attributes["certificate_arn"] {
+ 					return errors.New("LB listener certificate not destroyed")
+ 				}
+ 			}
+diff --git a/internal/service/elbv2/listener_data_source.go b/internal/service/elbv2/listener_data_source.go
+index a209c9338b..c9ec31a266 100644
+--- a/internal/service/elbv2/listener_data_source.go
++++ b/internal/service/elbv2/listener_data_source.go
+@@ -338,7 +338,7 @@ func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta in
+ 	sort.Slice(listener.DefaultActions, func(i, j int) bool {
+ 		return aws.ToInt32(listener.DefaultActions[i].Order) < aws.ToInt32(listener.DefaultActions[j].Order)
+ 	})
+-	if err := d.Set("default_action", flattenLbListenerActions(d, "default_action", listener.DefaultActions)); err != nil {
++	if err := d.Set("default_action", flattenLbListenerActions(d, listener.DefaultActions)); err != nil {
+ 		return sdkdiag.AppendErrorf(diags, "setting default_action: %s", err)
+ 	}
+ 	d.Set("load_balancer_arn", listener.LoadBalancerArn)
+diff --git a/internal/service/elbv2/listener_rule.go b/internal/service/elbv2/listener_rule.go
+index 047ee68dee..6da74fd123 100644
+--- a/internal/service/elbv2/listener_rule.go
++++ b/internal/service/elbv2/listener_rule.go
+@@ -98,11 +98,9 @@ func ResourceListenerRule() *schema.Resource {
+ 						},
+ 
+ 						"forward": {
+-							Type:                  schema.TypeList,
+-							Optional:              true,
+-							DiffSuppressOnRefresh: true,
+-							DiffSuppressFunc:      diffSuppressMissingForward("action"),
+-							MaxItems:              1,
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
+ 							Elem: &schema.Resource{
+ 								Schema: map[string]*schema.Schema{
+ 									"target_group": {
+@@ -593,9 +591,41 @@ func resourceListenerRuleRead(ctx context.Context, d *schema.ResourceData, meta
+ 	sort.Slice(rule.Actions, func(i, j int) bool {
+ 		return aws.ToInt32(rule.Actions[i].Order) < aws.ToInt32(rule.Actions[j].Order)
+ 	})
+-	if err := d.Set("action", flattenLbListenerActions(d, "action", rule.Actions)); err != nil {
+-		return sdkdiag.AppendErrorf(diags, "setting action: %s", err)
++	actions := make([]interface{}, len(rule.Actions))
++	for i, action := range rule.Actions {
++		actionMap := map[string]interface{}{
++			"type":  string(action.Type),
++			"order": aws.ToInt32(action.Order),
++		}
++
++		switch action.Type {
++		case awstypes.ActionTypeEnumForward:
++			if aws.ToString(action.TargetGroupArn) != "" {
++				actionMap["target_group_arn"] = aws.ToString(action.TargetGroupArn)
++			} else {
++				actionMap["forward"] = flattenLbListenerActionForwardConfig(action.ForwardConfig)
++			}
++
++		case awstypes.ActionTypeEnumRedirect:
++			actionMap["redirect"] = flattenLbListenerActionRedirectConfig(action.RedirectConfig)
++
++		case awstypes.ActionTypeEnumFixedResponse:
++			actionMap["fixed_response"] = flattenLbListenerActionFixedResponseConfig(action.FixedResponseConfig)
++
++		case awstypes.ActionTypeEnumAuthenticateCognito:
++			actionMap["authenticate_cognito"] = flattenLbListenerActionAuthenticateCognitoConfig(action.AuthenticateCognitoConfig)
++
++		case awstypes.ActionTypeEnumAuthenticateOidc:
++			// The LB API currently provides no way to read the ClientSecret
++			// Instead we passthrough the configuration value into the state
++			clientSecret := d.Get("action." + strconv.Itoa(i) + ".authenticate_oidc.0.client_secret").(string)
++
++			actionMap["authenticate_oidc"] = flattenAuthenticateOIDCActionConfig(action.AuthenticateOidcConfig, clientSecret)
++		}
++
++		actions[i] = actionMap
+ 	}
++	d.Set("action", actions)
+ 
+ 	conditions := make([]interface{}, len(rule.Conditions))
+ 	for i, condition := range rule.Conditions {
+diff --git a/internal/service/elbv2/listener_rule_test.go b/internal/service/elbv2/listener_rule_test.go
+index f28fc7c62c..c5690cb813 100644
+--- a/internal/service/elbv2/listener_rule_test.go
++++ b/internal/service/elbv2/listener_rule_test.go
+@@ -12,15 +12,15 @@ import (
+ 	"testing"
+ 
+ 	"github.com/YakDriver/regexache"
+-	"github.com/aws/aws-sdk-go-v2/aws"
+-	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+ 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
++	"github.com/aws/aws-sdk-go/aws"
++	"github.com/aws/aws-sdk-go/service/elbv2"
++	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+ 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+ 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+ 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+ 	tfelbv2 "github.com/hashicorp/terraform-provider-aws/internal/service/elbv2"
+ 	"golang.org/x/exp/slices"
+ )
+@@ -70,7 +70,7 @@ func TestLBListenerARNFromRuleARN(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_basic(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_lb_listener_rule.test"
+ 	listenerResourceName := "aws_lb_listener.test"
+@@ -117,7 +117,7 @@ func TestAccELBV2ListenerRule_basic(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_disappears(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_lb_listener_rule.test"
+ 
+@@ -141,7 +141,7 @@ func TestAccELBV2ListenerRule_disappears(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_tags(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_lb_listener_rule.test"
+ 
+@@ -180,62 +180,9 @@ func TestAccELBV2ListenerRule_tags(t *testing.T) {
+ 	})
+ }
+ 
+-func TestAccELBV2ListenerRule_updateForwardBasic(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	rName = rName[:30]
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_forwardBasic(rName, "test1"),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.target_group_arn", "aws_lb_target_group.test1", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.forward",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_forwardBasic(rName, "test2"),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.target_group_arn", "aws_lb_target_group.test2", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+ func TestAccELBV2ListenerRule_forwardWeighted(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-weighted-%s", sdkacctest.RandString(13))
+ 	targetGroupName1 := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
+ 	targetGroupName2 := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
+@@ -322,7 +269,7 @@ func TestAccELBV2ListenerRule_forwardTargetARNAndBlock(t *testing.T) {
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+ 		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+ 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
++		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+ 				Config:      testAccListenerRuleConfig_forwardTargetARNAndBlock(rName),
+@@ -332,557 +279,10 @@ func TestAccELBV2ListenerRule_forwardTargetARNAndBlock(t *testing.T) {
+ 	})
+ }
+ 
+-func TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_NoChanges(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_TargetGroupARN(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.forward",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddStickiness(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveStickiness(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_TargetGroupARN(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.forward",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockWeightAndStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_NoChanges(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_TargetGroupARN(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockWeightAndStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_TargetGroupARN(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddAction(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockAddAction(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "authenticate-oidc"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.1.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.authenticate_oidc.0.client_secret",
+-					"action.1.target_group_arn",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveAction(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockAddAction(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "authenticate-oidc"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.1.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.1.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.authenticate_oidc.0.client_secret",
+-					"action.1.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.target_group_arn",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2ListenerRule_ActionForward_IgnoreFields(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
+-	resourceName := "aws_lb_listener_rule.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	rName = rName[:30]
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerRuleConfig_actionForward_ForwardBlockMultiTargetWithIgnore(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.target_group.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.fixed_response.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-			},
+-		},
+-	})
+-}
+-
+ // TestAccELBV2ListenerRule_backwardsCompatibility confirms that the resource type `aws_alb_listener_rule` works
+ func TestAccELBV2ListenerRule_backwardsCompatibility(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-basic-%s", sdkacctest.RandString(13))
+ 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
+ 
+@@ -930,7 +330,7 @@ func TestAccELBV2ListenerRule_backwardsCompatibility(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_redirect(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-redirect-%s", sdkacctest.RandString(14))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1020,7 +420,7 @@ func TestAccELBV2ListenerRule_redirect(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_fixedResponse(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-fixedresponse-%s", sdkacctest.RandString(9))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1060,7 +460,7 @@ func TestAccELBV2ListenerRule_fixedResponse(t *testing.T) {
+ // Updating Action breaks Condition change logic GH-11323 and GH-11362
+ func TestAccELBV2ListenerRule_updateFixedResponse(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var rule awstypes.Rule
++	var rule elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-basic-%s", sdkacctest.RandString(13))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1091,7 +491,7 @@ func TestAccELBV2ListenerRule_updateFixedResponse(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_updateRulePriority(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var before, after awstypes.Rule
++	var before, after elbv2.Rule
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_lb_listener_rule.test"
+ 
+@@ -1122,7 +522,7 @@ func TestAccELBV2ListenerRule_updateRulePriority(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var before, after awstypes.Rule
++	var before, after elbv2.Rule
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_lb_listener_rule.test"
+ 
+@@ -1151,7 +551,7 @@ func TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_priority(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var rule awstypes.Rule
++	var rule elbv2.Rule
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+ 	if testing.Short() {
+@@ -1169,37 +569,29 @@ func TestAccELBV2ListenerRule_priority(t *testing.T) {
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckListenerRuleExists(ctx, "aws_lb_listener_rule.first", &rule),
+ 					resource.TestCheckResourceAttr("aws_lb_listener_rule.first", "priority", "1"),
+-					resource.TestCheckResourceAttr("aws_lb_listener_rule.third", "priority", "3"),
+ 				),
+ 			},
+ 			{
+-				Config: testAccListenerRuleConfig_priorityLastNoPriority(rName),
++				Config: testAccListenerRuleConfig_priorityLast(rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckListenerRuleExists(ctx, "aws_lb_listener_rule.last", &rule),
+ 					resource.TestCheckResourceAttr("aws_lb_listener_rule.last", "priority", "4"),
+ 				),
+ 			},
+ 			{
+-				Config: testAccListenerRuleConfig_priorityLastSpecifyPriority(rName, "7"),
++				Config: testAccListenerRuleConfig_priorityStatic(rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckListenerRuleExists(ctx, "aws_lb_listener_rule.last", &rule),
+ 					resource.TestCheckResourceAttr("aws_lb_listener_rule.last", "priority", "7"),
+ 				),
+ 			},
+ 			{
+-				Config: testAccListenerRuleConfig_priorityLastNoPriority(rName),
++				Config: testAccListenerRuleConfig_priorityLast(rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckListenerRuleExists(ctx, "aws_lb_listener_rule.last", &rule),
+ 					resource.TestCheckResourceAttr("aws_lb_listener_rule.last", "priority", "7"),
+ 				),
+ 			},
+-			{
+-				Config: testAccListenerRuleConfig_priorityLastSpecifyPriority(rName, "6"),
+-				Check: resource.ComposeTestCheckFunc(
+-					testAccCheckListenerRuleExists(ctx, "aws_lb_listener_rule.last", &rule),
+-					resource.TestCheckResourceAttr("aws_lb_listener_rule.last", "priority", "6"),
+-				),
+-			},
+ 			{
+ 				Config: testAccListenerRuleConfig_priorityParallelism(rName),
+ 				Check: resource.ComposeTestCheckFunc(
+@@ -1246,7 +638,7 @@ func TestAccELBV2ListenerRule_priority(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_cognito(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+@@ -1290,7 +682,7 @@ func TestAccELBV2ListenerRule_cognito(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_oidc(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+@@ -1334,7 +726,7 @@ func TestAccELBV2ListenerRule_oidc(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_Action_defaultOrder(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var rule awstypes.Rule
++	var rule elbv2.Rule
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+@@ -1356,13 +748,10 @@ func TestAccELBV2ListenerRule_Action_defaultOrder(t *testing.T) {
+ 				),
+ 			},
+ 			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.authenticate_oidc.0.client_secret",
+-					"action.1.forward",
+-				},
++				ResourceName:            resourceName,
++				ImportState:             true,
++				ImportStateVerify:       true,
++				ImportStateVerifyIgnore: []string{"action.0.authenticate_oidc.0.client_secret"},
+ 			},
+ 		},
+ 	})
+@@ -1370,7 +759,7 @@ func TestAccELBV2ListenerRule_Action_defaultOrder(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_Action_specifyOrder(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var rule awstypes.Rule
++	var rule elbv2.Rule
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+@@ -1392,13 +781,10 @@ func TestAccELBV2ListenerRule_Action_specifyOrder(t *testing.T) {
+ 				),
+ 			},
+ 			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"action.0.authenticate_oidc.0.client_secret",
+-					"action.1.forward",
+-				},
++				ResourceName:            resourceName,
++				ImportState:             true,
++				ImportStateVerify:       true,
++				ImportStateVerifyIgnore: []string{"action.0.authenticate_oidc.0.client_secret"},
+ 			},
+ 		},
+ 	})
+@@ -1407,7 +793,7 @@ func TestAccELBV2ListenerRule_Action_specifyOrder(t *testing.T) {
+ // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6171
+ func TestAccELBV2ListenerRule_Action_actionDisappears(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var rule awstypes.Rule
++	var rule elbv2.Rule
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+@@ -1498,7 +884,7 @@ func TestAccELBV2ListenerRule_EmptyAction(t *testing.T) {
+ 				PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+ 				ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+ 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-				CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
++				CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 				Steps: []resource.TestStep{
+ 					{
+ 						Config:      testAccListenerRuleConfig_EmptyAction(rName, testcase.actionType),
+@@ -1546,7 +932,7 @@ func TestAccELBV2ListenerRule_conditionAttributesCount(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionHostHeader(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-hostHeader-%s", sdkacctest.RandString(12))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1586,7 +972,7 @@ func TestAccELBV2ListenerRule_conditionHostHeader(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionHTTPHeader(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-httpHeader-%s", sdkacctest.RandString(12))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1654,7 +1040,7 @@ func TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionHTTPRequestMethod(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-httpRequest-%s", sdkacctest.RandString(11))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1694,7 +1080,7 @@ func TestAccELBV2ListenerRule_conditionHTTPRequestMethod(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionPathPattern(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-pathPattern-%s", sdkacctest.RandString(11))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1734,7 +1120,7 @@ func TestAccELBV2ListenerRule_conditionPathPattern(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionQueryString(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-queryString-%s", sdkacctest.RandString(11))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1798,7 +1184,7 @@ func TestAccELBV2ListenerRule_conditionQueryString(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionSourceIP(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-sourceIp-%s", sdkacctest.RandString(14))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1838,7 +1224,7 @@ func TestAccELBV2ListenerRule_conditionSourceIP(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionUpdateMixed(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-mixed-%s", sdkacctest.RandString(17))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -1917,7 +1303,7 @@ func TestAccELBV2ListenerRule_conditionUpdateMixed(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionMultiple(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-condMulti-%s", sdkacctest.RandString(13))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -2001,7 +1387,7 @@ func TestAccELBV2ListenerRule_conditionMultiple(t *testing.T) {
+ 
+ func TestAccELBV2ListenerRule_conditionUpdateMultiple(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Rule
++	var conf elbv2.Rule
+ 	lbName := fmt.Sprintf("testrule-condMulti-%s", sdkacctest.RandString(13))
+ 
+ 	resourceName := "aws_lb_listener_rule.static"
+@@ -2097,12 +1483,12 @@ func TestAccELBV2ListenerRule_conditionUpdateMultiple(t *testing.T) {
+ 	})
+ }
+ 
+-func testAccCheckListenerRuleActionOrderDisappears(ctx context.Context, rule *awstypes.Rule, actionOrderToDelete int) resource.TestCheckFunc {
++func testAccCheckListenerRuleActionOrderDisappears(ctx context.Context, rule *elbv2.Rule, actionOrderToDelete int) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+-		var newActions []awstypes.Action
++		var newActions []*elbv2.Action
+ 
+ 		for i, action := range rule.Actions {
+-			if int(aws.ToInt32(action.Order)) == actionOrderToDelete {
++			if int(aws.Int64Value(action.Order)) == actionOrderToDelete {
+ 				newActions = slices.Delete(rule.Actions, i, i+1)
+ 				break
+ 			}
+@@ -2112,22 +1498,22 @@ func testAccCheckListenerRuleActionOrderDisappears(ctx context.Context, rule *aw
+ 			return fmt.Errorf("Unable to find action order %d from actions: %#v", actionOrderToDelete, rule.Actions)
+ 		}
+ 
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Conn(ctx)
+ 
+-		input := &elasticloadbalancingv2.ModifyRuleInput{
++		input := &elbv2.ModifyRuleInput{
+ 			Actions: newActions,
+ 			RuleArn: rule.RuleArn,
+ 		}
+ 
+-		_, err := conn.ModifyRule(ctx, input)
++		_, err := conn.ModifyRuleWithContext(ctx, input)
+ 
+ 		return err
+ 	}
+ }
+ 
+-func testAccCheckListenerRuleNotRecreated(t *testing.T, before, after *awstypes.Rule) resource.TestCheckFunc {
++func testAccCheckListenerRuleNotRecreated(t *testing.T, before, after *elbv2.Rule) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+-		if before, after := aws.ToString(before.RuleArn), aws.ToString(after.RuleArn); before != after {
++		if before, after := aws.StringValue(before.RuleArn), aws.StringValue(after.RuleArn); before != after {
+ 			t.Fatalf("ELBv2 Listener Rule (%s) was recreated: %s", before, after)
+ 		}
+ 
+@@ -2135,9 +1521,9 @@ func testAccCheckListenerRuleNotRecreated(t *testing.T, before, after *awstypes.
+ 	}
+ }
+ 
+-func testAccCheckListenerRuleRecreated(t *testing.T, before, after *awstypes.Rule) resource.TestCheckFunc {
++func testAccCheckListenerRuleRecreated(t *testing.T, before, after *elbv2.Rule) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+-		if before, after := aws.ToString(before.RuleArn), aws.ToString(after.RuleArn); before == after {
++		if before, after := aws.StringValue(before.RuleArn), aws.StringValue(after.RuleArn); before == after {
+ 			t.Fatalf("ELBv2 Listener Rule (%s) was not recreated", before)
+ 		}
+ 
+@@ -2145,7 +1531,7 @@ func testAccCheckListenerRuleRecreated(t *testing.T, before, after *awstypes.Rul
+ 	}
+ }
+ 
+-func testAccCheckListenerRuleExists(ctx context.Context, n string, res *awstypes.Rule) resource.TestCheckFunc {
++func testAccCheckListenerRuleExists(ctx context.Context, n string, res *elbv2.Rule) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+ 		rs, ok := s.RootModule().Resources[n]
+ 		if !ok {
+@@ -2156,10 +1542,10 @@ func testAccCheckListenerRuleExists(ctx context.Context, n string, res *awstypes
+ 			return errors.New("No Listener Rule ID is set")
+ 		}
+ 
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Conn(ctx)
+ 
+-		describe, err := conn.DescribeRules(ctx, &elasticloadbalancingv2.DescribeRulesInput{
+-			RuleArns: []string{rs.Primary.ID},
++		describe, err := conn.DescribeRulesWithContext(ctx, &elbv2.DescribeRulesInput{
++			RuleArns: []*string{aws.String(rs.Primary.ID)},
+ 		})
+ 
+ 		if err != nil {
+@@ -2171,22 +1557,22 @@ func testAccCheckListenerRuleExists(ctx context.Context, n string, res *awstypes
+ 			return errors.New("Listener Rule not found")
+ 		}
+ 
+-		*res = describe.Rules[0]
++		*res = *describe.Rules[0]
+ 		return nil
+ 	}
+ }
+ 
+ func testAccCheckListenerRuleDestroy(ctx context.Context) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Conn(ctx)
+ 
+ 		for _, rs := range s.RootModule().Resources {
+ 			if rs.Type != "aws_lb_listener_rule" && rs.Type != "aws_alb_listener_rule" {
+ 				continue
+ 			}
+ 
+-			describe, err := conn.DescribeRules(ctx, &elasticloadbalancingv2.DescribeRulesInput{
+-				RuleArns: []string{rs.Primary.ID},
++			describe, err := conn.DescribeRulesWithContext(ctx, &elbv2.DescribeRulesInput{
++				RuleArns: []*string{aws.String(rs.Primary.ID)},
+ 			})
+ 
+ 			if err == nil {
+@@ -2197,7 +1583,7 @@ func testAccCheckListenerRuleDestroy(ctx context.Context) resource.TestCheckFunc
+ 			}
+ 
+ 			// Verify the error
+-			if errs.IsA[*awstypes.RuleNotFoundException](err) {
++			if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeRuleNotFoundException) {
+ 				return nil
+ 			} else {
+ 				return fmt.Errorf("Unexpected error checking LB Listener Rule destroyed: %s", err)
+@@ -2271,7 +1657,7 @@ resource "aws_lb_target_group" "test" {
+ `, rName))
+ }
+ 
+-func testAccListenerRuleConfig_baseWithHTTPListener(rName string) string {
++func testAccListenerRuleConfig_baseWithListener(rName string) string {
+ 	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+@@ -2290,35 +1676,8 @@ resource "aws_lb_listener" "test" {
+ `, rName))
+ }
+ 
+-func testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
+-  port              = "443"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
+-
+-  default_action {
+-    target_group_arn = aws_lb_target_group.test.id
+-    type             = "forward"
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
+-}
+-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
+-}
+-
+ func testAccListenerRuleConfig_basic(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), `
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), `
+ resource "aws_lb_listener_rule" "test" {
+   listener_arn = aws_lb_listener.test.arn
+   priority     = 100
+@@ -2337,62 +1696,6 @@ resource "aws_lb_listener_rule" "test" {
+ `)
+ }
+ 
+-func testAccListenerRuleConfig_forwardBasic(rName, targetName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type             = "forward"
+-    target_group_arn = aws_lb_target_group.%[2]s.arn
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test1" {
+-  name     = "%[1]s-1"
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test2" {
+-  name     = "%[1]s-2"
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-}
+-`, rName, targetName))
+-}
+-
+ func testAccListenerRuleConfig_forwardWeighted(lbName, targetGroupName1 string, targetGroupName2 string) string {
+ 	return fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "weighted" {
+@@ -2832,212 +2135,6 @@ resource "aws_security_group" "alb_test" {
+ `, rName)
+ }
+ 
+-func testAccListenerRuleConfig_actionForward_TargetGroupARN(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate), `
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type             = "forward"
+-    target_group_arn = aws_lb_target_group.test.arn
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-`)
+-}
+-
+-func testAccListenerRuleConfig_actionForward_ForwardBlockBasic(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate), `
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type = "forward"
+-    forward {
+-      target_group {
+-        arn = aws_lb_target_group.test.arn
+-      }
+-    }
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-`)
+-}
+-
+-func testAccListenerRuleConfig_actionForward_ForwardBlockStickiness(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate), `
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type = "forward"
+-    forward {
+-      target_group {
+-        arn = aws_lb_target_group.test.arn
+-      }
+-
+-      stickiness {
+-        enabled  = true
+-        duration = 3600
+-      }
+-    }
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-`)
+-}
+-
+-func testAccListenerRuleConfig_actionForward_ForwardBlockWeightAndStickiness(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate), `
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type = "forward"
+-    forward {
+-      target_group {
+-        arn    = aws_lb_target_group.test.arn
+-        weight = 2
+-      }
+-
+-      stickiness {
+-        enabled  = true
+-        duration = 3600
+-      }
+-    }
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-`)
+-}
+-
+-func testAccListenerRuleConfig_actionForward_ForwardBlockAddAction(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate), `
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type = "authenticate-oidc"
+-
+-    authenticate_oidc {
+-      authorization_endpoint = "https://example.com/authorization_endpoint"
+-      client_id              = "s6BhdRkqt3"
+-      client_secret          = "7Fjfp0ZBr1KtDRbnfVdmIw"
+-      issuer                 = "https://example.com"
+-      token_endpoint         = "https://example.com/token_endpoint"
+-      user_info_endpoint     = "https://example.com/user_info_endpoint"
+-
+-      authentication_request_extra_params = {
+-        param = "test"
+-      }
+-    }
+-  }
+-
+-  action {
+-    type = "forward"
+-    forward {
+-      target_group {
+-        arn = aws_lb_target_group.test.arn
+-      }
+-    }
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-}
+-`)
+-}
+-
+-func testAccListenerRuleConfig_actionForward_ForwardBlockMultiTargetWithIgnore(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPSListener(rName, key, certificate), fmt.Sprintf(`
+-resource "aws_lb_listener_rule" "test" {
+-  listener_arn = aws_lb_listener.test.arn
+-  priority     = 100
+-
+-  action {
+-    type = "forward"
+-
+-    forward {
+-      target_group {
+-        arn    = aws_lb_target_group.test.arn
+-        weight = 100
+-      }
+-
+-      target_group {
+-        arn    = aws_lb_target_group.test2.arn
+-        weight = 0
+-      }
+-    }
+-  }
+-
+-  condition {
+-    path_pattern {
+-      values = ["/static/*"]
+-    }
+-  }
+-
+-  lifecycle {
+-    ignore_changes = [
+-      action[0].forward,
+-      action[0].target_group_arn,
+-    ]
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test2" {
+-  name     = "%[1]s-2"
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-}
+-`, rName))
+-}
+-
+ func testAccListenerRuleConfig_changeForwardWeightedToBasic(lbName, targetGroupName1 string, targetGroupName2 string) string {
+ 	return fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "weighted" {
+@@ -3532,7 +2629,7 @@ resource "aws_security_group" "alb_test" {
+ }
+ 
+ func testAccListenerRuleConfig_updatePriority(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), `
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), `
+ resource "aws_lb_listener_rule" "test" {
+   listener_arn = aws_lb_listener.test.arn
+   priority     = 101
+@@ -3552,7 +2649,7 @@ resource "aws_lb_listener_rule" "test" {
+ }
+ 
+ func testAccListenerRuleConfig_changeARN(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "test" {
+   listener_arn = aws_lb_listener.test2.arn
+   priority     = 101
+@@ -3587,8 +2684,7 @@ resource "aws_lb_listener" "test2" {
+ }
+ 
+ func testAccListenerRuleConfig_priorityFirst(rName string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "first" {
+   listener_arn = aws_lb_listener.test.arn
+ 
+@@ -3632,9 +2728,8 @@ resource "aws_lb_listener_rule" "third" {
+ `, rName))
+ }
+ 
+-func testAccListenerRuleConfig_priorityLastNoPriority(rName string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_priorityFirst(rName), fmt.Sprintf(`
++func testAccListenerRuleConfig_priorityLast(rName string) string {
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "last" {
+   listener_arn = aws_lb_listener.test.arn
+ 
+@@ -3656,12 +2751,11 @@ resource "aws_lb_listener_rule" "last" {
+ `, rName))
+ }
+ 
+-func testAccListenerRuleConfig_priorityLastSpecifyPriority(rName, priority string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerRuleConfig_priorityFirst(rName), fmt.Sprintf(`
++func testAccListenerRuleConfig_priorityStatic(rName string) string {
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "last" {
+   listener_arn = aws_lb_listener.test.arn
+-  priority     = %[2]s
++  priority     = 7
+ 
+   action {
+     type             = "forward"
+@@ -3678,11 +2772,11 @@ resource "aws_lb_listener_rule" "last" {
+     Name = %[1]q
+   }
+ }
+-`, rName, priority))
++`, rName))
+ }
+ 
+ func testAccListenerRuleConfig_priorityParallelism(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "parallelism" {
+   count = 10
+ 
+@@ -3707,7 +2801,7 @@ resource "aws_lb_listener_rule" "parallelism" {
+ }
+ 
+ func testAccListenerRuleConfig_priority50000(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "priority50000" {
+   listener_arn = aws_lb_listener.test.arn
+   priority     = 50000
+@@ -3732,7 +2826,7 @@ resource "aws_lb_listener_rule" "priority50000" {
+ 
+ // priority out of range (1, 50000)
+ func testAccListenerRuleConfig_priority50001(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "priority50001" {
+   listener_arn = aws_lb_listener.test.arn
+ 
+@@ -3755,7 +2849,7 @@ resource "aws_lb_listener_rule" "priority50001" {
+ }
+ 
+ func testAccListenerRuleConfig_priorityInUse(rName string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "priority50000" {
+   listener_arn = aws_lb_listener.test.arn
+   priority     = 50000
+@@ -4770,7 +3864,7 @@ condition {
+ }
+ 
+ func testAccListenerRuleConfig_tags1(rName, tagKey1, tagValue1 string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "test" {
+   listener_arn = aws_lb_listener.test.arn
+   priority     = 100
+@@ -4794,7 +3888,7 @@ resource "aws_lb_listener_rule" "test" {
+ }
+ 
+ func testAccListenerRuleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+-	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithHTTPListener(rName), fmt.Sprintf(`
++	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
+ resource "aws_lb_listener_rule" "test" {
+   listener_arn = aws_lb_listener.test.arn
+   priority     = 100
+diff --git a/internal/service/elbv2/listener_test.go b/internal/service/elbv2/listener_test.go
+index ce31802724..457bb3fe01 100644
+--- a/internal/service/elbv2/listener_test.go
++++ b/internal/service/elbv2/listener_test.go
+@@ -67,9 +67,6 @@ func TestAccELBV2Listener_Application_basic(t *testing.T) {
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+ 			},
+ 		},
+ 	})
+@@ -118,9 +115,6 @@ func TestAccELBV2Listener_Network_basic(t *testing.T) {
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+ 			},
+ 		},
+ 	})
+@@ -148,7 +142,7 @@ func TestAccELBV2Listener_Gateway_basic(t *testing.T) {
+ 					resource.TestCheckNoResourceAttr(resourceName, "alpn_policy"),
+ 					resource.TestCheckNoResourceAttr(resourceName, "certificate_arn"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "0"), // A Gateway Listener can only have one action, so the API never returns a value
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "0"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+ 					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.#", "0"),
+@@ -169,9 +163,6 @@ func TestAccELBV2Listener_Gateway_basic(t *testing.T) {
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+ 			},
+ 		},
+ 	})
+@@ -230,9 +221,6 @@ func TestAccELBV2Listener_tags(t *testing.T) {
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+ 			},
+ 			{
+ 				Config: testAccListenerConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+@@ -243,14 +231,6 @@ func TestAccELBV2Listener_tags(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+ 				),
+ 			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+ 			{
+ 				Config: testAccListenerConfig_tags1(rName, "key2", "value2"),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+@@ -259,67 +239,6 @@ func TestAccELBV2Listener_tags(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+ 				),
+ 			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_updateForwardBasic(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	rName = rName[:30]
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_forwardBasic(rName, "test1"),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test1", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_forwardBasic(rName, "test2"),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test2", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+ 		},
+ 	})
+ }
+@@ -346,6 +265,7 @@ func TestAccELBV2Listener_forwardWeighted(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+ 					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "2"),
+@@ -369,6 +289,7 @@ func TestAccELBV2Listener_forwardWeighted(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+ 					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "2"),
+@@ -392,20 +313,13 @@ func TestAccELBV2Listener_forwardWeighted(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+ 					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+ 					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test1", "arn"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+ 				),
+ 			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+ 		},
+ 	})
+ }
+@@ -428,13 +342,11 @@ func TestAccELBV2Listener_forwardTargetARNAndBlock(t *testing.T) {
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_TargetGroupARNToForwardBlock_NoChanges(t *testing.T) {
++func TestAccELBV2Listener_Protocol_upd(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+ 	resourceName := "aws_lb_listener.test"
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -443,58 +355,75 @@ func TestAccELBV2Listener_ActionForward_TargetGroupARNToForwardBlock_NoChanges(t
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_TargetGroupARN(rName, key, certificate),
++				Config: testAccListenerConfig_basicUdp(rName),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "UDP"),
++					resource.TestCheckResourceAttr(resourceName, "port", "514"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+ 					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+ 			},
++		},
++	})
++}
++
++// TestAccELBV2Listener_backwardsCompatibility confirms that the resource type `aws_alb_listener` works
++func TestAccELBV2Listener_backwardsCompatibility(t *testing.T) {
++	ctx := acctest.Context(t)
++	var conf awstypes.Listener
++	resourceName := "aws_alb_listener.test"
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++
++	resource.ParallelTest(t, resource.TestCase{
++		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
++		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckListenerDestroy(ctx),
++		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
++				Config: testAccListenerConfig_backwardsCompatibility(rName),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_alb.test", "arn"),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
++					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
++					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_alb_target_group.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_ForwardBlock_AddStickiness(t *testing.T) {
++func TestAccELBV2Listener_Protocol_https(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
++	resourceName := "aws_lb_listener.test"
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -503,64 +432,43 @@ func TestAccELBV2Listener_ActionForward_ForwardBlock_AddStickiness(t *testing.T)
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockStickiness(rName, key, certificate),
++				Config: testAccListenerConfig_https(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
++					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
++					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
++					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationOff),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", "false"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.trust_store_arn", ""),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_ForwardBlock_RemoveStickiness(t *testing.T) {
++func TestAccELBV2Listener_mutualAuthentication(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
++	resourceName := "aws_lb_listener.test"
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -569,64 +477,45 @@ func TestAccELBV2Listener_ActionForward_ForwardBlock_RemoveStickiness(t *testing
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
++				Config: testAccListenerConfig_mutualAuthentication(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationVerify),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", "false"),
++					resource.TestCheckResourceAttrPair(resourceName, "mutual_authentication.0.trust_store_arn", "aws_lb_trust_store.test", "arn"),
++
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
++
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
++					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
++					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
++					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness(t *testing.T) {
++func TestAccELBV2Listener_mutualAuthenticationPassthrough(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
++	resourceName := "aws_lb_listener.test"
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -635,58 +524,48 @@ func TestAccELBV2Listener_ActionForward_TargetGroupARNToForwardBlock_WeightAndSt
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_TargetGroupARN(rName, key, certificate),
++				Config: testAccListenerConfig_mutualAuthenticationPassthrough(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationPassthrough),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", "false"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.trust_store_arn", ""),
++
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
++
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
++					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+ 					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
++					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockWeightAndStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_ForwardBlockToTargetGroupARN_NoChanges(t *testing.T) {
++func TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
++	lbResourceName := "aws_lb.test"
++	resourceName := "aws_lb_listener.test"
++
++	if testing.Short() {
++		t.Skip("skipping long-running test in short mode")
++	}
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -695,58 +574,30 @@ func TestAccELBV2Listener_ActionForward_ForwardBlockToTargetGroupARN_NoChanges(t
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
++				Config: testAccListenerConfig_arnGateway(rName),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_TargetGroupARN(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", lbResourceName, "arn"),
++					resource.TestCheckResourceAttr(resourceName, "protocol", ""),
++					resource.TestCheckResourceAttr(resourceName, "port", "0"),
++					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+ 				),
+ 			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness(t *testing.T) {
++func TestAccELBV2Listener_Protocol_tls(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	var listener1 awstypes.Listener
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_lb_listener.test"
++
++	if testing.Short() {
++		t.Skip("skipping long-running test in short mode")
++	}
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -755,58 +606,30 @@ func TestAccELBV2Listener_ActionForward_ForwardBlockToTargetGroupARN_WeightAndSt
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockWeightAndStickiness(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "3600"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "true"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_TargetGroupARN(rName, key, certificate),
++				Config: testAccListenerConfig_protocolTLS(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
++					testAccCheckListenerExists(ctx, resourceName, &listener1),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "TLS"),
++					resource.TestCheckResourceAttr(resourceName, "alpn_policy", tfelbv2.AlpnPolicyHTTP2Preferred),
++					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_acm_certificate.test", "arn"),
++					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
++					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "0"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_ForwardBlock_AddAction(t *testing.T) {
++func TestAccELBV2Listener_redirect(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+ 	resourceName := "aws_lb_listener.test"
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -815,66 +638,41 @@ func TestAccELBV2Listener_ActionForward_ForwardBlock_AddAction(t *testing.T) {
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
++				Config: testAccListenerConfig_redirect(rName),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
++					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "redirect"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.host", "#{host}"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.path", "/#{path}"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.port", "443"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.protocol", "HTTPS"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.query", "#{query}"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.status_code", "HTTP_301"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockAddAction(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "authenticate-oidc"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.1.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.authenticate_oidc.0.client_secret",
+-					"default_action.1.target_group_arn",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_ForwardBlock_RemoveAction(t *testing.T) {
++func TestAccELBV2Listener_fixedResponse(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+ 	resourceName := "aws_lb_listener.test"
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -883,67 +681,40 @@ func TestAccELBV2Listener_ActionForward_ForwardBlock_RemoveAction(t *testing.T)
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockAddAction(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "authenticate-oidc"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.1.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.target_group_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.authenticate_oidc.0.client_secret",
+-					"default_action.1.target_group_arn",
+-				},
+-			},
+-			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate),
++				Config: testAccListenerConfig_fixedResponse(rName),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
++					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
++					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
++					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "1"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.forward.0.target_group.0.arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.0.weight", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "fixed-response"),
+ 					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.0.content_type", "text/plain"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.0.message_body", "Fixed response content"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.0.status_code", "200"),
+ 				),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+ 				ImportState:       true,
+ 				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.target_group_arn",
+-				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_ActionForward_IgnoreFields(t *testing.T) {
++func TestAccELBV2Listener_cognito(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	rName = rName[:30]
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
++	resourceName := "aws_lb_listener.test"
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
++	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -952,22 +723,25 @@ func TestAccELBV2Listener_ActionForward_IgnoreFields(t *testing.T) {
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_actionForward_ForwardBlockMultiTargetWithIgnore(rName, key, certificate),
++				Config: testAccListenerConfig_cognito(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
+ 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+ 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+ 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "440"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.target_group.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.enabled", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.0.stickiness.0.duration", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
++					resource.TestCheckResourceAttr(resourceName, "port", "443"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "authenticate-cognito"),
++					resource.TestCheckResourceAttrSet(resourceName, "default_action.0.authenticate_cognito.0.user_pool_arn"),
++					resource.TestCheckResourceAttrSet(resourceName, "default_action.0.authenticate_cognito.0.user_pool_client_id"),
++					resource.TestCheckResourceAttrSet(resourceName, "default_action.0.authenticate_cognito.0.user_pool_domain"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.0.authentication_request_extra_params.%", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.0.authentication_request_extra_params.param", "test"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.type", "forward"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
++					resource.TestCheckResourceAttrPair(resourceName, "default_action.1.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+ 				),
+ 			},
+ 			{
+@@ -979,10 +753,12 @@ func TestAccELBV2Listener_ActionForward_IgnoreFields(t *testing.T) {
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_Protocol_upd(t *testing.T) {
++func TestAccELBV2Listener_oidc(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var conf awstypes.Listener
++	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+ 	resourceName := "aws_lb_listener.test"
++	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+@@ -992,38 +768,47 @@ func TestAccELBV2Listener_Protocol_upd(t *testing.T) {
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_basicUdp(rName),
++				Config: testAccListenerConfig_oidc(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+ 					testAccCheckListenerExists(ctx, resourceName, &conf),
+ 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+ 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "UDP"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "514"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
++					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
++					resource.TestCheckResourceAttr(resourceName, "port", "443"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "authenticate-oidc"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.authorization_endpoint", "https://example.com/authorization_endpoint"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.client_id", "s6BhdRkqt3"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.client_secret", "7Fjfp0ZBr1KtDRbnfVdmIw"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.issuer", "https://example.com"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.token_endpoint", "https://example.com/token_endpoint"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.user_info_endpoint", "https://example.com/user_info_endpoint"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.authentication_request_extra_params.%", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.authentication_request_extra_params.param", "test"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.type", "forward"),
++					resource.TestCheckResourceAttrPair(resourceName, "default_action.1.target_group_arn", "aws_lb_target_group.test", "arn"),
++					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+ 				),
+ 			},
+ 			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
++				ResourceName:            resourceName,
++				ImportState:             true,
++				ImportStateVerify:       true,
++				ImportStateVerifyIgnore: []string{"default_action.0.authenticate_oidc.0.client_secret"},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-// TestAccELBV2Listener_backwardsCompatibility confirms that the resource type `aws_alb_listener` works
+-func TestAccELBV2Listener_backwardsCompatibility(t *testing.T) {
++func TestAccELBV2Listener_DefaultAction_defaultOrder(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	resourceName := "aws_alb_listener.test"
++	var listener awstypes.Listener
++	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
++	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_lb_listener.test"
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -1032,42 +817,31 @@ func TestAccELBV2Listener_backwardsCompatibility(t *testing.T) {
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_backwardsCompatibility(rName),
++				Config: testAccListenerConfig_defaultAction_defaultOrder(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_alb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_alb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
++					testAccCheckListenerExists(ctx, resourceName, &listener),
++					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
+ 				),
+ 			},
+ 			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
++				ResourceName:            resourceName,
++				ImportState:             true,
++				ImportStateVerify:       true,
++				ImportStateVerifyIgnore: []string{"default_action.0.authenticate_oidc.0.client_secret"},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_Protocol_https(t *testing.T) {
++func TestAccELBV2Listener_DefaultAction_specifyOrder(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
++	var listener awstypes.Listener
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	resourceName := "aws_lb_listener.test"
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_lb_listener.test"
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -1076,92 +850,32 @@ func TestAccELBV2Listener_Protocol_https(t *testing.T) {
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_https(rName, key, certificate),
++				Config: testAccListenerConfig_defaultAction_specifyOrder(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationOff),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.trust_store_arn", ""),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_mutualAuthentication(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	resourceName := "aws_lb_listener.test"
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_mutualAuthentication(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationVerify),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", "false"),
+-					resource.TestCheckResourceAttrPair(resourceName, "mutual_authentication.0.trust_store_arn", "aws_lb_trust_store.test", "arn"),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
++					testAccCheckListenerExists(ctx, resourceName, &listener),
++					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "4"),
+ 				),
+ 			},
+ 			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
++				ResourceName:            resourceName,
++				ImportState:             true,
++				ImportStateVerify:       true,
++				ImportStateVerifyIgnore: []string{"default_action.0.authenticate_oidc.0.client_secret"},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_mutualAuthenticationPassthrough(t *testing.T) {
++// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6171
++func TestAccELBV2Listener_DefaultAction_actionDisappears(t *testing.T) {
+ 	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
++	var listener awstypes.Listener
+ 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	resourceName := "aws_lb_listener.test"
+ 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	resourceName := "aws_lb_listener.test"
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+@@ -1170,990 +884,225 @@ func TestAccELBV2Listener_mutualAuthenticationPassthrough(t *testing.T) {
+ 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccListenerConfig_mutualAuthenticationPassthrough(rName, key, certificate),
++				Config: testAccListenerConfig_defaultAction_defaultOrder(rName, key, certificate),
+ 				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationPassthrough),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", "false"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.trust_store_arn", ""),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+-					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
++					testAccCheckListenerExists(ctx, resourceName, &listener),
++					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
++					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
++					testAccCheckListenerDefaultActionOrderDisappears(ctx, &listener, 1),
+ 				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
++				ExpectNonEmptyPlan: true,
++				ConfigPlanChecks: resource.ConfigPlanChecks{
++					PostApplyPostRefresh: []plancheck.PlanCheck{
++						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
++						// TODO: change `default_action[0]`
++						// TODO: add `default_action[1]`
++					},
+ 				},
+ 			},
+ 		},
+ 	})
+ }
+ 
+-func TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	lbResourceName := "aws_lb.test"
+-	resourceName := "aws_lb_listener.test"
+-
+-	if testing.Short() {
+-		t.Skip("skipping long-running test in short mode")
+-	}
++func TestAccELBV2Listener_EmptyDefaultAction(t *testing.T) {
++	t.Parallel()
+ 
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_arnGateway(rName),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", lbResourceName, "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", ""),
+-					resource.TestCheckResourceAttr(resourceName, "port", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+-				),
+-			},
++	testcases := map[awstypes.ActionTypeEnum]struct {
++		actionType    awstypes.ActionTypeEnum
++		expectedError *regexp.Regexp
++	}{
++		awstypes.ActionTypeEnumForward: {
++			actionType: awstypes.ActionTypeEnumForward,
++			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Either %q or %q must be specified when %q is %q.",
++				"default_action[0].target_group_arn", "default_action[0].forward",
++				"default_action[0].type",
++				awstypes.ActionTypeEnumForward,
++			))),
+ 		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_Protocol_tls(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var listener1 awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	resourceName := "aws_lb_listener.test"
+ 
+-	if testing.Short() {
+-		t.Skip("skipping long-running test in short mode")
+-	}
++		awstypes.ActionTypeEnumAuthenticateOidc: {
++			actionType: awstypes.ActionTypeEnumAuthenticateOidc,
++			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
++				"default_action[0].authenticate_oidc",
++				"default_action[0].type",
++				awstypes.ActionTypeEnumAuthenticateOidc,
++			))),
++		},
+ 
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_protocolTLS(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &listener1),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "TLS"),
+-					resource.TestCheckResourceAttr(resourceName, "alpn_policy", tfelbv2.AlpnPolicyHTTP2Preferred),
+-					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_acm_certificate.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
+-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "0"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.forward",
+-				},
+-			},
++		awstypes.ActionTypeEnumAuthenticateCognito: {
++			actionType: awstypes.ActionTypeEnumAuthenticateCognito,
++			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
++				"default_action[0].authenticate_cognito",
++				"default_action[0].type",
++				awstypes.ActionTypeEnumAuthenticateCognito,
++			))),
+ 		},
+-	})
+-}
+ 
+-func TestAccELBV2Listener_redirect(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++		awstypes.ActionTypeEnumRedirect: {
++			actionType: awstypes.ActionTypeEnumRedirect,
++			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
++				"default_action[0].redirect",
++				"default_action[0].type",
++				awstypes.ActionTypeEnumRedirect,
++			))),
++		},
+ 
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_redirect(rName),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "redirect"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.host", "#{host}"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.path", "/#{path}"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.port", "443"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.query", "#{query}"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.0.status_code", "HTTP_301"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-			},
++		awstypes.ActionTypeEnumFixedResponse: {
++			actionType: awstypes.ActionTypeEnumFixedResponse,
++			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
++				"default_action[0].fixed_response",
++				"default_action[0].type",
++				awstypes.ActionTypeEnumFixedResponse,
++			))),
+ 		},
+-	})
+-}
++	}
+ 
+-func TestAccELBV2Listener_fixedResponse(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	resourceName := "aws_lb_listener.test"
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
++		testcase := testcase
+ 
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_fixedResponse(rName),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "fixed-response"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.0.content_type", "text/plain"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.0.message_body", "Fixed response content"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.0.status_code", "200"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_cognito(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	resourceName := "aws_lb_listener.test"
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_cognito(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "authenticate-cognito"),
+-					resource.TestCheckResourceAttrSet(resourceName, "default_action.0.authenticate_cognito.0.user_pool_arn"),
+-					resource.TestCheckResourceAttrSet(resourceName, "default_action.0.authenticate_cognito.0.user_pool_client_id"),
+-					resource.TestCheckResourceAttrSet(resourceName, "default_action.0.authenticate_cognito.0.user_pool_domain"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.0.authentication_request_extra_params.%", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.0.authentication_request_extra_params.param", "test"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.1.target_group_arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.1.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_oidc(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var conf awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	resourceName := "aws_lb_listener.test"
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_oidc(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &conf),
+-					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+-					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "authenticate-oidc"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.authorization_endpoint", "https://example.com/authorization_endpoint"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.client_id", "s6BhdRkqt3"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.client_secret", "7Fjfp0ZBr1KtDRbnfVdmIw"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.issuer", "https://example.com"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.token_endpoint", "https://example.com/token_endpoint"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.user_info_endpoint", "https://example.com/user_info_endpoint"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.authentication_request_extra_params.%", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.0.authentication_request_extra_params.param", "test"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.type", "forward"),
+-					resource.TestCheckResourceAttrPair(resourceName, "default_action.1.target_group_arn", "aws_lb_target_group.test", "arn"),
+-					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", "aws_iam_server_certificate.test", "arn"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.authenticate_oidc.0.client_secret",
+-					"default_action.1.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_DefaultAction_defaultOrder(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var listener awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	resourceName := "aws_lb_listener.test"
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_defaultAction_defaultOrder(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &listener),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.authenticate_oidc.0.client_secret",
+-					"default_action.1.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_DefaultAction_specifyOrder(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var listener awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	resourceName := "aws_lb_listener.test"
+-
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_defaultAction_specifyOrder(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &listener),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "4"),
+-				),
+-			},
+-			{
+-				ResourceName:      resourceName,
+-				ImportState:       true,
+-				ImportStateVerify: true,
+-				ImportStateVerifyIgnore: []string{
+-					"default_action.0.authenticate_oidc.0.client_secret",
+-					"default_action.1.forward",
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6171
+-func TestAccELBV2Listener_DefaultAction_actionDisappears(t *testing.T) {
+-	ctx := acctest.Context(t)
+-	var listener awstypes.Listener
+-	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-	resourceName := "aws_lb_listener.test"
++		t.Run(string(name), func(t *testing.T) {
++			ctx := acctest.Context(t)
++			rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 
+-	resource.ParallelTest(t, resource.TestCase{
+-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-		ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-		Steps: []resource.TestStep{
+-			{
+-				Config: testAccListenerConfig_defaultAction_defaultOrder(rName, key, certificate),
+-				Check: resource.ComposeAggregateTestCheckFunc(
+-					testAccCheckListenerExists(ctx, resourceName, &listener),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
+-					testAccCheckListenerDefaultActionOrderDisappears(ctx, &listener, 1),
+-				),
+-				ExpectNonEmptyPlan: true,
+-				ConfigPlanChecks: resource.ConfigPlanChecks{
+-					PostApplyPostRefresh: []plancheck.PlanCheck{
+-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+-						// TODO: change `default_action[0]`
+-						// TODO: add `default_action[1]`
+-					},
+-				},
+-			},
+-		},
+-	})
+-}
+-
+-func TestAccELBV2Listener_EmptyDefaultAction(t *testing.T) {
+-	t.Parallel()
+-
+-	testcases := map[awstypes.ActionTypeEnum]struct {
+-		actionType    awstypes.ActionTypeEnum
+-		expectedError *regexp.Regexp
+-	}{
+-		awstypes.ActionTypeEnumForward: {
+-			actionType: awstypes.ActionTypeEnumForward,
+-			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Either %q or %q must be specified when %q is %q.",
+-				"default_action[0].target_group_arn", "default_action[0].forward",
+-				"default_action[0].type",
+-				awstypes.ActionTypeEnumForward,
+-			))),
+-		},
+-
+-		awstypes.ActionTypeEnumAuthenticateOidc: {
+-			actionType: awstypes.ActionTypeEnumAuthenticateOidc,
+-			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
+-				"default_action[0].authenticate_oidc",
+-				"default_action[0].type",
+-				awstypes.ActionTypeEnumAuthenticateOidc,
+-			))),
+-		},
+-
+-		awstypes.ActionTypeEnumAuthenticateCognito: {
+-			actionType: awstypes.ActionTypeEnumAuthenticateCognito,
+-			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
+-				"default_action[0].authenticate_cognito",
+-				"default_action[0].type",
+-				awstypes.ActionTypeEnumAuthenticateCognito,
+-			))),
+-		},
+-
+-		awstypes.ActionTypeEnumRedirect: {
+-			actionType: awstypes.ActionTypeEnumRedirect,
+-			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
+-				"default_action[0].redirect",
+-				"default_action[0].type",
+-				awstypes.ActionTypeEnumRedirect,
+-			))),
+-		},
+-
+-		awstypes.ActionTypeEnumFixedResponse: {
+-			actionType: awstypes.ActionTypeEnumFixedResponse,
+-			expectedError: regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf("Attribute %q must be specified when %q is %q.",
+-				"default_action[0].fixed_response",
+-				"default_action[0].type",
+-				awstypes.ActionTypeEnumFixedResponse,
+-			))),
+-		},
+-	}
+-
+-	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+-		testcase := testcase
+-
+-		t.Run(string(name), func(t *testing.T) {
+-			ctx := acctest.Context(t)
+-			rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+-
+-			resource.ParallelTest(t, resource.TestCase{
+-				PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+-				ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+-				CheckDestroy:             testAccCheckListenerDestroy(ctx),
+-				Steps: []resource.TestStep{
+-					{
+-						Config:      testAccListenerConfig_EmptyDefaultAction(rName, testcase.actionType),
+-						ExpectError: testcase.expectedError,
++			resource.ParallelTest(t, resource.TestCase{
++				PreCheck:                 func() { acctest.PreCheck(ctx, t) },
++				ErrorCheck:               acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
++				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++				CheckDestroy:             testAccCheckListenerDestroy(ctx),
++				Steps: []resource.TestStep{
++					{
++						Config:      testAccListenerConfig_EmptyDefaultAction(rName, testcase.actionType),
++						ExpectError: testcase.expectedError,
+ 					},
+ 				},
+ 			})
+ 		})
+-	}
+-}
+-
+-func testAccCheckListenerDefaultActionOrderDisappears(ctx context.Context, listener *awstypes.Listener, actionOrderToDelete int) resource.TestCheckFunc {
+-	return func(s *terraform.State) error {
+-		var newDefaultActions []awstypes.Action
+-
+-		for i, action := range listener.DefaultActions {
+-			if int(aws.ToInt32(action.Order)) == actionOrderToDelete {
+-				newDefaultActions = slices.Delete(listener.DefaultActions, i, i+1)
+-				break
+-			}
+-		}
+-
+-		if len(newDefaultActions) == 0 {
+-			return fmt.Errorf("Unable to find default action order %d from default actions: %#v", actionOrderToDelete, listener.DefaultActions)
+-		}
+-
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
+-
+-		input := &elasticloadbalancingv2.ModifyListenerInput{
+-			DefaultActions: newDefaultActions,
+-			ListenerArn:    listener.ListenerArn,
+-		}
+-
+-		_, err := conn.ModifyListener(ctx, input)
+-
+-		return err
+-	}
+-}
+-
+-func testAccCheckListenerExists(ctx context.Context, n string, v *awstypes.Listener) resource.TestCheckFunc {
+-	return func(s *terraform.State) error {
+-		rs, ok := s.RootModule().Resources[n]
+-		if !ok {
+-			return fmt.Errorf("Not found: %s", n)
+-		}
+-
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
+-
+-		output, err := tfelbv2.FindListenerByARN(ctx, conn, rs.Primary.ID)
+-
+-		if err != nil {
+-			return err
+-		}
+-
+-		*v = *output
+-
+-		return nil
+-	}
+-}
+-
+-func testAccCheckListenerDestroy(ctx context.Context) resource.TestCheckFunc {
+-	return func(s *terraform.State) error {
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
+-
+-		for _, rs := range s.RootModule().Resources {
+-			if rs.Type != "aws_lb_listener" && rs.Type != "aws_alb_listener" {
+-				continue
+-			}
+-
+-			_, err := tfelbv2.FindListenerByARN(ctx, conn, rs.Primary.ID)
+-
+-			if tfresource.NotFound(err) {
+-				continue
+-			}
+-
+-			if err != nil {
+-				return err
+-			}
+-
+-			return fmt.Errorf("ELBv2 Listener %s still exists", rs.Primary.ID)
+-		}
+-
+-		return nil
+-	}
+-}
+-
+-func testAccListenerConfig_base(rName string) string {
+-	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+-resource "aws_security_group" "test" {
+-  name        = %[1]q
+-  description = "Used for ALB Testing"
+-  vpc_id      = aws_vpc.test.id
+-
+-  ingress {
+-    from_port   = 0
+-    to_port     = 0
+-    protocol    = "-1"
+-    cidr_blocks = ["0.0.0.0/0"]
+-  }
+-
+-  egress {
+-    from_port   = 0
+-    to_port     = 0
+-    protocol    = "-1"
+-    cidr_blocks = ["0.0.0.0/0"]
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-`, rName))
+-}
+-
+-func testAccListenerConfig_Application_basic(rName string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  port              = "80"
+-
+-  default_action {
+-    target_group_arn = aws_lb_target_group.test.id
+-    type             = "forward"
+-  }
+-}
+-
+-resource "aws_lb" "test" {
+-  name               = %[1]q
+-  load_balancer_type = "application"
+-  internal           = true
+-  security_groups    = [aws_security_group.test.id]
+-  subnets            = aws_subnet.test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test" {
+-  name     = %[1]q
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-`, rName))
+-}
+-
+-func testAccListenerConfig_Network_basic(rName string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "TCP"
+-  port              = "80"
+-
+-  default_action {
+-    target_group_arn = aws_lb_target_group.test.id
+-    type             = "forward"
+-  }
+-}
+-
+-resource "aws_lb" "test" {
+-  name               = %[1]q
+-  load_balancer_type = "network"
+-  internal           = true
+-  security_groups    = [aws_security_group.test.id]
+-  subnets            = aws_subnet.test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test" {
+-  name     = %[1]q
+-  port     = 8080
+-  protocol = "TCP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    interval            = 10
+-    port                = 8081
+-    protocol            = "TCP"
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-`, rName))
+-}
+-
+-func testAccListenerConfig_Gateway_basic(rName string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-
+-  default_action {
+-    target_group_arn = aws_lb_target_group.test.id
+-    type             = "forward"
+-  }
+-}
+-
+-resource "aws_lb" "test" {
+-  name               = %[1]q
+-  load_balancer_type = "gateway"
+-  subnets            = aws_subnet.test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test" {
+-  name     = %[1]q
+-  port     = 6081
+-  protocol = "GENEVE"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    interval            = 10
+-    port                = 8081
+-    protocol            = "TCP"
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-`, rName))
+-}
+-
+-func testAccListenerConfig_forwardBasic(rName, targetName string) string {
+-	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTP"
+-  port              = "440"
+-
+-  default_action {
+-    type             = "forward"
+-    target_group_arn = aws_lb_target_group.%[2]s.arn
+-  }
+-}
+-
+-resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-}
+-
+-resource "aws_lb_target_group" "test1" {
+-  name     = "%[1]s-1"
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test2" {
+-  name     = "%[1]s-2"
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-}
+-`, rName, targetName))
++	}
+ }
+ 
+-func testAccListenerConfig_forwardWeighted(rName, rName2 string) string {
+-	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTP"
+-  port              = "80"
++func testAccCheckListenerDefaultActionOrderDisappears(ctx context.Context, listener *awstypes.Listener, actionOrderToDelete int) resource.TestCheckFunc {
++	return func(s *terraform.State) error {
++		var newDefaultActions []awstypes.Action
+ 
+-  default_action {
+-    type = "forward"
++		for i, action := range listener.DefaultActions {
++			if int(aws.ToInt32(action.Order)) == actionOrderToDelete {
++				newDefaultActions = slices.Delete(listener.DefaultActions, i, i+1)
++				break
++			}
++		}
+ 
+-    forward {
+-      target_group {
+-        arn    = aws_lb_target_group.test1.arn
+-        weight = 1
+-      }
++		if len(newDefaultActions) == 0 {
++			return fmt.Errorf("Unable to find default action order %d from default actions: %#v", actionOrderToDelete, listener.DefaultActions)
++		}
+ 
+-      target_group {
+-        arn    = aws_lb_target_group.test2.arn
+-        weight = 1
+-      }
+-    }
+-  }
+-}
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
+ 
+-resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
++		input := &elasticloadbalancingv2.ModifyListenerInput{
++			DefaultActions: newDefaultActions,
++			ListenerArn:    listener.ListenerArn,
++		}
+ 
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
++		_, err := conn.ModifyListener(ctx, input)
+ 
+-  tags = {
+-    Name = %[1]q
+-  }
++		return err
++	}
+ }
+ 
+-resource "aws_lb_target_group" "test1" {
+-  name     = %[1]q
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
++func testAccCheckListenerExists(ctx context.Context, n string, v *awstypes.Listener) resource.TestCheckFunc {
++	return func(s *terraform.State) error {
++		rs, ok := s.RootModule().Resources[n]
++		if !ok {
++			return fmt.Errorf("Not found: %s", n)
++		}
+ 
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
+ 
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
++		output, err := tfelbv2.FindListenerByARN(ctx, conn, rs.Primary.ID)
+ 
+-resource "aws_lb_target_group" "test2" {
+-  name     = %[2]q
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
++		if err != nil {
++			return err
++		}
+ 
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
++		*v = *output
+ 
+-  tags = {
+-    Name = %[2]q
+-  }
+-}
+-`, rName, rName2))
++		return nil
++	}
+ }
+ 
+-func testAccListenerConfig_changeForwardWeightedStickiness(rName, rName2 string) string {
+-	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTP"
+-  port              = "80"
+-
+-  default_action {
+-    type = "forward"
++func testAccCheckListenerDestroy(ctx context.Context) resource.TestCheckFunc {
++	return func(s *terraform.State) error {
++		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
+ 
+-    forward {
+-      target_group {
+-        arn    = aws_lb_target_group.test1.arn
+-        weight = 1
+-      }
++		for _, rs := range s.RootModule().Resources {
++			if rs.Type != "aws_lb_listener" && rs.Type != "aws_alb_listener" {
++				continue
++			}
+ 
+-      target_group {
+-        arn    = aws_lb_target_group.test2.arn
+-        weight = 1
+-      }
++			_, err := tfelbv2.FindListenerByARN(ctx, conn, rs.Primary.ID)
+ 
+-      stickiness {
+-        enabled  = true
+-        duration = 3600
+-      }
+-    }
+-  }
+-}
++			if tfresource.NotFound(err) {
++				continue
++			}
+ 
+-resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
++			if err != nil {
++				return err
++			}
+ 
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
++			return fmt.Errorf("ELBv2 Listener %s still exists", rs.Primary.ID)
++		}
+ 
+-  tags = {
+-    Name = %[1]q
+-  }
++		return nil
++	}
+ }
+ 
+-resource "aws_lb_target_group" "test1" {
+-  name     = %[1]q
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
++func testAccListenerConfig_base(rName string) string {
++	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
++resource "aws_security_group" "test" {
++  name        = %[1]q
++  description = "Used for ALB Testing"
++  vpc_id      = aws_vpc.test.id
+ 
+-  tags = {
+-    Name = %[1]q
++  ingress {
++    from_port   = 0
++    to_port     = 0
++    protocol    = "-1"
++    cidr_blocks = ["0.0.0.0/0"]
+   }
+-}
+-
+-resource "aws_lb_target_group" "test2" {
+-  name     = %[2]q
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+ 
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
++  egress {
++    from_port   = 0
++    to_port     = 0
++    protocol    = "-1"
++    cidr_blocks = ["0.0.0.0/0"]
+   }
+ 
+   tags = {
+     Name = %[1]q
+   }
+ }
+-`, rName, rName2))
++`, rName))
+ }
+ 
+-func testAccListenerConfig_forwardTargetARNAndBlock(rName string) string {
++func testAccListenerConfig_Application_basic(rName string) string {
+ 	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName),
+-		fmt.Sprintf(`
++		testAccListenerConfig_base(rName), fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTP"
+-  port              = "440"
++  port              = "80"
+ 
+   default_action {
+-    type = "forward"
+-
+-    target_group_arn = aws_lb_target_group.test.arn
+-
+-    forward {
+-      target_group {
+-        arn    = aws_lb_target_group.test.arn
+-        weight = 1
+-      }
+-
+-      stickiness {
+-        enabled  = true
+-        duration = 3600
+-      }
+-    }
++    target_group_arn = aws_lb_target_group.test.id
++    type             = "forward"
+   }
+ }
+ 
+ resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
++  name               = %[1]q
++  load_balancer_type = "application"
++  internal           = true
++  security_groups    = [aws_security_group.test.id]
++  subnets            = aws_subnet.test[*].id
+ 
+   idle_timeout               = 30
+   enable_deletion_protection = false
+@@ -2187,29 +1136,26 @@ resource "aws_lb_target_group" "test" {
+ `, rName))
+ }
+ 
+-func testAccListenerConfig_actionForward_TargetGroupARN(rName, key, certificate string) string {
++func testAccListenerConfig_Network_basic(rName string) string {
+ 	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName),
+-		fmt.Sprintf(`
++		testAccListenerConfig_base(rName), fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
+-  port              = "443"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
+-
+-  default_action {
+-    type = "forward"
++  protocol          = "TCP"
++  port              = "80"
+ 
+-    target_group_arn = aws_lb_target_group.test.arn
++  default_action {
++    target_group_arn = aws_lb_target_group.test.id
++    type             = "forward"
+   }
+ }
+ 
+ resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
++  name               = %[1]q
++  load_balancer_type = "network"
++  internal           = true
++  security_groups    = [aws_security_group.test.id]
++  subnets            = aws_subnet.test[*].id
+ 
+   idle_timeout               = 30
+   enable_deletion_protection = false
+@@ -2222,60 +1168,40 @@ resource "aws_lb" "test" {
+ resource "aws_lb_target_group" "test" {
+   name     = %[1]q
+   port     = 8080
+-  protocol = "HTTP"
++  protocol = "TCP"
+   vpc_id   = aws_vpc.test.id
+ 
+   health_check {
+-    path                = "/health"
+-    interval            = 60
++    interval            = 10
+     port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
++    protocol            = "TCP"
+     healthy_threshold   = 3
+     unhealthy_threshold = 3
+-    matcher             = "200-299"
+   }
+ 
+   tags = {
+     Name = %[1]q
+   }
+ }
+-
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
+-}
+-  `, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
++`, rName))
+ }
+ 
+-func testAccListenerConfig_actionForward_ForwardBlockBasic(rName, key, certificate string) string {
++func testAccListenerConfig_Gateway_basic(rName string) string {
+ 	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName),
+-		fmt.Sprintf(`
++		testAccListenerConfig_base(rName), fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
+-  port              = "440"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
+ 
+   default_action {
+-    type = "forward"
+-
+-    forward {
+-      target_group {
+-        arn = aws_lb_target_group.test.arn
+-      }
+-    }
++    target_group_arn = aws_lb_target_group.test.id
++    type             = "forward"
+   }
+ }
+ 
+ resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
++  name               = %[1]q
++  load_balancer_type = "gateway"
++  subnets            = aws_subnet.test[*].id
+ 
+   idle_timeout               = 30
+   enable_deletion_protection = false
+@@ -2287,56 +1213,44 @@ resource "aws_lb" "test" {
+ 
+ resource "aws_lb_target_group" "test" {
+   name     = %[1]q
+-  port     = 8080
+-  protocol = "HTTP"
++  port     = 6081
++  protocol = "GENEVE"
+   vpc_id   = aws_vpc.test.id
+ 
+   health_check {
+-    path                = "/health"
+-    interval            = 60
++    interval            = 10
+     port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
++    protocol            = "TCP"
+     healthy_threshold   = 3
+     unhealthy_threshold = 3
+-    matcher             = "200-299"
+   }
+ 
+   tags = {
+     Name = %[1]q
+   }
+ }
+-
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
+-}
+-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
++`, rName))
+ }
+ 
+-func testAccListenerConfig_actionForward_ForwardBlockStickiness(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName),
+-		fmt.Sprintf(`
++func testAccListenerConfig_forwardWeighted(rName, rName2 string) string {
++	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
+-  port              = "440"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
++  protocol          = "HTTP"
++  port              = "80"
+ 
+   default_action {
+     type = "forward"
+ 
+     forward {
+       target_group {
+-        arn = aws_lb_target_group.test.arn
++        arn    = aws_lb_target_group.test1.arn
++        weight = 1
+       }
+ 
+-      stickiness {
+-        enabled  = true
+-        duration = 3600
++      target_group {
++        arn    = aws_lb_target_group.test2.arn
++        weight = 1
+       }
+     }
+   }
+@@ -2356,7 +1270,7 @@ resource "aws_lb" "test" {
+   }
+ }
+ 
+-resource "aws_lb_target_group" "test" {
++resource "aws_lb_target_group" "test1" {
+   name     = %[1]q
+   port     = 8080
+   protocol = "HTTP"
+@@ -2378,32 +1292,49 @@ resource "aws_lb_target_group" "test" {
+   }
+ }
+ 
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
++resource "aws_lb_target_group" "test2" {
++  name     = %[2]q
++  port     = 8080
++  protocol = "HTTP"
++  vpc_id   = aws_vpc.test.id
++
++  health_check {
++    path                = "/health"
++    interval            = 60
++    port                = 8081
++    protocol            = "HTTP"
++    timeout             = 3
++    healthy_threshold   = 3
++    unhealthy_threshold = 3
++    matcher             = "200-299"
++  }
++
++  tags = {
++    Name = %[2]q
++  }
+ }
+-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
++`, rName, rName2))
+ }
+ 
+-func testAccListenerConfig_actionForward_ForwardBlockWeightAndStickiness(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName),
+-		fmt.Sprintf(`
++func testAccListenerConfig_changeForwardWeightedStickiness(rName, rName2 string) string {
++	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
+-  port              = "443"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
++  protocol          = "HTTP"
++  port              = "80"
+ 
+   default_action {
+     type = "forward"
+ 
+     forward {
+       target_group {
+-        arn    = aws_lb_target_group.test.arn
+-        weight = 2
++        arn    = aws_lb_target_group.test1.arn
++        weight = 1
++      }
++
++      target_group {
++        arn    = aws_lb_target_group.test2.arn
++        weight = 1
+       }
+ 
+       stickiness {
+@@ -2428,7 +1359,7 @@ resource "aws_lb" "test" {
+   }
+ }
+ 
+-resource "aws_lb_target_group" "test" {
++resource "aws_lb_target_group" "test1" {
+   name     = %[1]q
+   port     = 8080
+   protocol = "HTTP"
+@@ -2450,69 +1381,8 @@ resource "aws_lb_target_group" "test" {
+   }
+ }
+ 
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
+-}
+-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
+-}
+-
+-func testAccListenerConfig_actionForward_ForwardBlockAddAction(rName, key, certificate string) string {
+-	return acctest.ConfigCompose(
+-		testAccListenerConfig_base(rName),
+-		fmt.Sprintf(`
+-resource "aws_lb_listener" "test" {
+-  load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
+-  port              = "443"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
+-
+-  default_action {
+-    type = "authenticate-oidc"
+-
+-    authenticate_oidc {
+-      authorization_endpoint = "https://example.com/authorization_endpoint"
+-      client_id              = "s6BhdRkqt3"
+-      client_secret          = "7Fjfp0ZBr1KtDRbnfVdmIw"
+-      issuer                 = "https://example.com"
+-      token_endpoint         = "https://example.com/token_endpoint"
+-      user_info_endpoint     = "https://example.com/user_info_endpoint"
+-
+-      authentication_request_extra_params = {
+-        param = "test"
+-      }
+-    }
+-  }
+-
+-  default_action {
+-    type = "forward"
+-
+-    forward {
+-      target_group {
+-        arn = aws_lb_target_group.test.arn
+-      }
+-    }
+-  }
+-}
+-
+-resource "aws_lb" "test" {
+-  name            = %[1]q
+-  internal        = true
+-  security_groups = [aws_security_group.test.id]
+-  subnets         = aws_subnet.test[*].id
+-
+-  idle_timeout               = 30
+-  enable_deletion_protection = false
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_lb_target_group" "test" {
+-  name     = %[1]q
++resource "aws_lb_target_group" "test2" {
++  name     = %[2]q
+   port     = 8080
+   protocol = "HTTP"
+   vpc_id   = aws_vpc.test.id
+@@ -2532,48 +1402,35 @@ resource "aws_lb_target_group" "test" {
+     Name = %[1]q
+   }
+ }
+-
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
+-}
+-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
++`, rName, rName2))
+ }
+ 
+-func testAccListenerConfig_actionForward_ForwardBlockMultiTargetWithIgnore(rName, key, certificate string) string {
++func testAccListenerConfig_forwardTargetARNAndBlock(rName string) string {
+ 	return acctest.ConfigCompose(
+ 		testAccListenerConfig_base(rName),
+ 		fmt.Sprintf(`
+ resource "aws_lb_listener" "test" {
+   load_balancer_arn = aws_lb.test.id
+-  protocol          = "HTTPS"
++  protocol          = "HTTP"
+   port              = "440"
+-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+-  certificate_arn   = aws_iam_server_certificate.test.arn
+ 
+   default_action {
+     type = "forward"
+ 
++    target_group_arn = aws_lb_target_group.test.arn
++
+     forward {
+       target_group {
+         arn    = aws_lb_target_group.test.arn
+-        weight = 100
++        weight = 1
+       }
+ 
+-      target_group {
+-        arn    = aws_lb_target_group.test2.arn
+-        weight = 0
++      stickiness {
++        enabled  = true
++        duration = 3600
+       }
+     }
+   }
+-
+-  lifecycle {
+-    ignore_changes = [
+-      default_action[0].forward,
+-      default_action[0].target_group_arn,
+-    ]
+-  }
+ }
+ 
+ resource "aws_lb" "test" {
+@@ -2611,35 +1468,7 @@ resource "aws_lb_target_group" "test" {
+     Name = %[1]q
+   }
+ }
+-
+-resource "aws_lb_target_group" "test2" {
+-  name     = "%[1]s-2"
+-  port     = 8080
+-  protocol = "HTTP"
+-  vpc_id   = aws_vpc.test.id
+-
+-  health_check {
+-    path                = "/health"
+-    interval            = 60
+-    port                = 8081
+-    protocol            = "HTTP"
+-    timeout             = 3
+-    healthy_threshold   = 3
+-    unhealthy_threshold = 3
+-    matcher             = "200-299"
+-  }
+-
+-  tags = {
+-    Name = %[1]q
+-  }
+-}
+-
+-resource "aws_iam_server_certificate" "test" {
+-  name             = %[1]q
+-  certificate_body = "%[2]s"
+-  private_key      = "%[3]s"
+-}
+-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
++`, rName))
+ }
+ 
+ func testAccListenerConfig_changeForwardWeightedToBasic(rName, rName2 string) string {
+@@ -3407,7 +2236,8 @@ resource "aws_lb_listener" "test" {
+   certificate_arn   = aws_iam_server_certificate.test.arn
+ 
+   default_action {
+-    type = "authenticate-oidc"
++    order = 1
++    type  = "authenticate-oidc"
+ 
+     authenticate_oidc {
+       authorization_endpoint = "https://example.com/authorization_endpoint"
+@@ -3424,6 +2254,7 @@ resource "aws_lb_listener" "test" {
+   }
+ 
+   default_action {
++    order            = 2
+     type             = "forward"
+     target_group_arn = aws_lb_target_group.test.arn
+   }
+diff --git a/website/docs/r/lb_listener.html.markdown b/website/docs/r/lb_listener.html.markdown
+index e3a16fed28..c98b41fea4 100644
+--- a/website/docs/r/lb_listener.html.markdown
++++ b/website/docs/r/lb_listener.html.markdown
+@@ -278,19 +278,10 @@ The following arguments are optional:
+ * `authenticate_cognito` - (Optional) Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
+ * `authenticate_oidc` - (Optional) Configuration block for an identity provider that is compliant with OpenID Connect (OIDC). Specify only when `type` is `authenticate-oidc`. Detailed below.
+ * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
+-* `forward` - (Optional) Configuration block for creating an action that distributes requests among one or more target groups.
+-  Specify only if `type` is `forward`.
+-  Cannot be specified with `target_group_arn`.
+-  Detailed below.
+-* `order` - (Optional) Order for the action.
+-  The action with the lowest value for order is performed first.
+-  Valid values are between `1` and `50000`.
+-  Defaults to the position in the list of actions.
++* `forward` - (Optional) Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
++* `order` - (Optional) Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
+ * `redirect` - (Optional) Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
+-* `target_group_arn` - (Optional) ARN of the Target Group to which to route traffic.
+-  Specify only if `type` is `forward` and you want to route to a single target group.
+-  To route to one or more target groups, use a `forward` block instead.
+-  Cannot be specified with `forward`.
++* `target_group_arn` - (Optional) ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
+ 
+ #### authenticate_cognito
+ 
+diff --git a/website/docs/r/lb_listener_rule.html.markdown b/website/docs/r/lb_listener_rule.html.markdown
+index f6f117d743..f3f610075d 100644
+--- a/website/docs/r/lb_listener_rule.html.markdown
++++ b/website/docs/r/lb_listener_rule.html.markdown
+@@ -219,21 +219,12 @@ This resource supports the following arguments:
+ Action Blocks (for `action`) support the following:
+ 
+ * `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
++* `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
++* `forward` - (Optional) Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
++* `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
++* `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
+ * `authenticate_cognito` - (Optional) Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
+ * `authenticate_oidc` - (Optional) Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
+-* `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
+-* `forward` - (Optional) Configuration block for creating an action that distributes requests among one or more target groups.
+-  Specify only if `type` is `forward`.
+-  Cannot be specified with `target_group_arn`.
+-* `order` - (Optional) Order for the action.
+-  The action with the lowest value for order is performed first.
+-  Valid values are between `1` and `50000`.
+-  Defaults to the position in the list of actions.
+-* `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
+-* `target_group_arn` - (Optional) ARN of the Target Group to which to route traffic.
+-  Specify only if `type` is `forward` and you want to route to a single target group.
+-  To route to one or more target groups, use a `forward` block instead.
+-  Cannot be specified with `forward`.
+ 
+ Forward Blocks (for `forward`) support the following:
+ 

--- a/sdk/dotnet/Alb/Inputs/ListenerDefaultActionArgs.cs
+++ b/sdk/dotnet/Alb/Inputs/ListenerDefaultActionArgs.cs
@@ -31,19 +31,13 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerDefaultActionFixedResponseArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
-        /// Detailed below.
+        /// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerDefaultActionForwardArgs>? Forward { get; set; }
 
         /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
+        /// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
@@ -55,10 +49,7 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerDefaultActionRedirectArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/Alb/Inputs/ListenerDefaultActionGetArgs.cs
+++ b/sdk/dotnet/Alb/Inputs/ListenerDefaultActionGetArgs.cs
@@ -31,19 +31,13 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerDefaultActionFixedResponseGetArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
-        /// Detailed below.
+        /// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerDefaultActionForwardGetArgs>? Forward { get; set; }
 
         /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
+        /// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
@@ -55,10 +49,7 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerDefaultActionRedirectGetArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/Alb/Inputs/ListenerRuleActionArgs.cs
+++ b/sdk/dotnet/Alb/Inputs/ListenerRuleActionArgs.cs
@@ -31,19 +31,11 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerRuleActionFixedResponseArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
+        /// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerRuleActionForwardArgs>? Forward { get; set; }
 
-        /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
-        /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
 
@@ -54,10 +46,7 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerRuleActionRedirectArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/Alb/Inputs/ListenerRuleActionGetArgs.cs
+++ b/sdk/dotnet/Alb/Inputs/ListenerRuleActionGetArgs.cs
@@ -31,19 +31,11 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerRuleActionFixedResponseGetArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
+        /// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerRuleActionForwardGetArgs>? Forward { get; set; }
 
-        /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
-        /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
 
@@ -54,10 +46,7 @@ namespace Pulumi.Aws.Alb.Inputs
         public Input<Inputs.ListenerRuleActionRedirectGetArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/Alb/Outputs/ListenerDefaultAction.cs
+++ b/sdk/dotnet/Alb/Outputs/ListenerDefaultAction.cs
@@ -26,17 +26,11 @@ namespace Pulumi.Aws.Alb.Outputs
         /// </summary>
         public readonly Outputs.ListenerDefaultActionFixedResponse? FixedResponse;
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
-        /// Detailed below.
+        /// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         /// </summary>
         public readonly Outputs.ListenerDefaultActionForward? Forward;
         /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
+        /// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         /// </summary>
         public readonly int? Order;
         /// <summary>
@@ -44,10 +38,7 @@ namespace Pulumi.Aws.Alb.Outputs
         /// </summary>
         public readonly Outputs.ListenerDefaultActionRedirect? Redirect;
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         public readonly string? TargetGroupArn;
         /// <summary>

--- a/sdk/dotnet/Alb/Outputs/ListenerRuleAction.cs
+++ b/sdk/dotnet/Alb/Outputs/ListenerRuleAction.cs
@@ -26,27 +26,16 @@ namespace Pulumi.Aws.Alb.Outputs
         /// </summary>
         public readonly Outputs.ListenerRuleActionFixedResponse? FixedResponse;
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
+        /// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         /// </summary>
         public readonly Outputs.ListenerRuleActionForward? Forward;
-        /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
-        /// </summary>
         public readonly int? Order;
         /// <summary>
         /// Information for creating a redirect action. Required if `type` is `redirect`.
         /// </summary>
         public readonly Outputs.ListenerRuleActionRedirect? Redirect;
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         public readonly string? TargetGroupArn;
         /// <summary>

--- a/sdk/dotnet/LB/Inputs/ListenerDefaultActionArgs.cs
+++ b/sdk/dotnet/LB/Inputs/ListenerDefaultActionArgs.cs
@@ -31,19 +31,13 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerDefaultActionFixedResponseArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
-        /// Detailed below.
+        /// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerDefaultActionForwardArgs>? Forward { get; set; }
 
         /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
+        /// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
@@ -55,10 +49,7 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerDefaultActionRedirectArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/LB/Inputs/ListenerDefaultActionGetArgs.cs
+++ b/sdk/dotnet/LB/Inputs/ListenerDefaultActionGetArgs.cs
@@ -31,19 +31,13 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerDefaultActionFixedResponseGetArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
-        /// Detailed below.
+        /// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerDefaultActionForwardGetArgs>? Forward { get; set; }
 
         /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
+        /// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
@@ -55,10 +49,7 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerDefaultActionRedirectGetArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/LB/Inputs/ListenerRuleActionArgs.cs
+++ b/sdk/dotnet/LB/Inputs/ListenerRuleActionArgs.cs
@@ -31,19 +31,11 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerRuleActionFixedResponseArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
+        /// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerRuleActionForwardArgs>? Forward { get; set; }
 
-        /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
-        /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
 
@@ -54,10 +46,7 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerRuleActionRedirectArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/LB/Inputs/ListenerRuleActionGetArgs.cs
+++ b/sdk/dotnet/LB/Inputs/ListenerRuleActionGetArgs.cs
@@ -31,19 +31,11 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerRuleActionFixedResponseGetArgs>? FixedResponse { get; set; }
 
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
+        /// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         /// </summary>
         [Input("forward")]
         public Input<Inputs.ListenerRuleActionForwardGetArgs>? Forward { get; set; }
 
-        /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
-        /// </summary>
         [Input("order")]
         public Input<int>? Order { get; set; }
 
@@ -54,10 +46,7 @@ namespace Pulumi.Aws.LB.Inputs
         public Input<Inputs.ListenerRuleActionRedirectGetArgs>? Redirect { get; set; }
 
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         [Input("targetGroupArn")]
         public Input<string>? TargetGroupArn { get; set; }

--- a/sdk/dotnet/LB/Outputs/ListenerDefaultAction.cs
+++ b/sdk/dotnet/LB/Outputs/ListenerDefaultAction.cs
@@ -26,17 +26,11 @@ namespace Pulumi.Aws.LB.Outputs
         /// </summary>
         public readonly Outputs.ListenerDefaultActionFixedResponse? FixedResponse;
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
-        /// Detailed below.
+        /// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         /// </summary>
         public readonly Outputs.ListenerDefaultActionForward? Forward;
         /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
+        /// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         /// </summary>
         public readonly int? Order;
         /// <summary>
@@ -44,10 +38,7 @@ namespace Pulumi.Aws.LB.Outputs
         /// </summary>
         public readonly Outputs.ListenerDefaultActionRedirect? Redirect;
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         public readonly string? TargetGroupArn;
         /// <summary>

--- a/sdk/dotnet/LB/Outputs/ListenerRuleAction.cs
+++ b/sdk/dotnet/LB/Outputs/ListenerRuleAction.cs
@@ -26,27 +26,16 @@ namespace Pulumi.Aws.LB.Outputs
         /// </summary>
         public readonly Outputs.ListenerRuleActionFixedResponse? FixedResponse;
         /// <summary>
-        /// Configuration block for creating an action that distributes requests among one or more target groups.
-        /// Specify only if `type` is `forward`.
-        /// Cannot be specified with `target_group_arn`.
+        /// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         /// </summary>
         public readonly Outputs.ListenerRuleActionForward? Forward;
-        /// <summary>
-        /// Order for the action.
-        /// The action with the lowest value for order is performed first.
-        /// Valid values are between `1` and `50000`.
-        /// Defaults to the position in the list of actions.
-        /// </summary>
         public readonly int? Order;
         /// <summary>
         /// Information for creating a redirect action. Required if `type` is `redirect`.
         /// </summary>
         public readonly Outputs.ListenerRuleActionRedirect? Redirect;
         /// <summary>
-        /// ARN of the Target Group to which to route traffic.
-        /// Specify only if `type` is `forward` and you want to route to a single target group.
-        /// To route to one or more target groups, use a `forward` block instead.
-        /// Cannot be specified with `forward`.
+        /// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         /// </summary>
         public readonly string? TargetGroupArn;
         /// <summary>

--- a/sdk/go/aws/alb/pulumiTypes.go
+++ b/sdk/go/aws/alb/pulumiTypes.go
@@ -20,22 +20,13 @@ type ListenerDefaultAction struct {
 	AuthenticateOidc *ListenerDefaultActionAuthenticateOidc `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse *ListenerDefaultActionFixedResponse `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
-	// Detailed below.
+	// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
 	Forward *ListenerDefaultActionForward `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
+	// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
 	Order *int `pulumi:"order"`
 	// Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
 	Redirect *ListenerDefaultActionRedirect `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn *string `pulumi:"targetGroupArn"`
 	// Type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	//
@@ -61,22 +52,13 @@ type ListenerDefaultActionArgs struct {
 	AuthenticateOidc ListenerDefaultActionAuthenticateOidcPtrInput `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse ListenerDefaultActionFixedResponsePtrInput `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
-	// Detailed below.
+	// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
 	Forward ListenerDefaultActionForwardPtrInput `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
+	// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
 	Order pulumi.IntPtrInput `pulumi:"order"`
 	// Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
 	Redirect ListenerDefaultActionRedirectPtrInput `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn pulumi.StringPtrInput `pulumi:"targetGroupArn"`
 	// Type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	//
@@ -150,18 +132,12 @@ func (o ListenerDefaultActionOutput) FixedResponse() ListenerDefaultActionFixedR
 	return o.ApplyT(func(v ListenerDefaultAction) *ListenerDefaultActionFixedResponse { return v.FixedResponse }).(ListenerDefaultActionFixedResponsePtrOutput)
 }
 
-// Configuration block for creating an action that distributes requests among one or more target groups.
-// Specify only if `type` is `forward`.
-// Cannot be specified with `targetGroupArn`.
-// Detailed below.
+// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
 func (o ListenerDefaultActionOutput) Forward() ListenerDefaultActionForwardPtrOutput {
 	return o.ApplyT(func(v ListenerDefaultAction) *ListenerDefaultActionForward { return v.Forward }).(ListenerDefaultActionForwardPtrOutput)
 }
 
-// Order for the action.
-// The action with the lowest value for order is performed first.
-// Valid values are between `1` and `50000`.
-// Defaults to the position in the list of actions.
+// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
 func (o ListenerDefaultActionOutput) Order() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ListenerDefaultAction) *int { return v.Order }).(pulumi.IntPtrOutput)
 }
@@ -171,10 +147,7 @@ func (o ListenerDefaultActionOutput) Redirect() ListenerDefaultActionRedirectPtr
 	return o.ApplyT(func(v ListenerDefaultAction) *ListenerDefaultActionRedirect { return v.Redirect }).(ListenerDefaultActionRedirectPtrOutput)
 }
 
-// ARN of the Target Group to which to route traffic.
-// Specify only if `type` is `forward` and you want to route to a single target group.
-// To route to one or more target groups, use a `forward` block instead.
-// Cannot be specified with `forward`.
+// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 func (o ListenerDefaultActionOutput) TargetGroupArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ListenerDefaultAction) *string { return v.TargetGroupArn }).(pulumi.StringPtrOutput)
 }
@@ -1868,21 +1841,12 @@ type ListenerRuleAction struct {
 	AuthenticateOidc *ListenerRuleActionAuthenticateOidc `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse *ListenerRuleActionFixedResponse `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
+	// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
 	Forward *ListenerRuleActionForward `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
-	Order *int `pulumi:"order"`
+	Order   *int                       `pulumi:"order"`
 	// Information for creating a redirect action. Required if `type` is `redirect`.
 	Redirect *ListenerRuleActionRedirect `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn *string `pulumi:"targetGroupArn"`
 	// The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	Type string `pulumi:"type"`
@@ -1906,21 +1870,12 @@ type ListenerRuleActionArgs struct {
 	AuthenticateOidc ListenerRuleActionAuthenticateOidcPtrInput `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse ListenerRuleActionFixedResponsePtrInput `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
+	// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
 	Forward ListenerRuleActionForwardPtrInput `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
-	Order pulumi.IntPtrInput `pulumi:"order"`
+	Order   pulumi.IntPtrInput                `pulumi:"order"`
 	// Information for creating a redirect action. Required if `type` is `redirect`.
 	Redirect ListenerRuleActionRedirectPtrInput `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn pulumi.StringPtrInput `pulumi:"targetGroupArn"`
 	// The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	Type pulumi.StringInput `pulumi:"type"`
@@ -1992,17 +1947,11 @@ func (o ListenerRuleActionOutput) FixedResponse() ListenerRuleActionFixedRespons
 	return o.ApplyT(func(v ListenerRuleAction) *ListenerRuleActionFixedResponse { return v.FixedResponse }).(ListenerRuleActionFixedResponsePtrOutput)
 }
 
-// Configuration block for creating an action that distributes requests among one or more target groups.
-// Specify only if `type` is `forward`.
-// Cannot be specified with `targetGroupArn`.
+// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
 func (o ListenerRuleActionOutput) Forward() ListenerRuleActionForwardPtrOutput {
 	return o.ApplyT(func(v ListenerRuleAction) *ListenerRuleActionForward { return v.Forward }).(ListenerRuleActionForwardPtrOutput)
 }
 
-// Order for the action.
-// The action with the lowest value for order is performed first.
-// Valid values are between `1` and `50000`.
-// Defaults to the position in the list of actions.
 func (o ListenerRuleActionOutput) Order() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ListenerRuleAction) *int { return v.Order }).(pulumi.IntPtrOutput)
 }
@@ -2012,10 +1961,7 @@ func (o ListenerRuleActionOutput) Redirect() ListenerRuleActionRedirectPtrOutput
 	return o.ApplyT(func(v ListenerRuleAction) *ListenerRuleActionRedirect { return v.Redirect }).(ListenerRuleActionRedirectPtrOutput)
 }
 
-// ARN of the Target Group to which to route traffic.
-// Specify only if `type` is `forward` and you want to route to a single target group.
-// To route to one or more target groups, use a `forward` block instead.
-// Cannot be specified with `forward`.
+// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 func (o ListenerRuleActionOutput) TargetGroupArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ListenerRuleAction) *string { return v.TargetGroupArn }).(pulumi.StringPtrOutput)
 }

--- a/sdk/go/aws/lb/pulumiTypes.go
+++ b/sdk/go/aws/lb/pulumiTypes.go
@@ -20,22 +20,13 @@ type ListenerDefaultAction struct {
 	AuthenticateOidc *ListenerDefaultActionAuthenticateOidc `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse *ListenerDefaultActionFixedResponse `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
-	// Detailed below.
+	// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
 	Forward *ListenerDefaultActionForward `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
+	// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
 	Order *int `pulumi:"order"`
 	// Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
 	Redirect *ListenerDefaultActionRedirect `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn *string `pulumi:"targetGroupArn"`
 	// Type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	//
@@ -61,22 +52,13 @@ type ListenerDefaultActionArgs struct {
 	AuthenticateOidc ListenerDefaultActionAuthenticateOidcPtrInput `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse ListenerDefaultActionFixedResponsePtrInput `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
-	// Detailed below.
+	// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
 	Forward ListenerDefaultActionForwardPtrInput `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
+	// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
 	Order pulumi.IntPtrInput `pulumi:"order"`
 	// Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
 	Redirect ListenerDefaultActionRedirectPtrInput `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn pulumi.StringPtrInput `pulumi:"targetGroupArn"`
 	// Type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	//
@@ -150,18 +132,12 @@ func (o ListenerDefaultActionOutput) FixedResponse() ListenerDefaultActionFixedR
 	return o.ApplyT(func(v ListenerDefaultAction) *ListenerDefaultActionFixedResponse { return v.FixedResponse }).(ListenerDefaultActionFixedResponsePtrOutput)
 }
 
-// Configuration block for creating an action that distributes requests among one or more target groups.
-// Specify only if `type` is `forward`.
-// Cannot be specified with `targetGroupArn`.
-// Detailed below.
+// Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
 func (o ListenerDefaultActionOutput) Forward() ListenerDefaultActionForwardPtrOutput {
 	return o.ApplyT(func(v ListenerDefaultAction) *ListenerDefaultActionForward { return v.Forward }).(ListenerDefaultActionForwardPtrOutput)
 }
 
-// Order for the action.
-// The action with the lowest value for order is performed first.
-// Valid values are between `1` and `50000`.
-// Defaults to the position in the list of actions.
+// Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
 func (o ListenerDefaultActionOutput) Order() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ListenerDefaultAction) *int { return v.Order }).(pulumi.IntPtrOutput)
 }
@@ -171,10 +147,7 @@ func (o ListenerDefaultActionOutput) Redirect() ListenerDefaultActionRedirectPtr
 	return o.ApplyT(func(v ListenerDefaultAction) *ListenerDefaultActionRedirect { return v.Redirect }).(ListenerDefaultActionRedirectPtrOutput)
 }
 
-// ARN of the Target Group to which to route traffic.
-// Specify only if `type` is `forward` and you want to route to a single target group.
-// To route to one or more target groups, use a `forward` block instead.
-// Cannot be specified with `forward`.
+// ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 func (o ListenerDefaultActionOutput) TargetGroupArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ListenerDefaultAction) *string { return v.TargetGroupArn }).(pulumi.StringPtrOutput)
 }
@@ -1868,21 +1841,12 @@ type ListenerRuleAction struct {
 	AuthenticateOidc *ListenerRuleActionAuthenticateOidc `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse *ListenerRuleActionFixedResponse `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
+	// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
 	Forward *ListenerRuleActionForward `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
-	Order *int `pulumi:"order"`
+	Order   *int                       `pulumi:"order"`
 	// Information for creating a redirect action. Required if `type` is `redirect`.
 	Redirect *ListenerRuleActionRedirect `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn *string `pulumi:"targetGroupArn"`
 	// The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	Type string `pulumi:"type"`
@@ -1906,21 +1870,12 @@ type ListenerRuleActionArgs struct {
 	AuthenticateOidc ListenerRuleActionAuthenticateOidcPtrInput `pulumi:"authenticateOidc"`
 	// Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 	FixedResponse ListenerRuleActionFixedResponsePtrInput `pulumi:"fixedResponse"`
-	// Configuration block for creating an action that distributes requests among one or more target groups.
-	// Specify only if `type` is `forward`.
-	// Cannot be specified with `targetGroupArn`.
+	// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
 	Forward ListenerRuleActionForwardPtrInput `pulumi:"forward"`
-	// Order for the action.
-	// The action with the lowest value for order is performed first.
-	// Valid values are between `1` and `50000`.
-	// Defaults to the position in the list of actions.
-	Order pulumi.IntPtrInput `pulumi:"order"`
+	Order   pulumi.IntPtrInput                `pulumi:"order"`
 	// Information for creating a redirect action. Required if `type` is `redirect`.
 	Redirect ListenerRuleActionRedirectPtrInput `pulumi:"redirect"`
-	// ARN of the Target Group to which to route traffic.
-	// Specify only if `type` is `forward` and you want to route to a single target group.
-	// To route to one or more target groups, use a `forward` block instead.
-	// Cannot be specified with `forward`.
+	// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 	TargetGroupArn pulumi.StringPtrInput `pulumi:"targetGroupArn"`
 	// The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 	Type pulumi.StringInput `pulumi:"type"`
@@ -1992,17 +1947,11 @@ func (o ListenerRuleActionOutput) FixedResponse() ListenerRuleActionFixedRespons
 	return o.ApplyT(func(v ListenerRuleAction) *ListenerRuleActionFixedResponse { return v.FixedResponse }).(ListenerRuleActionFixedResponsePtrOutput)
 }
 
-// Configuration block for creating an action that distributes requests among one or more target groups.
-// Specify only if `type` is `forward`.
-// Cannot be specified with `targetGroupArn`.
+// Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
 func (o ListenerRuleActionOutput) Forward() ListenerRuleActionForwardPtrOutput {
 	return o.ApplyT(func(v ListenerRuleAction) *ListenerRuleActionForward { return v.Forward }).(ListenerRuleActionForwardPtrOutput)
 }
 
-// Order for the action.
-// The action with the lowest value for order is performed first.
-// Valid values are between `1` and `50000`.
-// Defaults to the position in the list of actions.
 func (o ListenerRuleActionOutput) Order() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ListenerRuleAction) *int { return v.Order }).(pulumi.IntPtrOutput)
 }
@@ -2012,10 +1961,7 @@ func (o ListenerRuleActionOutput) Redirect() ListenerRuleActionRedirectPtrOutput
 	return o.ApplyT(func(v ListenerRuleAction) *ListenerRuleActionRedirect { return v.Redirect }).(ListenerRuleActionRedirectPtrOutput)
 }
 
-// ARN of the Target Group to which to route traffic.
-// Specify only if `type` is `forward` and you want to route to a single target group.
-// To route to one or more target groups, use a `forward` block instead.
-// Cannot be specified with `forward`.
+// The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 func (o ListenerRuleActionOutput) TargetGroupArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ListenerRuleAction) *string { return v.TargetGroupArn }).(pulumi.StringPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/inputs/ListenerDefaultActionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/inputs/ListenerDefaultActionArgs.java
@@ -68,20 +68,14 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
     }
 
     /**
-     * Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     @Import(name="forward")
     private @Nullable Output<ListenerDefaultActionForwardArgs> forward;
 
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * @return Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     public Optional<Output<ListenerDefaultActionForwardArgs>> forward() {
@@ -89,20 +83,14 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
     }
 
     /**
-     * Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     @Import(name="order")
     private @Nullable Output<Integer> order;
 
     /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * @return Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     public Optional<Output<Integer>> order() {
@@ -125,20 +113,14 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
     }
 
     /**
-     * ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     @Import(name="targetGroupArn")
     private @Nullable Output<String> targetGroupArn;
 
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<Output<String>> targetGroupArn() {
@@ -259,10 +241,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
-         * Detailed below.
+         * @param forward Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
          * 
          * @return builder
          * 
@@ -273,10 +252,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
-         * Detailed below.
+         * @param forward Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
          * 
          * @return builder
          * 
@@ -286,10 +262,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * @param order Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          * 
          * @return builder
          * 
@@ -300,10 +273,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * @param order Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          * 
          * @return builder
          * 
@@ -334,10 +304,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 
@@ -348,10 +315,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/inputs/ListenerRuleActionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/inputs/ListenerRuleActionArgs.java
@@ -68,41 +68,23 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
     }
 
     /**
-     * Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     @Import(name="forward")
     private @Nullable Output<ListenerRuleActionForwardArgs> forward;
 
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * @return Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     public Optional<Output<ListenerRuleActionForwardArgs>> forward() {
         return Optional.ofNullable(this.forward);
     }
 
-    /**
-     * Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     @Import(name="order")
     private @Nullable Output<Integer> order;
 
-    /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     public Optional<Output<Integer>> order() {
         return Optional.ofNullable(this.order);
     }
@@ -123,20 +105,14 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
     }
 
     /**
-     * ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     @Import(name="targetGroupArn")
     private @Nullable Output<String> targetGroupArn;
 
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<Output<String>> targetGroupArn() {
@@ -253,9 +229,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
+         * @param forward Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
          * 
          * @return builder
          * 
@@ -266,9 +240,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
+         * @param forward Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
          * 
          * @return builder
          * 
@@ -277,29 +249,11 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
             return forward(Output.of(forward));
         }
 
-        /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         * 
-         * @return builder
-         * 
-         */
         public Builder order(@Nullable Output<Integer> order) {
             $.order = order;
             return this;
         }
 
-        /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         * 
-         * @return builder
-         * 
-         */
         public Builder order(Integer order) {
             return order(Output.of(order));
         }
@@ -326,10 +280,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 
@@ -340,10 +291,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/outputs/ListenerDefaultAction.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/outputs/ListenerDefaultAction.java
@@ -34,18 +34,12 @@ public final class ListenerDefaultAction {
      */
     private @Nullable ListenerDefaultActionFixedResponse fixedResponse;
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * @return Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     private @Nullable ListenerDefaultActionForward forward;
     /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * @return Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     private @Nullable Integer order;
@@ -55,10 +49,7 @@ public final class ListenerDefaultAction {
      */
     private @Nullable ListenerDefaultActionRedirect redirect;
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     private @Nullable String targetGroupArn;
@@ -93,20 +84,14 @@ public final class ListenerDefaultAction {
         return Optional.ofNullable(this.fixedResponse);
     }
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * @return Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     public Optional<ListenerDefaultActionForward> forward() {
         return Optional.ofNullable(this.forward);
     }
     /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * @return Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     public Optional<Integer> order() {
@@ -120,10 +105,7 @@ public final class ListenerDefaultAction {
         return Optional.ofNullable(this.redirect);
     }
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<String> targetGroupArn() {

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/outputs/ListenerRuleAction.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/outputs/ListenerRuleAction.java
@@ -34,19 +34,10 @@ public final class ListenerRuleAction {
      */
     private @Nullable ListenerRuleActionFixedResponse fixedResponse;
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * @return Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     private @Nullable ListenerRuleActionForward forward;
-    /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     private @Nullable Integer order;
     /**
      * @return Information for creating a redirect action. Required if `type` is `redirect`.
@@ -54,10 +45,7 @@ public final class ListenerRuleAction {
      */
     private @Nullable ListenerRuleActionRedirect redirect;
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     private @Nullable String targetGroupArn;
@@ -90,21 +78,12 @@ public final class ListenerRuleAction {
         return Optional.ofNullable(this.fixedResponse);
     }
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * @return Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     public Optional<ListenerRuleActionForward> forward() {
         return Optional.ofNullable(this.forward);
     }
-    /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     public Optional<Integer> order() {
         return Optional.ofNullable(this.order);
     }
@@ -116,10 +95,7 @@ public final class ListenerRuleAction {
         return Optional.ofNullable(this.redirect);
     }
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<String> targetGroupArn() {

--- a/sdk/java/src/main/java/com/pulumi/aws/lb/inputs/ListenerDefaultActionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lb/inputs/ListenerDefaultActionArgs.java
@@ -68,20 +68,14 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
     }
 
     /**
-     * Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     @Import(name="forward")
     private @Nullable Output<ListenerDefaultActionForwardArgs> forward;
 
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * @return Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     public Optional<Output<ListenerDefaultActionForwardArgs>> forward() {
@@ -89,20 +83,14 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
     }
 
     /**
-     * Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     @Import(name="order")
     private @Nullable Output<Integer> order;
 
     /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * @return Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     public Optional<Output<Integer>> order() {
@@ -125,20 +113,14 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
     }
 
     /**
-     * ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     @Import(name="targetGroupArn")
     private @Nullable Output<String> targetGroupArn;
 
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<Output<String>> targetGroupArn() {
@@ -259,10 +241,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
-         * Detailed below.
+         * @param forward Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
          * 
          * @return builder
          * 
@@ -273,10 +252,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
-         * Detailed below.
+         * @param forward Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
          * 
          * @return builder
          * 
@@ -286,10 +262,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * @param order Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          * 
          * @return builder
          * 
@@ -300,10 +273,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * @param order Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          * 
          * @return builder
          * 
@@ -334,10 +304,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 
@@ -348,10 +315,7 @@ public final class ListenerDefaultActionArgs extends com.pulumi.resources.Resour
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/lb/inputs/ListenerRuleActionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lb/inputs/ListenerRuleActionArgs.java
@@ -68,41 +68,23 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
     }
 
     /**
-     * Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     @Import(name="forward")
     private @Nullable Output<ListenerRuleActionForwardArgs> forward;
 
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * @return Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     public Optional<Output<ListenerRuleActionForwardArgs>> forward() {
         return Optional.ofNullable(this.forward);
     }
 
-    /**
-     * Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     @Import(name="order")
     private @Nullable Output<Integer> order;
 
-    /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     public Optional<Output<Integer>> order() {
         return Optional.ofNullable(this.order);
     }
@@ -123,20 +105,14 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
     }
 
     /**
-     * ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     @Import(name="targetGroupArn")
     private @Nullable Output<String> targetGroupArn;
 
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<Output<String>> targetGroupArn() {
@@ -253,9 +229,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
+         * @param forward Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
          * 
          * @return builder
          * 
@@ -266,9 +240,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param forward Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `target_group_arn`.
+         * @param forward Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
          * 
          * @return builder
          * 
@@ -277,29 +249,11 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
             return forward(Output.of(forward));
         }
 
-        /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         * 
-         * @return builder
-         * 
-         */
         public Builder order(@Nullable Output<Integer> order) {
             $.order = order;
             return this;
         }
 
-        /**
-         * @param order Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         * 
-         * @return builder
-         * 
-         */
         public Builder order(Integer order) {
             return order(Output.of(order));
         }
@@ -326,10 +280,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 
@@ -340,10 +291,7 @@ public final class ListenerRuleActionArgs extends com.pulumi.resources.ResourceA
         }
 
         /**
-         * @param targetGroupArn ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * @param targetGroupArn The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/lb/outputs/ListenerDefaultAction.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lb/outputs/ListenerDefaultAction.java
@@ -34,18 +34,12 @@ public final class ListenerDefaultAction {
      */
     private @Nullable ListenerDefaultActionFixedResponse fixedResponse;
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * @return Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     private @Nullable ListenerDefaultActionForward forward;
     /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * @return Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     private @Nullable Integer order;
@@ -55,10 +49,7 @@ public final class ListenerDefaultAction {
      */
     private @Nullable ListenerDefaultActionRedirect redirect;
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     private @Nullable String targetGroupArn;
@@ -93,20 +84,14 @@ public final class ListenerDefaultAction {
         return Optional.ofNullable(this.fixedResponse);
     }
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
-     * Detailed below.
+     * @return Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
      * 
      */
     public Optional<ListenerDefaultActionForward> forward() {
         return Optional.ofNullable(this.forward);
     }
     /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
+     * @return Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
      * 
      */
     public Optional<Integer> order() {
@@ -120,10 +105,7 @@ public final class ListenerDefaultAction {
         return Optional.ofNullable(this.redirect);
     }
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<String> targetGroupArn() {

--- a/sdk/java/src/main/java/com/pulumi/aws/lb/outputs/ListenerRuleAction.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lb/outputs/ListenerRuleAction.java
@@ -34,19 +34,10 @@ public final class ListenerRuleAction {
      */
     private @Nullable ListenerRuleActionFixedResponse fixedResponse;
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * @return Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     private @Nullable ListenerRuleActionForward forward;
-    /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     private @Nullable Integer order;
     /**
      * @return Information for creating a redirect action. Required if `type` is `redirect`.
@@ -54,10 +45,7 @@ public final class ListenerRuleAction {
      */
     private @Nullable ListenerRuleActionRedirect redirect;
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     private @Nullable String targetGroupArn;
@@ -90,21 +78,12 @@ public final class ListenerRuleAction {
         return Optional.ofNullable(this.fixedResponse);
     }
     /**
-     * @return Configuration block for creating an action that distributes requests among one or more target groups.
-     * Specify only if `type` is `forward`.
-     * Cannot be specified with `target_group_arn`.
+     * @return Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
      * 
      */
     public Optional<ListenerRuleActionForward> forward() {
         return Optional.ofNullable(this.forward);
     }
-    /**
-     * @return Order for the action.
-     * The action with the lowest value for order is performed first.
-     * Valid values are between `1` and `50000`.
-     * Defaults to the position in the list of actions.
-     * 
-     */
     public Optional<Integer> order() {
         return Optional.ofNullable(this.order);
     }
@@ -116,10 +95,7 @@ public final class ListenerRuleAction {
         return Optional.ofNullable(this.redirect);
     }
     /**
-     * @return ARN of the Target Group to which to route traffic.
-     * Specify only if `type` is `forward` and you want to route to a single target group.
-     * To route to one or more target groups, use a `forward` block instead.
-     * Cannot be specified with `forward`.
+     * @return The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
      * 
      */
     public Optional<String> targetGroupArn() {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -1477,17 +1477,11 @@ export namespace alb {
          */
         fixedResponse?: pulumi.Input<inputs.alb.ListenerDefaultActionFixedResponse>;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
-         * Detailed below.
+         * Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
          */
         forward?: pulumi.Input<inputs.alb.ListenerDefaultActionForward>;
         /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          */
         order?: pulumi.Input<number>;
         /**
@@ -1495,10 +1489,7 @@ export namespace alb {
          */
         redirect?: pulumi.Input<inputs.alb.ListenerDefaultActionRedirect>;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: pulumi.Input<string>;
         /**
@@ -1709,27 +1700,16 @@ export namespace alb {
          */
         fixedResponse?: pulumi.Input<inputs.alb.ListenerRuleActionFixedResponse>;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
+         * Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
          */
         forward?: pulumi.Input<inputs.alb.ListenerRuleActionForward>;
-        /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         */
         order?: pulumi.Input<number>;
         /**
          * Information for creating a redirect action. Required if `type` is `redirect`.
          */
         redirect?: pulumi.Input<inputs.alb.ListenerRuleActionRedirect>;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: pulumi.Input<string>;
         /**
@@ -36163,17 +36143,11 @@ export namespace lb {
          */
         fixedResponse?: pulumi.Input<inputs.lb.ListenerDefaultActionFixedResponse>;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
-         * Detailed below.
+         * Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
          */
         forward?: pulumi.Input<inputs.lb.ListenerDefaultActionForward>;
         /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          */
         order?: pulumi.Input<number>;
         /**
@@ -36181,10 +36155,7 @@ export namespace lb {
          */
         redirect?: pulumi.Input<inputs.lb.ListenerDefaultActionRedirect>;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: pulumi.Input<string>;
         /**
@@ -36395,27 +36366,16 @@ export namespace lb {
          */
         fixedResponse?: pulumi.Input<inputs.lb.ListenerRuleActionFixedResponse>;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
+         * Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
          */
         forward?: pulumi.Input<inputs.lb.ListenerRuleActionForward>;
-        /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         */
         order?: pulumi.Input<number>;
         /**
          * Information for creating a redirect action. Required if `type` is `redirect`.
          */
         redirect?: pulumi.Input<inputs.lb.ListenerRuleActionRedirect>;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: pulumi.Input<string>;
         /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -413,17 +413,11 @@ export namespace alb {
          */
         fixedResponse?: outputs.alb.ListenerDefaultActionFixedResponse;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
-         * Detailed below.
+         * Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
          */
         forward?: outputs.alb.ListenerDefaultActionForward;
         /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          */
         order: number;
         /**
@@ -431,10 +425,7 @@ export namespace alb {
          */
         redirect?: outputs.alb.ListenerDefaultActionRedirect;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: string;
         /**
@@ -645,27 +636,16 @@ export namespace alb {
          */
         fixedResponse?: outputs.alb.ListenerRuleActionFixedResponse;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
+         * Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
          */
         forward?: outputs.alb.ListenerRuleActionForward;
-        /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         */
         order: number;
         /**
          * Information for creating a redirect action. Required if `type` is `redirect`.
          */
         redirect?: outputs.alb.ListenerRuleActionRedirect;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: string;
         /**
@@ -41679,17 +41659,11 @@ export namespace lb {
          */
         fixedResponse?: outputs.lb.ListenerDefaultActionFixedResponse;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
-         * Detailed below.
+         * Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`. Detailed below.
          */
         forward?: outputs.lb.ListenerDefaultActionForward;
         /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
+         * Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
          */
         order: number;
         /**
@@ -41697,10 +41671,7 @@ export namespace lb {
          */
         redirect?: outputs.lb.ListenerDefaultActionRedirect;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: string;
         /**
@@ -41911,27 +41882,16 @@ export namespace lb {
          */
         fixedResponse?: outputs.lb.ListenerRuleActionFixedResponse;
         /**
-         * Configuration block for creating an action that distributes requests among one or more target groups.
-         * Specify only if `type` is `forward`.
-         * Cannot be specified with `targetGroupArn`.
+         * Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `targetGroupArn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `targetGroupArn`.
          */
         forward?: outputs.lb.ListenerRuleActionForward;
-        /**
-         * Order for the action.
-         * The action with the lowest value for order is performed first.
-         * Valid values are between `1` and `50000`.
-         * Defaults to the position in the list of actions.
-         */
         order: number;
         /**
          * Information for creating a redirect action. Required if `type` is `redirect`.
          */
         redirect?: outputs.lb.ListenerRuleActionRedirect;
         /**
-         * ARN of the Target Group to which to route traffic.
-         * Specify only if `type` is `forward` and you want to route to a single target group.
-         * To route to one or more target groups, use a `forward` block instead.
-         * Cannot be specified with `forward`.
+         * The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
          */
         targetGroupArn?: string;
         /**

--- a/sdk/python/pulumi_aws/alb/_inputs.py
+++ b/sdk/python/pulumi_aws/alb/_inputs.py
@@ -62,19 +62,10 @@ class ListenerDefaultActionArgs:
         :param pulumi.Input['ListenerDefaultActionAuthenticateCognitoArgs'] authenticate_cognito: Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
         :param pulumi.Input['ListenerDefaultActionAuthenticateOidcArgs'] authenticate_oidc: Configuration block for an identity provider that is compliant with OpenID Connect (OIDC). Specify only when `type` is `authenticate-oidc`. Detailed below.
         :param pulumi.Input['ListenerDefaultActionFixedResponseArgs'] fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param pulumi.Input['ListenerDefaultActionForwardArgs'] forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-               Detailed below.
-        :param pulumi.Input[int] order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param pulumi.Input['ListenerDefaultActionForwardArgs'] forward: Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
+        :param pulumi.Input[int] order: Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         :param pulumi.Input['ListenerDefaultActionRedirectArgs'] redirect: Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
-        :param pulumi.Input[str] target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param pulumi.Input[str] target_group_arn: ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -146,10 +137,7 @@ class ListenerDefaultActionArgs:
     @pulumi.getter
     def forward(self) -> Optional[pulumi.Input['ListenerDefaultActionForwardArgs']]:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
-        Detailed below.
+        Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         """
         return pulumi.get(self, "forward")
 
@@ -161,10 +149,7 @@ class ListenerDefaultActionArgs:
     @pulumi.getter
     def order(self) -> Optional[pulumi.Input[int]]:
         """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
+        Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         """
         return pulumi.get(self, "order")
 
@@ -188,10 +173,7 @@ class ListenerDefaultActionArgs:
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[pulumi.Input[str]]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 
@@ -877,18 +859,9 @@ class ListenerRuleActionArgs:
         :param pulumi.Input['ListenerRuleActionAuthenticateCognitoArgs'] authenticate_cognito: Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
         :param pulumi.Input['ListenerRuleActionAuthenticateOidcArgs'] authenticate_oidc: Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
         :param pulumi.Input['ListenerRuleActionFixedResponseArgs'] fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param pulumi.Input['ListenerRuleActionForwardArgs'] forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-        :param pulumi.Input[int] order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param pulumi.Input['ListenerRuleActionForwardArgs'] forward: Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         :param pulumi.Input['ListenerRuleActionRedirectArgs'] redirect: Information for creating a redirect action. Required if `type` is `redirect`.
-        :param pulumi.Input[str] target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param pulumi.Input[str] target_group_arn: The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -958,9 +931,7 @@ class ListenerRuleActionArgs:
     @pulumi.getter
     def forward(self) -> Optional[pulumi.Input['ListenerRuleActionForwardArgs']]:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
+        Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         """
         return pulumi.get(self, "forward")
 
@@ -971,12 +942,6 @@ class ListenerRuleActionArgs:
     @property
     @pulumi.getter
     def order(self) -> Optional[pulumi.Input[int]]:
-        """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
-        """
         return pulumi.get(self, "order")
 
     @order.setter
@@ -999,10 +964,7 @@ class ListenerRuleActionArgs:
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[pulumi.Input[str]]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 

--- a/sdk/python/pulumi_aws/alb/outputs.py
+++ b/sdk/python/pulumi_aws/alb/outputs.py
@@ -100,19 +100,10 @@ class ListenerDefaultAction(dict):
         :param 'ListenerDefaultActionAuthenticateCognitoArgs' authenticate_cognito: Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
         :param 'ListenerDefaultActionAuthenticateOidcArgs' authenticate_oidc: Configuration block for an identity provider that is compliant with OpenID Connect (OIDC). Specify only when `type` is `authenticate-oidc`. Detailed below.
         :param 'ListenerDefaultActionFixedResponseArgs' fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param 'ListenerDefaultActionForwardArgs' forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-               Detailed below.
-        :param int order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param 'ListenerDefaultActionForwardArgs' forward: Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
+        :param int order: Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         :param 'ListenerDefaultActionRedirectArgs' redirect: Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
-        :param str target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param str target_group_arn: ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -168,10 +159,7 @@ class ListenerDefaultAction(dict):
     @pulumi.getter
     def forward(self) -> Optional['outputs.ListenerDefaultActionForward']:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
-        Detailed below.
+        Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         """
         return pulumi.get(self, "forward")
 
@@ -179,10 +167,7 @@ class ListenerDefaultAction(dict):
     @pulumi.getter
     def order(self) -> Optional[int]:
         """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
+        Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         """
         return pulumi.get(self, "order")
 
@@ -198,10 +183,7 @@ class ListenerDefaultAction(dict):
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[str]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 
@@ -894,18 +876,9 @@ class ListenerRuleAction(dict):
         :param 'ListenerRuleActionAuthenticateCognitoArgs' authenticate_cognito: Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
         :param 'ListenerRuleActionAuthenticateOidcArgs' authenticate_oidc: Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
         :param 'ListenerRuleActionFixedResponseArgs' fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param 'ListenerRuleActionForwardArgs' forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-        :param int order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param 'ListenerRuleActionForwardArgs' forward: Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         :param 'ListenerRuleActionRedirectArgs' redirect: Information for creating a redirect action. Required if `type` is `redirect`.
-        :param str target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param str target_group_arn: The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -959,21 +932,13 @@ class ListenerRuleAction(dict):
     @pulumi.getter
     def forward(self) -> Optional['outputs.ListenerRuleActionForward']:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
+        Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         """
         return pulumi.get(self, "forward")
 
     @property
     @pulumi.getter
     def order(self) -> Optional[int]:
-        """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
-        """
         return pulumi.get(self, "order")
 
     @property
@@ -988,10 +953,7 @@ class ListenerRuleAction(dict):
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[str]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 

--- a/sdk/python/pulumi_aws/lb/_inputs.py
+++ b/sdk/python/pulumi_aws/lb/_inputs.py
@@ -61,19 +61,10 @@ class ListenerDefaultActionArgs:
         :param pulumi.Input['ListenerDefaultActionAuthenticateCognitoArgs'] authenticate_cognito: Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
         :param pulumi.Input['ListenerDefaultActionAuthenticateOidcArgs'] authenticate_oidc: Configuration block for an identity provider that is compliant with OpenID Connect (OIDC). Specify only when `type` is `authenticate-oidc`. Detailed below.
         :param pulumi.Input['ListenerDefaultActionFixedResponseArgs'] fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param pulumi.Input['ListenerDefaultActionForwardArgs'] forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-               Detailed below.
-        :param pulumi.Input[int] order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param pulumi.Input['ListenerDefaultActionForwardArgs'] forward: Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
+        :param pulumi.Input[int] order: Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         :param pulumi.Input['ListenerDefaultActionRedirectArgs'] redirect: Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
-        :param pulumi.Input[str] target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param pulumi.Input[str] target_group_arn: ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -145,10 +136,7 @@ class ListenerDefaultActionArgs:
     @pulumi.getter
     def forward(self) -> Optional[pulumi.Input['ListenerDefaultActionForwardArgs']]:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
-        Detailed below.
+        Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         """
         return pulumi.get(self, "forward")
 
@@ -160,10 +148,7 @@ class ListenerDefaultActionArgs:
     @pulumi.getter
     def order(self) -> Optional[pulumi.Input[int]]:
         """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
+        Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         """
         return pulumi.get(self, "order")
 
@@ -187,10 +172,7 @@ class ListenerDefaultActionArgs:
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[pulumi.Input[str]]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 
@@ -876,18 +858,9 @@ class ListenerRuleActionArgs:
         :param pulumi.Input['ListenerRuleActionAuthenticateCognitoArgs'] authenticate_cognito: Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
         :param pulumi.Input['ListenerRuleActionAuthenticateOidcArgs'] authenticate_oidc: Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
         :param pulumi.Input['ListenerRuleActionFixedResponseArgs'] fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param pulumi.Input['ListenerRuleActionForwardArgs'] forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-        :param pulumi.Input[int] order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param pulumi.Input['ListenerRuleActionForwardArgs'] forward: Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         :param pulumi.Input['ListenerRuleActionRedirectArgs'] redirect: Information for creating a redirect action. Required if `type` is `redirect`.
-        :param pulumi.Input[str] target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param pulumi.Input[str] target_group_arn: The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -957,9 +930,7 @@ class ListenerRuleActionArgs:
     @pulumi.getter
     def forward(self) -> Optional[pulumi.Input['ListenerRuleActionForwardArgs']]:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
+        Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         """
         return pulumi.get(self, "forward")
 
@@ -970,12 +941,6 @@ class ListenerRuleActionArgs:
     @property
     @pulumi.getter
     def order(self) -> Optional[pulumi.Input[int]]:
-        """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
-        """
         return pulumi.get(self, "order")
 
     @order.setter
@@ -998,10 +963,7 @@ class ListenerRuleActionArgs:
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[pulumi.Input[str]]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 

--- a/sdk/python/pulumi_aws/lb/outputs.py
+++ b/sdk/python/pulumi_aws/lb/outputs.py
@@ -99,19 +99,10 @@ class ListenerDefaultAction(dict):
         :param 'ListenerDefaultActionAuthenticateCognitoArgs' authenticate_cognito: Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
         :param 'ListenerDefaultActionAuthenticateOidcArgs' authenticate_oidc: Configuration block for an identity provider that is compliant with OpenID Connect (OIDC). Specify only when `type` is `authenticate-oidc`. Detailed below.
         :param 'ListenerDefaultActionFixedResponseArgs' fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param 'ListenerDefaultActionForwardArgs' forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-               Detailed below.
-        :param int order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param 'ListenerDefaultActionForwardArgs' forward: Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
+        :param int order: Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         :param 'ListenerDefaultActionRedirectArgs' redirect: Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
-        :param str target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param str target_group_arn: ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -167,10 +158,7 @@ class ListenerDefaultAction(dict):
     @pulumi.getter
     def forward(self) -> Optional['outputs.ListenerDefaultActionForward']:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
-        Detailed below.
+        Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
         """
         return pulumi.get(self, "forward")
 
@@ -178,10 +166,7 @@ class ListenerDefaultAction(dict):
     @pulumi.getter
     def order(self) -> Optional[int]:
         """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
+        Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
         """
         return pulumi.get(self, "order")
 
@@ -197,10 +182,7 @@ class ListenerDefaultAction(dict):
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[str]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 
@@ -893,18 +875,9 @@ class ListenerRuleAction(dict):
         :param 'ListenerRuleActionAuthenticateCognitoArgs' authenticate_cognito: Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
         :param 'ListenerRuleActionAuthenticateOidcArgs' authenticate_oidc: Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
         :param 'ListenerRuleActionFixedResponseArgs' fixed_response: Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
-        :param 'ListenerRuleActionForwardArgs' forward: Configuration block for creating an action that distributes requests among one or more target groups.
-               Specify only if `type` is `forward`.
-               Cannot be specified with `target_group_arn`.
-        :param int order: Order for the action.
-               The action with the lowest value for order is performed first.
-               Valid values are between `1` and `50000`.
-               Defaults to the position in the list of actions.
+        :param 'ListenerRuleActionForwardArgs' forward: Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         :param 'ListenerRuleActionRedirectArgs' redirect: Information for creating a redirect action. Required if `type` is `redirect`.
-        :param str target_group_arn: ARN of the Target Group to which to route traffic.
-               Specify only if `type` is `forward` and you want to route to a single target group.
-               To route to one or more target groups, use a `forward` block instead.
-               Cannot be specified with `forward`.
+        :param str target_group_arn: The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         pulumi.set(__self__, "type", type)
         if authenticate_cognito is not None:
@@ -958,21 +931,13 @@ class ListenerRuleAction(dict):
     @pulumi.getter
     def forward(self) -> Optional['outputs.ListenerRuleActionForward']:
         """
-        Configuration block for creating an action that distributes requests among one or more target groups.
-        Specify only if `type` is `forward`.
-        Cannot be specified with `target_group_arn`.
+        Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
         """
         return pulumi.get(self, "forward")
 
     @property
     @pulumi.getter
     def order(self) -> Optional[int]:
-        """
-        Order for the action.
-        The action with the lowest value for order is performed first.
-        Valid values are between `1` and `50000`.
-        Defaults to the position in the list of actions.
-        """
         return pulumi.get(self, "order")
 
     @property
@@ -987,10 +952,7 @@ class ListenerRuleAction(dict):
     @pulumi.getter(name="targetGroupArn")
     def target_group_arn(self) -> Optional[str]:
         """
-        ARN of the Target Group to which to route traffic.
-        Specify only if `type` is `forward` and you want to route to a single target group.
-        To route to one or more target groups, use a `forward` block instead.
-        Cannot be specified with `forward`.
+        The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
         """
         return pulumi.get(self, "target_group_arn")
 


### PR DESCRIPTION
This reverts the following upstream PRs:
https://github.com/hashicorp/terraform-provider-aws/pull/35671
https://github.com/hashicorp/terraform-provider-aws/pull/35678
as a quick fix to mitigate https://github.com/pulumi/pulumi-aws/issues/3421 until we root-cause it.

Details on my findings so far: https://github.com/pulumi/pulumi-aws/issues/3421#issuecomment-1943569655
It looks to me like the issue originates somewhere in our handling of nulls/empty in the bridge, so seems unlikely to get fixed today.

It also adds a test for LB listeners. I've verified that the test triggers the panic without the patches and that the patches resolve it.