### PR TITLE
Introduce examples cache

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -209,6 +209,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -270,6 +276,33 @@ jobs:
 
 
           Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+    - if: github.event_name == 'pull_request'
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Configuration check
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        comment_tag: configurationCheck
+        message: >+
+          ### Is README.md missing any configuration options?
+
+          ${{ env.MISSING_CONFIG || 'No missing config!' }}
+
+
+          ${{ env.MISSING_CONFIG && 'Please add a description for each of these options to `README.md`.' }}
+          ${{ env.MISSING_CONFIG && 'Details about them can be found in either the upstream docs or `schema.json`.' }}
 
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,6 +55,12 @@ jobs:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -133,6 +139,7 @@ jobs:
         - dotnet
         - go
         - java
+
   generate_coverage_data:
     continue-on-error: true
     env:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -142,6 +142,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -203,6 +209,33 @@ jobs:
 
 
           Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+    - if: github.event_name == 'pull_request'
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Configuration check
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        comment_tag: configurationCheck
+        message: >+
+          ### Is README.md missing any configuration options?
+
+          ${{ env.MISSING_CONFIG || 'No missing config!' }}
+
+
+          ${{ env.MISSING_CONFIG && 'Please add a description for each of these options to `README.md`.' }}
+          ${{ env.MISSING_CONFIG && 'Details about them can be found in either the upstream docs or `schema.json`.' }}
 
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -55,6 +55,12 @@ jobs:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -145,6 +145,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -206,6 +212,33 @@ jobs:
 
 
           Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+    - if: github.event_name == 'pull_request'
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Configuration check
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        comment_tag: configurationCheck
+        message: >+
+          ### Is README.md missing any configuration options?
+
+          ${{ env.MISSING_CONFIG || 'No missing config!' }}
+
+
+          ${{ env.MISSING_CONFIG && 'Please add a description for each of these options to `README.md`.' }}
+          ${{ env.MISSING_CONFIG && 'Details about them can be found in either the upstream docs or `schema.json`.' }}
 
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -56,6 +56,12 @@ jobs:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -117,6 +123,7 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+        retention-days: 30
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -133,6 +140,7 @@ jobs:
         - dotnet
         - go
         - java
+
   license_check:
     name: License Check
     uses: ./.github/workflows/license.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -220,6 +226,33 @@ jobs:
 
 
           Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+    - if: github.event_name == 'pull_request'
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Configuration check
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        comment_tag: configurationCheck
+        message: >+
+          ### Is README.md missing any configuration options?
+
+          ${{ env.MISSING_CONFIG || 'No missing config!' }}
+
+
+          ${{ env.MISSING_CONFIG && 'Please add a description for each of these options to `README.md`.' }}
+          ${{ env.MISSING_CONFIG && 'Details about them can be found in either the upstream docs or `schema.json`.' }}
 
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,12 @@ jobs:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -116,6 +122,7 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+        retention-days: 30
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -132,6 +139,7 @@ jobs:
         - dotnet
         - go
         - java
+
   create_docs_build:
     name: create_docs_build
     needs: tag_sdk

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -167,6 +167,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -228,6 +234,33 @@ jobs:
 
 
           Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+    - if: github.event_name == 'pull_request'
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Configuration check
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        comment_tag: configurationCheck
+        message: >+
+          ### Is README.md missing any configuration options?
+
+          ${{ env.MISSING_CONFIG || 'No missing config!' }}
+
+
+          ${{ env.MISSING_CONFIG && 'Please add a description for each of these options to `README.md`.' }}
+          ${{ env.MISSING_CONFIG && 'Details about them can be found in either the upstream docs or `schema.json`.' }}
 
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -64,6 +64,12 @@ jobs:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
+    - name: Cache examples generation
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -142,6 +148,7 @@ jobs:
         - dotnet
         - go
         - java
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ only_build: build
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 build_dotnet: upstream
 	pulumictl get version --language dotnet
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
@@ -43,6 +44,7 @@ build_dotnet: upstream
 
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 build_go: upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
@@ -50,6 +52,7 @@ build_go: upstream
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
@@ -59,6 +62,7 @@ build_java: bin/pulumi-java-gen upstream
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 build_nodejs: upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -71,6 +75,7 @@ build_nodejs: upstream
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 build_python: upstream
 	rm -rf sdk/python/
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
@@ -144,6 +149,7 @@ test_provider:
 
 tfgen: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 tfgen: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+tfgen: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 tfgen: install_plugins upstream
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -17,6 +17,11 @@ require (
 	pgregory.net/rapid v0.6.1
 )
 
+replace (
+	github.com/pulumi/pulumi-terraform-bridge/pf => github.com/pulumi/pulumi-terraform-bridge/pf v0.31.1-0.20240326193937-f6ca6f9cb5ed
+	github.com/pulumi/pulumi-terraform-bridge/v3 => github.com/pulumi/pulumi-terraform-bridge/v3 v3.78.1-0.20240326193937-f6ca6f9cb5ed
+)
+
 // This replace is copied from upstream/go.mod, and should be maintained only as long as
 // upstream maintains the same replace.
 //

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -3128,10 +3128,10 @@ github.com/pulumi/providertest v0.0.11 h1:mg8MQ7Cq7+9XlHIkBD+aCqQO4mwAJEISngZgVd
 github.com/pulumi/providertest v0.0.11/go.mod h1:HsxjVsytcMIuNj19w1lT2W0QXY0oReXl1+h6eD2JXP8=
 github.com/pulumi/pulumi-java/pkg v0.9.9 h1:F3xJUtMFDVrTGCxb7Rh2Q8s6tj7gMfM5pcoUthz7vFY=
 github.com/pulumi/pulumi-java/pkg v0.9.9/go.mod h1:LVF1zeg3UkToHWxb67V+zEIxQc3EdMnlot5NWSt+FpA=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.31.0 h1:KnVMjyTmkqjUDBVoQNODPMH0VpPmRmu7JHMruBF+Fvs=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.31.0/go.mod h1:kdaazbdv0Hn6/innKvWcPfRRn/0YeNYI/oWA4j8lV3k=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.78.0 h1:zl1nXrx02X7u/w5kNjIVGVUzccEILcMWsIpg4QQanCI=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.78.0/go.mod h1:WpkN/lgtBrDYGrMyG9cmncy5pN95lnowbmjILHWcm0M=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.31.1-0.20240326193937-f6ca6f9cb5ed h1:q9NlHZbzknYLNgC0N2/6fWJ6sUCSVh0O1vC/01dhZXM=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.31.1-0.20240326193937-f6ca6f9cb5ed/go.mod h1:5SrAvHnjZSnKNUKU1e8n057PtvSqazMWlIkCr6MfWxs=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.78.1-0.20240326193937-f6ca6f9cb5ed h1:lEiQN1CzSA3JeXz5O75glaXAPeIRgDZqL8WyYOS8XxA=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.78.1-0.20240326193937-f6ca6f9cb5ed/go.mod h1:WpkN/lgtBrDYGrMyG9cmncy5pN95lnowbmjILHWcm0M=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKgepHyYsMzwaTm4cvp0dcTMYw=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi-yaml v1.6.0 h1:mb/QkebWXTa1fR+P3ZkCCHGXOYC6iTN8X8By9eNz8xM=


### PR DESCRIPTION
Rolling out the support for the external pulumi TF converter has slowed down iterating in the repo significantly. It's at a point where I find it extremely difficult to iterate.

make tfgen: 4:26-5:00 
make build_python: 5:00

And `make build_sdks` is 5 min per language.

We should wait until the next bridge release to merge this but I wanted to see if the cache helps. It seems like it does and it brings `make tfgen` down to 1:00, and so does `make build_python` etc. This is better. It also has potential to speed up CI a bit if we add cache handling to GHA.

Some remaining small opportunities:

- it's not caching rendering failures so continues to invoke external `pulumi` for them; this could be cached also
- cache key computation is very conservative and sensitive to go.mod etc changes; somewhat necessarily so, interesting to see how it works out in practice, will most of the jobs we do be a cache miss? 
- I'd really like to decouple building from generating as I most cases I'm just concerned with generating the SDKs; dotnet and java builds in particular take forever
- If we could share developer and CI caches we could profit, not obvious how though 