### PR TITLE
fix: role inline policies fail to create without a policy name

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -626,7 +626,7 @@ func TestRoleInlinePolicyAutoName(t *testing.T) {
 	res, err := test.CurrentStack().Up(test.Context())
 	require.NoError(t, err)
 
-	policy := res.Outputs["inline_policy"]
+	policy := res.Outputs["inlinePolicy"]
 	value, err := json.Marshal(policy.Value)
 	require.NoError(t, err)
 
@@ -634,9 +634,9 @@ func TestRoleInlinePolicyAutoName(t *testing.T) {
 	err = json.Unmarshal(value, &inlinePolicy)
 	require.NoError(t, err)
 
-	policyEmpty := res.Outputs["inline_policy_empty"]
+	policyEmpty := res.Outputs["inlinePolicyEmpty"]
 
 	require.Equal(t, policyEmpty.Value, []interface{}{})
 	require.Regexp(t, regexp.MustCompile("testrole-*"), inlinePolicy.Name)
-	require.Equal(t, "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"*\"\n    }\n  ]\n}", inlinePolicy.Policy)
+	require.JSONEq(t, `{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*" }]}`, inlinePolicy.Policy)
 }

--- a/examples/role-inline-policy-auto-name/Pulumi.yaml
+++ b/examples/role-inline-policy-auto-name/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: role-inline-policy-auto-name
+runtime: nodejs
+description: A simple example of role inline_policy auto naming

--- a/examples/role-inline-policy-auto-name/README.md
+++ b/examples/role-inline-policy-auto-name/README.md
@@ -1,0 +1,3 @@
+# examples/role-inline-policy-auto-name
+
+A simple example of role inline policy auto naming

--- a/examples/role-inline-policy-auto-name/index.ts
+++ b/examples/role-inline-policy-auto-name/index.ts
@@ -1,0 +1,63 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+
+const role = new aws.iam.Role('testrole', {
+  assumeRolePolicy: aws.iam.getPolicyDocumentOutput({
+    statements: [
+      {
+        actions: ['sts:AssumeRole'],
+        principals: [
+          {
+            type: 'Service',
+            identifiers: ['lambda.amazonaws.com'],
+          },
+        ],
+      },
+    ],
+  }).json,
+  inlinePolicies: [
+    {
+      policy: aws.iam.getPolicyDocumentOutput({
+        statements: [
+          {
+            actions: ['s3:GetObject'],
+            resources: ['*'],
+          },
+        ],
+      }).json,
+    },
+  ],
+});
+
+const role2 = new aws.iam.Role('testrole-with-empty-inline', {
+  assumeRolePolicy: aws.iam.getPolicyDocumentOutput({
+    statements: [
+      {
+        actions: ['sts:AssumeRole'],
+        principals: [
+          {
+            type: 'Service',
+            identifiers: ['lambda.amazonaws.com'],
+          },
+        ],
+      },
+    ],
+  }).json,
+  inlinePolicies: [{}],
+});
+
+export const inline_policy = role.inlinePolicies[0];
+export const inline_policy_empty = role2.inlinePolicies;

--- a/examples/role-inline-policy-auto-name/index.ts
+++ b/examples/role-inline-policy-auto-name/index.ts
@@ -59,5 +59,5 @@ const role2 = new aws.iam.Role('testrole-with-empty-inline', {
   inlinePolicies: [{}],
 });
 
-export const inline_policy = role.inlinePolicies[0];
-export const inline_policy_empty = role2.inlinePolicies;
+export const inlinePolicy = role.inlinePolicies[0];
+export const inlinePolicyEmpty = role2.inlinePolicies;

--- a/examples/role-inline-policy-auto-name/package.json
+++ b/examples/role-inline-policy-auto-name/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "bucket",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@aws-sdk/client-s3": "^3.362.0",
+        "@pulumi/aws": "^5.0.0",
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/role-inline-policy-auto-name/tsconfig.json
+++ b/examples/role-inline-policy-auto-name/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2484,7 +2484,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 								for _, value := range pv.ArrayValue() {
 									if value.IsObject() {
 										policy := value.ObjectValue()
-										if policy.HasValue("policy") && policy["policy"].StringValue() != "" {
+										if policy.HasValue("policy") && policy["policy"].IsString() && policy["policy"].StringValue() != "" {
 											inlinePolicy = append(inlinePolicy, value)
 										}
 									}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2470,7 +2470,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 						Transform: tfbridge.TransformJSONDocument,
 					},
 					"inline_policy": {
-						// inline_policy is an array of policy objects. It is allowed to provided an empty list
+						// inline_policy is an array of policy objects. The user is allowed to provided an empty list
 						//   inlinePolicies: []
 						// or a list with empty objects
 						//   inlinePolicies: [{}]

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2469,6 +2469,34 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
 						Transform: tfbridge.TransformJSONDocument,
 					},
+					"inline_policy": {
+						// inline_policy is an array of policy objects. It is allowed to provided an empty list
+						//   inlinePolicies: []
+						// or a list with empty objects
+						//   inlinePolicies: [{}]
+						// In both cases the role will be created _without_ any inline policies attached.
+						// If a policy is provided, then both the `policy` and the `name` fields are required.
+						// If one is provided and the other is not, then no error will be thrown and no inline policy
+						// will be created.
+						Transform: func(pv resource.PropertyValue) (resource.PropertyValue, error) {
+							inlinePolicy := []resource.PropertyValue{}
+							for _, value := range pv.ArrayValue() {
+								if value.IsObject() {
+									policy := value.ObjectValue()
+									if policy.HasValue("policy") && policy["policy"].StringValue() != "" {
+										inlinePolicy = append(inlinePolicy, value)
+									}
+								}
+							}
+
+							return resource.NewArrayProperty(inlinePolicy), nil
+						},
+						Elem: &tfbridge.SchemaInfo{
+							Fields: map[string]*tfbridge.SchemaInfo{
+								"name": tfbridge.AutoName("name", 128, "-"),
+							},
+						},
+					},
 				},
 			},
 			"aws_iam_saml_provider":         {Tok: awsResource(iamMod, "SamlProvider")},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2479,17 +2479,19 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 						// If one is provided and the other is not, then no error will be thrown and no inline policy
 						// will be created.
 						Transform: func(pv resource.PropertyValue) (resource.PropertyValue, error) {
-							inlinePolicy := []resource.PropertyValue{}
-							for _, value := range pv.ArrayValue() {
-								if value.IsObject() {
-									policy := value.ObjectValue()
-									if policy.HasValue("policy") && policy["policy"].StringValue() != "" {
-										inlinePolicy = append(inlinePolicy, value)
+							if pv.IsArray() {
+								inlinePolicy := []resource.PropertyValue{}
+								for _, value := range pv.ArrayValue() {
+									if value.IsObject() {
+										policy := value.ObjectValue()
+										if policy.HasValue("policy") && policy["policy"].StringValue() != "" {
+											inlinePolicy = append(inlinePolicy, value)
+										}
 									}
 								}
+								return resource.NewArrayProperty(inlinePolicy), nil
 							}
-
-							return resource.NewArrayProperty(inlinePolicy), nil
+							return pv, nil
 						},
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -35042,7 +35042,7 @@ export namespace iam {
         /**
          * Name of the role policy.
          */
-        name?: string;
+        name: string;
         /**
          * Policy document as a JSON formatted string.
          */


### PR DESCRIPTION
In order to create an `inline_policy` on a role, both the `policy` and the `name` fields are required. If only one is provided then the policy will not be created (and no error will be thrown). Both properties must be optional though to allow providing empty values, i.e.

```ts
inlinePolicies: []
// or
inlinePolicies: [{}]
```

This PR sets the `name` property to be auto named and adds a transform on `inline_policy` to only create policies if a `policy` is provided.

fixes #1949