### PR TITLE
Fix #2442

### DIFF
--- a/provider/pkg/rds/parameter_group.go
+++ b/provider/pkg/rds/parameter_group.go
@@ -1,0 +1,99 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rds
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Customize resources in the rds module.
+func ReconfigureResources(p *schema.Provider) {
+	parameterGroupReconfigure(p)
+}
+
+var (
+	parameterGroupApplyMethodRegexp = regexp.MustCompile(`^parameter\.(\d+)\.apply_method$`)
+)
+
+// Customize the aws_db_parameter_group resource.
+func parameterGroupReconfigure(p *schema.Provider) {
+	parameterGroup, ok := p.ResourcesMap["aws_db_parameter_group"]
+	if !ok {
+		return
+	}
+	// Need to mark apply_method as Computed so that the diff customizer is allowed to clear it.
+	parameterGroup.Schema["parameter"].Elem.(*schema.Resource).Schema["apply_method"].Computed = true
+	// Need to exclude apply_method from the set hash.
+	oldSetFunc := parameterGroup.Schema["parameter"].Set
+	parameterGroup.Schema["parameter"].Set = parameterGroupParameterSetFunc(oldSetFunc)
+	addDiffCustomizer(parameterGroup, parameterGroupCustomizeDiff)
+}
+
+// Exclude "apply_method" from influencing the set element hash for a parameter.
+func parameterGroupParameterSetFunc(oldSetFunc schema.SchemaSetFunc) schema.SchemaSetFunc {
+	return func(v interface{}) int {
+		m := v.(map[string]interface{})
+		// Pretend apply_method is always "immediate" to avoid changing the hash
+		copy := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			copy[k] = v
+		}
+		copy["apply_method"] = "immediate"
+		return oldSetFunc(copy)
+	}
+}
+
+// Customize the diff to pretend that no changes are happening for a parameter that changes its apply_method but not its
+// value. This makes the provider match cloud behavior better.
+func parameterGroupCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	// If the apply_method is changed, and the value is not, then clear the apply_method change to ignore it.
+	for _, changedKey := range diff.GetChangedKeysPrefix("parameter") {
+		// Surprisingly GetChangedKeysPrefix returns keys that did not actually change, so skip those.
+		if !diff.HasChange(changedKey) {
+			continue
+		}
+		if m := parameterGroupApplyMethodRegexp.FindStringSubmatch(changedKey); m != nil {
+			parameterIndex := m[1]
+			matchingValueKey := fmt.Sprintf("parameter.%s.value", parameterIndex)
+			if !diff.HasChange(matchingValueKey) {
+				if err := diff.Clear(changedKey); err != nil {
+					return fmt.Errorf("Failed clearing %s: %w", changedKey, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// This could have been a helper function in pulumi-terraform-bridge somewhere.
+func addDiffCustomizer(r *schema.Resource, cdf schema.CustomizeDiffFunc) {
+	// Just set it if it is not yet customized.
+	if r.CustomizeDiff == nil {
+		r.CustomizeDiff = cdf
+		return
+	}
+	// Sequence to compose the custom diff functions otherwise.
+	oldCDF := r.CustomizeDiff
+	r.CustomizeDiff = func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+		if err := oldCDF(ctx, diff, meta); err != nil {
+			return err
+		}
+		return cdf(ctx, diff, meta)
+	}
+}

--- a/provider/pkg/rds/rds.go
+++ b/provider/pkg/rds/rds.go
@@ -1,0 +1,24 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rds
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Customize resources in the rds module.
+func ReconfigureResources(p *schema.Provider) {
+	parameterGroupReconfigure(p)
+}

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -6,10 +6,22 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+
 	"github.com/pulumi/providertest"
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/assertpreview"
+	"github.com/pulumi/providertest/pulumitest/opttest"
 )
 
 func TestBucket(t *testing.T) {
@@ -125,4 +137,95 @@ func TestCloudfrontDistribution(t *testing.T) {
 
 func TestSecretVersion(t *testing.T) {
 	test(t, filepath.Join("test-programs", "secretversion"), "")
+}
+
+func TestRdsParameterGroupUnclearDiff(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without credentials")
+	}
+
+	type testCase struct {
+		name          string
+		applyMethod1  string
+		value1        string
+		applyMethod2  string
+		value2        string
+		expectChanges bool
+	}
+
+	testCases := []testCase{
+		{"changing only applyMethod", "immediate", "1", "pending-reboot", "1", false},
+		{"changing only value", "immediate", "1", "immediate", "0", true},
+		{"changing both applyMethod and value", "immediate", "1", "pending-reboot", "0", true},
+	}
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	yaml := `
+name: project
+runtime: yaml
+config:
+  applyMethod:
+    type: string
+  value:
+    type: string
+  randSuffix:
+    type: string
+resources:
+  default:
+    type: aws:rds/parameterGroup:ParameterGroup
+    properties:
+      name: securitygroup${randSuffix}
+      family: postgres14
+      parameters:
+        - name: track_io_timing
+          value: ${value}
+          applyMethod: ${applyMethod}
+        - name: "log_checkpoints"
+          applyMethod: "pending-reboot"
+          value: "1"
+`
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			workdir := t.TempDir()
+
+			err := os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"), []byte(yaml), 0600)
+			require.NoError(t, err)
+
+			pt := pulumitest.NewPulumiTest(t, workdir,
+				opttest.SkipInstall(),
+				opttest.TestInPlace(),
+				opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
+			)
+
+			pt.SetConfig("randSuffix", fmt.Sprintf("%d", rand.Intn(1024*1024)))
+
+			pt.SetConfig("applyMethod", tc.applyMethod1)
+			pt.SetConfig("value", tc.value1)
+
+			pt.Up()
+
+			assertpreview.HasNoChanges(t, pt.Preview())
+
+			pt.SetConfig("applyMethod", tc.applyMethod2)
+			pt.SetConfig("value", tc.value2)
+
+			if tc.expectChanges {
+				pr := pt.Preview()
+				assert.Equal(t, 1, pr.ChangeSummary[apitype.OpUpdate])
+			} else {
+				assertpreview.HasNoChanges(t, pt.Preview())
+			}
+
+			upr := pt.Up()
+			t.Logf("stdout: %s", upr.StdOut)
+			t.Logf("stderr: %s", upr.StdErr)
+
+			assertpreview.HasNoChanges(t, pt.Preview())
+		})
+	}
 }

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -6,7 +6,6 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -31,6 +31,7 @@ import (
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
+	"github.com/pulumi/pulumi-aws/provider/v6/pkg/rds"
 	"github.com/pulumi/pulumi-aws/provider/v6/pkg/version"
 
 	pftfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
@@ -3095,6 +3096,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 						Default: managedByPulumi,
 					},
 				},
+				Docs: rds.ParameterGroupDocs("upstream"),
 			},
 			"aws_db_instance_role_association": {
 				Tok: awsResource(rdsMod, "RoleAssociation"),

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -30,7 +30,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	awsShim "github.com/hashicorp/terraform-provider-aws/shim"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pulumi/pulumi-aws/provider/v6/pkg/version"
 
@@ -778,12 +777,6 @@ var runtimeMetadata []byte
 // Provider returns additional overlaid schema and metadata associated with the aws package.
 func Provider() *tfbridge.ProviderInfo {
 	return ProviderFromMeta(tfbridge.NewProviderMetadata(runtimeMetadata))
-}
-
-func newUpstreamProvider(ctx context.Context) awsShim.UpstreamProvider {
-	upstreamProvider, err := awsShim.NewUpstreamProvider(ctx)
-	contract.AssertNoErrorf(err, "NewUpstreamProvider failed to initialize")
-	return upstreamProvider
 }
 
 func deprecateRuntime(value, name string) schema.EnumValueSpec {

--- a/provider/upstream_provider.go
+++ b/provider/upstream_provider.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+
+	awsShim "github.com/hashicorp/terraform-provider-aws/shim"
+	"github.com/pulumi/pulumi-aws/provider/v6/pkg/rds"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// Initialize a representation of the upstream provider.
+//
+// Lightly modifies the upstream provider to fix behavior that did not yet make it upstream.
+//
+// NOTE that this code runs in two contexts, during schema generation and during provider startup at runtime. The
+// runtime startup is somewhat performance sensitive. Therefore any modifications undertaken here should complete
+// quickly.
+func newUpstreamProvider(ctx context.Context) awsShim.UpstreamProvider {
+	upstreamProvider, err := awsShim.NewUpstreamProvider(ctx)
+	contract.AssertNoErrorf(err, "NewUpstreamProvider failed to initialize")
+	rds.ReconfigureResources(upstreamProvider.SDKV2Provider)
+	return upstreamProvider
+}

--- a/sdk/dotnet/Rds/ParameterGroup.cs
+++ b/sdk/dotnet/Rds/ParameterGroup.cs
@@ -18,11 +18,12 @@ namespace Pulumi.Aws.Rds
     /// * [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
     /// * [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
     /// 
-    /// &gt; **NOTE:** After applying your changes, you may encounter a perpetual diff in your pulumi preview
-    /// output for a `parameter` whose `value` remains unchanged but whose `apply_method` is changing
-    /// (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`). If only the
-    /// apply method of a parameter is changing, the AWS API will not register this change. To change
-    /// the `apply_method` of a parameter, its value must also change.
+    /// &gt; **Hands-on:** For an example of the `aws.rds.ParameterGroup` in use, follow the Manage AWS RDS Instances tutorial on HashiCorp Learn.
+    /// 
+    /// &gt; **NOTE**: to make diffs less confusing, the AWS provider will ignore changes for a `parameter` whose `value` remains
+    /// unchanged but whose `apply_method` is changing (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to
+    /// `immediate`). This matches the cloud: if only the apply method of a parameter is changing, the AWS API will not register
+    /// this change. To change the `apply_method` of a parameter, its value must also change.
     /// 
     /// ## Example Usage
     /// 

--- a/sdk/go/aws/rds/parameterGroup.go
+++ b/sdk/go/aws/rds/parameterGroup.go
@@ -20,11 +20,12 @@ import (
 // * [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
 // * [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
 //
-// > **NOTE:** After applying your changes, you may encounter a perpetual diff in your pulumi preview
-// output for a `parameter` whose `value` remains unchanged but whose `applyMethod` is changing
-// (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`). If only the
-// apply method of a parameter is changing, the AWS API will not register this change. To change
-// the `applyMethod` of a parameter, its value must also change.
+// > **Hands-on:** For an example of the `rds.ParameterGroup` in use, follow the Manage AWS RDS Instances tutorial on HashiCorp Learn.
+//
+// > **NOTE**: to make diffs less confusing, the AWS provider will ignore changes for a `parameter` whose `value` remains
+// unchanged but whose `applyMethod` is changing (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to
+// `immediate`). This matches the cloud: if only the apply method of a parameter is changing, the AWS API will not register
+// this change. To change the `applyMethod` of a parameter, its value must also change.
 //
 // ## Example Usage
 //

--- a/sdk/java/src/main/java/com/pulumi/aws/rds/ParameterGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/rds/ParameterGroup.java
@@ -26,11 +26,12 @@ import javax.annotation.Nullable;
  * * [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
  * * [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
  * 
- * &gt; **NOTE:** After applying your changes, you may encounter a perpetual diff in your pulumi preview
- * output for a `parameter` whose `value` remains unchanged but whose `apply_method` is changing
- * (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`). If only the
- * apply method of a parameter is changing, the AWS API will not register this change. To change
- * the `apply_method` of a parameter, its value must also change.
+ * &gt; **Hands-on:** For an example of the `aws.rds.ParameterGroup` in use, follow the Manage AWS RDS Instances tutorial on HashiCorp Learn.
+ * 
+ * &gt; **NOTE**: to make diffs less confusing, the AWS provider will ignore changes for a `parameter` whose `value` remains
+ * unchanged but whose `apply_method` is changing (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to
+ * `immediate`). This matches the cloud: if only the apply method of a parameter is changing, the AWS API will not register
+ * this change. To change the `apply_method` of a parameter, its value must also change.
  * 
  * ## Example Usage
  * 

--- a/sdk/nodejs/rds/parameterGroup.ts
+++ b/sdk/nodejs/rds/parameterGroup.ts
@@ -16,11 +16,12 @@ import * as utilities from "../utilities";
  * * [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
  * * [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
  *
- * > **NOTE:** After applying your changes, you may encounter a perpetual diff in your pulumi preview
- * output for a `parameter` whose `value` remains unchanged but whose `applyMethod` is changing
- * (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`). If only the
- * apply method of a parameter is changing, the AWS API will not register this change. To change
- * the `applyMethod` of a parameter, its value must also change.
+ * > **Hands-on:** For an example of the `aws.rds.ParameterGroup` in use, follow the Manage AWS RDS Instances tutorial on HashiCorp Learn.
+ *
+ * > **NOTE**: to make diffs less confusing, the AWS provider will ignore changes for a `parameter` whose `value` remains
+ * unchanged but whose `applyMethod` is changing (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to
+ * `immediate`). This matches the cloud: if only the apply method of a parameter is changing, the AWS API will not register
+ * this change. To change the `applyMethod` of a parameter, its value must also change.
  *
  * ## Example Usage
  *

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -65945,7 +65945,7 @@ export namespace rds {
          * engines can't apply some parameters without a reboot, and you will need to
          * specify "pending-reboot" here.
          */
-        applyMethod?: string;
+        applyMethod: string;
         /**
          * The name of the DB parameter.
          */

--- a/sdk/python/pulumi_aws/rds/parameter_group.py
+++ b/sdk/python/pulumi_aws/rds/parameter_group.py
@@ -283,11 +283,12 @@ class ParameterGroup(pulumi.CustomResource):
         * [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
         * [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
 
-        > **NOTE:** After applying your changes, you may encounter a perpetual diff in your pulumi preview
-        output for a `parameter` whose `value` remains unchanged but whose `apply_method` is changing
-        (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`). If only the
-        apply method of a parameter is changing, the AWS API will not register this change. To change
-        the `apply_method` of a parameter, its value must also change.
+        > **Hands-on:** For an example of the `rds.ParameterGroup` in use, follow the Manage AWS RDS Instances tutorial on HashiCorp Learn.
+
+        > **NOTE**: to make diffs less confusing, the AWS provider will ignore changes for a `parameter` whose `value` remains
+        unchanged but whose `apply_method` is changing (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to
+        `immediate`). This matches the cloud: if only the apply method of a parameter is changing, the AWS API will not register
+        this change. To change the `apply_method` of a parameter, its value must also change.
 
         ## Example Usage
 
@@ -372,11 +373,12 @@ class ParameterGroup(pulumi.CustomResource):
         * [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
         * [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
 
-        > **NOTE:** After applying your changes, you may encounter a perpetual diff in your pulumi preview
-        output for a `parameter` whose `value` remains unchanged but whose `apply_method` is changing
-        (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`). If only the
-        apply method of a parameter is changing, the AWS API will not register this change. To change
-        the `apply_method` of a parameter, its value must also change.
+        > **Hands-on:** For an example of the `rds.ParameterGroup` in use, follow the Manage AWS RDS Instances tutorial on HashiCorp Learn.
+
+        > **NOTE**: to make diffs less confusing, the AWS provider will ignore changes for a `parameter` whose `value` remains
+        unchanged but whose `apply_method` is changing (e.g., from `immediate` to `pending-reboot`, or `pending-reboot` to
+        `immediate`). This matches the cloud: if only the apply method of a parameter is changing, the AWS API will not register
+        this change. To change the `apply_method` of a parameter, its value must also change.
 
         ## Example Usage
 


### PR DESCRIPTION
Fixes #2442 

This adds a diff customizer that ignores changes to parameters that only change the apply_method and not the value for the aws_db_parameter_group resource. To make this work, the change also needs to modify the set element hashing function to identify parameters that differ only by apply_method as identical. 

As a side-effect of the set hashing change, upgrading stacks to the newer version of the provider with this change will show a reordering update diff on the ParameterGroup resource.