### PR TITLE
Add EKS service principal for Node.js SDK

### DIFF
--- a/sdk/nodejs/iam/principals.ts
+++ b/sdk/nodejs/iam/principals.ts
@@ -140,6 +140,11 @@ export module Principals {
      * Service Principal for Edge Lambda
      */
     export const EdgeLambdaPrincipal: Principal = {Service: "edgelambda.amazonaws.com"};
+    
+    /**
+     * Service Principal for Elastic Kubernetes Service
+     */
+    export const EksPrincipal: Principal = {Service: "eks.amazonaws.com"};
 
     /**
      * Service Principal for Elasticache


### PR DESCRIPTION
`eks.amazonaws.com` service principal seems to be missing


https://docs.aws.amazon.com/eks/latest/userguide/using-service-linked-roles-eks.html#service-linked-role-permissions-eks