### PR TITLE
Increase parallelism to avoid credentials timeout test flake

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -504,10 +504,10 @@ jobs:
       run: make upstream
     - name: Run provider tests
       run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -337,10 +337,10 @@ jobs:
       run: make upstream
     - name: Run provider tests
       run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -422,10 +422,10 @@ jobs:
       run: make upstream
     - name: Run provider tests
       run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,10 +472,10 @@ jobs:
       run: make upstream
     - name: Run provider tests
       run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -412,11 +412,11 @@ jobs:
       run: make upstream
     - name: Run provider tests
       run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        matrix.language }} -skip TestPulumiExamples -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push' && matrix.testTarget == 'local'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -427,7 +427,7 @@ jobs:
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -run TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        matrix.language }} -run TestPulumiExamples -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:
@@ -547,7 +547,7 @@ jobs:
           - name: Make upstream
             run: make upstream
           - name: Run selected tests with manual web identity/OIDC auth
-            run: cd examples && go test -v -json -count=1 -run TestAccCloudWatchOidcManual -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+            run: cd examples && go test -v -json -count=1 -run TestAccCloudWatchOidcManual -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
           - name: Configure AWS Credentials for OIDC
             uses: aws-actions/configure-aws-credentials@v4
             with:
@@ -557,7 +557,7 @@ jobs:
               role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
               unset-current-credentials: true
           - name: Run selected tests with configure-aws-credentials web identity/OIDC auth
-            run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+            run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 8 . 2>&1 | tee /tmp/gotest.log | gotestfmt
           - if: failure() && github.event_name == 'push'
             name: Notify Slack
             uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Potential fix for #3637.

This will have to go through CI management if it works as expected but the hope is that by increasing the parallelism, our tests will run faster so that our credentials do not time out.
