### PR TITLE
run unit tests in separate job

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -200,8 +200,10 @@ extraTests:
         language:
         - nodejs
 
-  unit_test:
-    name: unit_test
+  provider_test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: provider_test
     needs: build_sdk
     permissions:
       contents: read
@@ -211,6 +213,7 @@ extraTests:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ env.PR_COMMIT_SHA }}
           submodules: true
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
@@ -220,6 +223,12 @@ extraTests:
           ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          cache-dependency-path: |
+            sdk/go.sum
+          go-version: 1.21.x
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
@@ -234,10 +243,24 @@ extraTests:
         with:
           node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHONVERSION }}
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: ${{ env.JAVAVERSION }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: ${{ env.GRADLEVERSION }}
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:
@@ -249,6 +272,7 @@ extraTests:
           github.workspace}}/bin
           
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+      - run: dotnet nuget add source ${{ github.workspace }}/nuget
       - name: Download SDK
         uses: actions/download-artifact@v4
         with:
@@ -275,6 +299,11 @@ extraTests:
         with:
           swap-storage: false
           tool-cache: false
+      - if: ${{ matrix.language == 'dotnet' }}
+        name: Setup DotNet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -286,14 +315,14 @@ extraTests:
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Make upstream
         run: make upstream
-      - name: Run provider unit tests
+      - name: Run provider tests
         run: |
           cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
       - if: failure() && github.event_name == 'push'
         name: Notify Slack
         uses: 8398a7/action-slack@v3
         with:
-          author_name: Failure in running ${{ matrix.language }} unit tests
+          author_name: Failure in running ${{ matrix.language }} provider tests
           fields: repo,commit,author,action
           status: ${{ job.status }}
     strategy:
@@ -302,3 +331,6 @@ extraTests:
         language:
           - nodejs
           - python
+          - dotnet
+          - go
+          - java

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -58,9 +58,6 @@ actions:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Make upstream
       run: make upstream
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
   preBuild:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
@@ -202,3 +199,106 @@ extraTests:
       matrix:
         language:
         - nodejs
+
+  unit_test:
+    name: unit_test
+    needs: build_sdk
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v4
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+          ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
+        with:
+          tag: v0.0.46
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: ^3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODEVERSION }}
+          registry-url: https://registry.npmjs.org
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
+      - name: Download provider + tfgen binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run: >-
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+          github.workspace}}/bin
+          
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+      - name: Download SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.language }}-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress SDK folder
+        run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
+          github.workspace }}/sdk/${{ matrix.language }}
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Install Python deps
+        run: |-
+          pip3 install virtualenv==20.0.23
+          pip3 install pipenv
+      - name: Install dependencies
+        run: make install_${{ matrix.language}}_sdk
+      - name: Install gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.5.0
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          swap-storage: false
+          tool-cache: false
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 3600
+          role-session-name: ${{ env.PROVIDER }}@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Make upstream
+        run: make upstream
+      - name: Run provider unit tests
+        run: |
+          cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      - if: failure() && github.event_name == 'push'
+        name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          author_name: Failure in running ${{ matrix.language }} unit tests
+          fields: repo,commit,author,action
+          status: ${{ job.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - nodejs
+          - python

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -296,8 +296,8 @@ jobs:
       - test
       - license_check
       - go_test_shim
+      - provider_test
       - test_oidc
-      - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -554,6 +554,142 @@ jobs:
             name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
+  provider_test:
+      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+      name: provider_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ env.PR_COMMIT_SHA }}
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - if: matrix.testTarget == 'pulumiExamples'
+            name: Checkout p/examples
+            uses: actions/checkout@v4
+            with:
+              path: p-examples
+              repository: pulumi/examples
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install Go
+            uses: actions/setup-go@v5
+            with:
+              cache-dependency-path: |
+                  sdk/go.sum
+              go-version: 1.21.x
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Setup Java
+            uses: actions/setup-java@v4
+            with:
+              cache: gradle
+              distribution: temurin
+              java-version: ${{ env.JAVAVERSION }}
+          - name: Setup Gradle
+            uses: gradle/gradle-build-action@v3
+            with:
+              gradle-version: ${{ env.GRADLEVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - run: dotnet nuget add source ${{ github.workspace }}/nuget
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - if: ${{ matrix.language == 'dotnet' }}
+            name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} provider tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
+                  - dotnet
+                  - go
+                  - java
   test_oidc:
       name: test_oidc
       needs: build_sdk
@@ -650,105 +786,6 @@ jobs:
           matrix:
               language:
                   - nodejs
-  unit_test:
-      name: unit_test
-      needs: build_sdk
-      permissions:
-          contents: read
-          id-token: write
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
-            with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: ${{ env.NODEVERSION }}
-              registry-url: https://registry.npmjs.org
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: ${{ env.PYTHONVERSION }}
-          - name: Download provider + tfgen binaries
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ env.PROVIDER }}-provider.tar.gz
-              path: ${{ github.workspace }}/bin
-          - name: Untar provider binaries
-            run: |-
-              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
-              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-          - name: Download SDK
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ matrix.language }}-sdk.tar.gz
-              path: ${{ github.workspace}}/sdk/
-          - name: Uncompress SDK folder
-            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
-          - name: Update path
-            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-          - name: Install Python deps
-            run: |-
-              pip3 install virtualenv==20.0.23
-              pip3 install pipenv
-          - name: Install dependencies
-            run: make install_${{ matrix.language}}_sdk
-          - name: Install gotestfmt
-            uses: GoTestTools/gotestfmt-action@v2
-            with:
-              token: ${{ secrets.GITHUB_TOKEN }}
-              version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Configure AWS Credentials
-            uses: aws-actions/configure-aws-credentials@v4
-            with:
-              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-              aws-region: ${{ env.AWS_REGION }}
-              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              role-duration-seconds: 3600
-              role-session-name: ${{ env.PROVIDER }}@githubActions
-              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
-          - name: Run provider unit tests
-            run: |
-              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} unit tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
-      strategy:
-          fail-fast: false
-          matrix:
-              language:
-                  - nodejs
-                  - python
 
 name: master
 on:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -297,6 +297,7 @@ jobs:
       - license_check
       - go_test_shim
       - test_oidc
+      - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -502,9 +503,6 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Make upstream
       run: make upstream
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
@@ -652,6 +650,105 @@ jobs:
           matrix:
               language:
                   - nodejs
+  unit_test:
+      name: unit_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider unit tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} unit tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
 
 name: master
 on:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -335,9 +335,6 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Make upstream
       run: make upstream
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -233,6 +233,7 @@ jobs:
       - license_check
       - go_test_shim
       - test_oidc
+      - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -420,9 +421,6 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Make upstream
       run: make upstream
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
@@ -570,6 +568,105 @@ jobs:
           matrix:
               language:
                   - nodejs
+  unit_test:
+      name: unit_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider unit tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} unit tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
 
 name: prerelease
 on:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -232,8 +232,8 @@ jobs:
       - test
       - license_check
       - go_test_shim
+      - provider_test
       - test_oidc
-      - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -472,6 +472,142 @@ jobs:
             name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
+  provider_test:
+      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+      name: provider_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ env.PR_COMMIT_SHA }}
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - if: matrix.testTarget == 'pulumiExamples'
+            name: Checkout p/examples
+            uses: actions/checkout@v4
+            with:
+              path: p-examples
+              repository: pulumi/examples
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install Go
+            uses: actions/setup-go@v5
+            with:
+              cache-dependency-path: |
+                  sdk/go.sum
+              go-version: 1.21.x
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Setup Java
+            uses: actions/setup-java@v4
+            with:
+              cache: gradle
+              distribution: temurin
+              java-version: ${{ env.JAVAVERSION }}
+          - name: Setup Gradle
+            uses: gradle/gradle-build-action@v3
+            with:
+              gradle-version: ${{ env.GRADLEVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - run: dotnet nuget add source ${{ github.workspace }}/nuget
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - if: ${{ matrix.language == 'dotnet' }}
+            name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} provider tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
+                  - dotnet
+                  - go
+                  - java
   test_oidc:
       name: test_oidc
       needs: build_sdk
@@ -568,105 +704,6 @@ jobs:
           matrix:
               language:
                   - nodejs
-  unit_test:
-      name: unit_test
-      needs: build_sdk
-      permissions:
-          contents: read
-          id-token: write
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
-            with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: ${{ env.NODEVERSION }}
-              registry-url: https://registry.npmjs.org
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: ${{ env.PYTHONVERSION }}
-          - name: Download provider + tfgen binaries
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ env.PROVIDER }}-provider.tar.gz
-              path: ${{ github.workspace }}/bin
-          - name: Untar provider binaries
-            run: |-
-              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
-              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-          - name: Download SDK
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ matrix.language }}-sdk.tar.gz
-              path: ${{ github.workspace}}/sdk/
-          - name: Uncompress SDK folder
-            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
-          - name: Update path
-            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-          - name: Install Python deps
-            run: |-
-              pip3 install virtualenv==20.0.23
-              pip3 install pipenv
-          - name: Install dependencies
-            run: make install_${{ matrix.language}}_sdk
-          - name: Install gotestfmt
-            uses: GoTestTools/gotestfmt-action@v2
-            with:
-              token: ${{ secrets.GITHUB_TOKEN }}
-              version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Configure AWS Credentials
-            uses: aws-actions/configure-aws-credentials@v4
-            with:
-              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-              aws-region: ${{ env.AWS_REGION }}
-              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              role-duration-seconds: 3600
-              role-session-name: ${{ env.PROVIDER }}@githubActions
-              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
-          - name: Run provider unit tests
-            run: |
-              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} unit tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
-      strategy:
-          fail-fast: false
-          matrix:
-              language:
-                  - nodejs
-                  - python
 
 name: prerelease
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,8 +246,8 @@ jobs:
       - test
       - license_check
       - go_test_shim
+      - provider_test
       - test_oidc
-      - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -522,6 +522,142 @@ jobs:
             name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
+  provider_test:
+      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+      name: provider_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ env.PR_COMMIT_SHA }}
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - if: matrix.testTarget == 'pulumiExamples'
+            name: Checkout p/examples
+            uses: actions/checkout@v4
+            with:
+              path: p-examples
+              repository: pulumi/examples
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install Go
+            uses: actions/setup-go@v5
+            with:
+              cache-dependency-path: |
+                  sdk/go.sum
+              go-version: 1.21.x
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Setup Java
+            uses: actions/setup-java@v4
+            with:
+              cache: gradle
+              distribution: temurin
+              java-version: ${{ env.JAVAVERSION }}
+          - name: Setup Gradle
+            uses: gradle/gradle-build-action@v3
+            with:
+              gradle-version: ${{ env.GRADLEVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - run: dotnet nuget add source ${{ github.workspace }}/nuget
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - if: ${{ matrix.language == 'dotnet' }}
+            name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} provider tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
+                  - dotnet
+                  - go
+                  - java
   test_oidc:
       name: test_oidc
       needs: build_sdk
@@ -618,105 +754,6 @@ jobs:
           matrix:
               language:
                   - nodejs
-  unit_test:
-      name: unit_test
-      needs: build_sdk
-      permissions:
-          contents: read
-          id-token: write
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
-            with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: ${{ env.NODEVERSION }}
-              registry-url: https://registry.npmjs.org
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: ${{ env.PYTHONVERSION }}
-          - name: Download provider + tfgen binaries
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ env.PROVIDER }}-provider.tar.gz
-              path: ${{ github.workspace }}/bin
-          - name: Untar provider binaries
-            run: |-
-              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
-              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-          - name: Download SDK
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ matrix.language }}-sdk.tar.gz
-              path: ${{ github.workspace}}/sdk/
-          - name: Uncompress SDK folder
-            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
-          - name: Update path
-            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-          - name: Install Python deps
-            run: |-
-              pip3 install virtualenv==20.0.23
-              pip3 install pipenv
-          - name: Install dependencies
-            run: make install_${{ matrix.language}}_sdk
-          - name: Install gotestfmt
-            uses: GoTestTools/gotestfmt-action@v2
-            with:
-              token: ${{ secrets.GITHUB_TOKEN }}
-              version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Configure AWS Credentials
-            uses: aws-actions/configure-aws-credentials@v4
-            with:
-              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-              aws-region: ${{ env.AWS_REGION }}
-              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              role-duration-seconds: 3600
-              role-session-name: ${{ env.PROVIDER }}@githubActions
-              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
-          - name: Run provider unit tests
-            run: |
-              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} unit tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
-      strategy:
-          fail-fast: false
-          matrix:
-              language:
-                  - nodejs
-                  - python
 
 name: release
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,7 @@ jobs:
       - license_check
       - go_test_shim
       - test_oidc
+      - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -470,9 +471,6 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Make upstream
       run: make upstream
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
@@ -620,6 +618,105 @@ jobs:
           matrix:
               language:
                   - nodejs
+  unit_test:
+      name: unit_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider unit tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} unit tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
 
 name: release
 on:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -290,8 +290,6 @@ jobs:
       run: echo "🎉🎈🎉🎈🎉"
 
   unit_test:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: unit_test
     needs: build_sdk
     permissions:
@@ -299,78 +297,99 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.PR_COMMIT_SHA }}
-        submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: ^3
-    - name: Download provider + tfgen binaries
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.PROVIDER }}-provider.tar.gz
-        path: ${{ github.workspace }}/bin
-    - name: Untar provider binaries
-      run: >-
-        tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-        github.workspace}}/bin
-
-        find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-    - name: Update path
-      run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        version: v2.5.0
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 3600
-        role-session-name: ${{ env.PROVIDER }}@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-    - name: Make upstream
-      run: make upstream
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in running unit tests
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v4
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+          ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
+        with:
+          tag: v0.0.46
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: ^3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODEVERSION }}
+          registry-url: https://registry.npmjs.org
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
+      - name: Download provider + tfgen binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run: >-
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+          github.workspace}}/bin
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+      - name: Download SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.language }}-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress SDK folder
+        run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
+          github.workspace }}/sdk/${{ matrix.language }}
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Install Python deps
+        run: |-
+          pip3 install virtualenv==20.0.23
+          pip3 install pipenv
+      - name: Install dependencies
+        run: make install_${{ matrix.language}}_sdk
+      - name: Install gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.5.0
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          swap-storage: false
+          tool-cache: false
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 3600
+          role-session-name: ${{ env.PROVIDER }}@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Make upstream
+        run: make upstream
+      - name: Run provider unit tests
+        run: |
+          cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      - if: failure() && github.event_name == 'push'
+        name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          author_name: Failure in running ${{ matrix.language }} unit tests
+          fields: repo,commit,author,action
+          status: ${{ job.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - nodejs
+          - python
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -289,10 +289,10 @@ jobs:
     - name: Workflow is a success
       run: echo "🎉🎈🎉🎈🎉"
 
-  test:
+  unit_test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    name: test
+    name: unit_test
     needs: build_sdk
     permissions:
       contents: read
@@ -310,12 +310,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - name: Checkout p/examples
-      if: matrix.testTarget == 'pulumiExamples'
-      uses: actions/checkout@v4
-      with:
-        repository: pulumi/examples
-        path: p-examples
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -333,29 +327,6 @@ jobs:
       uses: pulumi/actions@v5
       with:
         pulumi-version: ^3
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:
@@ -367,23 +338,8 @@ jobs:
         github.workspace}}/bin
 
         find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-    - run: dotnet nuget add source ${{ github.workspace }}/nuget
-    - name: Download SDK
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ matrix.language }}-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress SDK folder
-      run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
-        github.workspace }}/sdk/${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-    - name: Install Python deps
-      run: |-
-        pip3 install virtualenv==20.0.23
-        pip3 install pipenv
-    - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -394,11 +350,6 @@ jobs:
       with:
         swap-storage: false
         tool-cache: false
-    - if: ${{ matrix.language == 'dotnet' }}
-      name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -413,31 +364,162 @@ jobs:
     - name: Run provider tests
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-    - name: Run tests
-      if: matrix.testTarget == 'local'
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-    - if: failure() && github.event_name == 'push' && matrix.testTarget == 'local'
+    - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
       with:
-        author_name: Failure in running ${{ matrix.language }} tests
+        author_name: Failure in running unit tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
-    - name: Run pulumi/examples tests
-      if: matrix.testTarget == 'pulumiExamples'
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -run TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+  test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: test
+    needs: unit_test
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
+          submodules: true
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v4
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+          ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      - name: Checkout p/examples
+        if: matrix.testTarget == 'pulumiExamples'
+        uses: actions/checkout@v4
+        with:
+          repository: pulumi/examples
+          path: p-examples
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          cache-dependency-path: |
+            sdk/go.sum
+          go-version: 1.21.x
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
+        with:
+          tag: v0.0.46
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: ^3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODEVERSION }}
+          registry-url: https://registry.npmjs.org
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNETVERSION }}
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: ${{ env.JAVAVERSION }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: ${{ env.GRADLEVERSION }}
+      - name: Download provider + tfgen binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run: >-
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+          github.workspace}}/bin
+          
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+      - run: dotnet nuget add source ${{ github.workspace }}/nuget
+      - name: Download SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.language }}-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress SDK folder
+        run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
+          github.workspace }}/sdk/${{ matrix.language }}
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Install Python deps
+        run: |-
+          pip3 install virtualenv==20.0.23
+          pip3 install pipenv
+      - name: Install dependencies
+        run: make install_${{ matrix.language}}_sdk
+      - name: Install gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.5.0
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          swap-storage: false
+          tool-cache: false
+      - if: ${{ matrix.language == 'dotnet' }}
+        name: Setup DotNet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNETVERSION }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 3600
+          role-session-name: ${{ env.PROVIDER }}@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Make upstream
+        run: make upstream
+      - name: Run provider tests
+        run: |
+          cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      - name: Run tests
+        if: matrix.testTarget == 'local'
+        run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
+          matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      - if: failure() && github.event_name == 'push' && matrix.testTarget == 'local'
+        name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          author_name: Failure in running ${{ matrix.language }} tests
+          fields: repo,commit,author,action
+          status: ${{ job.status }}
+      - name: Run pulumi/examples tests
+        if: matrix.testTarget == 'pulumiExamples'
+        run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
+          matrix.language }} -run TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
-        testTarget: [local]
+          - nodejs
+          - python
+          - dotnet
+          - go
+          - java
+        testTarget: [ local ]
   license_check:
     name: License Check
     uses: ./.github/workflows/license.yml

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -280,8 +280,8 @@ jobs:
     - test
     - license_check
     - go_test_shim
+    - provider_test
     - test_oidc
-    - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Workflow is not a success
@@ -472,6 +472,142 @@ jobs:
             name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
+  provider_test:
+      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+      name: provider_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ env.PR_COMMIT_SHA }}
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - if: matrix.testTarget == 'pulumiExamples'
+            name: Checkout p/examples
+            uses: actions/checkout@v4
+            with:
+              path: p-examples
+              repository: pulumi/examples
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install Go
+            uses: actions/setup-go@v5
+            with:
+              cache-dependency-path: |
+                  sdk/go.sum
+              go-version: 1.21.x
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Setup Java
+            uses: actions/setup-java@v4
+            with:
+              cache: gradle
+              distribution: temurin
+              java-version: ${{ env.JAVAVERSION }}
+          - name: Setup Gradle
+            uses: gradle/gradle-build-action@v3
+            with:
+              gradle-version: ${{ env.GRADLEVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - run: dotnet nuget add source ${{ github.workspace }}/nuget
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - if: ${{ matrix.language == 'dotnet' }}
+            name: Setup DotNet
+            uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: ${{ env.DOTNETVERSION }}
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} provider tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
+                  - dotnet
+                  - go
+                  - java
   test_oidc:
       name: test_oidc
       needs: build_sdk
@@ -568,105 +704,6 @@ jobs:
           matrix:
               language:
                   - nodejs
-  unit_test:
-      name: unit_test
-      needs: build_sdk
-      permissions:
-          contents: read
-          id-token: write
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
-            with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: ${{ env.NODEVERSION }}
-              registry-url: https://registry.npmjs.org
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: ${{ env.PYTHONVERSION }}
-          - name: Download provider + tfgen binaries
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ env.PROVIDER }}-provider.tar.gz
-              path: ${{ github.workspace }}/bin
-          - name: Untar provider binaries
-            run: |-
-              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
-              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-          - name: Download SDK
-            uses: actions/download-artifact@v4
-            with:
-              name: ${{ matrix.language }}-sdk.tar.gz
-              path: ${{ github.workspace}}/sdk/
-          - name: Uncompress SDK folder
-            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
-          - name: Update path
-            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-          - name: Install Python deps
-            run: |-
-              pip3 install virtualenv==20.0.23
-              pip3 install pipenv
-          - name: Install dependencies
-            run: make install_${{ matrix.language}}_sdk
-          - name: Install gotestfmt
-            uses: GoTestTools/gotestfmt-action@v2
-            with:
-              token: ${{ secrets.GITHUB_TOKEN }}
-              version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Configure AWS Credentials
-            uses: aws-actions/configure-aws-credentials@v4
-            with:
-              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-              aws-region: ${{ env.AWS_REGION }}
-              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              role-duration-seconds: 3600
-              role-session-name: ${{ env.PROVIDER }}@githubActions
-              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
-          - name: Run provider unit tests
-            run: |
-              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} unit tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
-      strategy:
-          fail-fast: false
-          matrix:
-              language:
-                  - nodejs
-                  - python
 
 name: run-acceptance-tests
 on:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -281,6 +281,7 @@ jobs:
     - license_check
     - go_test_shim
     - test_oidc
+    - unit_test
     runs-on: ubuntu-latest
     steps:
     - name: Workflow is not a success
@@ -289,257 +290,152 @@ jobs:
     - name: Workflow is a success
       run: echo "🎉🎈🎉🎈🎉"
 
-  unit_test:
-    name: unit_test
+  test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: test
     needs: build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-          ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
-        with:
-          tag: v0.0.46
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/actions@v5
-        with:
-          pulumi-version: ^3
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: Untar provider binaries
-        run: >-
-          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-          
-          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-      - name: Download SDK
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.language }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress SDK folder
-        run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
-          github.workspace }}/sdk/${{ matrix.language }}
-      - name: Update path
-        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-      - name: Install Python deps
-        run: |-
-          pip3 install virtualenv==20.0.23
-          pip3 install pipenv
-      - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.5.0
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          swap-storage: false
-          tool-cache: false
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Make upstream
-        run: make upstream
-      - name: Run provider unit tests
-        run: |
-          cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in running ${{ matrix.language }} unit tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - nodejs
-          - python
-  test:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    name: test
-    needs: unit_test
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.PR_COMMIT_SHA }}
-          submodules: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-          ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      - name: Checkout p/examples
-        if: matrix.testTarget == 'pulumiExamples'
-        uses: actions/checkout@v4
-        with:
-          repository: pulumi/examples
-          path: p-examples
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: |
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.PR_COMMIT_SHA }}
+        submodules: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v4
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+    - name: Checkout p/examples
+      if: matrix.testTarget == 'pulumiExamples'
+      uses: actions/checkout@v4
+      with:
+        repository: pulumi/examples
+        path: p-examples
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        cache-dependency-path: |
             sdk/go.sum
-          go-version: 1.21.x
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
-        with:
-          tag: v0.0.46
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/actions@v5
-        with:
-          pulumi-version: ^3
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: ${{ env.JAVAVERSION }}
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: ${{ env.GRADLEVERSION }}
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: Untar provider binaries
-        run: >-
-          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-          
-          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-      - run: dotnet nuget add source ${{ github.workspace }}/nuget
-      - name: Download SDK
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.language }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress SDK folder
-        run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
-          github.workspace }}/sdk/${{ matrix.language }}
-      - name: Update path
-        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-      - name: Install Python deps
-        run: |-
-          pip3 install virtualenv==20.0.23
-          pip3 install pipenv
-      - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.5.0
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          swap-storage: false
-          tool-cache: false
-      - if: ${{ matrix.language == 'dotnet' }}
-        name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Make upstream
-        run: make upstream
-      - name: Run provider tests
-        run: |
-          cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - name: Run tests
-        if: matrix.testTarget == 'local'
-        run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-          matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push' && matrix.testTarget == 'local'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in running ${{ matrix.language }} tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
-      - name: Run pulumi/examples tests
-        if: matrix.testTarget == 'pulumiExamples'
-        run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-          matrix.language }} -run TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        go-version: 1.21.x
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        tag: v0.0.46
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/actions@v5
+      with:
+        pulumi-version: ^3
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{ env.JAVAVERSION }}
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v3
+      with:
+        gradle-version: ${{ env.GRADLEVERSION }}
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: >-
+        tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+
+        find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+    - run: dotnet nuget add source ${{ github.workspace }}/nuget
+    - name: Download SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ matrix.language }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress SDK folder
+      run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
+        github.workspace }}/sdk/${{ matrix.language }}
+    - name: Update path
+      run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+    - name: Install Python deps
+      run: |-
+        pip3 install virtualenv==20.0.23
+        pip3 install pipenv
+    - name: Install dependencies
+      run: make install_${{ matrix.language}}_sdk
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        version: v2.5.0
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        swap-storage: false
+        tool-cache: false
+    - if: ${{ matrix.language == 'dotnet' }}
+      name: Setup DotNet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 3600
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    - name: Make upstream
+      run: make upstream
+    - name: Run tests
+      if: matrix.testTarget == 'local'
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
+        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push' && matrix.testTarget == 'local'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in running ${{ matrix.language }} tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+    - name: Run pulumi/examples tests
+      if: matrix.testTarget == 'pulumiExamples'
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
+        matrix.language }} -run TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
-        testTarget: [ local ]
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
+        testTarget: [local]
   license_check:
     name: License Check
     uses: ./.github/workflows/license.yml
@@ -672,6 +568,105 @@ jobs:
           matrix:
               language:
                   - nodejs
+  unit_test:
+      name: unit_test
+      needs: build_sdk
+      permissions:
+          contents: read
+          id-token: write
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout Repo
+            uses: actions/checkout@v4
+            with:
+              submodules: true
+          - name: Checkout Scripts Repo
+            uses: actions/checkout@v4
+            with:
+              path: ci-scripts
+              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+              repository: pulumi/scripts
+          - name: Unshallow clone for tags
+            run: git fetch --prune --unshallow --tags
+          - name: Install pulumictl
+            uses: jaxxstorm/action-install-gh-release@v1.11.0
+            with:
+              repo: pulumi/pulumictl
+              tag: v0.0.46
+          - name: Install Pulumi CLI
+            uses: pulumi/actions@v5
+            with:
+              pulumi-version: ^3
+          - name: Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: ${{ env.NODEVERSION }}
+              registry-url: https://registry.npmjs.org
+          - name: Setup Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: ${{ env.PYTHONVERSION }}
+          - name: Download provider + tfgen binaries
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ env.PROVIDER }}-provider.tar.gz
+              path: ${{ github.workspace }}/bin
+          - name: Untar provider binaries
+            run: |-
+              tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+              find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+          - name: Download SDK
+            uses: actions/download-artifact@v4
+            with:
+              name: ${{ matrix.language }}-sdk.tar.gz
+              path: ${{ github.workspace}}/sdk/
+          - name: Uncompress SDK folder
+            run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ matrix.language }}
+          - name: Update path
+            run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+          - name: Install Python deps
+            run: |-
+              pip3 install virtualenv==20.0.23
+              pip3 install pipenv
+          - name: Install dependencies
+            run: make install_${{ matrix.language}}_sdk
+          - name: Install gotestfmt
+            uses: GoTestTools/gotestfmt-action@v2
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              version: v2.5.0
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+              aws-region: ${{ env.AWS_REGION }}
+              aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              role-duration-seconds: 3600
+              role-session-name: ${{ env.PROVIDER }}@githubActions
+              role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          - name: Make upstream
+            run: make upstream
+          - name: Run provider unit tests
+            run: |
+              cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          - if: failure() && github.event_name == 'push'
+            name: Notify Slack
+            uses: 8398a7/action-slack@v3
+            with:
+              author_name: Failure in running ${{ matrix.language }} unit tests
+              fields: repo,commit,author,action
+              status: ${{ job.status }}
+      strategy:
+          fail-fast: false
+          matrix:
+              language:
+                  - nodejs
+                  - python
 
 name: run-acceptance-tests
 on:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -336,6 +336,7 @@ jobs:
         run: >-
           tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
           github.workspace}}/bin
+          
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
       - name: Download SDK
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request adds the `provider/` unit tests as a separate job via `.ci-mgmt.yaml` ExtraTests config.

It only runs python and nodejs matrix, as there are currently no other unit tests enabled that need other languages. I'm happy to adjust this as necessary.

This refactor is meant to address the AWS credentials timeout that causes #3637.