### PR TITLE
Deprecation: inline rules for SecurityGroup and NetworkAcl resources

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1819,8 +1819,26 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				Tok: awsResource(ec2Mod, "NetworkAcl"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Use "ingress" instead of "ingresses" to match AWS APIs
-					"ingress": {Name: "ingress"},
-					"egress":  {Name: "egress"},
+					"ingress": {
+						Name: "ingress",
+						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
+							"with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.",
+					},
+					"egress": {
+						Name: "egress",
+						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
+							"with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.",
+					},
+				},
+				PreCheckCallback: func(ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
+				) (resource.PropertyMap, error) {
+					_, hasIngress := config["ingress"]
+					_, hasEgress := config["egress"]
+					if hasIngress || hasEgress {
+						tfbridge.GetLogger(ctx).Warn("Use of inline rules is discouraged as they cannot be used in conjunction " +
+							"with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")
+					}
+					return config, nil
 				},
 			},
 			"aws_default_network_acl": {
@@ -1879,8 +1897,26 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"description": {Default: managedByPulumi},
 					// Use "ingress" instead of "ingresses" to match AWS APIs
-					"ingress": {Name: "ingress"},
-					"egress":  {Name: "egress"},
+					"ingress": {
+						Name: "ingress",
+						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
+							"with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.",
+					},
+					"egress": {
+						Name: "egress",
+						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
+							"with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.",
+					},
+				},
+				PreCheckCallback: func(ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
+				) (resource.PropertyMap, error) {
+					_, hasIngress := config["ingress"]
+					_, hasEgress := config["egress"]
+					if hasIngress || hasEgress {
+						tfbridge.GetLogger(ctx).Warn("Use of inline rules is discouraged as they cannot be used in conjunction " +
+							"with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")
+					}
+					return config, nil
 				},
 			},
 			"aws_network_interface_sg_attachment": {Tok: awsResource(ec2Mod, "NetworkInterfaceSecurityGroupAttachment")},

--- a/sdk/dotnet/Ec2/NetworkAcl.cs
+++ b/sdk/dotnet/Ec2/NetworkAcl.cs
@@ -182,6 +182,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an egress rule. Parameters defined below.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclEgressArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.NetworkAclEgressArgs>());
@@ -194,6 +195,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an ingress rule. Parameters defined below.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclIngressArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.NetworkAclIngressArgs>());
@@ -250,6 +252,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an egress rule. Parameters defined below.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclEgressGetArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.NetworkAclEgressGetArgs>());
@@ -262,6 +265,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an ingress rule. Parameters defined below.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclIngressGetArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.NetworkAclIngressGetArgs>());

--- a/sdk/dotnet/Ec2/SecurityGroup.cs
+++ b/sdk/dotnet/Ec2/SecurityGroup.cs
@@ -486,6 +486,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupEgressArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.SecurityGroupEgressArgs>());
@@ -498,6 +499,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupIngressArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.SecurityGroupIngressArgs>());
@@ -567,6 +569,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupEgressGetArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.SecurityGroupEgressGetArgs>());
@@ -579,6 +582,7 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
+        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupIngressGetArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.SecurityGroupIngressGetArgs>());

--- a/sdk/go/aws/ec2/networkAcl.go
+++ b/sdk/go/aws/ec2/networkAcl.go
@@ -89,8 +89,12 @@ type NetworkAcl struct {
 	// The ARN of the network ACL
 	Arn pulumi.StringOutput `pulumi:"arn"`
 	// Specifies an egress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress NetworkAclEgressArrayOutput `pulumi:"egress"`
 	// Specifies an ingress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress NetworkAclIngressArrayOutput `pulumi:"ingress"`
 	// The ID of the AWS account that owns the network ACL.
 	OwnerId pulumi.StringOutput `pulumi:"ownerId"`
@@ -142,8 +146,12 @@ type networkAclState struct {
 	// The ARN of the network ACL
 	Arn *string `pulumi:"arn"`
 	// Specifies an egress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []NetworkAclEgress `pulumi:"egress"`
 	// Specifies an ingress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []NetworkAclIngress `pulumi:"ingress"`
 	// The ID of the AWS account that owns the network ACL.
 	OwnerId *string `pulumi:"ownerId"`
@@ -163,8 +171,12 @@ type NetworkAclState struct {
 	// The ARN of the network ACL
 	Arn pulumi.StringPtrInput
 	// Specifies an egress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress NetworkAclEgressArrayInput
 	// Specifies an ingress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress NetworkAclIngressArrayInput
 	// The ID of the AWS account that owns the network ACL.
 	OwnerId pulumi.StringPtrInput
@@ -186,8 +198,12 @@ func (NetworkAclState) ElementType() reflect.Type {
 
 type networkAclArgs struct {
 	// Specifies an egress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []NetworkAclEgress `pulumi:"egress"`
 	// Specifies an ingress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []NetworkAclIngress `pulumi:"ingress"`
 	// A list of Subnet IDs to apply the ACL to
 	SubnetIds []string `pulumi:"subnetIds"`
@@ -200,8 +216,12 @@ type networkAclArgs struct {
 // The set of arguments for constructing a NetworkAcl resource.
 type NetworkAclArgs struct {
 	// Specifies an egress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress NetworkAclEgressArrayInput
 	// Specifies an ingress rule. Parameters defined below.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress NetworkAclIngressArrayInput
 	// A list of Subnet IDs to apply the ACL to
 	SubnetIds pulumi.StringArrayInput
@@ -304,11 +324,15 @@ func (o NetworkAclOutput) Arn() pulumi.StringOutput {
 }
 
 // Specifies an egress rule. Parameters defined below.
+//
+// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o NetworkAclOutput) Egress() NetworkAclEgressArrayOutput {
 	return o.ApplyT(func(v *NetworkAcl) NetworkAclEgressArrayOutput { return v.Egress }).(NetworkAclEgressArrayOutput)
 }
 
 // Specifies an ingress rule. Parameters defined below.
+//
+// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o NetworkAclOutput) Ingress() NetworkAclIngressArrayOutput {
 	return o.ApplyT(func(v *NetworkAcl) NetworkAclIngressArrayOutput { return v.Ingress }).(NetworkAclIngressArrayOutput)
 }

--- a/sdk/go/aws/ec2/securityGroup.go
+++ b/sdk/go/aws/ec2/securityGroup.go
@@ -424,8 +424,12 @@ type SecurityGroup struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description pulumi.StringOutput `pulumi:"description"`
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress SecurityGroupEgressArrayOutput `pulumi:"egress"`
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress SecurityGroupIngressArrayOutput `pulumi:"ingress"`
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name pulumi.StringOutput `pulumi:"name"`
@@ -483,8 +487,12 @@ type securityGroupState struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description *string `pulumi:"description"`
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []SecurityGroupEgress `pulumi:"egress"`
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []SecurityGroupIngress `pulumi:"ingress"`
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name *string `pulumi:"name"`
@@ -510,8 +518,12 @@ type SecurityGroupState struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description pulumi.StringPtrInput
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress SecurityGroupEgressArrayInput
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress SecurityGroupIngressArrayInput
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name pulumi.StringPtrInput
@@ -539,8 +551,12 @@ type securityGroupArgs struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description *string `pulumi:"description"`
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []SecurityGroupEgress `pulumi:"egress"`
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []SecurityGroupIngress `pulumi:"ingress"`
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name *string `pulumi:"name"`
@@ -559,8 +575,12 @@ type SecurityGroupArgs struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description pulumi.StringPtrInput
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress SecurityGroupEgressArrayInput
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+	//
+	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress SecurityGroupIngressArrayInput
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name pulumi.StringPtrInput
@@ -672,11 +692,15 @@ func (o SecurityGroupOutput) Description() pulumi.StringOutput {
 }
 
 // Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+//
+// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o SecurityGroupOutput) Egress() SecurityGroupEgressArrayOutput {
 	return o.ApplyT(func(v *SecurityGroup) SecurityGroupEgressArrayOutput { return v.Egress }).(SecurityGroupEgressArrayOutput)
 }
 
 // Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+//
+// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o SecurityGroupOutput) Ingress() SecurityGroupIngressArrayOutput {
 	return o.ApplyT(func(v *SecurityGroup) SecurityGroupIngressArrayOutput { return v.Ingress }).(SecurityGroupIngressArrayOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAcl.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAcl.java
@@ -112,7 +112,11 @@ public class NetworkAcl extends com.pulumi.resources.CustomResource {
     /**
      * Specifies an egress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="egress", refs={List.class,NetworkAclEgress.class}, tree="[0,1]")
     private Output<List<NetworkAclEgress>> egress;
 
@@ -126,7 +130,11 @@ public class NetworkAcl extends com.pulumi.resources.CustomResource {
     /**
      * Specifies an ingress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="ingress", refs={List.class,NetworkAclIngress.class}, tree="[0,1]")
     private Output<List<NetworkAclIngress>> ingress;
 

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAclArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAclArgs.java
@@ -23,14 +23,22 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an egress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<NetworkAclEgressArgs>> egress;
 
     /**
      * @return Specifies an egress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -38,14 +46,22 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an ingress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<NetworkAclIngressArgs>> ingress;
 
     /**
      * @return Specifies an ingress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -128,7 +144,11 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<NetworkAclEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -139,7 +159,11 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<NetworkAclEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -149,7 +173,11 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(NetworkAclEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -159,7 +187,11 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<NetworkAclIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -170,7 +202,11 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<NetworkAclIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -180,7 +216,11 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(NetworkAclIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroup.java
@@ -474,7 +474,11 @@ public class SecurityGroup extends com.pulumi.resources.CustomResource {
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="egress", refs={List.class,SecurityGroupEgress.class}, tree="[0,1]")
     private Output<List<SecurityGroupEgress>> egress;
 
@@ -488,7 +492,11 @@ public class SecurityGroup extends com.pulumi.resources.CustomResource {
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="ingress", refs={List.class,SecurityGroupIngress.class}, tree="[0,1]")
     private Output<List<SecurityGroupIngress>> ingress;
 

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroupArgs.java
@@ -39,14 +39,22 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<SecurityGroupEgressArgs>> egress;
 
     /**
      * @return Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -54,14 +62,22 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<SecurityGroupIngressArgs>> ingress;
 
     /**
      * @return Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -198,7 +214,11 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<SecurityGroupEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -209,7 +229,11 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<SecurityGroupEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -219,7 +243,11 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(SecurityGroupEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -229,7 +257,11 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<SecurityGroupIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -240,7 +272,11 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<SecurityGroupIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -250,7 +286,11 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(SecurityGroupIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/NetworkAclState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/NetworkAclState.java
@@ -37,14 +37,22 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an egress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<NetworkAclEgressArgs>> egress;
 
     /**
      * @return Specifies an egress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -52,14 +60,22 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an ingress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<NetworkAclIngressArgs>> ingress;
 
     /**
      * @return Specifies an ingress rule. Parameters defined below.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -204,7 +220,11 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<NetworkAclEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -215,7 +235,11 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<NetworkAclEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -225,7 +249,11 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(NetworkAclEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -235,7 +263,11 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<NetworkAclIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -246,7 +278,11 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<NetworkAclIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -256,7 +292,11 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(NetworkAclIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/SecurityGroupState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/SecurityGroupState.java
@@ -54,14 +54,22 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<SecurityGroupEgressArgs>> egress;
 
     /**
      * @return Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -69,14 +77,22 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<SecurityGroupIngressArgs>> ingress;
 
     /**
      * @return Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
+     * @deprecated
+     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+     * 
      */
+    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -275,7 +291,11 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<SecurityGroupEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -286,7 +306,11 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<SecurityGroupEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -296,7 +320,11 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(SecurityGroupEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -306,7 +334,11 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<SecurityGroupIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -317,7 +349,11 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<SecurityGroupIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -327,7 +363,11 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
+         * @deprecated
+         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
+         * 
          */
+        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(SecurityGroupIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/nodejs/ec2/networkAcl.ts
+++ b/sdk/nodejs/ec2/networkAcl.ts
@@ -95,10 +95,14 @@ export class NetworkAcl extends pulumi.CustomResource {
     public /*out*/ readonly arn!: pulumi.Output<string>;
     /**
      * Specifies an egress rule. Parameters defined below.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly egress!: pulumi.Output<outputs.ec2.NetworkAclEgress[]>;
     /**
      * Specifies an ingress rule. Parameters defined below.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly ingress!: pulumi.Output<outputs.ec2.NetworkAclIngress[]>;
     /**
@@ -174,10 +178,14 @@ export interface NetworkAclState {
     arn?: pulumi.Input<string>;
     /**
      * Specifies an egress rule. Parameters defined below.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclEgress>[]>;
     /**
      * Specifies an ingress rule. Parameters defined below.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclIngress>[]>;
     /**
@@ -210,10 +218,14 @@ export interface NetworkAclState {
 export interface NetworkAclArgs {
     /**
      * Specifies an egress rule. Parameters defined below.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclEgress>[]>;
     /**
      * Specifies an ingress rule. Parameters defined below.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclIngress>[]>;
     /**

--- a/sdk/nodejs/ec2/securityGroup.ts
+++ b/sdk/nodejs/ec2/securityGroup.ts
@@ -274,10 +274,14 @@ export class SecurityGroup extends pulumi.CustomResource {
     public readonly description!: pulumi.Output<string>;
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly egress!: pulumi.Output<outputs.ec2.SecurityGroupEgress[]>;
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly ingress!: pulumi.Output<outputs.ec2.SecurityGroupIngress[]>;
     /**
@@ -368,10 +372,14 @@ export interface SecurityGroupState {
     description?: pulumi.Input<string>;
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupEgress>[]>;
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupIngress>[]>;
     /**
@@ -416,10 +424,14 @@ export interface SecurityGroupArgs {
     description?: pulumi.Input<string>;
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupEgress>[]>;
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
+     *
+     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupIngress>[]>;
     /**

--- a/sdk/python/pulumi_aws/ec2/network_acl.py
+++ b/sdk/python/pulumi_aws/ec2/network_acl.py
@@ -31,7 +31,13 @@ class NetworkAclArgs:
         """
         pulumi.set(__self__, "vpc_id", vpc_id)
         if egress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+        if egress is not None:
             pulumi.set(__self__, "egress", egress)
+        if ingress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if subnet_ids is not None:
@@ -57,6 +63,9 @@ class NetworkAclArgs:
         """
         Specifies an egress rule. Parameters defined below.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -69,6 +78,9 @@ class NetworkAclArgs:
         """
         Specifies an ingress rule. Parameters defined below.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -125,7 +137,13 @@ class _NetworkAclState:
         if arn is not None:
             pulumi.set(__self__, "arn", arn)
         if egress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+        if egress is not None:
             pulumi.set(__self__, "egress", egress)
+        if ingress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if owner_id is not None:
@@ -160,6 +178,9 @@ class _NetworkAclState:
         """
         Specifies an egress rule. Parameters defined below.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -172,6 +193,9 @@ class _NetworkAclState:
         """
         Specifies an ingress rule. Parameters defined below.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -474,6 +498,9 @@ class NetworkAcl(pulumi.CustomResource):
         """
         Specifies an egress rule. Parameters defined below.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "egress")
 
     @property
@@ -482,6 +509,9 @@ class NetworkAcl(pulumi.CustomResource):
         """
         Specifies an ingress rule. Parameters defined below.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "ingress")
 
     @property

--- a/sdk/python/pulumi_aws/ec2/security_group.py
+++ b/sdk/python/pulumi_aws/ec2/security_group.py
@@ -40,7 +40,13 @@ class SecurityGroupArgs:
         if description is not None:
             pulumi.set(__self__, "description", description)
         if egress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+        if egress is not None:
             pulumi.set(__self__, "egress", egress)
+        if ingress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if name is not None:
@@ -72,6 +78,9 @@ class SecurityGroupArgs:
         """
         Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -84,6 +93,9 @@ class SecurityGroupArgs:
         """
         Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -186,7 +198,13 @@ class _SecurityGroupState:
         if description is not None:
             pulumi.set(__self__, "description", description)
         if egress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+        if egress is not None:
             pulumi.set(__self__, "egress", egress)
+        if ingress is not None:
+            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if name is not None:
@@ -237,6 +255,9 @@ class _SecurityGroupState:
         """
         Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -249,6 +270,9 @@ class _SecurityGroupState:
         """
         Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -926,6 +950,9 @@ class SecurityGroup(pulumi.CustomResource):
         """
         Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "egress")
 
     @property
@@ -934,6 +961,9 @@ class SecurityGroup(pulumi.CustomResource):
         """
         Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
+        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
+        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
+
         return pulumi.get(self, "ingress")
 
     @property


### PR DESCRIPTION
Marks the `ingress` and `egress` properties of `ec2.SecurityGroup` as deprecated, and emits a warning at deployment time.  Same for `ec2.NetworkAcl`. It is recommended that the standalone "rule" resources be used instead.

The output resembles:

```
Diagnostics:
  aws:ec2:SecurityGroup (clusterSecurityGroup):
    warning: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
```

Closes https://github.com/pulumi/pulumi-eks/issues/1031