### PR TITLE
Fix release.yml

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -201,8 +201,6 @@ extraTests:
         - nodejs
 
   provider_test:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: provider_test
     needs: build_sdk
     permissions:
@@ -223,11 +221,14 @@ extraTests:
           ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
+      - name: Make upstream
+        run: make upstream
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           cache-dependency-path: |
-            sdk/go.sum
+            provider/*.sum
+            upstream/*.sum
           go-version: 1.21.x
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -270,7 +271,7 @@ extraTests:
         run: >-
           tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
           github.workspace}}/bin
-          
+
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
       - run: dotnet nuget add source ${{ github.workspace }}/nuget
       - name: Download SDK
@@ -313,8 +314,6 @@ extraTests:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Make upstream
-        run: make upstream
       - name: Run provider tests
         run: |
           cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,6 +133,7 @@ jobs:
         - dotnet
         - go
         - java
+
   generate_coverage_data:
     continue-on-error: true
     env:
@@ -217,12 +218,15 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -243,8 +247,14 @@ jobs:
         dotnet: ${{ matrix.language != 'dotnet' }}
         swap-storage: false
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'
@@ -275,7 +285,7 @@ jobs:
       name: Check Configuration section
       run: |
         sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
-        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "MISSING_CONFIG<<$EOF";
@@ -582,7 +592,6 @@ jobs:
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
   provider_test:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: provider_test
       needs: build_sdk
       permissions:
@@ -603,11 +612,14 @@ jobs:
               repository: pulumi/scripts
           - name: Unshallow clone for tags
             run: git fetch --prune --unshallow --tags
+          - name: Make upstream
+            run: make upstream
           - name: Install Go
             uses: actions/setup-go@v5
             with:
               cache-dependency-path: |
-                  sdk/go.sum
+                  provider/*.sum
+                  upstream/*.sum
               go-version: 1.21.x
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -690,8 +702,6 @@ jobs:
               role-duration-seconds: 3600
               role-session-name: ${{ env.PROVIDER }}@githubActions
               role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -150,12 +150,15 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -176,8 +179,14 @@ jobs:
         dotnet: ${{ matrix.language != 'dotnet' }}
         swap-storage: false
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'
@@ -208,7 +217,7 @@ jobs:
       name: Check Configuration section
       run: |
         sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
-        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "MISSING_CONFIG<<$EOF";

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -117,6 +117,7 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+        retention-days: 30
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -133,6 +134,7 @@ jobs:
         - dotnet
         - go
         - java
+
   license_check:
     name: License Check
     uses: ./.github/workflows/license.yml
@@ -153,12 +155,15 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -179,8 +184,14 @@ jobs:
         dotnet: ${{ matrix.language != 'dotnet' }}
         swap-storage: false
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'
@@ -211,7 +222,7 @@ jobs:
       name: Check Configuration section
       run: |
         sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
-        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "MISSING_CONFIG<<$EOF";
@@ -500,7 +511,6 @@ jobs:
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
   provider_test:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: provider_test
       needs: build_sdk
       permissions:
@@ -521,11 +531,14 @@ jobs:
               repository: pulumi/scripts
           - name: Unshallow clone for tags
             run: git fetch --prune --unshallow --tags
+          - name: Make upstream
+            run: make upstream
           - name: Install Go
             uses: actions/setup-go@v5
             with:
               cache-dependency-path: |
-                  sdk/go.sum
+                  provider/*.sum
+                  upstream/*.sum
               go-version: 1.21.x
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -608,8 +621,6 @@ jobs:
               role-duration-seconds: 3600
               role-session-name: ${{ env.PROVIDER }}@githubActions
               role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+        retention-days: 30
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -132,6 +133,7 @@ jobs:
         - dotnet
         - go
         - java
+
   create_docs_build:
     name: create_docs_build
     needs: tag_sdk
@@ -167,12 +169,15 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -193,8 +198,14 @@ jobs:
         dotnet: ${{ matrix.language != 'dotnet' }}
         swap-storage: false
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'
@@ -225,7 +236,7 @@ jobs:
       name: Check Configuration section
       run: |
         sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
-        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "MISSING_CONFIG<<$EOF";
@@ -550,7 +561,6 @@ jobs:
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
   provider_test:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: provider_test
       needs: build_sdk
       permissions:
@@ -571,11 +581,14 @@ jobs:
               repository: pulumi/scripts
           - name: Unshallow clone for tags
             run: git fetch --prune --unshallow --tags
+          - name: Make upstream
+            run: make upstream
           - name: Install Go
             uses: actions/setup-go@v5
             with:
               cache-dependency-path: |
-                  sdk/go.sum
+                  provider/*.sum
+                  upstream/*.sum
               go-version: 1.21.x
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -658,8 +671,6 @@ jobs:
               role-duration-seconds: 3600
               role-session-name: ${{ env.PROVIDER }}@githubActions
               role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -142,6 +142,7 @@ jobs:
         - dotnet
         - go
         - java
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification
@@ -175,12 +176,15 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -201,8 +205,14 @@ jobs:
         dotnet: ${{ matrix.language != 'dotnet' }}
         swap-storage: false
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'
@@ -233,7 +243,7 @@ jobs:
       name: Check Configuration section
       run: |
         sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
-        jq -r '.config[] | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> keys.txt
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "MISSING_CONFIG<<$EOF";
@@ -500,7 +510,6 @@ jobs:
             uses: codecov/codecov-action@v4
       timeout-minutes: 60
   provider_test:
-      if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
       name: provider_test
       needs: build_sdk
       permissions:
@@ -521,11 +530,14 @@ jobs:
               repository: pulumi/scripts
           - name: Unshallow clone for tags
             run: git fetch --prune --unshallow --tags
+          - name: Make upstream
+            run: make upstream
           - name: Install Go
             uses: actions/setup-go@v5
             with:
               cache-dependency-path: |
-                  sdk/go.sum
+                  provider/*.sum
+                  upstream/*.sum
               go-version: 1.21.x
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -608,8 +620,6 @@ jobs:
               role-duration-seconds: 3600
               role-session-name: ${{ env.PROVIDER }}@githubActions
               role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          - name: Make upstream
-            run: make upstream
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/Makefile
+++ b/Makefile
@@ -142,11 +142,14 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-tfgen: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen: install_plugins upstream
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
+tfgen: install_plugins upstream tfgen_no_deps
+
+tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+tfgen_no_deps: tfgen_build_only
+	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
 tfgen_build_only:


### PR DESCRIPTION
Instead of https://github.com/pulumi/pulumi-aws/pull/3744

It looks like simply reverting the change that caused us being unable to release hits disk space limits. 

Trying this change instead that avoids skipping the job so that releases are not skipped.

As part of this,  I ran `make ci-mgmt` which also inherited latest ci-mgmt changes.
