### PR TITLE
fix: rds.dataSourceEngineVersionRead panic

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -651,3 +651,14 @@ func TestRoleInlinePolicyAutoName(t *testing.T) {
 	require.Regexp(t, regexp.MustCompile("testrole-*"), inlinePolicy.Name)
 	require.JSONEq(t, `{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*" }]}`, inlinePolicy.Policy)
 }
+
+func TestRdsGetEngineVersion(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "rds-getengineversion",
+		opttest.LocalProviderPath("aws", filepath.Join(getCwd(t), "..", "bin")),
+	)
+	res, err := test.CurrentStack().Up(test.Context())
+	require.NoError(t, err)
+
+	engineVersion := res.Outputs["vs"]
+	require.NotEmpty(t, engineVersion.Value)
+}

--- a/examples/rds-getengineversion/Pulumi.yaml
+++ b/examples/rds-getengineversion/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: rds
+runtime: nodejs
+description: Ensure getEngineVersionOutput handles nil values

--- a/examples/rds-getengineversion/index.ts
+++ b/examples/rds-getengineversion/index.ts
@@ -1,0 +1,3 @@
+import * as aws from "@pulumi/aws";
+
+export const vs = aws.rds.getEngineVersionOutput({engine: "postgres"});

--- a/examples/rds-getengineversion/package.json
+++ b/examples/rds-getengineversion/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "rds",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/rds-getengineversion/tsconfig.json
+++ b/examples/rds-getengineversion/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
+++ b/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 16:49:08 +0000
-Subject: [PATCH 01/46] Add TagsSchemaTrulyComputed definition
+Subject: [PATCH 01/47] Add TagsSchemaTrulyComputed definition
 
 
 diff --git a/internal/tags/tags.go b/internal/tags/tags.go

--- a/patches/0002-Conns-user-agent.patch
+++ b/patches/0002-Conns-user-agent.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:03:31 +0000
-Subject: [PATCH 02/46] Conns user agent
+Subject: [PATCH 02/47] Conns user agent
 
 Replace the useragent used for AWS client connections with a
 Pulumi-flavoured one.

--- a/patches/0003-Add-S3-legacy-bucket-to-resources.patch
+++ b/patches/0003-Add-S3-legacy-bucket-to-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:05:11 +0000
-Subject: [PATCH 03/46] Add S3 legacy bucket to resources
+Subject: [PATCH 03/47] Add S3 legacy bucket to resources
 
 This preserves the old S3 Resource in the SDK, by duplicating the code
 as a new service (in internal/service/s3legacy), and making an explicit

--- a/patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
+++ b/patches/0004-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Thu, 9 Mar 2023 09:47:49 -0600
-Subject: [PATCH 04/46] Marks SSE Configuration as Computed for Legacy S3
+Subject: [PATCH 04/47] Marks SSE Configuration as Computed for Legacy S3
  Bucket
 
 In January, AWS enabled SSE by default for all new S3 buckets.

--- a/patches/0005-De-deprecate-bucket_object.patch
+++ b/patches/0005-De-deprecate-bucket_object.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:06:11 +0000
-Subject: [PATCH 05/46] De-deprecate bucket_object
+Subject: [PATCH 05/47] De-deprecate bucket_object
 
 
 diff --git a/internal/service/s3/bucket_object.go b/internal/service/s3/bucket_object.go

--- a/patches/0006-Remove-lakeformation-catalog_resource-default.patch
+++ b/patches/0006-Remove-lakeformation-catalog_resource-default.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:08:23 +0000
-Subject: [PATCH 06/46] Remove lakeformation catalog_resource default
+Subject: [PATCH 06/47] Remove lakeformation catalog_resource default
 
 
 diff --git a/internal/service/lakeformation/permissions.go b/internal/service/lakeformation/permissions.go

--- a/patches/0007-Workaround-SSM-Parameter-tier-bug.patch
+++ b/patches/0007-Workaround-SSM-Parameter-tier-bug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:24:42 +0000
-Subject: [PATCH 07/46] Workaround SSM Parameter tier bug
+Subject: [PATCH 07/47] Workaround SSM Parameter tier bug
 
 - Disable "computed".
 - Disable diff suppression & counteractions

--- a/patches/0008-Add-EKS-cluster-certificate_authorities-plural.patch
+++ b/patches/0008-Add-EKS-cluster-certificate_authorities-plural.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:32:49 +0000
-Subject: [PATCH 08/46] Add EKS cluster certificate_authorities (plural)
+Subject: [PATCH 08/47] Add EKS cluster certificate_authorities (plural)
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0009-Workaround-Autoscaling-launch_configuration-associat.patch
+++ b/patches/0009-Workaround-Autoscaling-launch_configuration-associat.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:34:56 +0000
-Subject: [PATCH 09/46] Workaround Autoscaling launch_configuration
+Subject: [PATCH 09/47] Workaround Autoscaling launch_configuration
  associate_public_ip_address
 
 - Disable computation of property until fixed.

--- a/patches/0010-Add-ECR-credentials_data_source.patch
+++ b/patches/0010-Add-ECR-credentials_data_source.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:36:34 +0000
-Subject: [PATCH 10/46] Add ECR credentials_data_source
+Subject: [PATCH 10/47] Add ECR credentials_data_source
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0011-Add-custom-appautoscaling-examples.patch
+++ b/patches/0011-Add-custom-appautoscaling-examples.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Wed, 9 Nov 2022 17:37:35 +0000
-Subject: [PATCH 11/46] Add custom appautoscaling examples
+Subject: [PATCH 11/47] Add custom appautoscaling examples
 
 
 diff --git a/website/docs/r/appautoscaling_policy.html.markdown b/website/docs/r/appautoscaling_policy.html.markdown

--- a/patches/0012-Add-dedicated_host-docs.patch
+++ b/patches/0012-Add-dedicated_host-docs.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 10:08:05 +0000
-Subject: [PATCH 12/46] Add dedicated_host docs
+Subject: [PATCH 12/47] Add dedicated_host docs
 
 
 diff --git a/website/docs/d/dedicated_host.html.markdown b/website/docs/d/dedicated_host.html.markdown

--- a/patches/0013-Revert-WAF-schema-changes.patch
+++ b/patches/0013-Revert-WAF-schema-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 13:59:57 +0000
-Subject: [PATCH 13/46] Revert WAF schema changes
+Subject: [PATCH 13/47] Revert WAF schema changes
 
 - This causes far too many types to be generated downstream.
 

--- a/patches/0014-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
+++ b/patches/0014-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@gmail.com>
 Date: Thu, 1 Dec 2022 10:56:32 -0800
-Subject: [PATCH 14/46] Catch cty panic in new
+Subject: [PATCH 14/47] Catch cty panic in new
  resourceTopicSubscriptionCustomizeDiff.
 
 The root cause is not fully understood yet but this might unblock us.

--- a/patches/0015-add-matchmaking-configuration-72.patch
+++ b/patches/0015-add-matchmaking-configuration-72.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Lee Briggs <jaxxstorm@users.noreply.github.com>
 Date: Wed, 21 Dec 2022 12:23:59 -0800
-Subject: [PATCH 15/46] add matchmaking configuration (#72)
+Subject: [PATCH 15/47] add matchmaking configuration (#72)
 
 * add matchmaking configuration
 * add matchmaking rule set

--- a/patches/0016-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
+++ b/patches/0016-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Fri, 27 Jan 2023 09:37:43 -0600
-Subject: [PATCH 16/46] Reverts patches to S3BucketLegacy and GameLift
+Subject: [PATCH 16/47] Reverts patches to S3BucketLegacy and GameLift
 
 Previously, we were pulling along patches which removed a few simplifications
 to waiters in AWS GameLift, and a newer patch which plumbed through context.Context

--- a/patches/0017-Revert-Update-endpointHashIPAddress.patch
+++ b/patches/0017-Revert-Update-endpointHashIPAddress.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@pulumi.com>
 Date: Fri, 3 Feb 2023 17:31:18 -0800
-Subject: [PATCH 17/46] Revert "Update endpointHashIPAddress"
+Subject: [PATCH 17/47] Revert "Update endpointHashIPAddress"
 
 This reverts commit 2197a6c2c7a0ff306cec3432acb9f5680866f034.
 

--- a/patches/0018-Fixup-gamelift-context.patch
+++ b/patches/0018-Fixup-gamelift-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Thu, 9 Mar 2023 14:50:51 +0000
-Subject: [PATCH 18/46] Fixup gamelift context
+Subject: [PATCH 18/47] Fixup gamelift context
 
 
 diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go

--- a/patches/0019-Change-default-descriptions-to-Managed-by-Pulumi.patch
+++ b/patches/0019-Change-default-descriptions-to-Managed-by-Pulumi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 28 Feb 2023 15:19:24 +0000
-Subject: [PATCH 19/46] Change default descriptions to "Managed by Pulumi"
+Subject: [PATCH 19/47] Change default descriptions to "Managed by Pulumi"
 
 
 diff --git a/internal/service/apigateway/api_key.go b/internal/service/apigateway/api_key.go

--- a/patches/0020-remove-required-elements-from-schema-and-fix-tests-7.patch
+++ b/patches/0020-remove-required-elements-from-schema-and-fix-tests-7.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel.dbphoto@gmail.com>
 Date: Tue, 28 Mar 2023 19:54:00 +0100
-Subject: [PATCH 20/46] remove required elements from schema and fix tests
+Subject: [PATCH 20/47] remove required elements from schema and fix tests
  (#77)
 
 Co-authored-by: Lee Briggs <lee@leebriggs.co.uk>

--- a/patches/0021-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
+++ b/patches/0021-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 24 Apr 2023 10:36:36 -0400
-Subject: [PATCH 21/46] Temp remove cognito_identity_pool_roles_attachment
+Subject: [PATCH 21/47] Temp remove cognito_identity_pool_roles_attachment
  example beacuse of flaky translation
 
 

--- a/patches/0022-Fix-elbv2-target-group-read-to-workaround-2517.patch
+++ b/patches/0022-Fix-elbv2-target-group-read-to-workaround-2517.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 17:36:47 -0500
-Subject: [PATCH 22/46] Fix elbv2 target group read to workaround #2517
+Subject: [PATCH 22/47] Fix elbv2 target group read to workaround #2517
 
 
 diff --git a/internal/service/elbv2/target_group.go b/internal/service/elbv2/target_group.go

--- a/patches/0023-Fix-spurrious-json-diff-for-redrive_policy.patch
+++ b/patches/0023-Fix-spurrious-json-diff-for-redrive_policy.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ramon Quitales <ramon@pulumi.com>
 Date: Thu, 18 May 2023 15:21:33 -0700
-Subject: [PATCH 23/46] Fix spurrious json diff for redrive_policy
+Subject: [PATCH 23/47] Fix spurrious json diff for redrive_policy
 
 We need to normalize the json input to compare agasint the one stored
 in state.

--- a/patches/0024-Provide-context-to-conns.patch
+++ b/patches/0024-Provide-context-to-conns.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Mon, 10 Jul 2023 11:51:24 +0200
-Subject: [PATCH 24/46] Provide context to conns
+Subject: [PATCH 24/47] Provide context to conns
 
 
 diff --git a/internal/service/ecr/credentials_data_source.go b/internal/service/ecr/credentials_data_source.go

--- a/patches/0025-Match-the-tags-behavior-of-other-resources.patch
+++ b/patches/0025-Match-the-tags-behavior-of-other-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Wed, 2 Aug 2023 14:12:03 +0200
-Subject: [PATCH 25/46] Match the "tags" behavior of other resources
+Subject: [PATCH 25/47] Match the "tags" behavior of other resources
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0026-move-shim-logic-to-upstream-as-a-patch.patch
+++ b/patches/0026-move-shim-logic-to-upstream-as-a-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 6 Sep 2023 10:43:30 -0700
-Subject: [PATCH 26/46] move shim logic to upstream as a patch
+Subject: [PATCH 26/47] move shim logic to upstream as a patch
 
 
 diff --git a/shim/shim.go b/shim/shim.go

--- a/patches/0027-Restore-S3ConnURICleaningDisabled.patch
+++ b/patches/0027-Restore-S3ConnURICleaningDisabled.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 25 Sep 2023 15:22:30 -0400
-Subject: [PATCH 27/46] Restore S3ConnURICleaningDisabled
+Subject: [PATCH 27/47] Restore S3ConnURICleaningDisabled
 
 
 diff --git a/internal/conns/awsclient.go b/internal/conns/awsclient.go

--- a/patches/0028-Do-not-compute-tags_all-at-TF-level.patch
+++ b/patches/0028-Do-not-compute-tags_all-at-TF-level.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 6 Nov 2023 11:17:16 -0500
-Subject: [PATCH 28/46] Do not compute tags_all at TF level
+Subject: [PATCH 28/47] Do not compute tags_all at TF level
 
 
 diff --git a/internal/framework/base.go b/internal/framework/base.go

--- a/patches/0029-aws_eks_cluster-implement-default_addons_to_remove.patch
+++ b/patches/0029-aws_eks_cluster-implement-default_addons_to_remove.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 15 Nov 2023 11:53:09 -0500
-Subject: [PATCH 29/46] aws_eks_cluster: implement default_addons_to_remove
+Subject: [PATCH 29/47] aws_eks_cluster: implement default_addons_to_remove
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0030-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
+++ b/patches/0030-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 29 Nov 2023 17:23:09 -0500
-Subject: [PATCH 30/46] Fix markTagsAllNotComputedForResources to recognize
+Subject: [PATCH 30/47] Fix markTagsAllNotComputedForResources to recognize
  SchemaFunc
 
 

--- a/patches/0031-Optimize-startup-performance.patch
+++ b/patches/0031-Optimize-startup-performance.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 30 Nov 2023 14:28:37 -0500
-Subject: [PATCH 31/46] Optimize startup performance
+Subject: [PATCH 31/47] Optimize startup performance
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0032-Fix-job-queue-sdkv2-migration.patch
+++ b/patches/0032-Fix-job-queue-sdkv2-migration.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:41:21 -0500
-Subject: [PATCH 32/46] Fix job queue sdkv2 migration
+Subject: [PATCH 32/47] Fix job queue sdkv2 migration
 
 
 diff --git a/internal/service/batch/job_queue_schema.go b/internal/service/batch/job_queue_schema.go

--- a/patches/0033-DisableTagSchemaCheck-for-PF-provider.patch
+++ b/patches/0033-DisableTagSchemaCheck-for-PF-provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:44:25 -0500
-Subject: [PATCH 33/46] DisableTagSchemaCheck for PF provider
+Subject: [PATCH 33/47] DisableTagSchemaCheck for PF provider
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0034-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
+++ b/patches/0034-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:05:40 -0500
-Subject: [PATCH 34/46] Run scripts/patch_computed_only.sh to patch
+Subject: [PATCH 34/47] Run scripts/patch_computed_only.sh to patch
  eks/pod_identity_association and more
 
 

--- a/patches/0035-Fail-fast-when-PF-resources-are-dropped.patch
+++ b/patches/0035-Fail-fast-when-PF-resources-are-dropped.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:18:14 -0500
-Subject: [PATCH 35/46] Fail fast when PF resources are dropped
+Subject: [PATCH 35/47] Fail fast when PF resources are dropped
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0036-Fix-tags_all-Computed-for-PF-resources.patch
+++ b/patches/0036-Fix-tags_all-Computed-for-PF-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 7 Feb 2024 12:24:44 -0500
-Subject: [PATCH 36/46] Fix tags_all Computed for PF resources
+Subject: [PATCH 36/47] Fix tags_all Computed for PF resources
 
 
 diff --git a/internal/service/amp/scraper.go b/internal/service/amp/scraper.go

--- a/patches/0037-Disable-retry-for-KMS-access-denied-in-lambda.patch
+++ b/patches/0037-Disable-retry-for-KMS-access-denied-in-lambda.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 8 Jan 2024 16:58:44 -0500
-Subject: [PATCH 37/46] Disable retry for KMS access denied in lambda
+Subject: [PATCH 37/47] Disable retry for KMS access denied in lambda
 
 
 diff --git a/internal/service/lambda/service_package_extra.go b/internal/service/lambda/service_package_extra.go

--- a/patches/0038-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
+++ b/patches/0038-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 18:08:51 -0500
-Subject: [PATCH 38/46] Patch ACM retry to not retry after
+Subject: [PATCH 38/47] Patch ACM retry to not retry after
  LimitExceededException (#3290)
 
 

--- a/patches/0039-Restore-legacy-bucket.patch
+++ b/patches/0039-Restore-legacy-bucket.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 28 Feb 2024 16:01:28 +0000
-Subject: [PATCH 39/46] Restore legacy bucket
+Subject: [PATCH 39/47] Restore legacy bucket
 
 
 diff --git a/go.mod b/go.mod

--- a/patches/0040-Patch-osis_pipeline-tags-flags.patch
+++ b/patches/0040-Patch-osis_pipeline-tags-flags.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 9 Feb 2024 14:39:32 -0500
-Subject: [PATCH 40/46] Patch osis_pipeline tags flags
+Subject: [PATCH 40/47] Patch osis_pipeline tags flags
 
 
 diff --git a/internal/service/osis/pipeline.go b/internal/service/osis/pipeline.go

--- a/patches/0041-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
+++ b/patches/0041-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 14 Feb 2024 14:49:33 +0000
-Subject: [PATCH 41/46] Revert "Merge pull request #35678 from
+Subject: [PATCH 41/47] Revert "Merge pull request #35678 from
  hashicorp/b-elbv2-unexpected-diff"
 
 This reverts commit bfcae6ad3e8a226083f803b40e772e045ec78baa, reversing

--- a/patches/0042-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
+++ b/patches/0042-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 14 Feb 2024 14:49:38 +0000
-Subject: [PATCH 42/46] Revert "Merge pull request #35671 from
+Subject: [PATCH 42/47] Revert "Merge pull request #35671 from
  hashicorp/b-lb-listener-stickiness-3"
 
 This reverts commit 32a681fcfcd8d78c5ac9e199384a980bb71c82ed, reversing

--- a/patches/0043-Allow-creating-lambdas-without-code-related-properti.patch
+++ b/patches/0043-Allow-creating-lambdas-without-code-related-properti.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Tue, 13 Feb 2024 11:36:02 +0000
-Subject: [PATCH 43/46] Allow creating lambdas without code related properties
+Subject: [PATCH 43/47] Allow creating lambdas without code related properties
 
 
 diff --git a/internal/service/lambda/function.go b/internal/service/lambda/function.go

--- a/patches/0044-Do-not-Compute-tags_all-of-aws_bedrock_provisioned_m.patch
+++ b/patches/0044-Do-not-Compute-tags_all-of-aws_bedrock_provisioned_m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: guineveresaenger <guinevere@pulumi.com>
 Date: Wed, 21 Feb 2024 14:46:27 -0800
-Subject: [PATCH 44/46] Do not Compute tags_all of
+Subject: [PATCH 44/47] Do not Compute tags_all of
  aws_bedrock_provisioned_model_throughput
 
 

--- a/patches/0045-fix-legacy-bucket-context.patch
+++ b/patches/0045-fix-legacy-bucket-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 28 Feb 2024 16:06:02 +0000
-Subject: [PATCH 45/46] fix legacy bucket context
+Subject: [PATCH 45/47] fix legacy bucket context
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0046-securitylake_subscriber-tags_all-patch.patch
+++ b/patches/0046-securitylake_subscriber-tags_all-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Tue, 12 Mar 2024 18:05:28 -0400
-Subject: [PATCH 46/46] securitylake_subscriber tags_all patch
+Subject: [PATCH 46/47] securitylake_subscriber tags_all patch
 
 
 diff --git a/internal/service/securitylake/subscriber.go b/internal/service/securitylake/subscriber.go

--- a/patches/0047-Revert-rds-engine_version-Fix-bugs-with-default-only.patch
+++ b/patches/0047-Revert-rds-engine_version-Fix-bugs-with-default-only.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: corymhall <43035978+corymhall@users.noreply.github.com>
+Date: Fri, 29 Mar 2024 10:29:15 -0400
+Subject: [PATCH 47/47] Revert "rds/engine_version: Fix bugs with default only
+ flag"
+
+
+diff --git a/internal/service/rds/engine_version_data_source.go b/internal/service/rds/engine_version_data_source.go
+index a370148391..3b593585f5 100644
+--- a/internal/service/rds/engine_version_data_source.go
++++ b/internal/service/rds/engine_version_data_source.go
+@@ -11,7 +11,6 @@ import (
+ 	"github.com/YakDriver/go-version"
+ 	"github.com/aws/aws-sdk-go/aws"
+ 	"github.com/aws/aws-sdk-go/service/rds"
+-	"github.com/hashicorp/go-cty/cty"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+@@ -215,27 +214,37 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
+ 		input.EngineVersion = aws.String(v.(string))
+ 	}
+ 
++	input.DefaultOnly = aws.Bool(true)
++	defaultOnlySet := false
++
++	if v, ok := d.GetOk("default_only"); ok {
++		input.DefaultOnly = aws.Bool(v.(bool))
++		defaultOnlySet = true
++	}
++
+ 	if v, ok := d.GetOk("include_all"); ok {
+ 		input.IncludeAll = aws.Bool(v.(bool))
++		input.DefaultOnly = nil
+ 	}
+ 
+-	if v, ok := d.GetOk("default_only"); ok {
+-		input.DefaultOnly = aws.Bool(v.(bool))
++	if _, ok := d.GetOk("version"); ok && !defaultOnlySet {
++		input.DefaultOnly = nil
++	}
++
++	if _, ok := d.GetOk("preferred_major_targets"); ok && !defaultOnlySet {
++		input.DefaultOnly = nil
++	}
++
++	if _, ok := d.GetOk("preferred_upgrade_targets"); ok && !defaultOnlySet {
++		input.DefaultOnly = nil
+ 	}
+ 
+-	// Make sure any optional arguments in the schema are in this list except for "default_only"
+-	if _, ok := d.GetOk("default_only"); !ok && !criteriaSet(d, []string{
+-		"filter",
+-		"has_major_target",
+-		"has_minor_target",
+-		"include_all",
+-		"latest",
+-		"preferred_major_targets",
+-		"preferred_upgrade_targets",
+-		"preferred_versions",
+-		"version",
+-	}) {
+-		input.DefaultOnly = aws.Bool(true)
++	if _, ok := d.GetOk("preferred_versions"); ok && !defaultOnlySet {
++		input.DefaultOnly = nil
++	}
++
++	if v, ok := d.GetOk("latest"); ok && v.(bool) && !defaultOnlySet {
++		input.DefaultOnly = nil
+ 	}
+ 
+ 	log.Printf("[DEBUG] Reading RDS engine versions: %v", input)
+@@ -473,25 +482,3 @@ func sortEngineVersions(engineVersions []*rds.DBEngineVersion) {
+ 		return version.LessThanWithTime(engineVersions[i].CreateTime, engineVersions[j].CreateTime, aws.StringValue(engineVersions[i].EngineVersion), aws.StringValue(engineVersions[j].EngineVersion))
+ 	})
+ }
+-
+-// criteriaSet returns true if any of the given criteria are set. "set" means that, in the config,
+-// a bool is set and true, a list is set and not empty, or a string is set and not empty.
+-func criteriaSet(d *schema.ResourceData, args []string) bool {
+-	for _, arg := range args {
+-		val := d.GetRawConfig().GetAttr(arg)
+-
+-		switch {
+-		case val.CanIterateElements():
+-			if !val.IsNull() && val.IsKnown() && val.LengthInt() > 0 {
+-				return true
+-			}
+-		case val.Equals(cty.True) == cty.True:
+-			return true
+-
+-		case val.Type() == cty.String && !val.IsNull() && val.IsKnown():
+-			return true
+-		}
+-	}
+-
+-	return false
+-}


### PR DESCRIPTION
This temporarily reverts the upstream change https://github.com/hashicorp/terraform-provider-aws/commit/f8ab2903c9b0d9b30c53ad14e968bd54e2b93e30 because we cannot currently deal with `RawConfig` during read.

re #3752, re https://github.com/pulumi/pulumi-terraform-bridge/issues/1809