### PR TITLE
Retry for all tag fetching

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	appconfigsdk "github.com/aws/aws-sdk-go/service/appconfig"
 	s3sdk "github.com/aws/aws-sdk-go/service/s3"
@@ -218,7 +219,8 @@ func fetchBucketTags(t *testing.T, awsBucket string) map[string]string {
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 
-	client := s3sdk.New(sess)
+	retries := 5
+	client := s3sdk.New(sess, &aws.Config{MaxRetries: &retries})
 
 	input := &s3sdk.GetBucketTaggingInput{
 		Bucket: &awsBucket,
@@ -242,7 +244,8 @@ func fetchAppConfigTags(t *testing.T, arn string) map[string]string {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
-	client := appconfigsdk.New(sess)
+	retries := 5
+	client := appconfigsdk.New(sess, &aws.Config{MaxRetries: &retries})
 	out, err := client.ListTagsForResource(&appconfigsdk.ListTagsForResourceInput{
 		ResourceArn: &arn,
 	})

--- a/examples/tags-combinations-go/main.go
+++ b/examples/tags-combinations-go/main.go
@@ -21,6 +21,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		conf := config.New(ctx, "")
 		tagsState := conf.Require("state1")
+		testIdent := conf.Require("testIdent")
 
 		var s state
 
@@ -48,21 +49,21 @@ func main() {
 			return err
 		}
 
-		bucket, err := s3.NewBucketV2(ctx, "bucketv2", &s3.BucketV2Args{
+		bucket, err := s3.NewBucketV2(ctx, "bucketv2"+testIdent, &s3.BucketV2Args{
 			Tags: tagsMap,
 		}, pulumi.Provider(p))
 		if err != nil {
 			return err
 		}
 
-		legacyBucket, err := s3.NewBucket(ctx, "bucketlegacy", &s3.BucketArgs{
+		legacyBucket, err := s3.NewBucket(ctx, "bucketlegacy"+testIdent, &s3.BucketArgs{
 			Tags: tagsMap,
 		}, pulumi.Provider(p))
 		if err != nil {
 			return err
 		}
 
-		app, err := appconfig.NewApplication(ctx, "testappconfigapp",
+		app, err := appconfig.NewApplication(ctx, "testappconfigapp"+testIdent,
 			&appconfig.ApplicationArgs{
 				Tags: tagsMap,
 			}, pulumi.Provider(p))

--- a/examples/tags-combinations-go/step1/main.go
+++ b/examples/tags-combinations-go/step1/main.go
@@ -21,6 +21,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		conf := config.New(ctx, "")
 		tagsState := conf.Require("state2")
+		testIdent := conf.Require("testIdent")
 
 		var s state
 
@@ -48,21 +49,21 @@ func main() {
 			return err
 		}
 
-		bucket, err := s3.NewBucketV2(ctx, "bucketv2", &s3.BucketV2Args{
+		bucket, err := s3.NewBucketV2(ctx, "bucketv2"+testIdent, &s3.BucketV2Args{
 			Tags: tagsMap,
 		}, pulumi.Provider(p))
 		if err != nil {
 			return err
 		}
 
-		legacyBucket, err := s3.NewBucket(ctx, "bucketlegacy", &s3.BucketArgs{
+		legacyBucket, err := s3.NewBucket(ctx, "bucketlegacy"+testIdent, &s3.BucketArgs{
 			Tags: tagsMap,
 		}, pulumi.Provider(p))
 		if err != nil {
 			return err
 		}
 
-		app, err := appconfig.NewApplication(ctx, "testappconfigapp",
+		app, err := appconfig.NewApplication(ctx, "testappconfigapp"+testIdent,
 			&appconfig.ApplicationArgs{
 				Tags: tagsMap,
 			}, pulumi.Provider(p))


### PR DESCRIPTION
TestRandomTagsComabinationsGo periodically flakes up on failing to retrieve tags from AWS. This small change should add a retry to hopefully make it more robust. 

Fixes https://github.com/pulumi/pulumi-aws/issues/3403