### PR TITLE
Revert "Deprecation: inline rules for SecurityGroup and NetworkAcl resources"

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1822,26 +1822,8 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				Tok: awsResource(ec2Mod, "NetworkAcl"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Use "ingress" instead of "ingresses" to match AWS APIs
-					"ingress": {
-						Name: "ingress",
-						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
-							"with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.",
-					},
-					"egress": {
-						Name: "egress",
-						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
-							"with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.",
-					},
-				},
-				PreCheckCallback: func(ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
-				) (resource.PropertyMap, error) {
-					_, hasIngress := config["ingress"]
-					_, hasEgress := config["egress"]
-					if hasIngress || hasEgress {
-						tfbridge.GetLogger(ctx).Warn("Use of inline rules is discouraged as they cannot be used in conjunction " +
-							"with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")
-					}
-					return config, nil
+					"ingress": {Name: "ingress"},
+					"egress":  {Name: "egress"},
 				},
 			},
 			"aws_default_network_acl": {
@@ -1900,26 +1882,8 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"description": {Default: managedByPulumi},
 					// Use "ingress" instead of "ingresses" to match AWS APIs
-					"ingress": {
-						Name: "ingress",
-						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
-							"with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.",
-					},
-					"egress": {
-						Name: "egress",
-						DeprecationMessage: "Use of inline rules is discouraged as they cannot be used in conjunction " +
-							"with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.",
-					},
-				},
-				PreCheckCallback: func(ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
-				) (resource.PropertyMap, error) {
-					_, hasIngress := config["ingress"]
-					_, hasEgress := config["egress"]
-					if hasIngress || hasEgress {
-						tfbridge.GetLogger(ctx).Warn("Use of inline rules is discouraged as they cannot be used in conjunction " +
-							"with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")
-					}
-					return config, nil
+					"ingress": {Name: "ingress"},
+					"egress":  {Name: "egress"},
 				},
 			},
 			"aws_network_interface_sg_attachment": {Tok: awsResource(ec2Mod, "NetworkInterfaceSecurityGroupAttachment")},

--- a/sdk/dotnet/Ec2/NetworkAcl.cs
+++ b/sdk/dotnet/Ec2/NetworkAcl.cs
@@ -182,7 +182,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an egress rule. Parameters defined below.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclEgressArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.NetworkAclEgressArgs>());
@@ -195,7 +194,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an ingress rule. Parameters defined below.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclIngressArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.NetworkAclIngressArgs>());
@@ -252,7 +250,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an egress rule. Parameters defined below.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclEgressGetArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.NetworkAclEgressGetArgs>());
@@ -265,7 +262,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Specifies an ingress rule. Parameters defined below.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.NetworkAclIngressGetArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.NetworkAclIngressGetArgs>());

--- a/sdk/dotnet/Ec2/SecurityGroup.cs
+++ b/sdk/dotnet/Ec2/SecurityGroup.cs
@@ -429,7 +429,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupEgressArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.SecurityGroupEgressArgs>());
@@ -442,7 +441,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupIngressArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.SecurityGroupIngressArgs>());
@@ -512,7 +510,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupEgressGetArgs> Egress
         {
             get => _egress ?? (_egress = new InputList<Inputs.SecurityGroupEgressGetArgs>());
@@ -525,7 +522,6 @@ namespace Pulumi.Aws.Ec2
         /// <summary>
         /// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         /// </summary>
-        [Obsolete(@"Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.")]
         public InputList<Inputs.SecurityGroupIngressGetArgs> Ingress
         {
             get => _ingress ?? (_ingress = new InputList<Inputs.SecurityGroupIngressGetArgs>());

--- a/sdk/go/aws/ec2/networkAcl.go
+++ b/sdk/go/aws/ec2/networkAcl.go
@@ -89,12 +89,8 @@ type NetworkAcl struct {
 	// The ARN of the network ACL
 	Arn pulumi.StringOutput `pulumi:"arn"`
 	// Specifies an egress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress NetworkAclEgressArrayOutput `pulumi:"egress"`
 	// Specifies an ingress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress NetworkAclIngressArrayOutput `pulumi:"ingress"`
 	// The ID of the AWS account that owns the network ACL.
 	OwnerId pulumi.StringOutput `pulumi:"ownerId"`
@@ -146,12 +142,8 @@ type networkAclState struct {
 	// The ARN of the network ACL
 	Arn *string `pulumi:"arn"`
 	// Specifies an egress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []NetworkAclEgress `pulumi:"egress"`
 	// Specifies an ingress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []NetworkAclIngress `pulumi:"ingress"`
 	// The ID of the AWS account that owns the network ACL.
 	OwnerId *string `pulumi:"ownerId"`
@@ -171,12 +163,8 @@ type NetworkAclState struct {
 	// The ARN of the network ACL
 	Arn pulumi.StringPtrInput
 	// Specifies an egress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress NetworkAclEgressArrayInput
 	// Specifies an ingress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress NetworkAclIngressArrayInput
 	// The ID of the AWS account that owns the network ACL.
 	OwnerId pulumi.StringPtrInput
@@ -198,12 +186,8 @@ func (NetworkAclState) ElementType() reflect.Type {
 
 type networkAclArgs struct {
 	// Specifies an egress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []NetworkAclEgress `pulumi:"egress"`
 	// Specifies an ingress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []NetworkAclIngress `pulumi:"ingress"`
 	// A list of Subnet IDs to apply the ACL to
 	SubnetIds []string `pulumi:"subnetIds"`
@@ -216,12 +200,8 @@ type networkAclArgs struct {
 // The set of arguments for constructing a NetworkAcl resource.
 type NetworkAclArgs struct {
 	// Specifies an egress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress NetworkAclEgressArrayInput
 	// Specifies an ingress rule. Parameters defined below.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress NetworkAclIngressArrayInput
 	// A list of Subnet IDs to apply the ACL to
 	SubnetIds pulumi.StringArrayInput
@@ -324,15 +304,11 @@ func (o NetworkAclOutput) Arn() pulumi.StringOutput {
 }
 
 // Specifies an egress rule. Parameters defined below.
-//
-// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o NetworkAclOutput) Egress() NetworkAclEgressArrayOutput {
 	return o.ApplyT(func(v *NetworkAcl) NetworkAclEgressArrayOutput { return v.Egress }).(NetworkAclEgressArrayOutput)
 }
 
 // Specifies an ingress rule. Parameters defined below.
-//
-// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o NetworkAclOutput) Ingress() NetworkAclIngressArrayOutput {
 	return o.ApplyT(func(v *NetworkAcl) NetworkAclIngressArrayOutput { return v.Ingress }).(NetworkAclIngressArrayOutput)
 }

--- a/sdk/go/aws/ec2/securityGroup.go
+++ b/sdk/go/aws/ec2/securityGroup.go
@@ -351,12 +351,8 @@ type SecurityGroup struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description pulumi.StringOutput `pulumi:"description"`
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress SecurityGroupEgressArrayOutput `pulumi:"egress"`
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress SecurityGroupIngressArrayOutput `pulumi:"ingress"`
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name pulumi.StringOutput `pulumi:"name"`
@@ -414,12 +410,8 @@ type securityGroupState struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description *string `pulumi:"description"`
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []SecurityGroupEgress `pulumi:"egress"`
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []SecurityGroupIngress `pulumi:"ingress"`
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name *string `pulumi:"name"`
@@ -445,12 +437,8 @@ type SecurityGroupState struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description pulumi.StringPtrInput
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress SecurityGroupEgressArrayInput
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress SecurityGroupIngressArrayInput
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name pulumi.StringPtrInput
@@ -478,12 +466,8 @@ type securityGroupArgs struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description *string `pulumi:"description"`
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress []SecurityGroupEgress `pulumi:"egress"`
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress []SecurityGroupIngress `pulumi:"ingress"`
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name *string `pulumi:"name"`
@@ -502,12 +486,8 @@ type SecurityGroupArgs struct {
 	// Security group description. Defaults to `Managed by Pulumi`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 	Description pulumi.StringPtrInput
 	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Egress SecurityGroupEgressArrayInput
 	// Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-	//
-	// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 	Ingress SecurityGroupIngressArrayInput
 	// Name of the security group. If omitted, the provider will assign a random, unique name.
 	Name pulumi.StringPtrInput
@@ -619,15 +599,11 @@ func (o SecurityGroupOutput) Description() pulumi.StringOutput {
 }
 
 // Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-//
-// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o SecurityGroupOutput) Egress() SecurityGroupEgressArrayOutput {
 	return o.ApplyT(func(v *SecurityGroup) SecurityGroupEgressArrayOutput { return v.Egress }).(SecurityGroupEgressArrayOutput)
 }
 
 // Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-//
-// Deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
 func (o SecurityGroupOutput) Ingress() SecurityGroupIngressArrayOutput {
 	return o.ApplyT(func(v *SecurityGroup) SecurityGroupIngressArrayOutput { return v.Ingress }).(SecurityGroupIngressArrayOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAcl.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAcl.java
@@ -112,11 +112,7 @@ public class NetworkAcl extends com.pulumi.resources.CustomResource {
     /**
      * Specifies an egress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="egress", refs={List.class,NetworkAclEgress.class}, tree="[0,1]")
     private Output<List<NetworkAclEgress>> egress;
 
@@ -130,11 +126,7 @@ public class NetworkAcl extends com.pulumi.resources.CustomResource {
     /**
      * Specifies an ingress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="ingress", refs={List.class,NetworkAclIngress.class}, tree="[0,1]")
     private Output<List<NetworkAclIngress>> ingress;
 

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAclArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/NetworkAclArgs.java
@@ -23,22 +23,14 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an egress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<NetworkAclEgressArgs>> egress;
 
     /**
      * @return Specifies an egress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -46,22 +38,14 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an ingress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<NetworkAclIngressArgs>> ingress;
 
     /**
      * @return Specifies an ingress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -144,11 +128,7 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<NetworkAclEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -159,11 +139,7 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<NetworkAclEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -173,11 +149,7 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(NetworkAclEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -187,11 +159,7 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<NetworkAclIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -202,11 +170,7 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<NetworkAclIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -216,11 +180,7 @@ public final class NetworkAclArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(NetworkAclIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroup.java
@@ -393,11 +393,7 @@ public class SecurityGroup extends com.pulumi.resources.CustomResource {
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="egress", refs={List.class,SecurityGroupEgress.class}, tree="[0,1]")
     private Output<List<SecurityGroupEgress>> egress;
 
@@ -411,11 +407,7 @@ public class SecurityGroup extends com.pulumi.resources.CustomResource {
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Export(name="ingress", refs={List.class,SecurityGroupIngress.class}, tree="[0,1]")
     private Output<List<SecurityGroupIngress>> ingress;
 

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/SecurityGroupArgs.java
@@ -39,22 +39,14 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<SecurityGroupEgressArgs>> egress;
 
     /**
      * @return Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -62,22 +54,14 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<SecurityGroupIngressArgs>> ingress;
 
     /**
      * @return Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -214,11 +198,7 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<SecurityGroupEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -229,11 +209,7 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<SecurityGroupEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -243,11 +219,7 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(SecurityGroupEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -257,11 +229,7 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<SecurityGroupIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -272,11 +240,7 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<SecurityGroupIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -286,11 +250,7 @@ public final class SecurityGroupArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(SecurityGroupIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/NetworkAclState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/NetworkAclState.java
@@ -37,22 +37,14 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an egress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<NetworkAclEgressArgs>> egress;
 
     /**
      * @return Specifies an egress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -60,22 +52,14 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
     /**
      * Specifies an ingress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<NetworkAclIngressArgs>> ingress;
 
     /**
      * @return Specifies an ingress rule. Parameters defined below.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<NetworkAclIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -220,11 +204,7 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<NetworkAclEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -235,11 +215,7 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<NetworkAclEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -249,11 +225,7 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(NetworkAclEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -263,11 +235,7 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<NetworkAclIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -278,11 +246,7 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<NetworkAclIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -292,11 +256,7 @@ public final class NetworkAclState extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(NetworkAclIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/SecurityGroupState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/inputs/SecurityGroupState.java
@@ -54,22 +54,14 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="egress")
     private @Nullable Output<List<SecurityGroupEgressArgs>> egress;
 
     /**
      * @return Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupEgressArgs>>> egress() {
         return Optional.ofNullable(this.egress);
     }
@@ -77,22 +69,14 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     @Import(name="ingress")
     private @Nullable Output<List<SecurityGroupIngressArgs>> ingress;
 
     /**
      * @return Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
      * 
-     * @deprecated
-     * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-     * 
      */
-    @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
     public Optional<Output<List<SecurityGroupIngressArgs>>> ingress() {
         return Optional.ofNullable(this.ingress);
     }
@@ -291,11 +275,7 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(@Nullable Output<List<SecurityGroupEgressArgs>> egress) {
             $.egress = egress;
             return this;
@@ -306,11 +286,7 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(List<SecurityGroupEgressArgs> egress) {
             return egress(Output.of(egress));
         }
@@ -320,11 +296,7 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder egress(SecurityGroupEgressArgs... egress) {
             return egress(List.of(egress));
         }
@@ -334,11 +306,7 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(@Nullable Output<List<SecurityGroupIngressArgs>> ingress) {
             $.ingress = ingress;
             return this;
@@ -349,11 +317,7 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(List<SecurityGroupIngressArgs> ingress) {
             return ingress(Output.of(ingress));
         }
@@ -363,11 +327,7 @@ public final class SecurityGroupState extends com.pulumi.resources.ResourceArgs 
          * 
          * @return builder
          * 
-         * @deprecated
-         * Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
-         * 
          */
-        @Deprecated /* Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules. */
         public Builder ingress(SecurityGroupIngressArgs... ingress) {
             return ingress(List.of(ingress));
         }

--- a/sdk/nodejs/ec2/networkAcl.ts
+++ b/sdk/nodejs/ec2/networkAcl.ts
@@ -95,14 +95,10 @@ export class NetworkAcl extends pulumi.CustomResource {
     public /*out*/ readonly arn!: pulumi.Output<string>;
     /**
      * Specifies an egress rule. Parameters defined below.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly egress!: pulumi.Output<outputs.ec2.NetworkAclEgress[]>;
     /**
      * Specifies an ingress rule. Parameters defined below.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly ingress!: pulumi.Output<outputs.ec2.NetworkAclIngress[]>;
     /**
@@ -178,14 +174,10 @@ export interface NetworkAclState {
     arn?: pulumi.Input<string>;
     /**
      * Specifies an egress rule. Parameters defined below.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclEgress>[]>;
     /**
      * Specifies an ingress rule. Parameters defined below.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclIngress>[]>;
     /**
@@ -218,14 +210,10 @@ export interface NetworkAclState {
 export interface NetworkAclArgs {
     /**
      * Specifies an egress rule. Parameters defined below.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclEgress>[]>;
     /**
      * Specifies an ingress rule. Parameters defined below.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.NetworkAclIngress>[]>;
     /**

--- a/sdk/nodejs/ec2/securityGroup.ts
+++ b/sdk/nodejs/ec2/securityGroup.ts
@@ -240,14 +240,10 @@ export class SecurityGroup extends pulumi.CustomResource {
     public readonly description!: pulumi.Output<string>;
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly egress!: pulumi.Output<outputs.ec2.SecurityGroupEgress[]>;
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     public readonly ingress!: pulumi.Output<outputs.ec2.SecurityGroupIngress[]>;
     /**
@@ -338,14 +334,10 @@ export interface SecurityGroupState {
     description?: pulumi.Input<string>;
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupEgress>[]>;
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupIngress>[]>;
     /**
@@ -390,14 +382,10 @@ export interface SecurityGroupArgs {
     description?: pulumi.Input<string>;
     /**
      * Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     egress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupEgress>[]>;
     /**
      * Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
-     *
-     * @deprecated Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.
      */
     ingress?: pulumi.Input<pulumi.Input<inputs.ec2.SecurityGroupIngress>[]>;
     /**

--- a/sdk/python/pulumi_aws/ec2/network_acl.py
+++ b/sdk/python/pulumi_aws/ec2/network_acl.py
@@ -31,13 +31,7 @@ class NetworkAclArgs:
         """
         pulumi.set(__self__, "vpc_id", vpc_id)
         if egress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-        if egress is not None:
             pulumi.set(__self__, "egress", egress)
-        if ingress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if subnet_ids is not None:
@@ -63,9 +57,6 @@ class NetworkAclArgs:
         """
         Specifies an egress rule. Parameters defined below.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -78,9 +69,6 @@ class NetworkAclArgs:
         """
         Specifies an ingress rule. Parameters defined below.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -137,13 +125,7 @@ class _NetworkAclState:
         if arn is not None:
             pulumi.set(__self__, "arn", arn)
         if egress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-        if egress is not None:
             pulumi.set(__self__, "egress", egress)
-        if ingress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if owner_id is not None:
@@ -178,9 +160,6 @@ class _NetworkAclState:
         """
         Specifies an egress rule. Parameters defined below.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -193,9 +172,6 @@ class _NetworkAclState:
         """
         Specifies an ingress rule. Parameters defined below.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -498,9 +474,6 @@ class NetworkAcl(pulumi.CustomResource):
         """
         Specifies an egress rule. Parameters defined below.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "egress")
 
     @property
@@ -509,9 +482,6 @@ class NetworkAcl(pulumi.CustomResource):
         """
         Specifies an ingress rule. Parameters defined below.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Network ACL Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "ingress")
 
     @property

--- a/sdk/python/pulumi_aws/ec2/security_group.py
+++ b/sdk/python/pulumi_aws/ec2/security_group.py
@@ -40,13 +40,7 @@ class SecurityGroupArgs:
         if description is not None:
             pulumi.set(__self__, "description", description)
         if egress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-        if egress is not None:
             pulumi.set(__self__, "egress", egress)
-        if ingress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if name is not None:
@@ -78,9 +72,6 @@ class SecurityGroupArgs:
         """
         Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -93,9 +84,6 @@ class SecurityGroupArgs:
         """
         Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -198,13 +186,7 @@ class _SecurityGroupState:
         if description is not None:
             pulumi.set(__self__, "description", description)
         if egress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-        if egress is not None:
             pulumi.set(__self__, "egress", egress)
-        if ingress is not None:
-            warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-            pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
         if ingress is not None:
             pulumi.set(__self__, "ingress", ingress)
         if name is not None:
@@ -255,9 +237,6 @@ class _SecurityGroupState:
         """
         Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "egress")
 
     @egress.setter
@@ -270,9 +249,6 @@ class _SecurityGroupState:
         """
         Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "ingress")
 
     @ingress.setter
@@ -884,9 +860,6 @@ class SecurityGroup(pulumi.CustomResource):
         """
         Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""egress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "egress")
 
     @property
@@ -895,9 +868,6 @@ class SecurityGroup(pulumi.CustomResource):
         """
         Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in attribute-as-blocks mode.
         """
-        warnings.warn("""Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""", DeprecationWarning)
-        pulumi.log.warn("""ingress is deprecated: Use of inline rules is discouraged as they cannot be used in conjunction with any Security Group Rule resources. Doing so will cause a conflict and may overwrite rules.""")
-
         return pulumi.get(self, "ingress")
 
     @property


### PR DESCRIPTION

This reverts commit 8fc4907dee19c2b85b6a589e626cbd764b9f45ab from https://github.com/pulumi/pulumi-aws/pull/3729

The warning message is considered too noisy for this sort of issue.