### PR TITLE
Normalize rententionDays in controltower.LandingZone

### DIFF
--- a/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
+++ b/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 16:49:08 +0000
-Subject: [PATCH 01/52] Add TagsSchemaTrulyComputed definition
+Subject: [PATCH 01/53] Add TagsSchemaTrulyComputed definition
 
 
 diff --git a/internal/tags/tags.go b/internal/tags/tags.go

--- a/patches/0002-Add-S3-legacy-bucket-to-resources.patch
+++ b/patches/0002-Add-S3-legacy-bucket-to-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:05:11 +0000
-Subject: [PATCH 02/52] Add S3 legacy bucket to resources
+Subject: [PATCH 02/53] Add S3 legacy bucket to resources
 
 This preserves the old S3 Resource in the SDK, by duplicating the code
 as a new service (in internal/service/s3legacy), and making an explicit

--- a/patches/0003-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
+++ b/patches/0003-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Thu, 9 Mar 2023 09:47:49 -0600
-Subject: [PATCH 03/52] Marks SSE Configuration as Computed for Legacy S3
+Subject: [PATCH 03/53] Marks SSE Configuration as Computed for Legacy S3
  Bucket
 
 In January, AWS enabled SSE by default for all new S3 buckets.

--- a/patches/0004-De-deprecate-bucket_object.patch
+++ b/patches/0004-De-deprecate-bucket_object.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:06:11 +0000
-Subject: [PATCH 04/52] De-deprecate bucket_object
+Subject: [PATCH 04/53] De-deprecate bucket_object
 
 
 diff --git a/internal/service/s3/bucket_object.go b/internal/service/s3/bucket_object.go

--- a/patches/0005-Remove-lakeformation-catalog_resource-default.patch
+++ b/patches/0005-Remove-lakeformation-catalog_resource-default.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:08:23 +0000
-Subject: [PATCH 05/52] Remove lakeformation catalog_resource default
+Subject: [PATCH 05/53] Remove lakeformation catalog_resource default
 
 
 diff --git a/internal/service/lakeformation/permissions.go b/internal/service/lakeformation/permissions.go

--- a/patches/0006-Workaround-SSM-Parameter-tier-bug.patch
+++ b/patches/0006-Workaround-SSM-Parameter-tier-bug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:24:42 +0000
-Subject: [PATCH 06/52] Workaround SSM Parameter tier bug
+Subject: [PATCH 06/53] Workaround SSM Parameter tier bug
 
 - Disable "computed".
 - Disable diff suppression & counteractions

--- a/patches/0007-Add-EKS-cluster-certificate_authorities-plural.patch
+++ b/patches/0007-Add-EKS-cluster-certificate_authorities-plural.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:32:49 +0000
-Subject: [PATCH 07/52] Add EKS cluster certificate_authorities (plural)
+Subject: [PATCH 07/53] Add EKS cluster certificate_authorities (plural)
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0008-Workaround-Autoscaling-launch_configuration-associat.patch
+++ b/patches/0008-Workaround-Autoscaling-launch_configuration-associat.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:34:56 +0000
-Subject: [PATCH 08/52] Workaround Autoscaling launch_configuration
+Subject: [PATCH 08/53] Workaround Autoscaling launch_configuration
  associate_public_ip_address
 
 - Disable computation of property until fixed.

--- a/patches/0009-Add-ECR-credentials_data_source.patch
+++ b/patches/0009-Add-ECR-credentials_data_source.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:36:34 +0000
-Subject: [PATCH 09/52] Add ECR credentials_data_source
+Subject: [PATCH 09/53] Add ECR credentials_data_source
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0010-Add-custom-appautoscaling-examples.patch
+++ b/patches/0010-Add-custom-appautoscaling-examples.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Wed, 9 Nov 2022 17:37:35 +0000
-Subject: [PATCH 10/52] Add custom appautoscaling examples
+Subject: [PATCH 10/53] Add custom appautoscaling examples
 
 
 diff --git a/website/docs/r/appautoscaling_policy.html.markdown b/website/docs/r/appautoscaling_policy.html.markdown

--- a/patches/0011-Add-dedicated_host-docs.patch
+++ b/patches/0011-Add-dedicated_host-docs.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 10:08:05 +0000
-Subject: [PATCH 11/52] Add dedicated_host docs
+Subject: [PATCH 11/53] Add dedicated_host docs
 
 
 diff --git a/website/docs/d/dedicated_host.html.markdown b/website/docs/d/dedicated_host.html.markdown

--- a/patches/0012-Revert-WAF-schema-changes.patch
+++ b/patches/0012-Revert-WAF-schema-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 13:59:57 +0000
-Subject: [PATCH 12/52] Revert WAF schema changes
+Subject: [PATCH 12/53] Revert WAF schema changes
 
 - This causes far too many types to be generated downstream.
 

--- a/patches/0013-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
+++ b/patches/0013-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@gmail.com>
 Date: Thu, 1 Dec 2022 10:56:32 -0800
-Subject: [PATCH 13/52] Catch cty panic in new
+Subject: [PATCH 13/53] Catch cty panic in new
  resourceTopicSubscriptionCustomizeDiff.
 
 The root cause is not fully understood yet but this might unblock us.

--- a/patches/0014-add-matchmaking-configuration-72.patch
+++ b/patches/0014-add-matchmaking-configuration-72.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Lee Briggs <jaxxstorm@users.noreply.github.com>
 Date: Wed, 21 Dec 2022 12:23:59 -0800
-Subject: [PATCH 14/52] add matchmaking configuration (#72)
+Subject: [PATCH 14/53] add matchmaking configuration (#72)
 
 * add matchmaking configuration
 * add matchmaking rule set

--- a/patches/0015-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
+++ b/patches/0015-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Fri, 27 Jan 2023 09:37:43 -0600
-Subject: [PATCH 15/52] Reverts patches to S3BucketLegacy and GameLift
+Subject: [PATCH 15/53] Reverts patches to S3BucketLegacy and GameLift
 
 Previously, we were pulling along patches which removed a few simplifications
 to waiters in AWS GameLift, and a newer patch which plumbed through context.Context

--- a/patches/0016-Revert-Update-endpointHashIPAddress.patch
+++ b/patches/0016-Revert-Update-endpointHashIPAddress.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@pulumi.com>
 Date: Fri, 3 Feb 2023 17:31:18 -0800
-Subject: [PATCH 16/52] Revert "Update endpointHashIPAddress"
+Subject: [PATCH 16/53] Revert "Update endpointHashIPAddress"
 
 This reverts commit 2197a6c2c7a0ff306cec3432acb9f5680866f034.
 

--- a/patches/0017-Fixup-gamelift-context.patch
+++ b/patches/0017-Fixup-gamelift-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Thu, 9 Mar 2023 14:50:51 +0000
-Subject: [PATCH 17/52] Fixup gamelift context
+Subject: [PATCH 17/53] Fixup gamelift context
 
 
 diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go

--- a/patches/0018-Change-default-descriptions-to-Managed-by-Pulumi.patch
+++ b/patches/0018-Change-default-descriptions-to-Managed-by-Pulumi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 28 Feb 2023 15:19:24 +0000
-Subject: [PATCH 18/52] Change default descriptions to "Managed by Pulumi"
+Subject: [PATCH 18/53] Change default descriptions to "Managed by Pulumi"
 
 
 diff --git a/internal/service/apigateway/api_key.go b/internal/service/apigateway/api_key.go

--- a/patches/0019-remove-required-elements-from-schema-and-fix-tests-7.patch
+++ b/patches/0019-remove-required-elements-from-schema-and-fix-tests-7.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel.dbphoto@gmail.com>
 Date: Tue, 28 Mar 2023 19:54:00 +0100
-Subject: [PATCH 19/52] remove required elements from schema and fix tests
+Subject: [PATCH 19/53] remove required elements from schema and fix tests
  (#77)
 
 Co-authored-by: Lee Briggs <lee@leebriggs.co.uk>

--- a/patches/0020-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
+++ b/patches/0020-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 24 Apr 2023 10:36:36 -0400
-Subject: [PATCH 20/52] Temp remove cognito_identity_pool_roles_attachment
+Subject: [PATCH 20/53] Temp remove cognito_identity_pool_roles_attachment
  example beacuse of flaky translation
 
 

--- a/patches/0021-Fix-elbv2-target-group-read-to-workaround-2517.patch
+++ b/patches/0021-Fix-elbv2-target-group-read-to-workaround-2517.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 17:36:47 -0500
-Subject: [PATCH 21/52] Fix elbv2 target group read to workaround #2517
+Subject: [PATCH 21/53] Fix elbv2 target group read to workaround #2517
 
 
 diff --git a/internal/service/elbv2/target_group.go b/internal/service/elbv2/target_group.go

--- a/patches/0022-Fix-spurrious-json-diff-for-redrive_policy.patch
+++ b/patches/0022-Fix-spurrious-json-diff-for-redrive_policy.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ramon Quitales <ramon@pulumi.com>
 Date: Thu, 18 May 2023 15:21:33 -0700
-Subject: [PATCH 22/52] Fix spurrious json diff for redrive_policy
+Subject: [PATCH 22/53] Fix spurrious json diff for redrive_policy
 
 We need to normalize the json input to compare agasint the one stored
 in state.

--- a/patches/0023-Provide-context-to-conns.patch
+++ b/patches/0023-Provide-context-to-conns.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Mon, 10 Jul 2023 11:51:24 +0200
-Subject: [PATCH 23/52] Provide context to conns
+Subject: [PATCH 23/53] Provide context to conns
 
 
 diff --git a/internal/service/ecr/credentials_data_source.go b/internal/service/ecr/credentials_data_source.go

--- a/patches/0024-Match-the-tags-behavior-of-other-resources.patch
+++ b/patches/0024-Match-the-tags-behavior-of-other-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Wed, 2 Aug 2023 14:12:03 +0200
-Subject: [PATCH 24/52] Match the "tags" behavior of other resources
+Subject: [PATCH 24/53] Match the "tags" behavior of other resources
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0025-move-shim-logic-to-upstream-as-a-patch.patch
+++ b/patches/0025-move-shim-logic-to-upstream-as-a-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 6 Sep 2023 10:43:30 -0700
-Subject: [PATCH 25/52] move shim logic to upstream as a patch
+Subject: [PATCH 25/53] move shim logic to upstream as a patch
 
 
 diff --git a/shim/shim.go b/shim/shim.go

--- a/patches/0026-Restore-S3ConnURICleaningDisabled.patch
+++ b/patches/0026-Restore-S3ConnURICleaningDisabled.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Tue, 9 Apr 2024 15:24:26 -0400
-Subject: [PATCH 26/52] Restore S3ConnURICleaningDisabled
+Subject: [PATCH 26/53] Restore S3ConnURICleaningDisabled
 
 
 diff --git a/internal/conns/awsclient.go b/internal/conns/awsclient.go

--- a/patches/0027-Do-not-compute-tags_all-at-TF-level.patch
+++ b/patches/0027-Do-not-compute-tags_all-at-TF-level.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 6 Nov 2023 11:17:16 -0500
-Subject: [PATCH 27/52] Do not compute tags_all at TF level
+Subject: [PATCH 27/53] Do not compute tags_all at TF level
 
 
 diff --git a/internal/framework/base.go b/internal/framework/base.go

--- a/patches/0028-aws_eks_cluster-implement-default_addons_to_remove.patch
+++ b/patches/0028-aws_eks_cluster-implement-default_addons_to_remove.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 15 Nov 2023 11:53:09 -0500
-Subject: [PATCH 28/52] aws_eks_cluster: implement default_addons_to_remove
+Subject: [PATCH 28/53] aws_eks_cluster: implement default_addons_to_remove
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0029-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
+++ b/patches/0029-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 29 Nov 2023 17:23:09 -0500
-Subject: [PATCH 29/52] Fix markTagsAllNotComputedForResources to recognize
+Subject: [PATCH 29/53] Fix markTagsAllNotComputedForResources to recognize
  SchemaFunc
 
 

--- a/patches/0030-Optimize-startup-performance.patch
+++ b/patches/0030-Optimize-startup-performance.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 30 Nov 2023 14:28:37 -0500
-Subject: [PATCH 30/52] Optimize startup performance
+Subject: [PATCH 30/53] Optimize startup performance
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0031-Fix-job-queue-sdkv2-migration.patch
+++ b/patches/0031-Fix-job-queue-sdkv2-migration.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:41:21 -0500
-Subject: [PATCH 31/52] Fix job queue sdkv2 migration
+Subject: [PATCH 31/53] Fix job queue sdkv2 migration
 
 
 diff --git a/internal/service/batch/job_queue_schema.go b/internal/service/batch/job_queue_schema.go

--- a/patches/0032-DisableTagSchemaCheck-for-PF-provider.patch
+++ b/patches/0032-DisableTagSchemaCheck-for-PF-provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:44:25 -0500
-Subject: [PATCH 32/52] DisableTagSchemaCheck for PF provider
+Subject: [PATCH 32/53] DisableTagSchemaCheck for PF provider
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0033-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
+++ b/patches/0033-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:05:40 -0500
-Subject: [PATCH 33/52] Run scripts/patch_computed_only.sh to patch
+Subject: [PATCH 33/53] Run scripts/patch_computed_only.sh to patch
  eks/pod_identity_association and more
 
 

--- a/patches/0034-Fail-fast-when-PF-resources-are-dropped.patch
+++ b/patches/0034-Fail-fast-when-PF-resources-are-dropped.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:18:14 -0500
-Subject: [PATCH 34/52] Fail fast when PF resources are dropped
+Subject: [PATCH 34/53] Fail fast when PF resources are dropped
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0035-Fix-tags_all-Computed-for-PF-resources.patch
+++ b/patches/0035-Fix-tags_all-Computed-for-PF-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 7 Feb 2024 12:24:44 -0500
-Subject: [PATCH 35/52] Fix tags_all Computed for PF resources
+Subject: [PATCH 35/53] Fix tags_all Computed for PF resources
 
 
 diff --git a/internal/service/amp/scraper.go b/internal/service/amp/scraper.go

--- a/patches/0036-Disable-retry-for-KMS-access-denied-in-lambda.patch
+++ b/patches/0036-Disable-retry-for-KMS-access-denied-in-lambda.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 8 Jan 2024 16:58:44 -0500
-Subject: [PATCH 36/52] Disable retry for KMS access denied in lambda
+Subject: [PATCH 36/53] Disable retry for KMS access denied in lambda
 
 
 diff --git a/internal/service/lambda/service_package_extra.go b/internal/service/lambda/service_package_extra.go

--- a/patches/0037-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
+++ b/patches/0037-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 18:08:51 -0500
-Subject: [PATCH 37/52] Patch ACM retry to not retry after
+Subject: [PATCH 37/53] Patch ACM retry to not retry after
  LimitExceededException (#3290)
 
 

--- a/patches/0038-Restore-legacy-bucket.patch
+++ b/patches/0038-Restore-legacy-bucket.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Tue, 9 Apr 2024 15:27:59 -0400
-Subject: [PATCH 38/52] Restore legacy bucket
+Subject: [PATCH 38/53] Restore legacy bucket
 
 
 diff --git a/go.mod b/go.mod

--- a/patches/0039-Patch-osis_pipeline-tags-flags.patch
+++ b/patches/0039-Patch-osis_pipeline-tags-flags.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 9 Feb 2024 14:39:32 -0500
-Subject: [PATCH 39/52] Patch osis_pipeline tags flags
+Subject: [PATCH 39/53] Patch osis_pipeline tags flags
 
 
 diff --git a/internal/service/osis/pipeline.go b/internal/service/osis/pipeline.go

--- a/patches/0040-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
+++ b/patches/0040-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 14 Feb 2024 14:49:33 +0000
-Subject: [PATCH 40/52] Revert "Merge pull request #35678 from
+Subject: [PATCH 40/53] Revert "Merge pull request #35678 from
  hashicorp/b-elbv2-unexpected-diff"
 
 This reverts commit bfcae6ad3e8a226083f803b40e772e045ec78baa, reversing

--- a/patches/0041-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
+++ b/patches/0041-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 14 Feb 2024 14:49:38 +0000
-Subject: [PATCH 41/52] Revert "Merge pull request #35671 from
+Subject: [PATCH 41/53] Revert "Merge pull request #35671 from
  hashicorp/b-lb-listener-stickiness-3"
 
 This reverts commit 32a681fcfcd8d78c5ac9e199384a980bb71c82ed, reversing

--- a/patches/0042-Allow-creating-lambdas-without-code-related-properti.patch
+++ b/patches/0042-Allow-creating-lambdas-without-code-related-properti.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Tue, 13 Feb 2024 11:36:02 +0000
-Subject: [PATCH 42/52] Allow creating lambdas without code related properties
+Subject: [PATCH 42/53] Allow creating lambdas without code related properties
 
 
 diff --git a/internal/service/lambda/function.go b/internal/service/lambda/function.go

--- a/patches/0043-Do-not-Compute-tags_all-of-aws_bedrock_provisioned_m.patch
+++ b/patches/0043-Do-not-Compute-tags_all-of-aws_bedrock_provisioned_m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: guineveresaenger <guinevere@pulumi.com>
 Date: Wed, 21 Feb 2024 14:46:27 -0800
-Subject: [PATCH 43/52] Do not Compute tags_all of
+Subject: [PATCH 43/53] Do not Compute tags_all of
  aws_bedrock_provisioned_model_throughput
 
 

--- a/patches/0044-fix-legacy-bucket-context.patch
+++ b/patches/0044-fix-legacy-bucket-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 28 Feb 2024 16:06:02 +0000
-Subject: [PATCH 44/52] fix legacy bucket context
+Subject: [PATCH 44/53] fix legacy bucket context
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0045-securitylake_subscriber-tags_all-patch.patch
+++ b/patches/0045-securitylake_subscriber-tags_all-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Tue, 12 Mar 2024 18:05:28 -0400
-Subject: [PATCH 45/52] securitylake_subscriber tags_all patch
+Subject: [PATCH 45/53] securitylake_subscriber tags_all patch
 
 
 diff --git a/internal/service/securitylake/subscriber.go b/internal/service/securitylake/subscriber.go

--- a/patches/0046-Revert-rds-engine_version-Fix-bugs-with-default-only.patch
+++ b/patches/0046-Revert-rds-engine_version-Fix-bugs-with-default-only.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Fri, 29 Mar 2024 10:29:15 -0400
-Subject: [PATCH 46/52] Revert "rds/engine_version: Fix bugs with default only
+Subject: [PATCH 46/53] Revert "rds/engine_version: Fix bugs with default only
  flag"
 
 

--- a/patches/0047-Patch-tags-ComputedOnly-for-m2-resources.patch
+++ b/patches/0047-Patch-tags-ComputedOnly-for-m2-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 1 Apr 2024 17:25:06 -0400
-Subject: [PATCH 47/52] Patch tags ComputedOnly for m2 resources
+Subject: [PATCH 47/53] Patch tags ComputedOnly for m2 resources
 
 
 diff --git a/internal/service/m2/application.go b/internal/service/m2/application.go

--- a/patches/0048-restore-ECRConn.patch
+++ b/patches/0048-restore-ECRConn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Wed, 10 Apr 2024 08:49:35 -0400
-Subject: [PATCH 48/52] restore ECRConn
+Subject: [PATCH 48/53] restore ECRConn
 
 
 diff --git a/internal/conns/awsclient_gen.go b/internal/conns/awsclient_gen.go

--- a/patches/0049-update-testing-types.patch
+++ b/patches/0049-update-testing-types.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Wed, 10 Apr 2024 08:50:03 -0400
-Subject: [PATCH 49/52] update testing types
+Subject: [PATCH 49/53] update testing types
 
 
 diff --git a/internal/service/ecr/credentials_data_source_test.go b/internal/service/ecr/credentials_data_source_test.go

--- a/patches/0050-restore-ecr-NewConn.patch
+++ b/patches/0050-restore-ecr-NewConn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Wed, 10 Apr 2024 13:43:56 -0400
-Subject: [PATCH 50/52] restore ecr NewConn
+Subject: [PATCH 50/53] restore ecr NewConn
 
 
 diff --git a/internal/service/ecr/service_package_gen.go b/internal/service/ecr/service_package_gen.go

--- a/patches/0051-update-apn-info.patch
+++ b/patches/0051-update-apn-info.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Thu, 11 Apr 2024 08:06:27 -0400
-Subject: [PATCH 51/52] update apn info
+Subject: [PATCH 51/53] update apn info
 
 
 diff --git a/internal/conns/config.go b/internal/conns/config.go

--- a/patches/0052-non-idempotent-sns-topic-creation.patch
+++ b/patches/0052-non-idempotent-sns-topic-creation.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Thu, 11 Apr 2024 14:42:01 -0400
-Subject: [PATCH 52/52] non-idempotent sns topic creation
+Subject: [PATCH 52/53] non-idempotent sns topic creation
 
 
 diff --git a/internal/service/sns/topic.go b/internal/service/sns/topic.go

--- a/patches/0053-Normalize-retentionDays-in-aws_controltower_landing_.patch
+++ b/patches/0053-Normalize-retentionDays-in-aws_controltower_landing_.patch
@@ -1,0 +1,190 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Tayanovskyy <anton@pulumi.com>
+Date: Fri, 12 Apr 2024 16:34:51 -0400
+Subject: [PATCH 53/53] Normalize retentionDays in
+ aws_controltower_landing_zone manifest_json
+
+Prior to this change interacting with aws_controltower_landing_zone could cause spurious diffs where retentionDays
+sub-property would cycle between a string form like "365" and an integer form like 365.
+
+With this change such diffs are suppressed and data is written to state in a form that is normalized to the integer like
+365.
+
+According to https://docs.aws.amazon.com/controltower/latest/userguide/lz-api-launch.html the numerical form is the
+preferred one.
+
+diff --git a/internal/service/controltower/landing_zone.go b/internal/service/controltower/landing_zone.go
+index 1491a3dbf6..7ef2910ff7 100644
+--- a/internal/service/controltower/landing_zone.go
++++ b/internal/service/controltower/landing_zone.go
+@@ -5,8 +5,10 @@ package controltower
+ 
+ import (
+ 	"context"
++	stdjson "encoding/json"
+ 	"errors"
+ 	"log"
++	"strconv"
+ 	"strings"
+ 	"time"
+ 
+@@ -18,7 +20,6 @@ import (
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+@@ -75,12 +76,9 @@ func resourceLandingZone() *schema.Resource {
+ 				Type:                  schema.TypeString,
+ 				Required:              true,
+ 				ValidateFunc:          validation.StringIsJSON,
+-				DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
++				DiffSuppressFunc:      resourceLandingZoneManfiestSuppressEquivalentJSONDiffs,
+ 				DiffSuppressOnRefresh: true,
+-				StateFunc: func(v interface{}) string {
+-					json, _ := structure.NormalizeJsonString(v)
+-					return json
+-				},
++				StateFunc:             resourceLandingZoneManfiestStateFunc,
+ 			},
+ 			"version": {
+ 				Type:     schema.TypeString,
+@@ -328,3 +326,80 @@ func flattenLandingZoneDriftStatusSummary(apiObject *types.LandingZoneDriftStatu
+ 
+ 	return tfMap
+ }
++
++// Normalize JSON manifest to avoid significant space and fix retentionDays cycling between string and number. This
++// normalizes retentionDays to always use numbers.
++func resourceLandingZoneNormalizeManifest(jsonManifest string) (string, error) {
++	var data any
++	if err := stdjson.Unmarshal([]byte(jsonManifest), &data); err != nil {
++		return "", err
++	}
++
++	normRetentionDays := func(key string, value any) (any, bool) {
++		if key != "retentionDays" {
++			return nil, false
++		}
++		valueStr, isStr := value.(string)
++		if !isStr {
++			return nil, false
++		}
++		valueInt, err := strconv.Atoi(valueStr)
++		if err != nil {
++			return nil, false
++		}
++		return valueInt, true
++	}
++
++	var walk func(any)
++	walk = func(node any) {
++		switch n := node.(type) {
++		case []any:
++			for _, elem := range n {
++				walk(elem)
++			}
++		case map[string]any:
++			for key, elem := range n {
++				if newElem, ok := normRetentionDays(key, elem); ok {
++					n[key] = newElem
++				}
++			}
++			for _, elem := range n {
++				walk(elem)
++			}
++		default:
++			{
++			}
++		}
++	}
++	walk(data)
++
++	bytes, err := stdjson.Marshal(data)
++	if err != nil {
++		return "", err
++	}
++	return string(bytes[:]), nil
++}
++
++func resourceLandingZoneManfiestSuppressEquivalentJSONDiffs(k, old, new string, d *schema.ResourceData) bool {
++	oldNorm, err := resourceLandingZoneNormalizeManifest(old)
++	if err != nil {
++		return false
++	}
++	newNorm, err := resourceLandingZoneNormalizeManifest(new)
++	if err != nil {
++		return false
++	}
++	return oldNorm == newNorm
++}
++
++func resourceLandingZoneManfiestStateFunc(jsonString interface{}) string {
++	s, ok := jsonString.(string)
++	if !ok {
++		return ""
++	}
++	ns, err := resourceLandingZoneNormalizeManifest(s)
++	if err != nil {
++		return s
++	}
++	return ns
++}
+diff --git a/internal/service/controltower/landing_zone_internals_test.go b/internal/service/controltower/landing_zone_internals_test.go
+new file mode 100644
+index 0000000000..a8bb57939e
+--- /dev/null
++++ b/internal/service/controltower/landing_zone_internals_test.go
+@@ -0,0 +1,50 @@
++// Copyright (c) HashiCorp, Inc.
++// SPDX-License-Identifier: MPL-2.0
++
++package controltower
++
++import (
++	"testing"
++)
++
++func TestResourceLandingZoneNormalizeManifest(t *testing.T) {
++	actual, err := resourceLandingZoneNormalizeManifest(`
++	{
++	  "governedRegions": [
++	    "ap-southeast-2"
++	  ],
++	  "organizationStructure": {
++	    "security": {
++	      "name": "Security"
++	    }
++	  },
++	  "centralizedLogging": {
++	    "accountId": "89XXXXXXXX39",
++	    "configurations": {
++	      "accessLoggingBucket": {
++		"retentionDays": "3650"
++	      },
++	      "kmsKeyArn": "arn:aws:kms:ap-southeast-2:89XXXXXXXX25:key/10e27ec4-5555-4444-b408-777777777777",
++	      "loggingBucket": {
++		"retentionDays": "365"
++	      }
++	    },
++	    "enabled": true
++	  },
++	  "securityRoles": {
++	    "accountId": "89XXXXXXXX42"
++	  },
++	  "accessManagement": {
++	    "enabled": true
++	  }
++	}`)
++	if err != nil {
++		t.Error(err)
++	}
++	expected := `{"accessManagement":{"enabled":true},"centralizedLogging":{"accountId":"89XXXXXXXX39","configurations":{"accessLoggingBucket":{"retentionDays":3650},"kmsKeyArn":"arn:aws:kms:ap-southeast-2:89XXXXXXXX25:key/10e27ec4-5555-4444-b408-777777777777","loggingBucket":{"retentionDays":365}},"enabled":true},"governedRegions":["ap-southeast-2"],"organizationStructure":{"security":{"name":"Security"}},"securityRoles":{"accountId":"89XXXXXXXX42"}}`
++	if expected != actual {
++		t.Logf("Expected: %s", expected)
++		t.Logf("Actual: %s", actual)
++		t.Error("Unexpected result")
++	}
++}

--- a/provider/diff_test.go
+++ b/provider/diff_test.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+)
+
+// Check that having manifest...retentionDays as "3650" in the state but 3650 (numeric value) in the program does not
+// induce a diff as it is suppressed by the underlying provider.
+//
+// See also pulumi/pulumi-aws#3650.
+func TestRegressLandingZoneDiff(t *testing.T) {
+	event := `
+	[{
+	  "method": "/pulumirpc.ResourceProvider/Diff",
+	  "request": {
+	    "id": "4UHHTLE0W30UX0TC",
+	    "urn": "urn:pulumi:operations::aws-3650::aws:controltower/landingZone:LandingZone::lz_operations",
+	    "olds": {
+	      "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":7200000000000,\"delete\":7200000000000,\"update\":7200000000000}}",
+	      "arn": "arn:aws:controltower:ap-southeast-2:89XXXXXXXX25:landingzone/4UHHTLE0W30UX0TC",
+	      "driftStatuses": [
+		{
+		  "status": "IN_SYNC"
+		}
+	      ],
+	      "id": "4UHHTLE0W30UX0TC",
+	      "latestAvailableVersion": "3.3",
+	      "manifestJson": "{\"accessManagement\":{\"enabled\":true},\"centralizedLogging\":{\"accountId\":\"89XXXXXXXX39\",\"configurations\":{\"accessLoggingBucket\":{\"retentionDays\":\"3650\"},\"kmsKeyArn\":\"arn:aws:kms:ap-southeast-2:89XXXXXXXX25:key/10e27ec4-55b0-42b7-b408-72b11a3f4550\",\"loggingBucket\":{\"retentionDays\":365}},\"enabled\":true},\"governedRegions\":[\"ap-southeast-2\"],\"organizationStructure\":{\"security\":{\"name\":\"Security\"}},\"securityRoles\":{\"accountId\":\"89XXXXXXXX42\"}}",
+	      "version": "3.3"
+	    },
+	    "news": {
+	      "__defaults": [],
+	      "manifestJson": "{\"governedRegions\": [\"ap-southeast-2\"], \"organizationStructure\": {\"security\": {\"name\": \"Security\"}}, \"centralizedLogging\": {\"accountId\": \"89XXXXXXXX39\", \"configurations\": {\"accessLoggingBucket\": {\"retentionDays\": 3650}, \"kmsKeyArn\": \"arn:aws:kms:ap-southeast-2:89XXXXXXXX25:key/10e27ec4-55b0-42b7-b408-72b11a3f4550\", \"loggingBucket\": {\"retentionDays\": 365}}, \"enabled\": true}, \"securityRoles\": {\"accountId\": \"89XXXXXXXX42\"}, \"accessManagement\": {\"enabled\": true}}",
+	      "version": "3.3"
+	    },
+	    "oldInputs": {
+	      "__defaults": [],
+	      "manifestJson": "{\"governedRegions\": [\"ap-southeast-2\"], \"organizationStructure\": {\"security\": {\"name\": \"Security\"}}, \"centralizedLogging\": {\"accountId\": \"89XXXXXXXX39\", \"configurations\": {\"accessLoggingBucket\": {\"retentionDays\": \"3650\"}, \"kmsKeyArn\": \"arn:aws:kms:ap-southeast-2:89XXXXXXXX25:key/10e27ec4-55b0-42b7-b408-72b11a3f4550\", \"loggingBucket\": {\"retentionDays\": 365}}, \"enabled\": true}, \"securityRoles\": {\"accountId\": \"89XXXXXXXX42\"}, \"accessManagement\": {\"enabled\": true}}",
+	      "version": "3.3"
+	    }
+	  },
+	  "response": {
+	    "changes": "DIFF_NONE",
+	    "hasDetailedDiff": true
+	  }
+	}]`
+	replaySequence(t, event)
+}


### PR DESCRIPTION
Fix #3650 

Adds a patch to rewrite LandingZone manifest JSON blobs to always perform normalization of the following kind:

```
- "retentionDays": "3650"
+ "retentionDays": 3650
```