### PR TITLE
Fix flaky test TestAccKmsAliasTs

### DIFF
--- a/examples/kms-alias/index.ts
+++ b/examples/kms-alias/index.ts
@@ -23,7 +23,7 @@ const aliasAutoPrefixedWithAlias = new aws.kms.Alias("should-be-prefixed", {targ
 
 const aliasWithDedicatedName = new aws.kms.Alias("wont-be-autonamed", {
     targetKeyId: key.keyId,
-    name: "alias/my-decicated-name"
+    namePrefix: "alias/my-decicated-name-"
 }, providerOpts);
 
 export const autonamedAlias = aliasAutoPrefixedWithAlias.name;


### PR DESCRIPTION
The test is creating a KMS key alias with a static name. When multiple
instances of this test are running in the same AWS account and region they'll race
and occasionally fail because the alias already exists.

This changes the key alias to use a name prefix to guarantee uniqueness.

This fixes: https://github.com/pulumi/pulumi-aws/issues/3817
