### PR TITLE
Fix panic in aws.rds.Proxy

### DIFF
--- a/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
+++ b/patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 16:49:08 +0000
-Subject: [PATCH 01/53] Add TagsSchemaTrulyComputed definition
+Subject: [PATCH] Add TagsSchemaTrulyComputed definition
 
 
 diff --git a/internal/tags/tags.go b/internal/tags/tags.go

--- a/patches/0002-Add-S3-legacy-bucket-to-resources.patch
+++ b/patches/0002-Add-S3-legacy-bucket-to-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:05:11 +0000
-Subject: [PATCH 02/53] Add S3 legacy bucket to resources
+Subject: [PATCH] Add S3 legacy bucket to resources
 
 This preserves the old S3 Resource in the SDK, by duplicating the code
 as a new service (in internal/service/s3legacy), and making an explicit

--- a/patches/0003-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
+++ b/patches/0003-Marks-SSE-Configuration-as-Computed-for-Legacy-S3-Bu.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Thu, 9 Mar 2023 09:47:49 -0600
-Subject: [PATCH 03/53] Marks SSE Configuration as Computed for Legacy S3
- Bucket
+Subject: [PATCH] Marks SSE Configuration as Computed for Legacy S3 Bucket
 
 In January, AWS enabled SSE by default for all new S3 buckets.
 Since we maintain a forked version of the legacy S3 bucket resource,

--- a/patches/0004-De-deprecate-bucket_object.patch
+++ b/patches/0004-De-deprecate-bucket_object.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:06:11 +0000
-Subject: [PATCH 04/53] De-deprecate bucket_object
+Subject: [PATCH] De-deprecate bucket_object
 
 
 diff --git a/internal/service/s3/bucket_object.go b/internal/service/s3/bucket_object.go

--- a/patches/0005-Remove-lakeformation-catalog_resource-default.patch
+++ b/patches/0005-Remove-lakeformation-catalog_resource-default.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:08:23 +0000
-Subject: [PATCH 05/53] Remove lakeformation catalog_resource default
+Subject: [PATCH] Remove lakeformation catalog_resource default
 
 
 diff --git a/internal/service/lakeformation/permissions.go b/internal/service/lakeformation/permissions.go

--- a/patches/0006-Workaround-SSM-Parameter-tier-bug.patch
+++ b/patches/0006-Workaround-SSM-Parameter-tier-bug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:24:42 +0000
-Subject: [PATCH 06/53] Workaround SSM Parameter tier bug
+Subject: [PATCH] Workaround SSM Parameter tier bug
 
 - Disable "computed".
 - Disable diff suppression & counteractions

--- a/patches/0007-Add-EKS-cluster-certificate_authorities-plural.patch
+++ b/patches/0007-Add-EKS-cluster-certificate_authorities-plural.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:32:49 +0000
-Subject: [PATCH 07/53] Add EKS cluster certificate_authorities (plural)
+Subject: [PATCH] Add EKS cluster certificate_authorities (plural)
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0008-Workaround-Autoscaling-launch_configuration-associat.patch
+++ b/patches/0008-Workaround-Autoscaling-launch_configuration-associat.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:34:56 +0000
-Subject: [PATCH 08/53] Workaround Autoscaling launch_configuration
+Subject: [PATCH] Workaround Autoscaling launch_configuration
  associate_public_ip_address
 
 - Disable computation of property until fixed.

--- a/patches/0009-Add-ECR-credentials_data_source.patch
+++ b/patches/0009-Add-ECR-credentials_data_source.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Fri, 4 Nov 2022 17:36:34 +0000
-Subject: [PATCH 09/53] Add ECR credentials_data_source
+Subject: [PATCH] Add ECR credentials_data_source
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0010-Add-custom-appautoscaling-examples.patch
+++ b/patches/0010-Add-custom-appautoscaling-examples.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Wed, 9 Nov 2022 17:37:35 +0000
-Subject: [PATCH 10/53] Add custom appautoscaling examples
+Subject: [PATCH] Add custom appautoscaling examples
 
 
 diff --git a/website/docs/r/appautoscaling_policy.html.markdown b/website/docs/r/appautoscaling_policy.html.markdown

--- a/patches/0011-Add-dedicated_host-docs.patch
+++ b/patches/0011-Add-dedicated_host-docs.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 10:08:05 +0000
-Subject: [PATCH 11/53] Add dedicated_host docs
+Subject: [PATCH] Add dedicated_host docs
 
 
 diff --git a/website/docs/d/dedicated_host.html.markdown b/website/docs/d/dedicated_host.html.markdown

--- a/patches/0012-Revert-WAF-schema-changes.patch
+++ b/patches/0012-Revert-WAF-schema-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 15 Nov 2022 13:59:57 +0000
-Subject: [PATCH 12/53] Revert WAF schema changes
+Subject: [PATCH] Revert WAF schema changes
 
 - This causes far too many types to be generated downstream.
 

--- a/patches/0013-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
+++ b/patches/0013-Catch-cty-panic-in-new-resourceTopicSubscriptionCust.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@gmail.com>
 Date: Thu, 1 Dec 2022 10:56:32 -0800
-Subject: [PATCH 13/53] Catch cty panic in new
+Subject: [PATCH] Catch cty panic in new
  resourceTopicSubscriptionCustomizeDiff.
 
 The root cause is not fully understood yet but this might unblock us.

--- a/patches/0014-add-matchmaking-configuration-72.patch
+++ b/patches/0014-add-matchmaking-configuration-72.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Lee Briggs <jaxxstorm@users.noreply.github.com>
 Date: Wed, 21 Dec 2022 12:23:59 -0800
-Subject: [PATCH 14/53] add matchmaking configuration (#72)
+Subject: [PATCH] add matchmaking configuration (#72)
 
 * add matchmaking configuration
 * add matchmaking rule set

--- a/patches/0015-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
+++ b/patches/0015-Reverts-patches-to-S3BucketLegacy-and-GameLift.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Pitzen <kpitzen@pulumi.com>
 Date: Fri, 27 Jan 2023 09:37:43 -0600
-Subject: [PATCH 15/53] Reverts patches to S3BucketLegacy and GameLift
+Subject: [PATCH] Reverts patches to S3BucketLegacy and GameLift
 
 Previously, we were pulling along patches which removed a few simplifications
 to waiters in AWS GameLift, and a newer patch which plumbed through context.Context

--- a/patches/0016-Revert-Update-endpointHashIPAddress.patch
+++ b/patches/0016-Revert-Update-endpointHashIPAddress.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@pulumi.com>
 Date: Fri, 3 Feb 2023 17:31:18 -0800
-Subject: [PATCH 16/53] Revert "Update endpointHashIPAddress"
+Subject: [PATCH] Revert "Update endpointHashIPAddress"
 
 This reverts commit 2197a6c2c7a0ff306cec3432acb9f5680866f034.
 

--- a/patches/0017-Fixup-gamelift-context.patch
+++ b/patches/0017-Fixup-gamelift-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Thu, 9 Mar 2023 14:50:51 +0000
-Subject: [PATCH 17/53] Fixup gamelift context
+Subject: [PATCH] Fixup gamelift context
 
 
 diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go

--- a/patches/0018-Change-default-descriptions-to-Managed-by-Pulumi.patch
+++ b/patches/0018-Change-default-descriptions-to-Managed-by-Pulumi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 28 Feb 2023 15:19:24 +0000
-Subject: [PATCH 18/53] Change default descriptions to "Managed by Pulumi"
+Subject: [PATCH] Change default descriptions to "Managed by Pulumi"
 
 
 diff --git a/internal/service/apigateway/api_key.go b/internal/service/apigateway/api_key.go

--- a/patches/0019-remove-required-elements-from-schema-and-fix-tests-7.patch
+++ b/patches/0019-remove-required-elements-from-schema-and-fix-tests-7.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel.dbphoto@gmail.com>
 Date: Tue, 28 Mar 2023 19:54:00 +0100
-Subject: [PATCH 19/53] remove required elements from schema and fix tests
- (#77)
+Subject: [PATCH] remove required elements from schema and fix tests (#77)
 
 Co-authored-by: Lee Briggs <lee@leebriggs.co.uk>
 

--- a/patches/0020-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
+++ b/patches/0020-Temp-remove-cognito_identity_pool_roles_attachment-e.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 24 Apr 2023 10:36:36 -0400
-Subject: [PATCH 20/53] Temp remove cognito_identity_pool_roles_attachment
- example beacuse of flaky translation
+Subject: [PATCH] Temp remove cognito_identity_pool_roles_attachment example
+ beacuse of flaky translation
 
 
 diff --git a/website/docs/r/cognito_identity_pool_roles_attachment.html.markdown b/website/docs/r/cognito_identity_pool_roles_attachment.html.markdown

--- a/patches/0021-Fix-elbv2-target-group-read-to-workaround-2517.patch
+++ b/patches/0021-Fix-elbv2-target-group-read-to-workaround-2517.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 17:36:47 -0500
-Subject: [PATCH 21/53] Fix elbv2 target group read to workaround #2517
+Subject: [PATCH] Fix elbv2 target group read to workaround #2517
 
 
 diff --git a/internal/service/elbv2/target_group.go b/internal/service/elbv2/target_group.go

--- a/patches/0022-Fix-spurrious-json-diff-for-redrive_policy.patch
+++ b/patches/0022-Fix-spurrious-json-diff-for-redrive_policy.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ramon Quitales <ramon@pulumi.com>
 Date: Thu, 18 May 2023 15:21:33 -0700
-Subject: [PATCH 22/53] Fix spurrious json diff for redrive_policy
+Subject: [PATCH] Fix spurrious json diff for redrive_policy
 
 We need to normalize the json input to compare agasint the one stored
 in state.

--- a/patches/0023-Provide-context-to-conns.patch
+++ b/patches/0023-Provide-context-to-conns.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Mon, 10 Jul 2023 11:51:24 +0200
-Subject: [PATCH 23/53] Provide context to conns
+Subject: [PATCH] Provide context to conns
 
 
 diff --git a/internal/service/ecr/credentials_data_source.go b/internal/service/ecr/credentials_data_source.go

--- a/patches/0024-Match-the-tags-behavior-of-other-resources.patch
+++ b/patches/0024-Match-the-tags-behavior-of-other-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
 Date: Wed, 2 Aug 2023 14:12:03 +0200
-Subject: [PATCH 24/53] Match the "tags" behavior of other resources
+Subject: [PATCH] Match the "tags" behavior of other resources
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0025-move-shim-logic-to-upstream-as-a-patch.patch
+++ b/patches/0025-move-shim-logic-to-upstream-as-a-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 6 Sep 2023 10:43:30 -0700
-Subject: [PATCH 25/53] move shim logic to upstream as a patch
+Subject: [PATCH] move shim logic to upstream as a patch
 
 
 diff --git a/shim/shim.go b/shim/shim.go

--- a/patches/0026-Restore-S3ConnURICleaningDisabled.patch
+++ b/patches/0026-Restore-S3ConnURICleaningDisabled.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Tue, 9 Apr 2024 15:24:26 -0400
-Subject: [PATCH 26/53] Restore S3ConnURICleaningDisabled
+Subject: [PATCH] Restore S3ConnURICleaningDisabled
 
 
 diff --git a/internal/conns/awsclient.go b/internal/conns/awsclient.go

--- a/patches/0027-Do-not-compute-tags_all-at-TF-level.patch
+++ b/patches/0027-Do-not-compute-tags_all-at-TF-level.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 6 Nov 2023 11:17:16 -0500
-Subject: [PATCH 27/53] Do not compute tags_all at TF level
+Subject: [PATCH] Do not compute tags_all at TF level
 
 
 diff --git a/internal/framework/base.go b/internal/framework/base.go

--- a/patches/0028-aws_eks_cluster-implement-default_addons_to_remove.patch
+++ b/patches/0028-aws_eks_cluster-implement-default_addons_to_remove.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 15 Nov 2023 11:53:09 -0500
-Subject: [PATCH 28/53] aws_eks_cluster: implement default_addons_to_remove
+Subject: [PATCH] aws_eks_cluster: implement default_addons_to_remove
 
 
 diff --git a/internal/service/eks/cluster.go b/internal/service/eks/cluster.go

--- a/patches/0029-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
+++ b/patches/0029-Fix-markTagsAllNotComputedForResources-to-recognize-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 29 Nov 2023 17:23:09 -0500
-Subject: [PATCH 29/53] Fix markTagsAllNotComputedForResources to recognize
+Subject: [PATCH] Fix markTagsAllNotComputedForResources to recognize
  SchemaFunc
 
 

--- a/patches/0030-Optimize-startup-performance.patch
+++ b/patches/0030-Optimize-startup-performance.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 30 Nov 2023 14:28:37 -0500
-Subject: [PATCH 30/53] Optimize startup performance
+Subject: [PATCH] Optimize startup performance
 
 
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go

--- a/patches/0031-Fix-job-queue-sdkv2-migration.patch
+++ b/patches/0031-Fix-job-queue-sdkv2-migration.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:41:21 -0500
-Subject: [PATCH 31/53] Fix job queue sdkv2 migration
+Subject: [PATCH] Fix job queue sdkv2 migration
 
 
 diff --git a/internal/service/batch/job_queue_schema.go b/internal/service/batch/job_queue_schema.go

--- a/patches/0032-DisableTagSchemaCheck-for-PF-provider.patch
+++ b/patches/0032-DisableTagSchemaCheck-for-PF-provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 6 Dec 2023 23:44:25 -0500
-Subject: [PATCH 32/53] DisableTagSchemaCheck for PF provider
+Subject: [PATCH] DisableTagSchemaCheck for PF provider
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0033-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
+++ b/patches/0033-Run-scripts-patch_computed_only.sh-to-patch-eks-pod_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:05:40 -0500
-Subject: [PATCH 33/53] Run scripts/patch_computed_only.sh to patch
+Subject: [PATCH] Run scripts/patch_computed_only.sh to patch
  eks/pod_identity_association and more
 
 

--- a/patches/0034-Fail-fast-when-PF-resources-are-dropped.patch
+++ b/patches/0034-Fail-fast-when-PF-resources-are-dropped.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Thu, 7 Dec 2023 00:18:14 -0500
-Subject: [PATCH 34/53] Fail fast when PF resources are dropped
+Subject: [PATCH] Fail fast when PF resources are dropped
 
 
 diff --git a/internal/provider/fwprovider/provider.go b/internal/provider/fwprovider/provider.go

--- a/patches/0035-Fix-tags_all-Computed-for-PF-resources.patch
+++ b/patches/0035-Fix-tags_all-Computed-for-PF-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Wed, 7 Feb 2024 12:24:44 -0500
-Subject: [PATCH 35/53] Fix tags_all Computed for PF resources
+Subject: [PATCH] Fix tags_all Computed for PF resources
 
 
 diff --git a/internal/service/amp/scraper.go b/internal/service/amp/scraper.go

--- a/patches/0036-Disable-retry-for-KMS-access-denied-in-lambda.patch
+++ b/patches/0036-Disable-retry-for-KMS-access-denied-in-lambda.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 8 Jan 2024 16:58:44 -0500
-Subject: [PATCH 36/53] Disable retry for KMS access denied in lambda
+Subject: [PATCH] Disable retry for KMS access denied in lambda
 
 
 diff --git a/internal/service/lambda/service_package_extra.go b/internal/service/lambda/service_package_extra.go

--- a/patches/0037-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
+++ b/patches/0037-Patch-ACM-retry-to-not-retry-after-LimitExceededExce.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 19 Jan 2024 18:08:51 -0500
-Subject: [PATCH 37/53] Patch ACM retry to not retry after
- LimitExceededException (#3290)
+Subject: [PATCH] Patch ACM retry to not retry after LimitExceededException
+ (#3290)
 
 
 diff --git a/internal/service/acm/service_package_gen.go b/internal/service/acm/service_package_gen.go

--- a/patches/0038-Restore-legacy-bucket.patch
+++ b/patches/0038-Restore-legacy-bucket.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Tue, 9 Apr 2024 15:27:59 -0400
-Subject: [PATCH 38/53] Restore legacy bucket
+Subject: [PATCH] Restore legacy bucket
 
 
 diff --git a/go.mod b/go.mod

--- a/patches/0039-Patch-osis_pipeline-tags-flags.patch
+++ b/patches/0039-Patch-osis_pipeline-tags-flags.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 9 Feb 2024 14:39:32 -0500
-Subject: [PATCH 39/53] Patch osis_pipeline tags flags
+Subject: [PATCH] Patch osis_pipeline tags flags
 
 
 diff --git a/internal/service/osis/pipeline.go b/internal/service/osis/pipeline.go

--- a/patches/0040-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
+++ b/patches/0040-Revert-Merge-pull-request-35678-from-hashicorp-b-elb.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 14 Feb 2024 14:49:33 +0000
-Subject: [PATCH 40/53] Revert "Merge pull request #35678 from
+Subject: [PATCH] Revert "Merge pull request #35678 from
  hashicorp/b-elbv2-unexpected-diff"
 
 This reverts commit bfcae6ad3e8a226083f803b40e772e045ec78baa, reversing

--- a/patches/0041-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
+++ b/patches/0041-Revert-Merge-pull-request-35671-from-hashicorp-b-lb-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 14 Feb 2024 14:49:38 +0000
-Subject: [PATCH 41/53] Revert "Merge pull request #35671 from
+Subject: [PATCH] Revert "Merge pull request #35671 from
  hashicorp/b-lb-listener-stickiness-3"
 
 This reverts commit 32a681fcfcd8d78c5ac9e199384a980bb71c82ed, reversing

--- a/patches/0042-Allow-creating-lambdas-without-code-related-properti.patch
+++ b/patches/0042-Allow-creating-lambdas-without-code-related-properti.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Tue, 13 Feb 2024 11:36:02 +0000
-Subject: [PATCH 42/53] Allow creating lambdas without code related properties
+Subject: [PATCH] Allow creating lambdas without code related properties
 
 
 diff --git a/internal/service/lambda/function.go b/internal/service/lambda/function.go

--- a/patches/0043-Do-not-Compute-tags_all-of-aws_bedrock_provisioned_m.patch
+++ b/patches/0043-Do-not-Compute-tags_all-of-aws_bedrock_provisioned_m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: guineveresaenger <guinevere@pulumi.com>
 Date: Wed, 21 Feb 2024 14:46:27 -0800
-Subject: [PATCH 43/53] Do not Compute tags_all of
+Subject: [PATCH] Do not Compute tags_all of
  aws_bedrock_provisioned_model_throughput
 
 

--- a/patches/0044-fix-legacy-bucket-context.patch
+++ b/patches/0044-fix-legacy-bucket-context.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Venelin <venelin@pulumi.com>
 Date: Wed, 28 Feb 2024 16:06:02 +0000
-Subject: [PATCH 44/53] fix legacy bucket context
+Subject: [PATCH] fix legacy bucket context
 
 
 diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go

--- a/patches/0045-securitylake_subscriber-tags_all-patch.patch
+++ b/patches/0045-securitylake_subscriber-tags_all-patch.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Tue, 12 Mar 2024 18:05:28 -0400
-Subject: [PATCH 45/53] securitylake_subscriber tags_all patch
+Subject: [PATCH] securitylake_subscriber tags_all patch
 
 
 diff --git a/internal/service/securitylake/subscriber.go b/internal/service/securitylake/subscriber.go

--- a/patches/0046-Revert-rds-engine_version-Fix-bugs-with-default-only.patch
+++ b/patches/0046-Revert-rds-engine_version-Fix-bugs-with-default-only.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Fri, 29 Mar 2024 10:29:15 -0400
-Subject: [PATCH 46/53] Revert "rds/engine_version: Fix bugs with default only
- flag"
+Subject: [PATCH] Revert "rds/engine_version: Fix bugs with default only flag"
 
 
 diff --git a/internal/service/rds/engine_version_data_source.go b/internal/service/rds/engine_version_data_source.go

--- a/patches/0047-Patch-tags-ComputedOnly-for-m2-resources.patch
+++ b/patches/0047-Patch-tags-ComputedOnly-for-m2-resources.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Mon, 1 Apr 2024 17:25:06 -0400
-Subject: [PATCH 47/53] Patch tags ComputedOnly for m2 resources
+Subject: [PATCH] Patch tags ComputedOnly for m2 resources
 
 
 diff --git a/internal/service/m2/application.go b/internal/service/m2/application.go

--- a/patches/0048-restore-ECRConn.patch
+++ b/patches/0048-restore-ECRConn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Wed, 10 Apr 2024 08:49:35 -0400
-Subject: [PATCH 48/53] restore ECRConn
+Subject: [PATCH] restore ECRConn
 
 
 diff --git a/internal/conns/awsclient_gen.go b/internal/conns/awsclient_gen.go

--- a/patches/0049-update-testing-types.patch
+++ b/patches/0049-update-testing-types.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Wed, 10 Apr 2024 08:50:03 -0400
-Subject: [PATCH 49/53] update testing types
+Subject: [PATCH] update testing types
 
 
 diff --git a/internal/service/ecr/credentials_data_source_test.go b/internal/service/ecr/credentials_data_source_test.go

--- a/patches/0050-restore-ecr-NewConn.patch
+++ b/patches/0050-restore-ecr-NewConn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Wed, 10 Apr 2024 13:43:56 -0400
-Subject: [PATCH 50/53] restore ecr NewConn
+Subject: [PATCH] restore ecr NewConn
 
 
 diff --git a/internal/service/ecr/service_package_gen.go b/internal/service/ecr/service_package_gen.go

--- a/patches/0051-update-apn-info.patch
+++ b/patches/0051-update-apn-info.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Thu, 11 Apr 2024 08:06:27 -0400
-Subject: [PATCH 51/53] update apn info
+Subject: [PATCH] update apn info
 
 
 diff --git a/internal/conns/config.go b/internal/conns/config.go

--- a/patches/0052-non-idempotent-sns-topic-creation.patch
+++ b/patches/0052-non-idempotent-sns-topic-creation.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: corymhall <43035978+corymhall@users.noreply.github.com>
 Date: Thu, 11 Apr 2024 14:42:01 -0400
-Subject: [PATCH 52/53] non-idempotent sns topic creation
+Subject: [PATCH] non-idempotent sns topic creation
 
 
 diff --git a/internal/service/sns/topic.go b/internal/service/sns/topic.go

--- a/patches/0053-Normalize-retentionDays-in-aws_controltower_landing_.patch
+++ b/patches/0053-Normalize-retentionDays-in-aws_controltower_landing_.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 12 Apr 2024 16:34:51 -0400
-Subject: [PATCH 53/53] Normalize retentionDays in
- aws_controltower_landing_zone manifest_json
+Subject: [PATCH] Normalize retentionDays in aws_controltower_landing_zone
+ manifest_json
 
 Prior to this change interacting with aws_controltower_landing_zone could cause spurious diffs where retentionDays
 sub-property would cycle between a string form like "365" and an integer form like 365.

--- a/patches/0054-Revert-r-aws_db_proxy-Change-auth-from-TypeList-to-T.patch
+++ b/patches/0054-Revert-r-aws_db_proxy-Change-auth-from-TypeList-to-T.patch
@@ -1,0 +1,526 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Tayanovskyy <anton@pulumi.com>
+Date: Wed, 17 Apr 2024 16:34:32 -0400
+Subject: [PATCH] Revert "r/aws_db_proxy: Change `auth` from `TypeList` to
+ `TypeSet` as order is not significant."
+
+This reverts commit 2db643f461c058fb7a9e9940afef240016412050.
+
+diff --git a/internal/service/rds/proxy.go b/internal/service/rds/proxy.go
+index 4c8527952c..fdba3cb5c9 100644
+--- a/internal/service/rds/proxy.go
++++ b/internal/service/rds/proxy.go
+@@ -52,7 +52,7 @@ func resourceProxy() *schema.Resource {
+ 				Computed: true,
+ 			},
+ 			"auth": {
+-				Type:     schema.TypeSet,
++				Type:     schema.TypeList,
+ 				Required: true,
+ 				Elem: &schema.Resource{
+ 					Schema: map[string]*schema.Schema{
+@@ -148,7 +148,7 @@ func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta inter
+ 
+ 	name := d.Get("name").(string)
+ 	input := &rds.CreateDBProxyInput{
+-		Auth:         expandUserAuthConfigs(d.Get("auth").(*schema.Set).List()),
++		Auth:         expandUserAuthConfigs(d.Get("auth").([]interface{})),
+ 		DBProxyName:  aws.String(name),
+ 		EngineFamily: types.EngineFamily(d.Get("engine_family").(string)),
+ 		RoleArn:      aws.String(d.Get("role_arn").(string)),
+@@ -225,7 +225,7 @@ func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
+ 	if d.HasChangesExcept("tags", "tags_all") {
+ 		oName, nName := d.GetChange("name")
+ 		input := &rds.ModifyDBProxyInput{
+-			Auth:           expandUserAuthConfigs(d.Get("auth").(*schema.Set).List()),
++			Auth:           expandUserAuthConfigs(d.Get("auth").([]interface{})),
+ 			DBProxyName:    aws.String(oName.(string)),
+ 			DebugLogging:   aws.Bool(d.Get("debug_logging").(bool)),
+ 			NewDBProxyName: aws.String(nName.(string)),
+diff --git a/internal/service/rds/proxy_test.go b/internal/service/rds/proxy_test.go
+index 6fbd15502d..bc3d3fadbd 100644
+--- a/internal/service/rds/proxy_test.go
++++ b/internal/service/rds/proxy_test.go
+@@ -40,28 +40,24 @@ func TestAccRDSProxy_basic(t *testing.T) {
+ 		Steps: []resource.TestStep{
+ 			{
+ 				Config: testAccProxyConfig_basic(rName),
+-				Check: resource.ComposeAggregateTestCheckFunc(
++				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &v),
+ 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+ 					resource.TestCheckResourceAttr(resourceName, "engine_family", "MYSQL"),
+ 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexache.MustCompile(`db-proxy:.+`)),
+ 					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+-						"auth_scheme":               "SECRETS",
+-						"client_password_auth_type": "MYSQL_NATIVE_PASSWORD",
+-						"description":               "test",
+-						"iam_auth":                  "DISABLED",
+-					}),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.auth_scheme", "SECRETS"),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.description", "test"),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.iam_auth", "DISABLED"),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.client_password_auth_type", "MYSQL_NATIVE_PASSWORD"),
+ 					resource.TestCheckResourceAttr(resourceName, "debug_logging", "false"),
+-					resource.TestMatchResourceAttr(resourceName, "endpoint", regexache.MustCompile(`^[\w\-\.]+\.rds\.amazonaws\.com$`)),
+ 					resource.TestCheckResourceAttr(resourceName, "idle_client_timeout", "1800"),
+-					resource.TestCheckResourceAttr(resourceName, "require_tls", "true"),
+ 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
+-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
++					resource.TestCheckResourceAttr(resourceName, "require_tls", "true"),
+ 					resource.TestCheckResourceAttr(resourceName, "vpc_subnet_ids.#", "2"),
+ 					resource.TestCheckTypeSetElemAttrPair(resourceName, "vpc_subnet_ids.*", "aws_subnet.test.0", "id"),
+ 					resource.TestCheckTypeSetElemAttrPair(resourceName, "vpc_subnet_ids.*", "aws_subnet.test.1", "id"),
+-				),
++					resource.TestMatchResourceAttr(resourceName, "endpoint", regexache.MustCompile(`^[\w\-\.]+\.rds\.amazonaws\.com$`))),
+ 			},
+ 			{
+ 				ResourceName:      resourceName,
+@@ -332,10 +328,7 @@ func TestAccRDSProxy_authDescription(t *testing.T) {
+ 				Config: testAccProxyConfig_name(rName, rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+-						"description": "test",
+-					}),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.description", "test"),
+ 				),
+ 			},
+ 			{
+@@ -347,10 +340,7 @@ func TestAccRDSProxy_authDescription(t *testing.T) {
+ 				Config: testAccProxyConfig_authDescription(rName, description),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+-						"description": description,
+-					}),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.description", description),
+ 				),
+ 			},
+ 		},
+@@ -378,10 +368,7 @@ func TestAccRDSProxy_authIAMAuth(t *testing.T) {
+ 				Config: testAccProxyConfig_name(rName, rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+-						"iam_auth": "DISABLED",
+-					}),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.iam_auth", "DISABLED"),
+ 				),
+ 			},
+ 			{
+@@ -393,10 +380,7 @@ func TestAccRDSProxy_authIAMAuth(t *testing.T) {
+ 				Config: testAccProxyConfig_authIAMAuth(rName, iamAuth),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+-						"iam_auth": iamAuth,
+-					}),
++					resource.TestCheckResourceAttr(resourceName, "auth.0.iam_auth", iamAuth),
+ 				),
+ 			},
+ 		},
+@@ -424,8 +408,7 @@ func TestAccRDSProxy_authSecretARN(t *testing.T) {
+ 				Config: testAccProxyConfig_name(rName, rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+-					resource.TestCheckTypeSetElemAttrPair(resourceName, "auth.*.secret_arn", "aws_secretsmanager_secret.test", "arn"),
++					resource.TestCheckResourceAttrPair(resourceName, "auth.0.secret_arn", "aws_secretsmanager_secret.test", "arn"),
+ 				),
+ 			},
+ 			{
+@@ -437,9 +420,7 @@ func TestAccRDSProxy_authSecretARN(t *testing.T) {
+ 				Config: testAccProxyConfig_authSecretARN(rName, nName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "auth.#", "2"),
+-					resource.TestCheckTypeSetElemAttrPair(resourceName, "auth.*.secret_arn", "aws_secretsmanager_secret.test", "arn"),
+-					resource.TestCheckTypeSetElemAttrPair(resourceName, "auth.*.secret_arn", "aws_secretsmanager_secret.test2", "arn"),
++					resource.TestCheckResourceAttrPair(resourceName, "auth.0.secret_arn", "aws_secretsmanager_secret.test2", "arn"),
+ 				),
+ 			},
+ 		},
+@@ -455,6 +436,8 @@ func TestAccRDSProxy_tags(t *testing.T) {
+ 	var dbProxy types.DBProxy
+ 	resourceName := "aws_db_proxy.test"
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
++	key := "foo"
++	value := "bar"
+ 
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccDBProxyPreCheck(ctx, t) },
+@@ -463,11 +446,10 @@ func TestAccRDSProxy_tags(t *testing.T) {
+ 		CheckDestroy:             testAccCheckProxyDestroy(ctx),
+ 		Steps: []resource.TestStep{
+ 			{
+-				Config: testAccProxyConfig_tags1(rName, "key1", "value1"),
++				Config: testAccProxyConfig_name(rName, rName),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
++					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+ 				),
+ 			},
+ 			{
+@@ -476,20 +458,10 @@ func TestAccRDSProxy_tags(t *testing.T) {
+ 				ImportStateVerify: true,
+ 			},
+ 			{
+-				Config: testAccProxyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+-				Check: resource.ComposeTestCheckFunc(
+-					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+-				),
+-			},
+-			{
+-				Config: testAccProxyConfig_tags1(rName, "key2", "value2"),
++				Config: testAccProxyConfig_tags(rName, key, value),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckProxyExists(ctx, resourceName, &dbProxy),
+-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
++					resource.TestCheckResourceAttr(resourceName, "tags.foo", value),
+ 				),
+ 			},
+ 		},
+@@ -585,7 +557,7 @@ func testAccCheckProxyExists(ctx context.Context, n string, v *types.DBProxy) re
+ 	}
+ }
+ 
+-func testAccProxyConfig_base(rName string) string {
++func testAccProxyBaseConfig(rName string) string {
+ 	return fmt.Sprintf(`
+ # Secrets Manager setup
+ 
+@@ -675,14 +647,14 @@ resource "aws_subnet" "test" {
+ }
+ 
+ func testAccProxyConfig_basic(rName string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[1]s"
+   debug_logging          = false
+   engine_family          = "MYSQL"
+   idle_client_timeout    = 1800
+@@ -697,19 +669,23 @@ resource "aws_db_proxy" "test" {
+     iam_auth    = "DISABLED"
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
++
++  tags = {
++    Name = "%[1]s"
++  }
+ }
+-`, rName))
++`, rName)
+ }
+ 
+ func testAccProxyConfig_name(rName, nName string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[2]s"
+   engine_family          = "MYSQL"
+   role_arn               = aws_iam_role.test.arn
+   vpc_security_group_ids = [aws_security_group.test.id]
+@@ -722,18 +698,18 @@ resource "aws_db_proxy" "test" {
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
+ }
+-`, nName))
++`, rName, nName)
+ }
+ 
+ func testAccProxyConfig_debugLogging(rName string, debugLogging bool) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name           = %[1]q
++  name           = "%[1]s"
+   debug_logging  = %[2]t
+   engine_family  = "MYSQL"
+   role_arn       = aws_iam_role.test.arn
+@@ -746,18 +722,18 @@ resource "aws_db_proxy" "test" {
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
+ }
+-`, rName, debugLogging))
++`, rName, debugLogging)
+ }
+ 
+ func testAccProxyConfig_idleClientTimeout(rName string, idleClientTimeout int) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                = %[1]q
++  name                = "%[1]s"
+   idle_client_timeout = %[2]d
+   engine_family       = "MYSQL"
+   role_arn            = aws_iam_role.test.arn
+@@ -770,18 +746,18 @@ resource "aws_db_proxy" "test" {
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
+ }
+-`, rName, idleClientTimeout))
++`, rName, idleClientTimeout)
+ }
+ 
+ func testAccProxyConfig_requireTLS(rName string, requireTls bool) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name           = %[1]q
++  name           = "%[1]s"
+   require_tls    = %[2]t
+   engine_family  = "MYSQL"
+   role_arn       = aws_iam_role.test.arn
+@@ -794,18 +770,18 @@ resource "aws_db_proxy" "test" {
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
+ }
+-`, rName, requireTls))
++`, rName, requireTls)
+ }
+ 
+ func testAccProxyConfig_roleARN(rName, nName string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test2
+   ]
+ 
+-  name           = %[1]q
++  name           = "%[1]s"
+   engine_family  = "MYSQL"
+   role_arn       = aws_iam_role.test2.arn
+   vpc_subnet_ids = aws_subnet.test[*].id
+@@ -818,8 +794,10 @@ resource "aws_db_proxy" "test" {
+   }
+ }
+ 
++# IAM setup
++
+ resource "aws_iam_role" "test2" {
+-  name               = %[2]q
++  name               = "%[2]s"
+   assume_role_policy = data.aws_iam_policy_document.assume.json
+ }
+ 
+@@ -827,18 +805,18 @@ resource "aws_iam_role_policy" "test2" {
+   role   = aws_iam_role.test.id
+   policy = data.aws_iam_policy_document.test.json
+ }
+-`, rName, nName))
++`, rName, nName)
+ }
+ 
+ func testAccProxyConfig_vpcSecurityGroupIDs(rName, nName string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[1]s"
+   engine_family          = "MYSQL"
+   role_arn               = aws_iam_role.test.arn
+   vpc_security_group_ids = [aws_security_group.test2.id]
+@@ -853,25 +831,21 @@ resource "aws_db_proxy" "test" {
+ }
+ 
+ resource "aws_security_group" "test2" {
+-  name   = %[2]q
++  name   = "%[2]s"
+   vpc_id = aws_vpc.test.id
+-
+-  tags = {
+-    Name = %[2]q
+-  }
+ }
+-`, rName, nName))
++`, rName, nName)
+ }
+ 
+ func testAccProxyConfig_authDescription(rName, description string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[1]s"
+   engine_family          = "MYSQL"
+   role_arn               = aws_iam_role.test.arn
+   vpc_security_group_ids = [aws_security_group.test.id]
+@@ -879,23 +853,23 @@ resource "aws_db_proxy" "test" {
+ 
+   auth {
+     auth_scheme = "SECRETS"
+-    description = %[2]q
++    description = "%[2]s"
+     iam_auth    = "DISABLED"
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
+ }
+-`, rName, description))
++`, rName, description)
+ }
+ 
+ func testAccProxyConfig_authIAMAuth(rName, iamAuth string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[1]s"
+   engine_family          = "MYSQL"
+   role_arn               = aws_iam_role.test.arn
+   require_tls            = true
+@@ -905,22 +879,22 @@ resource "aws_db_proxy" "test" {
+   auth {
+     auth_scheme = "SECRETS"
+     description = "test"
+-    iam_auth    = %[2]q
++    iam_auth    = "%[2]s"
+     secret_arn  = aws_secretsmanager_secret.test.arn
+   }
+ }
+-`, rName, iamAuth))
++`, rName, iamAuth)
+ }
+ 
+ func testAccProxyConfig_authSecretARN(rName, nName string) string {
+-	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[1]s"
+   engine_family          = "MYSQL"
+   role_arn               = aws_iam_role.test.arn
+   vpc_security_group_ids = [aws_security_group.test.id]
+@@ -944,7 +918,7 @@ resource "aws_db_proxy" "test" {
+ }
+ 
+ resource "aws_secretsmanager_secret" "test2" {
+-  name                    = %[2]q
++  name                    = "%[2]s"
+   recovery_window_in_days = 0
+ }
+ 
+@@ -952,46 +926,18 @@ resource "aws_secretsmanager_secret_version" "test2" {
+   secret_id     = aws_secretsmanager_secret.test2.id
+   secret_string = "{\"username\":\"db_user\",\"password\":\"db_user_password\"}"
+ }
+-`, rName, nName))
+-}
+-
+-func testAccProxyConfig_tags1(rName, tagKey1, tagValue1 string) string {
+-	return testAccProxyConfig_base(rName) + fmt.Sprintf(`
+-resource "aws_db_proxy" "test" {
+-  depends_on = [
+-    aws_secretsmanager_secret_version.test,
+-    aws_iam_role_policy.test
+-  ]
+-
+-  name                   = %[1]q
+-  engine_family          = "MYSQL"
+-  role_arn               = aws_iam_role.test.arn
+-  vpc_security_group_ids = [aws_security_group.test.id]
+-  vpc_subnet_ids         = aws_subnet.test[*].id
+-
+-  auth {
+-    auth_scheme = "SECRETS"
+-    description = "test"
+-    iam_auth    = "DISABLED"
+-    secret_arn  = aws_secretsmanager_secret.test.arn
+-  }
+-
+-  tags = {
+-    %[2]q = %[3]q
+-  }
+-}
+-`, rName, tagKey1, tagValue1)
++`, rName, nName)
+ }
+ 
+-func testAccProxyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+-	return testAccProxyConfig_base(rName) + fmt.Sprintf(`
++func testAccProxyConfig_tags(rName, key, value string) string {
++	return testAccProxyBaseConfig(rName) + fmt.Sprintf(`
+ resource "aws_db_proxy" "test" {
+   depends_on = [
+     aws_secretsmanager_secret_version.test,
+     aws_iam_role_policy.test
+   ]
+ 
+-  name                   = %[1]q
++  name                   = "%[1]s"
+   engine_family          = "MYSQL"
+   role_arn               = aws_iam_role.test.arn
+   vpc_security_group_ids = [aws_security_group.test.id]
+@@ -1005,9 +951,8 @@ resource "aws_db_proxy" "test" {
+   }
+ 
+   tags = {
+-    %[2]q = %[3]q
+-    %[4]q = %[5]q
++    %[2]s = "%[3]s"
+   }
+ }
+-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
++`, rName, key, value)
+ }

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -75,6 +75,6 @@ func TestRegress3835(t *testing.T) {
 		opttest.YarnLink("@pulumi/aws"),
 	}
 	test := pulumitest.NewPulumiTest(t, dir, options...)
-	upResult := test.Up()
-	t.Logf("#%v", upResult.Summary)
+	result := test.Preview()
+	t.Logf("#%v", result.ChangeSummary)
 }

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -63,3 +63,18 @@ func TestRegress3094(t *testing.T) {
 	upResult := test.Up()
 	t.Logf("#%v", upResult.Summary)
 }
+
+func TestRegress3835(t *testing.T) {
+	skipIfShort(t)
+	dir := filepath.Join("test-programs", "regress-3835")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	providerName := "aws"
+	options := []opttest.Option{
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+		opttest.YarnLink("@pulumi/aws"),
+	}
+	test := pulumitest.NewPulumiTest(t, dir, options...)
+	upResult := test.Up()
+	t.Logf("#%v", upResult.Summary)
+}

--- a/provider/test-programs/regress-3835/.gitignore
+++ b/provider/test-programs/regress-3835/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/provider/test-programs/regress-3835/Pulumi.yaml
+++ b/provider/test-programs/regress-3835/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: regress-3835
+runtime: nodejs
+description: Reproduce AWS 3835

--- a/provider/test-programs/regress-3835/index.ts
+++ b/provider/test-programs/regress-3835/index.ts
@@ -18,13 +18,13 @@ const vpc = new aws.ec2.Vpc("vpc", {
 const subnet = new aws.ec2.Subnet("subnet", {
   vpcId: vpc.id,
   cidrBlock: "10.0.1.0/24",
-  availabilityZone: "us-east-2a",
+  availabilityZone: "us-west-2a",
 });
 
 const anotherSubnet = new aws.ec2.Subnet("another-subnet", {
   vpcId: vpc.id,
   cidrBlock: "10.0.2.0/24",
-  availabilityZone: "us-east-2b",
+  availabilityZone: "us-west-2b",
 });
 
 const example = new aws.rds.Proxy("example", {

--- a/provider/test-programs/regress-3835/index.ts
+++ b/provider/test-programs/regress-3835/index.ts
@@ -1,0 +1,45 @@
+import * as aws from "@pulumi/aws";
+
+const proxyRole = new aws.iam.Role(
+  "role",
+  {
+    assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal(
+      aws.iam.Principals.RdsPrincipal,
+    ),
+    managedPolicyArns: [],
+  },
+  {},
+);
+
+const vpc = new aws.ec2.Vpc("vpc", {
+  cidrBlock: "10.0.0.0/16",
+});
+
+const subnet = new aws.ec2.Subnet("subnet", {
+  vpcId: vpc.id,
+  cidrBlock: "10.0.1.0/24",
+  availabilityZone: "us-east-2a",
+});
+
+const anotherSubnet = new aws.ec2.Subnet("another-subnet", {
+  vpcId: vpc.id,
+  cidrBlock: "10.0.2.0/24",
+  availabilityZone: "us-east-2b",
+});
+
+const example = new aws.rds.Proxy("example", {
+  name: "example",
+  debugLogging: false,
+  engineFamily: "MYSQL",
+  idleClientTimeout: 1800,
+  requireTls: true,
+  roleArn: proxyRole.arn,
+  vpcSubnetIds: [subnet.id, anotherSubnet.id],
+  auths: [{}],
+  tags: {
+    Name: "example",
+    Key: "value",
+  },
+});
+
+export const exmapleID = example.id;

--- a/provider/test-programs/regress-3835/index.ts
+++ b/provider/test-programs/regress-3835/index.ts
@@ -27,6 +27,8 @@ const anotherSubnet = new aws.ec2.Subnet("another-subnet", {
   availabilityZone: "us-west-2b",
 });
 
+const secret = new aws.secretsmanager.Secret("secret", {});
+
 const example = new aws.rds.Proxy("example", {
   name: "example",
   debugLogging: false,
@@ -35,7 +37,11 @@ const example = new aws.rds.Proxy("example", {
   requireTls: true,
   roleArn: proxyRole.arn,
   vpcSubnetIds: [subnet.id, anotherSubnet.id],
-  auths: [{}],
+  auths: secret.arn.apply(sec => [{
+    iamAuth: "DISABLED",
+    authScheme: "SECRETS",
+    secretArn: sec[0],
+  }]),
   tags: {
     Name: "example",
     Key: "value",

--- a/provider/test-programs/regress-3835/package.json
+++ b/provider/test-programs/regress-3835/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "regress-3835",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2"
+    }
+}

--- a/provider/test-programs/regress-3835/tsconfig.json
+++ b/provider/test-programs/regress-3835/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Fixes #3835 by reverting the upstream change until the upstream issue is root-caused and resolved. Passing an empty object to auths field of `aws.rds.Proxy` should no longer panic. 