### PR TITLE
Add CODEBUILD_CONFIG_AUTO_DISCOVER environment variable of CodeBuild example

### DIFF
--- a/examples/codebuild-project-py/__main__.py
+++ b/examples/codebuild-project-py/__main__.py
@@ -71,6 +71,11 @@ prebuild_project = codebuild.Project(
         "imagePullCredentialsType": "CODEBUILD",
         "type": "LINUX_CONTAINER",
         "privilegedMode": True,  # Required to use docker
+        "environmentVariables": [{
+            "name": "CODEBUILD_CONFIG_AUTO_DISCOVER",
+            "value": "true",
+            "type": "PLAINTEXT"
+        }]
     },
     service_role=cicd_role.arn,
     source={


### PR DESCRIPTION
AWS started setting an environment variable by default to auto discover reports (CODEBUILD_CONFIG_AUTO_DISCOVER) when creating CodeBuild projects.
This led to `pulumi preview` showing a diff after the initial deployment.

This change will fix the test, but the in behavior  from AWS will lead to users ending up with a drift when creating CodeBuild projects until they re-run `pulumi up` once.


This fixes https://github.com/pulumi/pulumi-aws/issues/3839
