### PR TITLE
Fix 0054 patch to pass schema checks

### DIFF
--- a/patches/0054-Revert-r-aws_db_proxy-Change-auth-from-TypeList-to-T.patch
+++ b/patches/0054-Revert-r-aws_db_proxy-Change-auth-from-TypeList-to-T.patch
@@ -7,10 +7,18 @@ Subject: [PATCH] Revert "r/aws_db_proxy: Change `auth` from `TypeList` to
 This reverts commit 2db643f461c058fb7a9e9940afef240016412050.
 
 diff --git a/internal/service/rds/proxy.go b/internal/service/rds/proxy.go
-index 4c8527952c..fdba3cb5c9 100644
+index 4c8527952c..4371869bf1 100644
 --- a/internal/service/rds/proxy.go
 +++ b/internal/service/rds/proxy.go
-@@ -52,7 +52,7 @@ func resourceProxy() *schema.Resource {
+@@ -19,7 +19,6 @@ import (
+ 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+-	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
+ 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+ 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+@@ -52,7 +51,7 @@ func resourceProxy() *schema.Resource {
  				Computed: true,
  			},
  			"auth": {
@@ -19,7 +27,15 @@ index 4c8527952c..fdba3cb5c9 100644
  				Required: true,
  				Elem: &schema.Resource{
  					Schema: map[string]*schema.Schema{
-@@ -148,7 +148,7 @@ func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta inter
+@@ -87,7 +86,6 @@ func resourceProxy() *schema.Resource {
+ 						},
+ 					},
+ 				},
+-				Set: sdkv2.SimpleSchemaSetFunc("auth_scheme", "description", "iam_auth", "secret_arn", "username"),
+ 			},
+ 			"debug_logging": {
+ 				Type:     schema.TypeBool,
+@@ -148,7 +146,7 @@ func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta inter
  
  	name := d.Get("name").(string)
  	input := &rds.CreateDBProxyInput{
@@ -28,7 +44,7 @@ index 4c8527952c..fdba3cb5c9 100644
  		DBProxyName:  aws.String(name),
  		EngineFamily: types.EngineFamily(d.Get("engine_family").(string)),
  		RoleArn:      aws.String(d.Get("role_arn").(string)),
-@@ -225,7 +225,7 @@ func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
+@@ -225,7 +223,7 @@ func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
  	if d.HasChangesExcept("tags", "tags_all") {
  		oName, nName := d.GetChange("name")
  		input := &rds.ModifyDBProxyInput{


### PR DESCRIPTION
In 0054-Revert-r-aws_db_proxy-Change-auth-from-TypeList-to-T patch we reverted an upstream change to avoid triggering a panic in Pulumi. The change moved rds.Proxy auths parameter from a List to a Set type. Unfortunately it looks like we neglected to remove the Set cutomizer that is not a valid customizer for list-typed properties. The resulting schema no longer passes InternalValidate which the new bridge release will run at make tfgen time, thus blocking the bridge upgrade.

This should unblock the bridge update.