### PR TITLE
Patch aws_directory_service_directory Read to avoid a panic

### DIFF
--- a/patches/0055-Fix-panic-in-aws_directory_service_directory-Read.patch
+++ b/patches/0055-Fix-panic-in-aws_directory_service_directory-Read.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Tayanovskyy <anton@pulumi.com>
+Date: Tue, 23 Apr 2024 13:57:01 -0400
+Subject: [PATCH] Fix panic in aws_directory_service_directory Read
+
+Per API docs VpcSettings is not always set, so accessing it can cause a nil panic.
+
+One case where this seems to happen (but difficult to reproduce) is importing a shared directory, see:
+
+https://github.com/pulumi/pulumi-aws/issues/1152
+
+diff --git a/internal/service/ds/directory.go b/internal/service/ds/directory.go
+index 33252ddb7d..9d283612cb 100644
+--- a/internal/service/ds/directory.go
++++ b/internal/service/ds/directory.go
+@@ -295,6 +295,11 @@ func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta int
+ 	if err != nil {
+ 		return sdkdiag.AppendErrorf(diags, "reading Directory Service Directory (%s): %s", d.Id(), err)
+ 	}
++	return resourceDirectoryReadDescription(d, dir)
++}
++
++func resourceDirectoryReadDescription(d *schema.ResourceData, dir *directoryservice.DirectoryDescription) diag.Diagnostics {
++	var diags diag.Diagnostics
+ 
+ 	d.Set("access_url", dir.AccessUrl)
+ 	d.Set("alias", dir.Alias)
+@@ -315,10 +320,16 @@ func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta int
+ 	d.Set("edition", dir.Edition)
+ 	d.Set("enable_sso", dir.SsoEnabled)
+ 	d.Set("name", dir.Name)
++
+ 	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {
+ 		d.Set("security_group_id", dir.ConnectSettings.SecurityGroupId)
+-	} else {
++	} else if dir.VpcSettings != nil {
+ 		d.Set("security_group_id", dir.VpcSettings.SecurityGroupId)
++	} else {
++		// From VpcSettings docs: this member is only present if the directory is a Simple AD or Managed
++		// Microsoft AD directory; possibly the user is trying to import a shared directory, but TF still
++		// requires a Computed to be set.
++		d.Set("security_group_id", nil)
+ 	}
+ 	d.Set("short_name", dir.ShortName)
+ 	d.Set("size", dir.Size)
+diff --git a/internal/service/ds/directory_internal_test.go b/internal/service/ds/directory_internal_test.go
+new file mode 100644
+index 0000000000..3651319f90
+--- /dev/null
++++ b/internal/service/ds/directory_internal_test.go
+@@ -0,0 +1,23 @@
++// Copyright (c) HashiCorp, Inc.
++// SPDX-License-Identifier: MPL-2.0
++
++package ds
++
++import (
++	"testing"
++
++	"github.com/aws/aws-sdk-go/service/directoryservice"
++	//"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++)
++
++func TestResourceDirectoryReadDoesNotPanicOnMissingVpcSettings(t *testing.T) {
++	d := ResourceDirectory().TestResourceData()
++	dir := &directoryservice.DirectoryDescription{
++		VpcSettings: nil,
++	}
++	diags := resourceDirectoryReadDescription(d, dir)
++	if diags.HasError() {
++		t.Errorf("Unexpected errors in diags: %v", diags)
++		t.Fail()
++	}
++}

--- a/patches/0055-Fix-panic-in-aws_directory_service_directory-Read.patch
+++ b/patches/0055-Fix-panic-in-aws_directory_service_directory-Read.patch
@@ -48,7 +48,7 @@ new file mode 100644
 index 0000000000..3651319f90
 --- /dev/null
 +++ b/internal/service/ds/directory_internal_test.go
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +// Copyright (c) HashiCorp, Inc.
 +// SPDX-License-Identifier: MPL-2.0
 +
@@ -58,7 +58,6 @@ index 0000000000..3651319f90
 +	"testing"
 +
 +	"github.com/aws/aws-sdk-go/service/directoryservice"
-+	//"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 +)
 +
 +func TestResourceDirectoryReadDoesNotPanicOnMissingVpcSettings(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/1152

Since it is difficult to repro at integration level, adding a unit test instead.