### PR TITLE
Pin to bridge at c0c57794d7bbf33f84620e4532d7e097abab3248

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -358,7 +358,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.6.2 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.0 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508204503-c0c57794d7bb // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 // indirect
 	github.com/pulumi/pulumi/sdk/v3 v3.113.0 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -3165,8 +3165,8 @@ github.com/pulumi/pulumi-terraform-bridge/pf v0.34.0 h1:krNRrR9XX9sR7YEHDHjSEV5P
 github.com/pulumi/pulumi-terraform-bridge/pf v0.34.0/go.mod h1:TqZuTmBQhYQVP2dQFpbbz9UcckW27+hZSjAniEGW5go=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3 h1:bBWWeAtSPPYpKYlPZr2h0BiYgWQpHRIk0HO/MQmB+jc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3/go.mod h1:vAQ7DeddebQ7FHdRaSG6ijuS28FS9PC4j8Y9wUuue0c=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.0 h1:RT/qOakgjLFaH6p2C/SyQuIlsD7pWoHvcgys7+nGUio=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.0/go.mod h1:B8/cgXxqjfBcOx+yntCG8suxaq2h+mhe2+1LbPQ7ajI=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508204503-c0c57794d7bb h1:eW9nJ5NcViF5aL0hyev4TK4D5q1bVy1exJqr36scPSE=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508204503-c0c57794d7bb/go.mod h1:B8/cgXxqjfBcOx+yntCG8suxaq2h+mhe2+1LbPQ7ajI=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKgepHyYsMzwaTm4cvp0dcTMYw=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi/pkg/v3 v3.113.0 h1:fo63QR2nB5ksqq0fxg5uPm/zbXW7eJVRdYpAawIda7I=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220923175450-ca71523cdc36
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pulumi/providertest v0.0.11
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.34.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240508204503-c0c57794d7bb
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508204503-c0c57794d7bb
 	github.com/pulumi/pulumi/pkg/v3 v3.113.0
 	github.com/pulumi/pulumi/sdk/v3 v3.113.0
 	github.com/stretchr/testify v1.9.0

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -3177,10 +3177,10 @@ github.com/pulumi/providertest v0.0.11 h1:mg8MQ7Cq7+9XlHIkBD+aCqQO4mwAJEISngZgVd
 github.com/pulumi/providertest v0.0.11/go.mod h1:HsxjVsytcMIuNj19w1lT2W0QXY0oReXl1+h6eD2JXP8=
 github.com/pulumi/pulumi-java/pkg v0.10.0 h1:D1i5MiiNrxYr2uJ1szcj1aQwF9DYv7TTsPmajB9dKSw=
 github.com/pulumi/pulumi-java/pkg v0.10.0/go.mod h1:xu6UgYtQm+xXOo1/DZNa2CWVPytu+RMkZVTtI7w7ffY=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.34.0 h1:krNRrR9XX9sR7YEHDHjSEV5PE3AdB59vmHc4VG5MQhY=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.34.0/go.mod h1:TqZuTmBQhYQVP2dQFpbbz9UcckW27+hZSjAniEGW5go=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.0 h1:RT/qOakgjLFaH6p2C/SyQuIlsD7pWoHvcgys7+nGUio=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.0/go.mod h1:B8/cgXxqjfBcOx+yntCG8suxaq2h+mhe2+1LbPQ7ajI=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240508204503-c0c57794d7bb h1:4ElhnkKEluxYk11oG8LCOghUAwLyizBmqNtXbFTzSdg=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240508204503-c0c57794d7bb/go.mod h1:6qtbayBR59VRykMOUJjmK/M22cJ5IynD1dLwqNXeGWM=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508204503-c0c57794d7bb h1:eW9nJ5NcViF5aL0hyev4TK4D5q1bVy1exJqr36scPSE=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508204503-c0c57794d7bb/go.mod h1:B8/cgXxqjfBcOx+yntCG8suxaq2h+mhe2+1LbPQ7ajI=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKgepHyYsMzwaTm4cvp0dcTMYw=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi-yaml v1.6.0 h1:mb/QkebWXTa1fR+P3ZkCCHGXOYC6iTN8X8By9eNz8xM=


### PR DESCRIPTION
This is a quick fix to address customer issues outlined in https://github.com/pulumi/pulumi-terraform-bridge/issues/1940.

While we develop a more complete fix for the above issue, this will unblock customers and enable them to upgrade.


