### PR TITLE
AWS Attribute must be whole number regression test

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -78,3 +78,19 @@ func TestRegress3835(t *testing.T) {
 	result := test.Preview()
 	t.Logf("#%v", result.ChangeSummary)
 }
+
+func TestRegressAttributeMustBeWholeNumber(t *testing.T) {
+	// pulumi/pulumi-terraform-bridge#1940
+	skipIfShort(t)
+	dir := filepath.Join("test-programs", "ec2-string-for-int")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	providerName := "aws"
+	options := []opttest.Option{
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+		opttest.YarnLink("@pulumi/aws"),
+	}
+	test := pulumitest.NewPulumiTest(t, dir, options...)
+	result := test.Preview()
+	t.Logf("#%v", result.ChangeSummary)
+}

--- a/provider/test-programs/ec2-string-for-int/.gitignore
+++ b/provider/test-programs/ec2-string-for-int/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/provider/test-programs/ec2-string-for-int/Pulumi.yaml
+++ b/provider/test-programs/ec2-string-for-int/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: aws_wrong_type
+runtime: nodejs
+description: A minimal AWS TypeScript Pulumi program
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/provider/test-programs/ec2-string-for-int/index.ts
+++ b/provider/test-programs/ec2-string-for-int/index.ts
@@ -1,0 +1,23 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const ubuntu = aws.ec2.getAmi({
+    mostRecent: true,
+    filters: [
+        {
+            name: "name",
+            values: ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"],
+        },
+        {
+            name: "virtualization-type",
+            values: ["hvm"],
+        },
+    ],
+    owners: ["099720109477"],
+});
+const web = new aws.ec2.Instance("web", {
+    ami: ubuntu.then(ubuntu => ubuntu.id),
+    instanceType: aws.ec2.InstanceType.T3_Micro,
+    // @ts-ignore
+    cpuCoreCount: "2" 
+});

--- a/provider/test-programs/ec2-string-for-int/package.json
+++ b/provider/test-programs/ec2-string-for-int/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "aws_wrong_type",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/aws": "6.33.1",
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
+    }
+}

--- a/provider/test-programs/ec2-string-for-int/tsconfig.json
+++ b/provider/test-programs/ec2-string-for-int/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This adds a program which uses a string for an int property.

This reproduces the issue seen in https://github.com/pulumi/pulumi-terraform-bridge/issues/1940