### PR TITLE
fix: sns topic creation fails in non-standard partitions

### DIFF
--- a/patches/0052-non-idempotent-sns-topic-creation.patch
+++ b/patches/0052-non-idempotent-sns-topic-creation.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] non-idempotent sns topic creation
 
 
 diff --git a/internal/service/sns/topic.go b/internal/service/sns/topic.go
-index 17c78c35c1..0d2e35b695 100644
+index 17c78c35c1..5ee99c0c44 100644
 --- a/internal/service/sns/topic.go
 +++ b/internal/service/sns/topic.go
 @@ -9,6 +9,7 @@ import (
@@ -20,8 +20,8 @@ index 17c78c35c1..0d2e35b695 100644
  	}
  }
  
-+func constructTopicArn(client *sns.Client, account, region, snsTopicName string) string {
-+	return fmt.Sprintf("arn:aws:sns:%s:%s:%s", region, account, snsTopicName)
++func constructTopicArn(client *sns.Client, account, region, partition, snsTopicName string) string {
++	return fmt.Sprintf("arn:%s:sns:%s:%s:%s", partition, region, account, snsTopicName)
 +}
 +
 +var snsGlobalMutex sync.Map
@@ -29,14 +29,15 @@ index 17c78c35c1..0d2e35b695 100644
  func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
  	var diags diag.Diagnostics
  	conn := meta.(*conns.AWSClient).SNSClient(ctx)
-@@ -284,6 +291,27 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta inter
+@@ -284,6 +291,28 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta inter
  		delete(attributes, topicAttributeNameFIFOTopic)
  	}
  
 +	// create a lock based on the topic ARN. We really want to make sure
 +	// that we prevent a race condition where two resources are created with
 +	// the same name.
-+	topicArn := constructTopicArn(conn, meta.(*conns.AWSClient).AccountID, meta.(*conns.AWSClient).Region, name)
++	awsClient := meta.(*conns.AWSClient)
++	topicArn := constructTopicArn(conn, awsClient.AccountID, awsClient.Region, awsClient.Partition, name)
 +	localMutex := &sync.Mutex{}
 +	if val, ok := snsGlobalMutex.LoadOrStore(topicArn, localMutex); ok {
 +		localMutex = val.(*sync.Mutex)

--- a/patches/0057-Fix-empty-retry_strategy-of-Batch-JobDefinitions-cau.patch
+++ b/patches/0057-Fix-empty-retry_strategy-of-Batch-JobDefinitions-cau.patch
@@ -12,7 +12,7 @@ This patch fixes that by adding the missing nil checks for the
 retry strategy.
 
 diff --git a/internal/service/batch/job_definition.go b/internal/service/batch/job_definition.go
-index d1b5102162..a6a9c190c8 100644
+index d1b5102162..6f0d4976e7 100644
 --- a/internal/service/batch/job_definition.go
 +++ b/internal/service/batch/job_definition.go
 @@ -528,12 +528,12 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {


### PR DESCRIPTION
Set the AWS partition dynamically instead of hardcoding the default `aws` partition.

I'm not sure there is a good way to test this since we do not have credentials for other partitions

fixes #3926