### PR TITLE
Explorations: rewire legacy bucket backend

### DIFF
--- a/patches/0057-Fix-empty-retry_strategy-of-Batch-JobDefinitions-cau.patch
+++ b/patches/0057-Fix-empty-retry_strategy-of-Batch-JobDefinitions-cau.patch
@@ -12,7 +12,7 @@ This patch fixes that by adding the missing nil checks for the
 retry strategy.
 
 diff --git a/internal/service/batch/job_definition.go b/internal/service/batch/job_definition.go
-index d1b5102162..a6a9c190c8 100644
+index d1b5102162..6f0d4976e7 100644
 --- a/internal/service/batch/job_definition.go
 +++ b/internal/service/batch/job_definition.go
 @@ -528,12 +528,12 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {

--- a/patches/0058-Remove-s3legacy.patch
+++ b/patches/0058-Remove-s3legacy.patch
@@ -1,0 +1,4403 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Tayanovskyy <anton@pulumi.com>
+Date: Mon, 13 May 2024 13:36:14 -0400
+Subject: [PATCH] Remove s3legacy
+
+
+diff --git a/internal/provider/provider.go b/internal/provider/provider.go
+index 0e7a94e470..f6628a3d63 100644
+--- a/internal/provider/provider.go
++++ b/internal/provider/provider.go
+@@ -275,7 +275,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
+ 	var errs []error
+ 	servicePackageMap := make(map[string]conns.ServicePackage)
+ 
+-	for _, sp := range servicePackagesAll(ctx) {
++	for _, sp := range servicePackages(ctx) {
+ 		servicePackageName := sp.ServicePackageName()
+ 		servicePackageMap[servicePackageName] = sp
+ 
+diff --git a/internal/provider/service_packages_all.go b/internal/provider/service_packages_all.go
+deleted file mode 100644
+index 51ca53f883..0000000000
+--- a/internal/provider/service_packages_all.go
++++ /dev/null
+@@ -1,12 +0,0 @@
+-package provider
+-
+-import (
+-	"context"
+-
+-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+-	"github.com/hashicorp/terraform-provider-aws/internal/service/s3legacy"
+-)
+-
+-func servicePackagesAll(ctx context.Context) []conns.ServicePackage {
+-	return append(servicePackages(ctx), s3legacy.ServicePackage(ctx))
+-}
+diff --git a/internal/service/s3/bucket_legacy.go b/internal/service/s3/bucket_legacy.go
+new file mode 100644
+index 0000000000..9cd6620e52
+--- /dev/null
++++ b/internal/service/s3/bucket_legacy.go
+@@ -0,0 +1,645 @@
++package s3
++
++import (
++	"github.com/aws/aws-sdk-go-v2/service/s3/types"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
++	"github.com/hashicorp/terraform-provider-aws/internal/enum"
++	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
++	"github.com/hashicorp/terraform-provider-aws/internal/verify"
++)
++
++func ResourceBucketLegacy() *schema.Resource {
++	return &schema.Resource{
++		CreateWithoutTimeout: resourceBucketCreate,
++		ReadWithoutTimeout:   resourceBucketRead,
++		UpdateWithoutTimeout: resourceBucketUpdate,
++		DeleteWithoutTimeout: resourceBucketDelete,
++
++		Importer: &schema.ResourceImporter{
++			StateContext: schema.ImportStatePassthroughContext,
++		},
++
++		Schema: map[string]*schema.Schema{
++			"bucket": {
++				Type:          schema.TypeString,
++				Optional:      true,
++				Computed:      true,
++				ForceNew:      true,
++				ConflictsWith: []string{"bucket_prefix"},
++				ValidateFunc:  validation.StringLenBetween(0, 63),
++			},
++			"bucket_prefix": {
++				Type:          schema.TypeString,
++				Optional:      true,
++				ForceNew:      true,
++				ConflictsWith: []string{"bucket"},
++				ValidateFunc:  validation.StringLenBetween(0, 63-id.UniqueIDSuffixLength),
++			},
++
++			"bucket_domain_name": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"bucket_regional_domain_name": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"arn": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"acl": {
++				Type:          schema.TypeString,
++				Default:       "private",
++				Optional:      true,
++				ConflictsWith: []string{"grant"},
++				ValidateFunc:  validation.StringInSlice(bucketCannedACL_Values(), false),
++			},
++
++			"grant": {
++				Type:     schema.TypeSet,
++				Optional: true,
++				//Set:           grantHashLegacy,
++				ConflictsWith: []string{"acl"},
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"id": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++						"type": {
++							Type:     schema.TypeString,
++							Required: true,
++							// TypeAmazonCustomerByEmail is not currently supported
++							ValidateFunc: validation.StringInSlice(enum.Slice(
++								types.TypeCanonicalUser,
++								types.TypeGroup,
++							), false),
++						},
++						"uri": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++
++						"permissions": {
++							Type:     schema.TypeSet,
++							Required: true,
++							Set:      schema.HashString,
++							Elem: &schema.Schema{
++								Type:             schema.TypeString,
++								ValidateDiagFunc: enum.Validate[types.Permission](),
++							},
++						},
++					},
++				},
++			},
++
++			"policy": {
++				Type:             schema.TypeString,
++				Optional:         true,
++				ValidateFunc:     validation.StringIsJSON,
++				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
++			},
++
++			"cors_rule": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"allowed_headers": {
++							Type:     schema.TypeList,
++							Optional: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"allowed_methods": {
++							Type:     schema.TypeList,
++							Required: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"allowed_origins": {
++							Type:     schema.TypeList,
++							Required: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"expose_headers": {
++							Type:     schema.TypeList,
++							Optional: true,
++							Elem:     &schema.Schema{Type: schema.TypeString},
++						},
++						"max_age_seconds": {
++							Type:     schema.TypeInt,
++							Optional: true,
++						},
++					},
++				},
++			},
++
++			"website": {
++				Type:     schema.TypeList,
++				Optional: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"index_document": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++
++						"error_document": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++
++						"redirect_all_requests_to": {
++							Type: schema.TypeString,
++							ConflictsWith: []string{
++								"website.0.index_document",
++								"website.0.error_document",
++								"website.0.routing_rules",
++							},
++							Optional: true,
++						},
++
++						"routing_rules": {
++							Type:         schema.TypeString,
++							Optional:     true,
++							ValidateFunc: validation.StringIsJSON,
++							StateFunc: func(v interface{}) string {
++								json, _ := structure.NormalizeJsonString(v)
++								return json
++							},
++						},
++					},
++				},
++			},
++
++			"hosted_zone_id": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"region": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"website_endpoint": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++			"website_domain": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"versioning": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Computed: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"enabled": {
++							Type:     schema.TypeBool,
++							Optional: true,
++							Default:  false,
++						},
++						"mfa_delete": {
++							Type:     schema.TypeBool,
++							Optional: true,
++							Default:  false,
++						},
++					},
++				},
++			},
++
++			"logging": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Computed: true,
++				// MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"target_bucket": {
++							Type:     schema.TypeString,
++							Required: true,
++						},
++						"target_prefix": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++					},
++				},
++			},
++
++			"lifecycle_rule": {
++				Type:     schema.TypeList,
++				Optional: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"id": {
++							Type:         schema.TypeString,
++							Optional:     true,
++							Computed:     true,
++							ValidateFunc: validation.StringLenBetween(0, 255),
++						},
++						"prefix": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++						"tags": tftags.TagsSchema(),
++						"enabled": {
++							Type:     schema.TypeBool,
++							Required: true,
++						},
++						"abort_incomplete_multipart_upload_days": {
++							Type:     schema.TypeInt,
++							Optional: true,
++						},
++						"expiration": {
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"date": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validBucketLifecycleTimestamp,
++									},
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(0),
++									},
++									"expired_object_delete_marker": {
++										Type:     schema.TypeBool,
++										Optional: true,
++									},
++								},
++							},
++						},
++						"noncurrent_version_expiration": {
++							Type:     schema.TypeList,
++							MaxItems: 1,
++							Optional: true,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(1),
++									},
++								},
++							},
++						},
++						"transition": {
++							Type:     schema.TypeSet,
++							Optional: true,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"date": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validBucketLifecycleTimestamp,
++									},
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(0),
++									},
++									"storage_class": {
++										Type:             schema.TypeString,
++										Required:         true,
++										ValidateDiagFunc: enum.Validate[types.StorageClass](),
++									},
++								},
++							},
++						},
++						"noncurrent_version_transition": {
++							Type:     schema.TypeSet,
++							Optional: true,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"days": {
++										Type:         schema.TypeInt,
++										Optional:     true,
++										ValidateFunc: validation.IntAtLeast(0),
++									},
++									"storage_class": {
++										Type:             schema.TypeString,
++										Required:         true,
++										ValidateDiagFunc: enum.Validate[types.TransitionStorageClass](),
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"force_destroy": {
++				Type:     schema.TypeBool,
++				Optional: true,
++				Default:  false,
++			},
++
++			"acceleration_status": {
++				Type:             schema.TypeString,
++				Optional:         true,
++				Computed:         true,
++				ValidateDiagFunc: enum.Validate[types.BucketAccelerateStatus](),
++			},
++
++			"request_payer": {
++				Type:             schema.TypeString,
++				Optional:         true,
++				Computed:         true,
++				ValidateDiagFunc: enum.Validate[types.Payer](),
++			},
++
++			"replication_configuration": {
++				Type:     schema.TypeList,
++				Optional: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"role": {
++							Type:     schema.TypeString,
++							Required: true,
++						},
++						"rules": {
++							Type:     schema.TypeSet,
++							Required: true,
++							//Set:      rulesHashLegacy,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"id": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validation.StringLenBetween(0, 255),
++									},
++									"destination": {
++										Type:     schema.TypeList,
++										MaxItems: 1,
++										MinItems: 1,
++										Required: true,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"account_id": {
++													Type:         schema.TypeString,
++													Optional:     true,
++													ValidateFunc: verify.ValidAccountID,
++												},
++												"bucket": {
++													Type:         schema.TypeString,
++													Required:     true,
++													ValidateFunc: verify.ValidARN,
++												},
++												"storage_class": {
++													Type:             schema.TypeString,
++													Optional:         true,
++													ValidateDiagFunc: enum.Validate[types.TransitionStorageClass](),
++												},
++												"replica_kms_key_id": {
++													Type:     schema.TypeString,
++													Optional: true,
++												},
++												"access_control_translation": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MinItems: 1,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"owner": {
++																Type:             schema.TypeString,
++																Required:         true,
++																ValidateDiagFunc: enum.Validate[types.OwnerOverride](),
++															},
++														},
++													},
++												},
++												"replication_time": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"minutes": {
++																Type:         schema.TypeInt,
++																Optional:     true,
++																Default:      15,
++																ValidateFunc: validation.IntBetween(15, 15),
++															},
++															"status": {
++																Type:     schema.TypeString,
++																Optional: true,
++																Default:  types.ReplicationTimeStatusEnabled,
++
++																ValidateDiagFunc: enum.Validate[types.ReplicationTimeStatus](),
++															},
++														},
++													},
++												},
++												"metrics": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"minutes": {
++																Type:         schema.TypeInt,
++																Optional:     true,
++																Default:      15,
++																ValidateFunc: validation.IntBetween(10, 15),
++															},
++															"status": {
++																Type:             schema.TypeString,
++																Optional:         true,
++																Default:          types.MetricsStatusEnabled,
++																ValidateDiagFunc: enum.Validate[types.MetricsStatus](),
++															},
++														},
++													},
++												},
++											},
++										},
++									},
++									"source_selection_criteria": {
++										Type:     schema.TypeList,
++										Optional: true,
++										MinItems: 1,
++										MaxItems: 1,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"sse_kms_encrypted_objects": {
++													Type:     schema.TypeList,
++													Optional: true,
++													MinItems: 1,
++													MaxItems: 1,
++													Elem: &schema.Resource{
++														Schema: map[string]*schema.Schema{
++															"enabled": {
++																Type:     schema.TypeBool,
++																Required: true,
++															},
++														},
++													},
++												},
++											},
++										},
++									},
++									"prefix": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validation.StringLenBetween(0, 1024),
++									},
++									"status": {
++										Type:             schema.TypeString,
++										Required:         true,
++										ValidateDiagFunc: enum.Validate[types.ReplicationRuleStatus](),
++									},
++									"priority": {
++										Type:     schema.TypeInt,
++										Optional: true,
++									},
++									"filter": {
++										Type:     schema.TypeList,
++										Optional: true,
++										MinItems: 1,
++										MaxItems: 1,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"prefix": {
++													Type:         schema.TypeString,
++													Optional:     true,
++													ValidateFunc: validation.StringLenBetween(0, 1024),
++												},
++												"tags": tftags.TagsSchema(),
++											},
++										},
++									},
++									"delete_marker_replication_status": {
++										Type:         schema.TypeString,
++										Optional:     true,
++										ValidateFunc: validation.StringInSlice(enum.Slice(types.DeleteMarkerReplicationStatusEnabled), false),
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"server_side_encryption_configuration": {
++				Type:     schema.TypeList,
++				MaxItems: 1,
++				Optional: true,
++				Computed: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"rule": {
++							Type:     schema.TypeList,
++							MaxItems: 1,
++							Required: true,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"apply_server_side_encryption_by_default": {
++										Type:     schema.TypeList,
++										MaxItems: 1,
++										Required: true,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"kms_master_key_id": {
++													Type:     schema.TypeString,
++													Optional: true,
++												},
++												"sse_algorithm": {
++													Type:             schema.TypeString,
++													Required:         true,
++													ValidateDiagFunc: enum.Validate[types.ServerSideEncryption](),
++												},
++											},
++										},
++									},
++									"bucket_key_enabled": {
++										Type:     schema.TypeBool,
++										Optional: true,
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"object_lock_configuration": {
++				Type:     schema.TypeList,
++				Optional: true,
++				MaxItems: 1,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"object_lock_enabled": {
++							Type:             schema.TypeString,
++							Required:         true,
++							ForceNew:         true,
++							ValidateDiagFunc: enum.Validate[types.ObjectLockEnabled](),
++						},
++
++						"rule": {
++							Type:     schema.TypeList,
++							Optional: true,
++							MaxItems: 1,
++							Elem: &schema.Resource{
++								Schema: map[string]*schema.Schema{
++									"default_retention": {
++										Type:     schema.TypeList,
++										Required: true,
++										MinItems: 1,
++										MaxItems: 1,
++										Elem: &schema.Resource{
++											Schema: map[string]*schema.Schema{
++												"mode": {
++													Type:             schema.TypeString,
++													Required:         true,
++													ValidateDiagFunc: enum.Validate[types.ObjectLockRetentionMode](),
++												},
++
++												"days": {
++													Type:         schema.TypeInt,
++													Optional:     true,
++													ValidateFunc: validation.IntAtLeast(1),
++												},
++
++												"years": {
++													Type:         schema.TypeInt,
++													Optional:     true,
++													ValidateFunc: validation.IntAtLeast(1),
++												},
++											},
++										},
++									},
++								},
++							},
++						},
++					},
++				},
++			},
++
++			"tags":     tftags.TagsSchema(),
++			"tags_all": tftags.TagsSchemaTrulyComputed(),
++		},
++
++		CustomizeDiff: verify.SetTagsDiff,
++	}
++}
+diff --git a/internal/service/s3/service_package_gen.go b/internal/service/s3/service_package_gen.go
+index 7cf7cd3990..9c322be177 100644
+--- a/internal/service/s3/service_package_gen.go
++++ b/internal/service/s3/service_package_gen.go
+@@ -72,6 +72,16 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
+ 
+ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
+ 	return []*types.ServicePackageSDKResource{
++		// TODO grafting this into a generated code file but need to work with the code generator.
++		{
++			Factory:  ResourceBucketLegacy,
++			TypeName: "aws_s3_bucket_legacy",
++			Name:     "BucketLegacy",
++			Tags: &types.ServicePackageResourceTags{
++				IdentifierAttribute: "bucket",
++				ResourceType:        "Bucket",
++			},
++		},
+ 		{
+ 			Factory:  resourceBucket,
+ 			TypeName: "aws_s3_bucket",
+diff --git a/internal/service/s3legacy/bucket_legacy.go b/internal/service/s3legacy/bucket_legacy.go
+deleted file mode 100644
+index d5c03b22fb..0000000000
+--- a/internal/service/s3legacy/bucket_legacy.go
++++ /dev/null
+@@ -1,3024 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"bytes"
+-	"context"
+-	"encoding/json"
+-	"fmt"
+-	"log"
+-	"net/http"
+-	"net/url"
+-	"regexp"
+-	"strings"
+-	"time"
+-
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/aws/arn"
+-	"github.com/aws/aws-sdk-go/aws/awserr"
+-	"github.com/aws/aws-sdk-go/aws/endpoints"
+-	"github.com/aws/aws-sdk-go/aws/request"
+-	"github.com/aws/aws-sdk-go/service/s3"
+-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+-	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+-	"github.com/hashicorp/terraform-provider-aws/internal/types/option"
+-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+-)
+-
+-func ResourceBucketLegacy() *schema.Resource {
+-	return &schema.Resource{
+-		CreateWithoutTimeout: resourceBucketLegacyCreate,
+-		ReadWithoutTimeout:   resourceBucketLegacyRead,
+-		UpdateWithoutTimeout: resourceBucketLegacyUpdate,
+-		DeleteWithoutTimeout: resourceBucketLegacyDelete,
+-		Importer: &schema.ResourceImporter{
+-			State: schema.ImportStatePassthrough,
+-		},
+-
+-		Schema: map[string]*schema.Schema{
+-			"bucket": {
+-				Type:          schema.TypeString,
+-				Optional:      true,
+-				Computed:      true,
+-				ForceNew:      true,
+-				ConflictsWith: []string{"bucket_prefix"},
+-				ValidateFunc:  validation.StringLenBetween(0, 63),
+-			},
+-			"bucket_prefix": {
+-				Type:          schema.TypeString,
+-				Optional:      true,
+-				ForceNew:      true,
+-				ConflictsWith: []string{"bucket"},
+-				ValidateFunc:  validation.StringLenBetween(0, 63-id.UniqueIDSuffixLength),
+-			},
+-
+-			"bucket_domain_name": {
+-				Type:     schema.TypeString,
+-				Computed: true,
+-			},
+-
+-			"bucket_regional_domain_name": {
+-				Type:     schema.TypeString,
+-				Computed: true,
+-			},
+-
+-			"arn": {
+-				Type:     schema.TypeString,
+-				Optional: true,
+-				Computed: true,
+-			},
+-
+-			"acl": {
+-				Type:          schema.TypeString,
+-				Default:       "private",
+-				Optional:      true,
+-				ConflictsWith: []string{"grant"},
+-				ValidateFunc:  validation.StringInSlice(BucketCannedACL_Values(), false),
+-			},
+-
+-			"grant": {
+-				Type:          schema.TypeSet,
+-				Optional:      true,
+-				Set:           grantHashLegacy,
+-				ConflictsWith: []string{"acl"},
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"id": {
+-							Type:     schema.TypeString,
+-							Optional: true,
+-						},
+-						"type": {
+-							Type:     schema.TypeString,
+-							Required: true,
+-							// TypeAmazonCustomerByEmail is not currently supported
+-							ValidateFunc: validation.StringInSlice([]string{
+-								s3.TypeCanonicalUser,
+-								s3.TypeGroup,
+-							}, false),
+-						},
+-						"uri": {
+-							Type:     schema.TypeString,
+-							Optional: true,
+-						},
+-
+-						"permissions": {
+-							Type:     schema.TypeSet,
+-							Required: true,
+-							Set:      schema.HashString,
+-							Elem: &schema.Schema{
+-								Type:         schema.TypeString,
+-								ValidateFunc: validation.StringInSlice(s3.Permission_Values(), false),
+-							},
+-						},
+-					},
+-				},
+-			},
+-
+-			"policy": {
+-				Type:             schema.TypeString,
+-				Optional:         true,
+-				ValidateFunc:     validation.StringIsJSON,
+-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+-			},
+-
+-			"cors_rule": {
+-				Type:     schema.TypeList,
+-				Optional: true,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"allowed_headers": {
+-							Type:     schema.TypeList,
+-							Optional: true,
+-							Elem:     &schema.Schema{Type: schema.TypeString},
+-						},
+-						"allowed_methods": {
+-							Type:     schema.TypeList,
+-							Required: true,
+-							Elem:     &schema.Schema{Type: schema.TypeString},
+-						},
+-						"allowed_origins": {
+-							Type:     schema.TypeList,
+-							Required: true,
+-							Elem:     &schema.Schema{Type: schema.TypeString},
+-						},
+-						"expose_headers": {
+-							Type:     schema.TypeList,
+-							Optional: true,
+-							Elem:     &schema.Schema{Type: schema.TypeString},
+-						},
+-						"max_age_seconds": {
+-							Type:     schema.TypeInt,
+-							Optional: true,
+-						},
+-					},
+-				},
+-			},
+-
+-			"website": {
+-				Type:     schema.TypeList,
+-				Optional: true,
+-				MaxItems: 1,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"index_document": {
+-							Type:     schema.TypeString,
+-							Optional: true,
+-						},
+-
+-						"error_document": {
+-							Type:     schema.TypeString,
+-							Optional: true,
+-						},
+-
+-						"redirect_all_requests_to": {
+-							Type: schema.TypeString,
+-							ConflictsWith: []string{
+-								"website.0.index_document",
+-								"website.0.error_document",
+-								"website.0.routing_rules",
+-							},
+-							Optional: true,
+-						},
+-
+-						"routing_rules": {
+-							Type:         schema.TypeString,
+-							Optional:     true,
+-							ValidateFunc: validation.StringIsJSON,
+-							StateFunc: func(v interface{}) string {
+-								json, _ := structure.NormalizeJsonString(v)
+-								return json
+-							},
+-						},
+-					},
+-				},
+-			},
+-
+-			"hosted_zone_id": {
+-				Type:     schema.TypeString,
+-				Optional: true,
+-				Computed: true,
+-			},
+-
+-			"region": {
+-				Type:     schema.TypeString,
+-				Computed: true,
+-			},
+-			"website_endpoint": {
+-				Type:     schema.TypeString,
+-				Optional: true,
+-				Computed: true,
+-			},
+-			"website_domain": {
+-				Type:     schema.TypeString,
+-				Optional: true,
+-				Computed: true,
+-			},
+-
+-			"versioning": {
+-				Type:     schema.TypeList,
+-				Optional: true,
+-				Computed: true,
+-				MaxItems: 1,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"enabled": {
+-							Type:     schema.TypeBool,
+-							Optional: true,
+-							Default:  false,
+-						},
+-						"mfa_delete": {
+-							Type:     schema.TypeBool,
+-							Optional: true,
+-							Default:  false,
+-						},
+-					},
+-				},
+-			},
+-
+-			"logging": {
+-				Type:     schema.TypeSet,
+-				Optional: true,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"target_bucket": {
+-							Type:     schema.TypeString,
+-							Required: true,
+-						},
+-						"target_prefix": {
+-							Type:     schema.TypeString,
+-							Optional: true,
+-						},
+-					},
+-				},
+-				Set: func(v interface{}) int {
+-					var buf bytes.Buffer
+-					m := v.(map[string]interface{})
+-					buf.WriteString(fmt.Sprintf("%s-", m["target_bucket"]))
+-					buf.WriteString(fmt.Sprintf("%s-", m["target_prefix"]))
+-					return create.StringHashcode(buf.String())
+-				},
+-			},
+-
+-			"lifecycle_rule": {
+-				Type:     schema.TypeList,
+-				Optional: true,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"id": {
+-							Type:         schema.TypeString,
+-							Optional:     true,
+-							Computed:     true,
+-							ValidateFunc: validation.StringLenBetween(0, 255),
+-						},
+-						"prefix": {
+-							Type:     schema.TypeString,
+-							Optional: true,
+-						},
+-						"tags": tftags.TagsSchema(),
+-						"enabled": {
+-							Type:     schema.TypeBool,
+-							Required: true,
+-						},
+-						"abort_incomplete_multipart_upload_days": {
+-							Type:     schema.TypeInt,
+-							Optional: true,
+-						},
+-						"expiration": {
+-							Type:     schema.TypeList,
+-							Optional: true,
+-							MaxItems: 1,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"date": {
+-										Type:         schema.TypeString,
+-										Optional:     true,
+-										ValidateFunc: validBucketLifecycleTimestampLegacy,
+-									},
+-									"days": {
+-										Type:         schema.TypeInt,
+-										Optional:     true,
+-										ValidateFunc: validation.IntAtLeast(0),
+-									},
+-									"expired_object_delete_marker": {
+-										Type:     schema.TypeBool,
+-										Optional: true,
+-									},
+-								},
+-							},
+-						},
+-						"noncurrent_version_expiration": {
+-							Type:     schema.TypeList,
+-							MaxItems: 1,
+-							Optional: true,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"days": {
+-										Type:         schema.TypeInt,
+-										Optional:     true,
+-										ValidateFunc: validation.IntAtLeast(1),
+-									},
+-								},
+-							},
+-						},
+-						"transition": {
+-							Type:     schema.TypeSet,
+-							Optional: true,
+-							Set:      transitionHashLegacy,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"date": {
+-										Type:         schema.TypeString,
+-										Optional:     true,
+-										ValidateFunc: validBucketLifecycleTimestampLegacy,
+-									},
+-									"days": {
+-										Type:         schema.TypeInt,
+-										Optional:     true,
+-										ValidateFunc: validation.IntAtLeast(0),
+-									},
+-									"storage_class": {
+-										Type:         schema.TypeString,
+-										Required:     true,
+-										ValidateFunc: validation.StringInSlice(s3.TransitionStorageClass_Values(), false),
+-									},
+-								},
+-							},
+-						},
+-						"noncurrent_version_transition": {
+-							Type:     schema.TypeSet,
+-							Optional: true,
+-							Set:      transitionHashLegacy,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"days": {
+-										Type:         schema.TypeInt,
+-										Optional:     true,
+-										ValidateFunc: validation.IntAtLeast(0),
+-									},
+-									"storage_class": {
+-										Type:         schema.TypeString,
+-										Required:     true,
+-										ValidateFunc: validation.StringInSlice(s3.TransitionStorageClass_Values(), false),
+-									},
+-								},
+-							},
+-						},
+-					},
+-				},
+-			},
+-
+-			"force_destroy": {
+-				Type:     schema.TypeBool,
+-				Optional: true,
+-				Default:  false,
+-			},
+-
+-			"acceleration_status": {
+-				Type:         schema.TypeString,
+-				Optional:     true,
+-				Computed:     true,
+-				ValidateFunc: validation.StringInSlice(s3.BucketAccelerateStatus_Values(), false),
+-			},
+-
+-			"request_payer": {
+-				Type:         schema.TypeString,
+-				Optional:     true,
+-				Computed:     true,
+-				ValidateFunc: validation.StringInSlice(s3.Payer_Values(), false),
+-			},
+-
+-			"replication_configuration": {
+-				Type:     schema.TypeList,
+-				Optional: true,
+-				MaxItems: 1,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"role": {
+-							Type:     schema.TypeString,
+-							Required: true,
+-						},
+-						"rules": {
+-							Type:     schema.TypeSet,
+-							Required: true,
+-							Set:      rulesHashLegacy,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"id": {
+-										Type:         schema.TypeString,
+-										Optional:     true,
+-										ValidateFunc: validation.StringLenBetween(0, 255),
+-									},
+-									"destination": {
+-										Type:     schema.TypeList,
+-										MaxItems: 1,
+-										MinItems: 1,
+-										Required: true,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"account_id": {
+-													Type:         schema.TypeString,
+-													Optional:     true,
+-													ValidateFunc: verify.ValidAccountID,
+-												},
+-												"bucket": {
+-													Type:         schema.TypeString,
+-													Required:     true,
+-													ValidateFunc: verify.ValidARN,
+-												},
+-												"storage_class": {
+-													Type:         schema.TypeString,
+-													Optional:     true,
+-													ValidateFunc: validation.StringInSlice(s3.StorageClass_Values(), false),
+-												},
+-												"replica_kms_key_id": {
+-													Type:     schema.TypeString,
+-													Optional: true,
+-												},
+-												"access_control_translation": {
+-													Type:     schema.TypeList,
+-													Optional: true,
+-													MinItems: 1,
+-													MaxItems: 1,
+-													Elem: &schema.Resource{
+-														Schema: map[string]*schema.Schema{
+-															"owner": {
+-																Type:         schema.TypeString,
+-																Required:     true,
+-																ValidateFunc: validation.StringInSlice(s3.OwnerOverride_Values(), false),
+-															},
+-														},
+-													},
+-												},
+-												"replication_time": {
+-													Type:     schema.TypeList,
+-													Optional: true,
+-													MaxItems: 1,
+-													Elem: &schema.Resource{
+-														Schema: map[string]*schema.Schema{
+-															"minutes": {
+-																Type:         schema.TypeInt,
+-																Optional:     true,
+-																Default:      15,
+-																ValidateFunc: validation.IntBetween(15, 15),
+-															},
+-															"status": {
+-																Type:         schema.TypeString,
+-																Optional:     true,
+-																Default:      s3.ReplicationTimeStatusEnabled,
+-																ValidateFunc: validation.StringInSlice(s3.ReplicationTimeStatus_Values(), false),
+-															},
+-														},
+-													},
+-												},
+-												"metrics": {
+-													Type:     schema.TypeList,
+-													Optional: true,
+-													MaxItems: 1,
+-													Elem: &schema.Resource{
+-														Schema: map[string]*schema.Schema{
+-															"minutes": {
+-																Type:         schema.TypeInt,
+-																Optional:     true,
+-																Default:      15,
+-																ValidateFunc: validation.IntBetween(10, 15),
+-															},
+-															"status": {
+-																Type:         schema.TypeString,
+-																Optional:     true,
+-																Default:      s3.MetricsStatusEnabled,
+-																ValidateFunc: validation.StringInSlice(s3.MetricsStatus_Values(), false),
+-															},
+-														},
+-													},
+-												},
+-											},
+-										},
+-									},
+-									"source_selection_criteria": {
+-										Type:     schema.TypeList,
+-										Optional: true,
+-										MinItems: 1,
+-										MaxItems: 1,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"sse_kms_encrypted_objects": {
+-													Type:     schema.TypeList,
+-													Optional: true,
+-													MinItems: 1,
+-													MaxItems: 1,
+-													Elem: &schema.Resource{
+-														Schema: map[string]*schema.Schema{
+-															"enabled": {
+-																Type:     schema.TypeBool,
+-																Required: true,
+-															},
+-														},
+-													},
+-												},
+-											},
+-										},
+-									},
+-									"prefix": {
+-										Type:         schema.TypeString,
+-										Optional:     true,
+-										ValidateFunc: validation.StringLenBetween(0, 1024),
+-									},
+-									"status": {
+-										Type:         schema.TypeString,
+-										Required:     true,
+-										ValidateFunc: validation.StringInSlice(s3.ReplicationRuleStatus_Values(), false),
+-									},
+-									"priority": {
+-										Type:     schema.TypeInt,
+-										Optional: true,
+-									},
+-									"filter": {
+-										Type:     schema.TypeList,
+-										Optional: true,
+-										MinItems: 1,
+-										MaxItems: 1,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"prefix": {
+-													Type:         schema.TypeString,
+-													Optional:     true,
+-													ValidateFunc: validation.StringLenBetween(0, 1024),
+-												},
+-												"tags": tftags.TagsSchema(),
+-											},
+-										},
+-									},
+-									"delete_marker_replication_status": {
+-										Type:         schema.TypeString,
+-										Optional:     true,
+-										ValidateFunc: validation.StringInSlice([]string{s3.DeleteMarkerReplicationStatusEnabled}, false),
+-									},
+-								},
+-							},
+-						},
+-					},
+-				},
+-			},
+-
+-			"server_side_encryption_configuration": {
+-				Type:     schema.TypeList,
+-				MaxItems: 1,
+-				Optional: true,
+-				Computed: true,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"rule": {
+-							Type:     schema.TypeList,
+-							MaxItems: 1,
+-							Required: true,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"apply_server_side_encryption_by_default": {
+-										Type:     schema.TypeList,
+-										MaxItems: 1,
+-										Required: true,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"kms_master_key_id": {
+-													Type:     schema.TypeString,
+-													Optional: true,
+-												},
+-												"sse_algorithm": {
+-													Type:         schema.TypeString,
+-													Required:     true,
+-													ValidateFunc: validation.StringInSlice(s3.ServerSideEncryption_Values(), false),
+-												},
+-											},
+-										},
+-									},
+-									"bucket_key_enabled": {
+-										Type:     schema.TypeBool,
+-										Optional: true,
+-									},
+-								},
+-							},
+-						},
+-					},
+-				},
+-			},
+-
+-			"object_lock_configuration": {
+-				Type:     schema.TypeList,
+-				Optional: true,
+-				MaxItems: 1,
+-				Elem: &schema.Resource{
+-					Schema: map[string]*schema.Schema{
+-						"object_lock_enabled": {
+-							Type:         schema.TypeString,
+-							Required:     true,
+-							ForceNew:     true,
+-							ValidateFunc: validation.StringInSlice(s3.ObjectLockEnabled_Values(), false),
+-						},
+-
+-						"rule": {
+-							Type:     schema.TypeList,
+-							Optional: true,
+-							MaxItems: 1,
+-							Elem: &schema.Resource{
+-								Schema: map[string]*schema.Schema{
+-									"default_retention": {
+-										Type:     schema.TypeList,
+-										Required: true,
+-										MinItems: 1,
+-										MaxItems: 1,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"mode": {
+-													Type:         schema.TypeString,
+-													Required:     true,
+-													ValidateFunc: validation.StringInSlice(s3.ObjectLockRetentionMode_Values(), false),
+-												},
+-
+-												"days": {
+-													Type:         schema.TypeInt,
+-													Optional:     true,
+-													ValidateFunc: validation.IntAtLeast(1),
+-												},
+-
+-												"years": {
+-													Type:         schema.TypeInt,
+-													Optional:     true,
+-													ValidateFunc: validation.IntAtLeast(1),
+-												},
+-											},
+-										},
+-									},
+-								},
+-							},
+-						},
+-					},
+-				},
+-			},
+-
+-			"tags":     tftags.TagsSchema(),
+-			"tags_all": tftags.TagsSchemaTrulyComputed(),
+-		},
+-
+-		CustomizeDiff: verify.SetTagsDiff,
+-	}
+-}
+-
+-func resourceBucketLegacyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+-
+-	// Get the bucket and acl
+-	var bucket string
+-	if v, ok := d.GetOk("bucket"); ok {
+-		bucket = v.(string)
+-	} else if v, ok := d.GetOk("bucket_prefix"); ok {
+-		bucket = id.PrefixedUniqueId(v.(string))
+-	} else {
+-		bucket = id.UniqueId()
+-	}
+-	d.Set("bucket", bucket)
+-
+-	log.Printf("[DEBUG] S3 bucket create: %s", bucket)
+-
+-	req := &s3.CreateBucketInput{
+-		Bucket: aws.String(bucket),
+-	}
+-
+-	if acl, ok := d.GetOk("acl"); ok {
+-		acl := acl.(string)
+-		req.ACL = aws.String(acl)
+-		log.Printf("[DEBUG] S3 bucket %s has canned ACL %s", bucket, acl)
+-	}
+-
+-	awsRegion := meta.(*conns.AWSClient).Region
+-	log.Printf("[DEBUG] S3 bucket create: %s, using region: %s", bucket, awsRegion)
+-
+-	// Special case us-east-1 region and do not set the LocationConstraint.
+-	// See "Request Elements: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
+-	if awsRegion != endpoints.UsEast1RegionID {
+-		req.CreateBucketConfiguration = &s3.CreateBucketConfiguration{
+-			LocationConstraint: aws.String(awsRegion),
+-		}
+-	}
+-
+-	if err := ValidBucketNameLegacy(bucket, awsRegion); err != nil {
+-		return diag.Errorf("Error validating S3 bucket name: %s", err)
+-	}
+-
+-	// S3 Object Lock can only be enabled on bucket creation.
+-	objectLockConfiguration := expandS3ObjectLockConfigurationLegacy(d.Get("object_lock_configuration").([]interface{}))
+-	if objectLockConfiguration != nil && aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled {
+-		req.ObjectLockEnabledForBucket = aws.Bool(true)
+-	}
+-
+-	err := retry.Retry(5*time.Minute, func() *retry.RetryError {
+-		_, err := conn.CreateBucket(req)
+-		if awsErr, ok := err.(awserr.Error); ok {
+-			if awsErr.Code() == "OperationAborted" {
+-				return retry.RetryableError(
+-					fmt.Errorf("Error creating S3 bucket %s, retrying: %s", bucket, err))
+-			}
+-		}
+-		if err != nil {
+-			return retry.NonRetryableError(err)
+-		}
+-
+-		return nil
+-	})
+-	if tfresource.TimedOut(err) {
+-		_, err = conn.CreateBucket(req)
+-	}
+-	if err != nil {
+-		return diag.Errorf("Error creating S3 bucket: %s", err)
+-	}
+-
+-	// Assign the bucket name as the resource ID
+-	d.SetId(bucket)
+-	return resourceBucketLegacyUpdate(ctx, d, meta)
+-}
+-
+-func resourceBucketLegacyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+-
+-	if d.HasChange("tags_all") {
+-		o, n := d.GetChange("tags_all")
+-
+-		// Retry due to S3 eventual consistency
+-		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-			terr := BucketUpdateTags(conn, d.Id(), o, n)
+-			return nil, terr
+-		})
+-		if err != nil {
+-			return diag.Errorf("error updating S3 Bucket (%s) tags: %s", d.Id(), err)
+-		}
+-	}
+-
+-	if d.HasChange("policy") {
+-		if err := resourceBucketLegacyPolicyUpdate(ctx, conn, d); err != nil {
+-			return err
+-		}
+-	}
+-
+-	if d.HasChange("cors_rule") {
+-		if err := resourceBucketLegacyCorsUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("website") {
+-		if err := resourceBucketLegacyWebsiteUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("versioning") {
+-		v := d.Get("versioning").([]interface{})
+-
+-		if d.IsNewResource() {
+-			if versioning := expandVersioningWhenIsNewResourceLegacy(v); versioning != nil {
+-				err := resourceBucketLegacyVersioningUpdate(conn, d.Id(), versioning)
+-				if err != nil {
+-					return diag.FromErr(err)
+-				}
+-			}
+-		} else {
+-			if err := resourceBucketLegacyVersioningUpdate(conn, d.Id(), expandVersioningLegacy(v)); err != nil {
+-				return diag.FromErr(err)
+-			}
+-		}
+-	}
+-
+-	if d.HasChange("acl") && !d.IsNewResource() {
+-		if err := resourceBucketLegacyACLUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("grant") {
+-		if err := resourceBucketLegacyGrantsUpdate(ctx, conn, d); err != nil {
+-			return err
+-		}
+-	}
+-
+-	if d.HasChange("logging") {
+-		if err := resourceBucketLegacyLoggingUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("lifecycle_rule") {
+-		if err := resourceBucketLegacyLifecycleUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("acceleration_status") {
+-		if err := resourceBucketLegacyAccelerationUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("request_payer") {
+-		if err := resourceBucketLegacyRequestPayerUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("replication_configuration") {
+-		if err := resourceBucketLegacyInternalReplicationConfigurationUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("server_side_encryption_configuration") {
+-		if err := resourceBucketLegacyServerSideEncryptionConfigurationUpdate(ctx, conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	if d.HasChange("object_lock_configuration") {
+-		if err := resourceBucketLegacyObjectLockConfigurationUpdate(conn, d); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	return resourceBucketLegacyRead(ctx, d, meta)
+-}
+-
+-func resourceBucketLegacyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+-
+-	input := &s3.HeadBucketInput{
+-		Bucket: aws.String(d.Id()),
+-	}
+-
+-	err := retry.Retry(bucketCreatedTimeout, func() *retry.RetryError {
+-		_, err := conn.HeadBucket(input)
+-
+-		if d.IsNewResource() && tfawserr.ErrStatusCodeEquals(err, http.StatusNotFound) {
+-			return retry.RetryableError(err)
+-		}
+-
+-		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+-			return retry.RetryableError(err)
+-		}
+-
+-		if err != nil {
+-			return retry.NonRetryableError(err)
+-		}
+-
+-		return nil
+-	})
+-
+-	if tfresource.TimedOut(err) {
+-		_, err = conn.HeadBucket(input)
+-	}
+-
+-	if !d.IsNewResource() && tfawserr.ErrStatusCodeEquals(err, http.StatusNotFound) {
+-		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+-		d.SetId("")
+-		return nil
+-	}
+-
+-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+-		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+-		d.SetId("")
+-		return nil
+-	}
+-
+-	if err != nil {
+-		return diag.Errorf("error reading S3 Bucket (%s): %w", d.Id(), err)
+-	}
+-
+-	// In the import case, we won't have this
+-	if _, ok := d.GetOk("bucket"); !ok {
+-		d.Set("bucket", d.Id())
+-	}
+-
+-	d.Set("bucket_domain_name", meta.(*conns.AWSClient).PartitionHostname(ctx, fmt.Sprintf("%s.s3", d.Get("bucket").(string))))
+-
+-	// Read the policy
+-	if _, ok := d.GetOk("policy"); ok {
+-
+-		pol, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-			return conn.GetBucketPolicy(&s3.GetBucketPolicyInput{
+-				Bucket: aws.String(d.Id()),
+-			})
+-		})
+-		log.Printf("[DEBUG] S3 bucket: %s, read policy: %v", d.Id(), pol)
+-		if err != nil {
+-			if err := d.Set("policy", ""); err != nil {
+-				return diag.FromErr(err)
+-			}
+-		} else {
+-			if v := pol.(*s3.GetBucketPolicyOutput).Policy; v == nil {
+-				if err := d.Set("policy", ""); err != nil {
+-					return diag.FromErr(err)
+-				}
+-			} else {
+-				policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.StringValue(v))
+-
+-				if err != nil {
+-					return diag.Errorf("while setting policy (%s), encountered: %w", aws.StringValue(v), err)
+-				}
+-
+-				policyToSet, err = structure.NormalizeJsonString(policyToSet)
+-
+-				if err != nil {
+-					return diag.Errorf("policy (%s) contains invalid JSON: %w", d.Get("policy").(string), err)
+-				}
+-
+-				d.Set("policy", policyToSet)
+-			}
+-		}
+-	}
+-
+-	//Read the Grant ACL. Reset if `acl` (canned ACL) is set.
+-	if acl, ok := d.GetOk("acl"); ok && acl.(string) != "private" {
+-		if err := d.Set("grant", nil); err != nil {
+-			return diag.Errorf("error resetting grant %s", err)
+-		}
+-	} else {
+-		apResponse, err := retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
+-			return conn.GetBucketAcl(&s3.GetBucketAclInput{
+-				Bucket: aws.String(d.Id()),
+-			})
+-		})
+-		if err != nil {
+-			return diag.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
+-		}
+-		log.Printf("[DEBUG] S3 bucket: %s, read ACL grants policy: %+v", d.Id(), apResponse)
+-		grants := flattenGrantsLegacy(apResponse.(*s3.GetBucketAclOutput))
+-		if err := d.Set("grant", schema.NewSet(grantHashLegacy, grants)); err != nil {
+-			return diag.Errorf("error setting grant %s", err)
+-		}
+-	}
+-
+-	// Read the CORS
+-	corsResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketCors(&s3.GetBucketCorsInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-	if err != nil && !tfawserr.ErrMessageContains(err, "NoSuchCORSConfiguration", "") {
+-		return diag.Errorf("error getting S3 Bucket CORS configuration: %s", err)
+-	}
+-
+-	corsRules := make([]map[string]interface{}, 0)
+-	if cors, ok := corsResponse.(*s3.GetBucketCorsOutput); ok && len(cors.CORSRules) > 0 {
+-		corsRules = make([]map[string]interface{}, 0, len(cors.CORSRules))
+-		for _, ruleObject := range cors.CORSRules {
+-			rule := make(map[string]interface{})
+-			rule["allowed_headers"] = flex.FlattenStringList(ruleObject.AllowedHeaders)
+-			rule["allowed_methods"] = flex.FlattenStringList(ruleObject.AllowedMethods)
+-			rule["allowed_origins"] = flex.FlattenStringList(ruleObject.AllowedOrigins)
+-			// Both the "ExposeHeaders" and "MaxAgeSeconds" might not be set.
+-			if ruleObject.AllowedOrigins != nil {
+-				rule["expose_headers"] = flex.FlattenStringList(ruleObject.ExposeHeaders)
+-			}
+-			if ruleObject.MaxAgeSeconds != nil {
+-				rule["max_age_seconds"] = int(aws.Int64Value(ruleObject.MaxAgeSeconds))
+-			}
+-			corsRules = append(corsRules, rule)
+-		}
+-	}
+-	if err := d.Set("cors_rule", corsRules); err != nil {
+-		return diag.Errorf("error setting cors_rule: %s", err)
+-	}
+-
+-	// Read the website configuration
+-	wsResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketWebsite(&s3.GetBucketWebsiteInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-	if err != nil && !tfawserr.ErrMessageContains(err, "NotImplemented", "") && !tfawserr.ErrMessageContains(err, "NoSuchWebsiteConfiguration", "") {
+-		return diag.Errorf("error getting S3 Bucket website configuration: %s", err)
+-	}
+-
+-	websites := make([]map[string]interface{}, 0, 1)
+-	if ws, ok := wsResponse.(*s3.GetBucketWebsiteOutput); ok {
+-		w := make(map[string]interface{})
+-
+-		if v := ws.IndexDocument; v != nil {
+-			w["index_document"] = aws.StringValue(v.Suffix)
+-		}
+-
+-		if v := ws.ErrorDocument; v != nil {
+-			w["error_document"] = aws.StringValue(v.Key)
+-		}
+-
+-		if v := ws.RedirectAllRequestsTo; v != nil {
+-			if v.Protocol == nil {
+-				w["redirect_all_requests_to"] = aws.StringValue(v.HostName)
+-			} else {
+-				var host string
+-				var path string
+-				var query string
+-				parsedHostName, err := url.Parse(aws.StringValue(v.HostName))
+-				if err == nil {
+-					host = parsedHostName.Host
+-					path = parsedHostName.Path
+-					query = parsedHostName.RawQuery
+-				} else {
+-					host = aws.StringValue(v.HostName)
+-					path = ""
+-				}
+-
+-				w["redirect_all_requests_to"] = (&url.URL{
+-					Host:     host,
+-					Path:     path,
+-					Scheme:   aws.StringValue(v.Protocol),
+-					RawQuery: query,
+-				}).String()
+-			}
+-		}
+-
+-		if v := ws.RoutingRules; v != nil {
+-			rr, err := normalizeRoutingRulesLegacy(v)
+-			if err != nil {
+-				return diag.Errorf("Error while marshaling routing rules: %s", err)
+-			}
+-			w["routing_rules"] = rr
+-		}
+-
+-		// We have special handling for the website configuration,
+-		// so only add the configuration if there is any
+-		if len(w) > 0 {
+-			websites = append(websites, w)
+-		}
+-	}
+-	if err := d.Set("website", websites); err != nil {
+-		return diag.Errorf("error setting website: %s", err)
+-	}
+-
+-	// Read the versioning configuration
+-
+-	versioningResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketVersioning(&s3.GetBucketVersioningInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-
+-	if err != nil {
+-		return diag.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
+-	}
+-
+-	if versioning, ok := versioningResponse.(*s3.GetBucketVersioningOutput); ok {
+-		if err := d.Set("versioning", flattenVersioningLegacy(versioning)); err != nil {
+-			return diag.Errorf("error setting versioning: %w", err)
+-		}
+-	}
+-
+-	// Read the acceleration status
+-
+-	accelerateResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketAccelerateConfiguration(&s3.GetBucketAccelerateConfigurationInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-
+-	// Amazon S3 Transfer Acceleration might not be supported in the region
+-	if err != nil && !tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") && !tfawserr.ErrMessageContains(err, "UnsupportedArgument", "") {
+-		return diag.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
+-	}
+-	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {
+-		d.Set("acceleration_status", accelerate.Status)
+-	}
+-
+-	// Read the request payer configuration.
+-
+-	payerResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketRequestPayment(&s3.GetBucketRequestPaymentInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-
+-	if err != nil {
+-		return diag.Errorf("error getting S3 Bucket request payment: %s", err)
+-	}
+-
+-	if payer, ok := payerResponse.(*s3.GetBucketRequestPaymentOutput); ok {
+-		d.Set("request_payer", payer.Payer)
+-	}
+-
+-	// Read the logging configuration
+-	loggingResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketLogging(&s3.GetBucketLoggingInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-
+-	if err != nil {
+-		return diag.Errorf("error getting S3 Bucket logging: %s", err)
+-	}
+-
+-	lcl := make([]map[string]interface{}, 0, 1)
+-	if logging, ok := loggingResponse.(*s3.GetBucketLoggingOutput); ok && logging.LoggingEnabled != nil {
+-		v := logging.LoggingEnabled
+-		lc := make(map[string]interface{})
+-		if aws.StringValue(v.TargetBucket) != "" {
+-			lc["target_bucket"] = aws.StringValue(v.TargetBucket)
+-		}
+-		if aws.StringValue(v.TargetPrefix) != "" {
+-			lc["target_prefix"] = aws.StringValue(v.TargetPrefix)
+-		}
+-		lcl = append(lcl, lc)
+-	}
+-	if err := d.Set("logging", lcl); err != nil {
+-		return diag.Errorf("error setting logging: %s", err)
+-	}
+-
+-	// Read the lifecycle configuration
+-
+-	lifecycleResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-	if err != nil && !tfawserr.ErrMessageContains(err, "NoSuchLifecycleConfiguration", "") {
+-		return diag.FromErr(err)
+-	}
+-
+-	lifecycleRules := make([]map[string]interface{}, 0)
+-	if lifecycle, ok := lifecycleResponse.(*s3.GetBucketLifecycleConfigurationOutput); ok && len(lifecycle.Rules) > 0 {
+-		lifecycleRules = make([]map[string]interface{}, 0, len(lifecycle.Rules))
+-
+-		for _, lifecycleRule := range lifecycle.Rules {
+-			log.Printf("[DEBUG] S3 bucket: %s, read lifecycle rule: %v", d.Id(), lifecycleRule)
+-			rule := make(map[string]interface{})
+-
+-			// ID
+-			if lifecycleRule.ID != nil && aws.StringValue(lifecycleRule.ID) != "" {
+-				rule["id"] = aws.StringValue(lifecycleRule.ID)
+-			}
+-			filter := lifecycleRule.Filter
+-			if filter != nil {
+-				if filter.And != nil {
+-					// Prefix
+-					if filter.And.Prefix != nil && aws.StringValue(filter.And.Prefix) != "" {
+-						rule["prefix"] = aws.StringValue(filter.And.Prefix)
+-					}
+-					// Tag
+-					if len(filter.And.Tags) > 0 {
+-						rule["tags"] = KeyValueTags(filter.And.Tags).IgnoreAWS().Map()
+-					}
+-				} else {
+-					// Prefix
+-					if filter.Prefix != nil && aws.StringValue(filter.Prefix) != "" {
+-						rule["prefix"] = aws.StringValue(filter.Prefix)
+-					}
+-					// Tag
+-					if filter.Tag != nil {
+-						rule["tags"] = KeyValueTags([]*s3.Tag{filter.Tag}).IgnoreAWS().Map()
+-					}
+-				}
+-			} else {
+-				if lifecycleRule.Prefix != nil {
+-					rule["prefix"] = aws.StringValue(lifecycleRule.Prefix)
+-				}
+-			}
+-
+-			// Enabled
+-			if lifecycleRule.Status != nil {
+-				if aws.StringValue(lifecycleRule.Status) == s3.ExpirationStatusEnabled {
+-					rule["enabled"] = true
+-				} else {
+-					rule["enabled"] = false
+-				}
+-			}
+-
+-			// AbortIncompleteMultipartUploadDays
+-			if lifecycleRule.AbortIncompleteMultipartUpload != nil {
+-				if lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
+-					rule["abort_incomplete_multipart_upload_days"] = int(aws.Int64Value(lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation))
+-				}
+-			}
+-
+-			// expiration
+-			if lifecycleRule.Expiration != nil {
+-				e := make(map[string]interface{})
+-				if lifecycleRule.Expiration.Date != nil {
+-					e["date"] = (aws.TimeValue(lifecycleRule.Expiration.Date)).Format("2006-01-02")
+-				}
+-				if lifecycleRule.Expiration.Days != nil {
+-					e["days"] = int(aws.Int64Value(lifecycleRule.Expiration.Days))
+-				}
+-				if lifecycleRule.Expiration.ExpiredObjectDeleteMarker != nil {
+-					e["expired_object_delete_marker"] = aws.BoolValue(lifecycleRule.Expiration.ExpiredObjectDeleteMarker)
+-				}
+-				rule["expiration"] = []interface{}{e}
+-			}
+-			// noncurrent_version_expiration
+-			if lifecycleRule.NoncurrentVersionExpiration != nil {
+-				e := make(map[string]interface{})
+-				if lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays != nil {
+-					e["days"] = int(aws.Int64Value(lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays))
+-				}
+-				rule["noncurrent_version_expiration"] = []interface{}{e}
+-			}
+-			//// transition
+-			if len(lifecycleRule.Transitions) > 0 {
+-				transitions := make([]interface{}, 0, len(lifecycleRule.Transitions))
+-				for _, v := range lifecycleRule.Transitions {
+-					t := make(map[string]interface{})
+-					if v.Date != nil {
+-						t["date"] = (aws.TimeValue(v.Date)).Format("2006-01-02")
+-					}
+-					if v.Days != nil {
+-						t["days"] = int(aws.Int64Value(v.Days))
+-					}
+-					if v.StorageClass != nil {
+-						t["storage_class"] = aws.StringValue(v.StorageClass)
+-					}
+-					transitions = append(transitions, t)
+-				}
+-				rule["transition"] = schema.NewSet(transitionHashLegacy, transitions)
+-			}
+-			// noncurrent_version_transition
+-			if len(lifecycleRule.NoncurrentVersionTransitions) > 0 {
+-				transitions := make([]interface{}, 0, len(lifecycleRule.NoncurrentVersionTransitions))
+-				for _, v := range lifecycleRule.NoncurrentVersionTransitions {
+-					t := make(map[string]interface{})
+-					if v.NoncurrentDays != nil {
+-						t["days"] = int(aws.Int64Value(v.NoncurrentDays))
+-					}
+-					if v.StorageClass != nil {
+-						t["storage_class"] = aws.StringValue(v.StorageClass)
+-					}
+-					transitions = append(transitions, t)
+-				}
+-				rule["noncurrent_version_transition"] = schema.NewSet(transitionHashLegacy, transitions)
+-			}
+-
+-			lifecycleRules = append(lifecycleRules, rule)
+-		}
+-	}
+-	if err := d.Set("lifecycle_rule", lifecycleRules); err != nil {
+-		return diag.Errorf("error setting lifecycle_rule: %s", err)
+-	}
+-
+-	// Read the bucket replication configuration
+-
+-	replicationResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketReplication(&s3.GetBucketReplicationInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-	if err != nil && !tfawserr.ErrMessageContains(err, "ReplicationConfigurationNotFoundError", "") {
+-		return diag.Errorf("error getting S3 Bucket replication: %s", err)
+-	}
+-
+-	replicationConfiguration := make([]map[string]interface{}, 0)
+-	if replication, ok := replicationResponse.(*s3.GetBucketReplicationOutput); ok {
+-		replicationConfiguration = flattenBucketReplicationConfigurationLegacy(replication.ReplicationConfiguration)
+-	}
+-	if err := d.Set("replication_configuration", replicationConfiguration); err != nil {
+-		return diag.Errorf("error setting replication_configuration: %s", err)
+-	}
+-
+-	// Read the bucket server side encryption configuration
+-
+-	encryptionResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetBucketEncryption(&s3.GetBucketEncryptionInput{
+-			Bucket: aws.String(d.Id()),
+-		})
+-	})
+-	if err != nil && !tfawserr.ErrMessageContains(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
+-		return diag.Errorf("error getting S3 Bucket encryption: %s", err)
+-	}
+-
+-	serverSideEncryptionConfiguration := make([]map[string]interface{}, 0)
+-	if encryption, ok := encryptionResponse.(*s3.GetBucketEncryptionOutput); ok && encryption.ServerSideEncryptionConfiguration != nil {
+-		serverSideEncryptionConfiguration = flattenServerSideEncryptionConfigurationLegacy(encryption.ServerSideEncryptionConfiguration)
+-	}
+-	if err := d.Set("server_side_encryption_configuration", serverSideEncryptionConfiguration); err != nil {
+-		return diag.Errorf("error setting server_side_encryption_configuration: %s", err)
+-	}
+-
+-	// Object Lock configuration.
+-	conf, err := readS3ObjectLockConfigurationLegacy(conn, d.Id())
+-
+-	// Object lock not supported in all partitions (extra guard, also guards in read func)
+-	if err != nil && (meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID) {
+-		return diag.Errorf("error getting S3 Bucket Object Lock configuration: %s", err)
+-	}
+-
+-	if err != nil {
+-		log.Printf("[WARN] Unable to read S3 bucket (%s) object lock configuration: %s", d.Id(), err)
+-	}
+-
+-	if err == nil {
+-		if err := d.Set("object_lock_configuration", conf); err != nil {
+-			return diag.Errorf("error setting object_lock_configuration: %s", err)
+-		}
+-	}
+-
+-	// Add the region as an attribute
+-	discoveredRegion, err := retryOnAWSCode("NotFound", func() (interface{}, error) {
+-		return s3manager.GetBucketRegionWithClient(context.Background(), conn, d.Id(), func(r *request.Request) {
+-			// By default, GetBucketRegion forces virtual host addressing, which
+-			// is not compatible with many non-AWS implementations. Instead, pass
+-			// the provider s3_force_path_style configuration, which defaults to
+-			// false, but allows override.
+-			r.Config.S3ForcePathStyle = conn.Config.S3ForcePathStyle
+-
+-			// By default, GetBucketRegion uses anonymous credentials when doing
+-			// a HEAD request to get the bucket region. This breaks in aws-cn regions
+-			// when the account doesn't have an ICP license to host public content.
+-			// Use the current credentials when getting the bucket region.
+-			r.Config.Credentials = conn.Config.Credentials
+-		})
+-	})
+-	if err != nil {
+-		return diag.Errorf("error getting S3 Bucket location: %s", err)
+-	}
+-
+-	region := discoveredRegion.(string)
+-	if err := d.Set("region", region); err != nil {
+-		return diag.FromErr(err)
+-	}
+-
+-	// Add the bucket_regional_domain_name as an attribute
+-	regionalEndpoint, err := bucketLegacyRegionalDomainName(d.Get("bucket").(string), region)
+-	if err != nil {
+-		return diag.FromErr(err)
+-	}
+-	d.Set("bucket_regional_domain_name", regionalEndpoint)
+-
+-	// Add the hosted zone ID for this bucket's region as an attribute
+-	hostedZoneID, err := HostedZoneIDForRegion(region)
+-	if err != nil {
+-		log.Printf("[WARN] %s", err)
+-	} else {
+-		d.Set("hosted_zone_id", hostedZoneID)
+-	}
+-
+-	// Add website_endpoint as an attribute
+-	websiteEndpoint, err := websiteLegacyEndpoint(ctx, meta.(*conns.AWSClient), d)
+-	if err != nil {
+-		return diag.FromErr(err)
+-	}
+-	if websiteEndpoint != nil {
+-		if err := d.Set("website_endpoint", websiteEndpoint.Endpoint); err != nil {
+-			return diag.FromErr(err)
+-		}
+-		if err := d.Set("website_domain", websiteEndpoint.Domain); err != nil {
+-			return diag.FromErr(err)
+-		}
+-	}
+-
+-	// Retry due to S3 eventual consistency
+-	tagsRaw, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return BucketListTags(conn, d.Id())
+-	})
+-
+-	if err != nil {
+-		return diag.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)
+-	}
+-
+-	tags, ok := tagsRaw.(tftags.KeyValueTags)
+-
+-	if !ok {
+-		return diag.Errorf("error listing tags for S3 Bucket (%s): unable to convert tags", d.Id())
+-	}
+-
+-	if inContext, ok := tftags.FromContext(ctx); ok {
+-		inContext.TagsOut = option.Some(tags)
+-	}
+-
+-	arn := arn.ARN{
+-		Partition: meta.(*conns.AWSClient).Partition,
+-		Service:   "s3",
+-		Resource:  d.Id(),
+-	}.String()
+-	d.Set("arn", arn)
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+-
+-	log.Printf("[DEBUG] S3 Delete Bucket: %s", d.Id())
+-	_, err := conn.DeleteBucket(&s3.DeleteBucketInput{
+-		Bucket: aws.String(d.Id()),
+-	})
+-
+-	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
+-		return nil
+-	}
+-
+-	if tfawserr.ErrMessageContains(err, "BucketNotEmpty", "") {
+-		if d.Get("force_destroy").(bool) {
+-			// Use a S3 service client that can handle multiple slashes in URIs.
+-			// While aws_s3_bucket_object resources cannot create these object
+-			// keys, other AWS services and applications using the S3 Bucket can.
+-			conn = meta.(*conns.AWSClient).S3ConnURICleaningDisabled(ctx)
+-
+-			// bucket may have things delete them
+-			log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
+-
+-			// Delete everything including locked objects.
+-			// Don't ignore any object errors or we could recurse infinitely.
+-			var objectLockEnabled bool
+-			objectLockConfiguration := expandS3ObjectLockConfigurationLegacy(d.Get("object_lock_configuration").([]interface{}))
+-			if objectLockConfiguration != nil {
+-				objectLockEnabled = aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled
+-			}
+-			err = DeleteAllObjectVersions(conn, d.Id(), "", objectLockEnabled, false)
+-
+-			if err != nil {
+-				return diag.Errorf("error S3 Bucket force_destroy: %s", err)
+-			}
+-
+-			// this line recurses until all objects are deleted or an error is returned
+-			return resourceBucketLegacyDelete(ctx, d, meta)
+-		}
+-	}
+-
+-	if err != nil {
+-		return diag.Errorf("error deleting S3 Bucket (%s): %s", d.Id(), err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyPolicyUpdate(ctx context.Context, conn *s3.S3, d *schema.ResourceData) diag.Diagnostics {
+-	bucket := d.Get("bucket").(string)
+-
+-	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+-
+-	if err != nil {
+-		return diag.Errorf("policy (%s) is an invalid JSON: %w", policy, err)
+-	}
+-
+-	if policy != "" {
+-		log.Printf("[DEBUG] S3 bucket: %s, put policy: %s", bucket, policy)
+-
+-		params := &s3.PutBucketPolicyInput{
+-			Bucket: aws.String(bucket),
+-			Policy: aws.String(policy),
+-		}
+-
+-		err := retry.Retry(1*time.Minute, func() *retry.RetryError {
+-			_, err := conn.PutBucketPolicy(params)
+-			if tfawserr.ErrMessageContains(err, "MalformedPolicy", "") || tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
+-				return retry.RetryableError(err)
+-			}
+-			if err != nil {
+-				return retry.NonRetryableError(err)
+-			}
+-			return nil
+-		})
+-		if tfresource.TimedOut(err) {
+-			_, err = conn.PutBucketPolicy(params)
+-		}
+-		if err != nil {
+-			return diag.Errorf("Error putting S3 policy: %s", err)
+-		}
+-	} else {
+-		log.Printf("[DEBUG] S3 bucket: %s, delete policy: %s", bucket, policy)
+-		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-			return conn.DeleteBucketPolicy(&s3.DeleteBucketPolicyInput{
+-				Bucket: aws.String(bucket),
+-			})
+-		})
+-
+-		if err != nil {
+-			return diag.Errorf("Error deleting S3 policy: %s", err)
+-		}
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyGrantsUpdate(ctx context.Context, conn *s3.S3, d *schema.ResourceData) diag.Diagnostics {
+-	bucket := d.Get("bucket").(string)
+-	rawGrants := d.Get("grant").(*schema.Set).List()
+-
+-	if len(rawGrants) == 0 {
+-		log.Printf("[DEBUG] S3 bucket: %s, Grants fallback to canned ACL", bucket)
+-		if err := resourceBucketLegacyACLUpdate(conn, d); err != nil {
+-			return diag.Errorf("Error fallback to canned ACL, %s", err)
+-		}
+-	} else {
+-		apResponse, err := retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
+-			return conn.GetBucketAcl(&s3.GetBucketAclInput{
+-				Bucket: aws.String(d.Id()),
+-			})
+-		})
+-
+-		if err != nil {
+-			return diag.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
+-		}
+-
+-		ap := apResponse.(*s3.GetBucketAclOutput)
+-		log.Printf("[DEBUG] S3 bucket: %s, read ACL grants policy: %+v", d.Id(), ap)
+-
+-		grants := make([]*s3.Grant, 0, len(rawGrants))
+-		for _, rawGrant := range rawGrants {
+-			log.Printf("[DEBUG] S3 bucket: %s, put grant: %#v", bucket, rawGrant)
+-			grantMap := rawGrant.(map[string]interface{})
+-			for _, rawPermission := range grantMap["permissions"].(*schema.Set).List() {
+-				ge := &s3.Grantee{}
+-				if i, ok := grantMap["id"].(string); ok && i != "" {
+-					ge.SetID(i)
+-				}
+-				if t, ok := grantMap["type"].(string); ok && t != "" {
+-					ge.SetType(t)
+-				}
+-				if u, ok := grantMap["uri"].(string); ok && u != "" {
+-					ge.SetURI(u)
+-				}
+-
+-				g := &s3.Grant{
+-					Grantee:    ge,
+-					Permission: aws.String(rawPermission.(string)),
+-				}
+-				grants = append(grants, g)
+-			}
+-		}
+-
+-		grantsInput := &s3.PutBucketAclInput{
+-			Bucket: aws.String(bucket),
+-			AccessControlPolicy: &s3.AccessControlPolicy{
+-				Grants: grants,
+-				Owner:  ap.Owner,
+-			},
+-		}
+-
+-		log.Printf("[DEBUG] S3 bucket: %s, put Grants: %#v", bucket, grantsInput)
+-
+-		_, err = retryOnAWSCode("NoSuchBucket", func() (interface{}, error) {
+-			return conn.PutBucketAcl(grantsInput)
+-		})
+-
+-		if err != nil {
+-			return diag.Errorf("Error putting S3 Grants: %s", err)
+-		}
+-	}
+-	return nil
+-}
+-
+-func resourceBucketLegacyCorsUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-	rawCors := d.Get("cors_rule").([]interface{})
+-
+-	if len(rawCors) == 0 {
+-		// Delete CORS
+-		log.Printf("[DEBUG] S3 bucket: %s, delete CORS", bucket)
+-
+-		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-			return conn.DeleteBucketCors(&s3.DeleteBucketCorsInput{
+-				Bucket: aws.String(bucket),
+-			})
+-		})
+-		if err != nil {
+-			return fmt.Errorf("Error deleting S3 CORS: %s", err)
+-		}
+-	} else {
+-		// Put CORS
+-		rules := make([]*s3.CORSRule, 0, len(rawCors))
+-		for _, cors := range rawCors {
+-			corsMap := cors.(map[string]interface{})
+-			r := &s3.CORSRule{}
+-			for k, v := range corsMap {
+-				log.Printf("[DEBUG] S3 bucket: %s, put CORS: %#v, %#v", bucket, k, v)
+-				if k == "max_age_seconds" {
+-					r.MaxAgeSeconds = aws.Int64(int64(v.(int)))
+-				} else {
+-					vMap := make([]*string, len(v.([]interface{})))
+-					for i, vv := range v.([]interface{}) {
+-						if str, ok := vv.(string); ok {
+-							vMap[i] = aws.String(str)
+-						}
+-					}
+-					switch k {
+-					case "allowed_headers":
+-						r.AllowedHeaders = vMap
+-					case "allowed_methods":
+-						r.AllowedMethods = vMap
+-					case "allowed_origins":
+-						r.AllowedOrigins = vMap
+-					case "expose_headers":
+-						r.ExposeHeaders = vMap
+-					}
+-				}
+-			}
+-			rules = append(rules, r)
+-		}
+-		corsInput := &s3.PutBucketCorsInput{
+-			Bucket: aws.String(bucket),
+-			CORSConfiguration: &s3.CORSConfiguration{
+-				CORSRules: rules,
+-			},
+-		}
+-		log.Printf("[DEBUG] S3 bucket: %s, put CORS: %#v", bucket, corsInput)
+-
+-		_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-			return conn.PutBucketCors(corsInput)
+-		})
+-		if err != nil {
+-			return fmt.Errorf("Error putting S3 CORS: %s", err)
+-		}
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyWebsiteUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	ws := d.Get("website").([]interface{})
+-
+-	if len(ws) == 0 {
+-		return resourceBucketLegacyWebsiteDelete(conn, d)
+-	}
+-
+-	var w map[string]interface{}
+-	if ws[0] != nil {
+-		w = ws[0].(map[string]interface{})
+-	} else {
+-		w = make(map[string]interface{})
+-	}
+-	return resourceBucketLegacyWebsitePut(conn, d, w)
+-}
+-
+-func resourceBucketLegacyWebsitePut(conn *s3.S3, d *schema.ResourceData, website map[string]interface{}) error {
+-	bucket := d.Get("bucket").(string)
+-
+-	var indexDocument, errorDocument, redirectAllRequestsTo, routingRules string
+-	if v, ok := website["index_document"]; ok {
+-		indexDocument = v.(string)
+-	}
+-	if v, ok := website["error_document"]; ok {
+-		errorDocument = v.(string)
+-	}
+-	if v, ok := website["redirect_all_requests_to"]; ok {
+-		redirectAllRequestsTo = v.(string)
+-	}
+-	if v, ok := website["routing_rules"]; ok {
+-		routingRules = v.(string)
+-	}
+-
+-	if indexDocument == "" && redirectAllRequestsTo == "" {
+-		return fmt.Errorf("Must specify either index_document or redirect_all_requests_to.")
+-	}
+-
+-	websiteConfiguration := &s3.WebsiteConfiguration{}
+-
+-	if indexDocument != "" {
+-		websiteConfiguration.IndexDocument = &s3.IndexDocument{Suffix: aws.String(indexDocument)}
+-	}
+-
+-	if errorDocument != "" {
+-		websiteConfiguration.ErrorDocument = &s3.ErrorDocument{Key: aws.String(errorDocument)}
+-	}
+-
+-	if redirectAllRequestsTo != "" {
+-		redirect, err := url.Parse(redirectAllRequestsTo)
+-		if err == nil && redirect.Scheme != "" {
+-			var redirectHostBuf bytes.Buffer
+-			redirectHostBuf.WriteString(redirect.Host)
+-			if redirect.Path != "" {
+-				redirectHostBuf.WriteString(redirect.Path)
+-			}
+-			if redirect.RawQuery != "" {
+-				redirectHostBuf.WriteString("?")
+-				redirectHostBuf.WriteString(redirect.RawQuery)
+-			}
+-			websiteConfiguration.RedirectAllRequestsTo = &s3.RedirectAllRequestsTo{HostName: aws.String(redirectHostBuf.String()), Protocol: aws.String(redirect.Scheme)}
+-		} else {
+-			websiteConfiguration.RedirectAllRequestsTo = &s3.RedirectAllRequestsTo{HostName: aws.String(redirectAllRequestsTo)}
+-		}
+-	}
+-
+-	if routingRules != "" {
+-		var unmarshaledRules []*s3.RoutingRule
+-		if err := json.Unmarshal([]byte(routingRules), &unmarshaledRules); err != nil {
+-			return err
+-		}
+-		websiteConfiguration.RoutingRules = unmarshaledRules
+-	}
+-
+-	putInput := &s3.PutBucketWebsiteInput{
+-		Bucket:               aws.String(bucket),
+-		WebsiteConfiguration: websiteConfiguration,
+-	}
+-
+-	log.Printf("[DEBUG] S3 put bucket website: %#v", putInput)
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketWebsite(putInput)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 website: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyWebsiteDelete(conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-	deleteInput := &s3.DeleteBucketWebsiteInput{Bucket: aws.String(bucket)}
+-
+-	log.Printf("[DEBUG] S3 delete bucket website: %#v", deleteInput)
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.DeleteBucketWebsite(deleteInput)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error deleting S3 website: %s", err)
+-	}
+-
+-	d.Set("website_endpoint", "")
+-	d.Set("website_domain", "")
+-
+-	return nil
+-}
+-
+-func websiteLegacyEndpoint(ctx context.Context, client *conns.AWSClient, d *schema.ResourceData) (*S3WebsiteLegacy, error) {
+-	// If the bucket doesn't have a website configuration, return an empty
+-	// endpoint
+-	if _, ok := d.GetOk("website"); !ok {
+-		return nil, nil
+-	}
+-
+-	bucket := d.Get("bucket").(string)
+-
+-	// Lookup the region for this bucket
+-
+-	locationResponse, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return client.S3Conn(ctx).GetBucketLocation(
+-			&s3.GetBucketLocationInput{
+-				Bucket: aws.String(bucket),
+-			},
+-		)
+-	})
+-	if err != nil {
+-		return nil, err
+-	}
+-	location := locationResponse.(*s3.GetBucketLocationOutput)
+-	var region string
+-	if location.LocationConstraint != nil {
+-		region = aws.StringValue(location.LocationConstraint)
+-	}
+-
+-	return WebsiteLegacyEndpoint(client, bucket, region), nil
+-}
+-
+-// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+-func bucketLegacyRegionalDomainName(bucket string, region string) (string, error) {
+-	// Return a default AWS Commercial domain name if no region is provided
+-	// Otherwise EndpointFor() will return BUCKET.s3..amazonaws.com
+-	if region == "" {
+-		return fmt.Sprintf("%s.s3.amazonaws.com", bucket), nil //lintignore:AWSR001
+-	}
+-	endpoint, err := endpoints.DefaultResolver().EndpointFor(endpoints.S3ServiceID, region)
+-	if err != nil {
+-		return "", err
+-	}
+-	return fmt.Sprintf("%s.%s", bucket, strings.TrimPrefix(endpoint.URL, "https://")), nil
+-}
+-
+-func WebsiteLegacyEndpoint(client *conns.AWSClient, bucket string, region string) *S3WebsiteLegacy {
+-	domain := websiteLegacyDomainUrl(client, region)
+-	return &S3WebsiteLegacy{Endpoint: fmt.Sprintf("%s.%s", bucket, domain), Domain: domain}
+-}
+-
+-func websiteLegacyDomainUrl(client *conns.AWSClient, region string) string {
+-	region = normalizeRegionLegacy(region)
+-
+-	// Different regions have different syntax for website endpoints
+-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
+-	// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
+-	if isOldRegionLegacy(region) {
+-		return fmt.Sprintf("s3-website-%s.amazonaws.com", region) //lintignore:AWSR001
+-	}
+-	return client.RegionalHostname(context.TODO(), "s3-website")
+-}
+-
+-func isOldRegionLegacy(region string) bool {
+-	oldRegions := []string{
+-		endpoints.ApNortheast1RegionID,
+-		endpoints.ApSoutheast1RegionID,
+-		endpoints.ApSoutheast2RegionID,
+-		endpoints.EuWest1RegionID,
+-		endpoints.SaEast1RegionID,
+-		endpoints.UsEast1RegionID,
+-		endpoints.UsGovWest1RegionID,
+-		endpoints.UsWest1RegionID,
+-		endpoints.UsWest2RegionID,
+-	}
+-	for _, r := range oldRegions {
+-		if region == r {
+-			return true
+-		}
+-	}
+-	return false
+-}
+-
+-func resourceBucketLegacyACLUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	acl := d.Get("acl").(string)
+-	bucket := d.Get("bucket").(string)
+-
+-	i := &s3.PutBucketAclInput{
+-		Bucket: aws.String(bucket),
+-		ACL:    aws.String(acl),
+-	}
+-	log.Printf("[DEBUG] S3 put bucket ACL: %#v", i)
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketAcl(i)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 ACL: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyVersioningUpdate(conn *s3.S3, bucket string, versioningConfig *s3.VersioningConfiguration) error {
+-	input := &s3.PutBucketVersioningInput{
+-		Bucket:                  aws.String(bucket),
+-		VersioningConfiguration: versioningConfig,
+-	}
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketVersioning(input)
+-	})
+-
+-	if err != nil {
+-		return fmt.Errorf("error putting S3 versioning for bucket (%s): %w", bucket, err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyLoggingUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	logging := d.Get("logging").(*schema.Set).List()
+-	bucket := d.Get("bucket").(string)
+-	loggingStatus := &s3.BucketLoggingStatus{}
+-
+-	if len(logging) > 0 {
+-		c := logging[0].(map[string]interface{})
+-
+-		loggingEnabled := &s3.LoggingEnabled{}
+-		if val, ok := c["target_bucket"]; ok {
+-			loggingEnabled.TargetBucket = aws.String(val.(string))
+-		}
+-		if val, ok := c["target_prefix"]; ok {
+-			loggingEnabled.TargetPrefix = aws.String(val.(string))
+-		}
+-
+-		loggingStatus.LoggingEnabled = loggingEnabled
+-	}
+-
+-	i := &s3.PutBucketLoggingInput{
+-		Bucket:              aws.String(bucket),
+-		BucketLoggingStatus: loggingStatus,
+-	}
+-	log.Printf("[DEBUG] S3 put bucket logging: %#v", i)
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketLogging(i)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 logging: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyAccelerationUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-	enableAcceleration := d.Get("acceleration_status").(string)
+-
+-	i := &s3.PutBucketAccelerateConfigurationInput{
+-		Bucket: aws.String(bucket),
+-		AccelerateConfiguration: &s3.AccelerateConfiguration{
+-			Status: aws.String(enableAcceleration),
+-		},
+-	}
+-	log.Printf("[DEBUG] S3 put bucket acceleration: %#v", i)
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketAccelerateConfiguration(i)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 acceleration: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyRequestPayerUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-	payer := d.Get("request_payer").(string)
+-
+-	i := &s3.PutBucketRequestPaymentInput{
+-		Bucket: aws.String(bucket),
+-		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
+-			Payer: aws.String(payer),
+-		},
+-	}
+-	log.Printf("[DEBUG] S3 put bucket request payer: %#v", i)
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketRequestPayment(i)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 request payer: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyServerSideEncryptionConfigurationUpdate(ctx context.Context, conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-	serverSideEncryptionConfiguration := d.Get("server_side_encryption_configuration").([]interface{})
+-	if len(serverSideEncryptionConfiguration) == 0 {
+-		log.Printf("[DEBUG] Delete server side encryption configuration: %#v", serverSideEncryptionConfiguration)
+-		i := &s3.DeleteBucketEncryptionInput{
+-			Bucket: aws.String(bucket),
+-		}
+-
+-		_, err := conn.DeleteBucketEncryption(i)
+-		if err != nil {
+-			return fmt.Errorf("error removing S3 bucket server side encryption: %s", err)
+-		}
+-		return nil
+-	}
+-
+-	c := serverSideEncryptionConfiguration[0].(map[string]interface{})
+-
+-	rc := &s3.ServerSideEncryptionConfiguration{}
+-
+-	rcRules := c["rule"].([]interface{})
+-	var rules []*s3.ServerSideEncryptionRule
+-	for _, v := range rcRules {
+-		rr := v.(map[string]interface{})
+-		rrDefault := rr["apply_server_side_encryption_by_default"].([]interface{})
+-		sseAlgorithm := rrDefault[0].(map[string]interface{})["sse_algorithm"].(string)
+-		kmsMasterKeyId := rrDefault[0].(map[string]interface{})["kms_master_key_id"].(string)
+-		rcDefaultRule := &s3.ServerSideEncryptionByDefault{
+-			SSEAlgorithm: aws.String(sseAlgorithm),
+-		}
+-		if kmsMasterKeyId != "" {
+-			rcDefaultRule.KMSMasterKeyID = aws.String(kmsMasterKeyId)
+-		}
+-		rcRule := &s3.ServerSideEncryptionRule{
+-			ApplyServerSideEncryptionByDefault: rcDefaultRule,
+-		}
+-
+-		if val, ok := rr["bucket_key_enabled"].(bool); ok {
+-			rcRule.BucketKeyEnabled = aws.Bool(val)
+-		}
+-
+-		rules = append(rules, rcRule)
+-	}
+-
+-	rc.Rules = rules
+-	i := &s3.PutBucketEncryptionInput{
+-		Bucket:                            aws.String(bucket),
+-		ServerSideEncryptionConfiguration: rc,
+-	}
+-	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
+-
+-	_, err := tfresource.RetryWhenAWSErrCodeEquals(
+-		ctx,
+-		propagationTimeout,
+-		func() (interface{}, error) {
+-			return conn.PutBucketEncryption(i)
+-		},
+-		s3.ErrCodeNoSuchBucket,
+-		ErrCodeOperationAborted,
+-	)
+-
+-	if err != nil {
+-		return fmt.Errorf("error putting S3 server side encryption configuration: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyObjectLockConfigurationUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	// S3 Object Lock configuration cannot be deleted, only updated.
+-	req := &s3.PutObjectLockConfigurationInput{
+-		Bucket:                  aws.String(d.Get("bucket").(string)),
+-		ObjectLockConfiguration: expandS3ObjectLockConfigurationLegacy(d.Get("object_lock_configuration").([]interface{})),
+-	}
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutObjectLockConfiguration(req)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("error putting S3 object lock configuration: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyInternalReplicationConfigurationUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-	replicationConfiguration := d.Get("replication_configuration").([]interface{})
+-
+-	if len(replicationConfiguration) == 0 {
+-		i := &s3.DeleteBucketReplicationInput{
+-			Bucket: aws.String(bucket),
+-		}
+-
+-		_, err := conn.DeleteBucketReplication(i)
+-		if err != nil {
+-			return fmt.Errorf("Error removing S3 bucket replication: %s", err)
+-		}
+-		return nil
+-	}
+-
+-	hasVersioning := false
+-	// Validate that bucket versioning is enabled
+-	if versioning, ok := d.GetOk("versioning"); ok {
+-		v := versioning.([]interface{})
+-
+-		if v[0].(map[string]interface{})["enabled"].(bool) {
+-			hasVersioning = true
+-		}
+-	}
+-
+-	if !hasVersioning {
+-		return fmt.Errorf("versioning must be enabled to allow S3 bucket replication")
+-	}
+-
+-	c := replicationConfiguration[0].(map[string]interface{})
+-
+-	rc := &s3.ReplicationConfiguration{}
+-	if val, ok := c["role"]; ok {
+-		rc.Role = aws.String(val.(string))
+-	}
+-
+-	rcRules := c["rules"].(*schema.Set).List()
+-	rules := []*s3.ReplicationRule{}
+-	for _, v := range rcRules {
+-		rr := v.(map[string]interface{})
+-		rcRule := &s3.ReplicationRule{}
+-		if status, ok := rr["status"]; ok && status != "" {
+-			rcRule.Status = aws.String(status.(string))
+-		} else {
+-			continue
+-		}
+-
+-		if rrid, ok := rr["id"]; ok && rrid != "" {
+-			rcRule.ID = aws.String(rrid.(string))
+-		}
+-
+-		ruleDestination := &s3.Destination{}
+-		if dest, ok := rr["destination"].([]interface{}); ok && len(dest) > 0 {
+-			if dest[0] != nil {
+-				bd := dest[0].(map[string]interface{})
+-				ruleDestination.Bucket = aws.String(bd["bucket"].(string))
+-
+-				if storageClass, ok := bd["storage_class"]; ok && storageClass != "" {
+-					ruleDestination.StorageClass = aws.String(storageClass.(string))
+-				}
+-
+-				if replicaKmsKeyId, ok := bd["replica_kms_key_id"]; ok && replicaKmsKeyId != "" {
+-					ruleDestination.EncryptionConfiguration = &s3.EncryptionConfiguration{
+-						ReplicaKmsKeyID: aws.String(replicaKmsKeyId.(string)),
+-					}
+-				}
+-
+-				if account, ok := bd["account_id"]; ok && account != "" {
+-					ruleDestination.Account = aws.String(account.(string))
+-				}
+-
+-				if aclTranslation, ok := bd["access_control_translation"].([]interface{}); ok && len(aclTranslation) > 0 {
+-					aclTranslationValues := aclTranslation[0].(map[string]interface{})
+-					ruleAclTranslation := &s3.AccessControlTranslation{}
+-					ruleAclTranslation.Owner = aws.String(aclTranslationValues["owner"].(string))
+-					ruleDestination.AccessControlTranslation = ruleAclTranslation
+-				}
+-
+-				// replication metrics (required for RTC)
+-				if metrics, ok := bd["metrics"].([]interface{}); ok && len(metrics) > 0 {
+-					metricsConfig := &s3.Metrics{}
+-					metricsValues := metrics[0].(map[string]interface{})
+-					metricsConfig.EventThreshold = &s3.ReplicationTimeValue{}
+-					metricsConfig.Status = aws.String(metricsValues["status"].(string))
+-					metricsConfig.EventThreshold.Minutes = aws.Int64(int64(metricsValues["minutes"].(int)))
+-					ruleDestination.Metrics = metricsConfig
+-				}
+-
+-				// replication time control (RTC)
+-				if rtc, ok := bd["replication_time"].([]interface{}); ok && len(rtc) > 0 {
+-					rtcValues := rtc[0].(map[string]interface{})
+-					rtcConfig := &s3.ReplicationTime{}
+-					rtcConfig.Status = aws.String(rtcValues["status"].(string))
+-					rtcConfig.Time = &s3.ReplicationTimeValue{}
+-					rtcConfig.Time.Minutes = aws.Int64(int64(rtcValues["minutes"].(int)))
+-					ruleDestination.ReplicationTime = rtcConfig
+-				}
+-			}
+-		}
+-		rcRule.Destination = ruleDestination
+-
+-		if ssc, ok := rr["source_selection_criteria"].([]interface{}); ok && len(ssc) > 0 {
+-			if ssc[0] != nil {
+-				sscValues := ssc[0].(map[string]interface{})
+-				ruleSsc := &s3.SourceSelectionCriteria{}
+-				if sseKms, ok := sscValues["sse_kms_encrypted_objects"].([]interface{}); ok && len(sseKms) > 0 {
+-					if sseKms[0] != nil {
+-						sseKmsValues := sseKms[0].(map[string]interface{})
+-						sseKmsEncryptedObjects := &s3.SseKmsEncryptedObjects{}
+-						if sseKmsValues["enabled"].(bool) {
+-							sseKmsEncryptedObjects.Status = aws.String(s3.SseKmsEncryptedObjectsStatusEnabled)
+-						} else {
+-							sseKmsEncryptedObjects.Status = aws.String(s3.SseKmsEncryptedObjectsStatusDisabled)
+-						}
+-						ruleSsc.SseKmsEncryptedObjects = sseKmsEncryptedObjects
+-					}
+-				}
+-				rcRule.SourceSelectionCriteria = ruleSsc
+-			}
+-		}
+-
+-		if f, ok := rr["filter"].([]interface{}); ok && len(f) > 0 && f[0] != nil {
+-			// XML schema V2.
+-			rcRule.Priority = aws.Int64(int64(rr["priority"].(int)))
+-			rcRule.Filter = &s3.ReplicationRuleFilter{}
+-			filter := f[0].(map[string]interface{})
+-			tags := Tags(tftags.New(context.Background(), filter["tags"]).IgnoreAWS())
+-			if len(tags) > 0 {
+-				rcRule.Filter.And = &s3.ReplicationRuleAndOperator{
+-					Prefix: aws.String(filter["prefix"].(string)),
+-					Tags:   tags,
+-				}
+-			} else {
+-				rcRule.Filter.Prefix = aws.String(filter["prefix"].(string))
+-			}
+-
+-			if dmr, ok := rr["delete_marker_replication_status"].(string); ok && dmr != "" {
+-				rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
+-					Status: aws.String(dmr),
+-				}
+-			} else {
+-				rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
+-					Status: aws.String(s3.DeleteMarkerReplicationStatusDisabled),
+-				}
+-			}
+-		} else {
+-			// XML schema V1.
+-			rcRule.Prefix = aws.String(rr["prefix"].(string))
+-		}
+-
+-		rules = append(rules, rcRule)
+-	}
+-
+-	rc.Rules = rules
+-	i := &s3.PutBucketReplicationInput{
+-		Bucket:                   aws.String(bucket),
+-		ReplicationConfiguration: rc,
+-	}
+-	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
+-
+-	err := retry.Retry(1*time.Minute, func() *retry.RetryError {
+-		_, err := conn.PutBucketReplication(i)
+-		if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") || tfawserr.ErrMessageContains(err, "InvalidRequest", "Versioning must be 'Enabled' on the bucket") {
+-			return retry.RetryableError(err)
+-		}
+-		if err != nil {
+-			return retry.NonRetryableError(err)
+-		}
+-		return nil
+-	})
+-	if tfresource.TimedOut(err) {
+-		_, err = conn.PutBucketReplication(i)
+-	}
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 replication configuration: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func resourceBucketLegacyLifecycleUpdate(conn *s3.S3, d *schema.ResourceData) error {
+-	bucket := d.Get("bucket").(string)
+-
+-	lifecycleRules := d.Get("lifecycle_rule").([]interface{})
+-
+-	if len(lifecycleRules) == 0 || lifecycleRules[0] == nil {
+-		i := &s3.DeleteBucketLifecycleInput{
+-			Bucket: aws.String(bucket),
+-		}
+-
+-		_, err := conn.DeleteBucketLifecycle(i)
+-		if err != nil {
+-			return fmt.Errorf("Error removing S3 lifecycle: %s", err)
+-		}
+-		return nil
+-	}
+-
+-	rules := make([]*s3.LifecycleRule, 0, len(lifecycleRules))
+-
+-	for i, lifecycleRule := range lifecycleRules {
+-		r := lifecycleRule.(map[string]interface{})
+-
+-		rule := &s3.LifecycleRule{}
+-
+-		// Filter
+-		tags := Tags(tftags.New(context.Background(), r["tags"]).IgnoreAWS())
+-		filter := &s3.LifecycleRuleFilter{}
+-		if len(tags) > 0 {
+-			lifecycleRuleAndOp := &s3.LifecycleRuleAndOperator{}
+-			lifecycleRuleAndOp.SetPrefix(r["prefix"].(string))
+-			lifecycleRuleAndOp.SetTags(tags)
+-			filter.SetAnd(lifecycleRuleAndOp)
+-		} else {
+-			filter.SetPrefix(r["prefix"].(string))
+-		}
+-		rule.SetFilter(filter)
+-
+-		// ID
+-		if val, ok := r["id"].(string); ok && val != "" {
+-			rule.ID = aws.String(val)
+-		} else {
+-			rule.ID = aws.String(id.PrefixedUniqueId("tf-s3-lifecycle-"))
+-		}
+-
+-		// Enabled
+-		if val, ok := r["enabled"].(bool); ok && val {
+-			rule.Status = aws.String(s3.ExpirationStatusEnabled)
+-		} else {
+-			rule.Status = aws.String(s3.ExpirationStatusDisabled)
+-		}
+-
+-		// AbortIncompleteMultipartUpload
+-		if val, ok := r["abort_incomplete_multipart_upload_days"].(int); ok && val > 0 {
+-			rule.AbortIncompleteMultipartUpload = &s3.AbortIncompleteMultipartUpload{
+-				DaysAfterInitiation: aws.Int64(int64(val)),
+-			}
+-		}
+-
+-		// Expiration
+-		expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.expiration", i)).([]interface{})
+-		if len(expiration) > 0 && expiration[0] != nil {
+-			e := expiration[0].(map[string]interface{})
+-			i := &s3.LifecycleExpiration{}
+-			if val, ok := e["date"].(string); ok && val != "" {
+-				t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", val))
+-				if err != nil {
+-					return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
+-				}
+-				i.Date = aws.Time(t)
+-			} else if val, ok := e["days"].(int); ok && val > 0 {
+-				i.Days = aws.Int64(int64(val))
+-			} else if val, ok := e["expired_object_delete_marker"].(bool); ok {
+-				i.ExpiredObjectDeleteMarker = aws.Bool(val)
+-			}
+-			rule.Expiration = i
+-		}
+-
+-		// NoncurrentVersionExpiration
+-		nc_expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_expiration", i)).([]interface{})
+-		if len(nc_expiration) > 0 && nc_expiration[0] != nil {
+-			e := nc_expiration[0].(map[string]interface{})
+-
+-			if val, ok := e["days"].(int); ok && val > 0 {
+-				rule.NoncurrentVersionExpiration = &s3.NoncurrentVersionExpiration{
+-					NoncurrentDays: aws.Int64(int64(val)),
+-				}
+-			}
+-		}
+-
+-		// Transitions
+-		transitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.transition", i)).(*schema.Set).List()
+-		if len(transitions) > 0 {
+-			rule.Transitions = make([]*s3.Transition, 0, len(transitions))
+-			for _, transition := range transitions {
+-				transition := transition.(map[string]interface{})
+-				i := &s3.Transition{}
+-				if val, ok := transition["date"].(string); ok && val != "" {
+-					t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", val))
+-					if err != nil {
+-						return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
+-					}
+-					i.Date = aws.Time(t)
+-				} else if val, ok := transition["days"].(int); ok && val >= 0 {
+-					i.Days = aws.Int64(int64(val))
+-				}
+-				if val, ok := transition["storage_class"].(string); ok && val != "" {
+-					i.StorageClass = aws.String(val)
+-				}
+-
+-				rule.Transitions = append(rule.Transitions, i)
+-			}
+-		}
+-		// NoncurrentVersionTransitions
+-		nc_transitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_transition", i)).(*schema.Set).List()
+-		if len(nc_transitions) > 0 {
+-			rule.NoncurrentVersionTransitions = make([]*s3.NoncurrentVersionTransition, 0, len(nc_transitions))
+-			for _, transition := range nc_transitions {
+-				transition := transition.(map[string]interface{})
+-				i := &s3.NoncurrentVersionTransition{}
+-				if val, ok := transition["days"].(int); ok && val >= 0 {
+-					i.NoncurrentDays = aws.Int64(int64(val))
+-				}
+-				if val, ok := transition["storage_class"].(string); ok && val != "" {
+-					i.StorageClass = aws.String(val)
+-				}
+-
+-				rule.NoncurrentVersionTransitions = append(rule.NoncurrentVersionTransitions, i)
+-			}
+-		}
+-
+-		// As a lifecycle rule requires 1 or more transition/expiration actions,
+-		// we explicitly pass a default ExpiredObjectDeleteMarker value to be able to create
+-		// the rule while keeping the policy unaffected if the conditions are not met.
+-		if rule.Expiration == nil && rule.NoncurrentVersionExpiration == nil &&
+-			rule.Transitions == nil && rule.NoncurrentVersionTransitions == nil &&
+-			rule.AbortIncompleteMultipartUpload == nil {
+-			rule.Expiration = &s3.LifecycleExpiration{ExpiredObjectDeleteMarker: aws.Bool(false)}
+-		}
+-
+-		rules = append(rules, rule)
+-	}
+-
+-	i := &s3.PutBucketLifecycleConfigurationInput{
+-		Bucket: aws.String(bucket),
+-		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+-			Rules: rules,
+-		},
+-	}
+-
+-	_, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.PutBucketLifecycleConfiguration(i)
+-	})
+-	if err != nil {
+-		return fmt.Errorf("Error putting S3 lifecycle: %s", err)
+-	}
+-
+-	return nil
+-}
+-
+-func flattenServerSideEncryptionConfigurationLegacy(c *s3.ServerSideEncryptionConfiguration) []map[string]interface{} {
+-	var encryptionConfiguration []map[string]interface{}
+-	rules := make([]interface{}, 0, len(c.Rules))
+-	for _, v := range c.Rules {
+-		if v.ApplyServerSideEncryptionByDefault != nil {
+-			r := make(map[string]interface{})
+-			d := make(map[string]interface{})
+-			d["kms_master_key_id"] = aws.StringValue(v.ApplyServerSideEncryptionByDefault.KMSMasterKeyID)
+-			d["sse_algorithm"] = aws.StringValue(v.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
+-			r["apply_server_side_encryption_by_default"] = []map[string]interface{}{d}
+-			r["bucket_key_enabled"] = aws.BoolValue(v.BucketKeyEnabled)
+-			rules = append(rules, r)
+-		}
+-	}
+-	encryptionConfiguration = append(encryptionConfiguration, map[string]interface{}{
+-		"rule": rules,
+-	})
+-	return encryptionConfiguration
+-}
+-
+-func flattenBucketReplicationConfigurationLegacy(r *s3.ReplicationConfiguration) []map[string]interface{} {
+-	replication_configuration := make([]map[string]interface{}, 0, 1)
+-
+-	if r == nil {
+-		return replication_configuration
+-	}
+-
+-	m := make(map[string]interface{})
+-
+-	if r.Role != nil && aws.StringValue(r.Role) != "" {
+-		m["role"] = aws.StringValue(r.Role)
+-	}
+-
+-	rules := make([]interface{}, 0, len(r.Rules))
+-	for _, v := range r.Rules {
+-		t := make(map[string]interface{})
+-		if v.Destination != nil {
+-			rd := make(map[string]interface{})
+-			if v.Destination.Bucket != nil {
+-				rd["bucket"] = aws.StringValue(v.Destination.Bucket)
+-			}
+-			if v.Destination.StorageClass != nil {
+-				rd["storage_class"] = aws.StringValue(v.Destination.StorageClass)
+-			}
+-			if v.Destination.ReplicationTime != nil {
+-				rtc := map[string]interface{}{
+-					"minutes": int(aws.Int64Value(v.Destination.ReplicationTime.Time.Minutes)),
+-					"status":  aws.StringValue(v.Destination.ReplicationTime.Status),
+-				}
+-				rd["replication_time"] = []interface{}{rtc}
+-			}
+-			if v.Destination.Metrics != nil {
+-				metrics := map[string]interface{}{
+-					"status": aws.StringValue(v.Destination.Metrics.Status),
+-				}
+-				if v.Destination.Metrics.EventThreshold != nil {
+-					metrics["minutes"] = int(aws.Int64Value(v.Destination.Metrics.EventThreshold.Minutes))
+-				}
+-				rd["metrics"] = []interface{}{metrics}
+-			}
+-			if v.Destination.EncryptionConfiguration != nil {
+-				if v.Destination.EncryptionConfiguration.ReplicaKmsKeyID != nil {
+-					rd["replica_kms_key_id"] = aws.StringValue(v.Destination.EncryptionConfiguration.ReplicaKmsKeyID)
+-				}
+-			}
+-			if v.Destination.Account != nil {
+-				rd["account_id"] = aws.StringValue(v.Destination.Account)
+-			}
+-			if v.Destination.AccessControlTranslation != nil {
+-				rdt := map[string]interface{}{
+-					"owner": aws.StringValue(v.Destination.AccessControlTranslation.Owner),
+-				}
+-				rd["access_control_translation"] = []interface{}{rdt}
+-			}
+-			t["destination"] = []interface{}{rd}
+-		}
+-
+-		if v.ID != nil {
+-			t["id"] = aws.StringValue(v.ID)
+-		}
+-		if v.Prefix != nil {
+-			t["prefix"] = aws.StringValue(v.Prefix)
+-		}
+-		if v.Status != nil {
+-			t["status"] = aws.StringValue(v.Status)
+-		}
+-		if vssc := v.SourceSelectionCriteria; vssc != nil {
+-			tssc := make(map[string]interface{})
+-			if vssc.SseKmsEncryptedObjects != nil {
+-				tSseKms := make(map[string]interface{})
+-				if aws.StringValue(vssc.SseKmsEncryptedObjects.Status) == s3.SseKmsEncryptedObjectsStatusEnabled {
+-					tSseKms["enabled"] = true
+-				} else if aws.StringValue(vssc.SseKmsEncryptedObjects.Status) == s3.SseKmsEncryptedObjectsStatusDisabled {
+-					tSseKms["enabled"] = false
+-				}
+-				tssc["sse_kms_encrypted_objects"] = []interface{}{tSseKms}
+-			}
+-			t["source_selection_criteria"] = []interface{}{tssc}
+-		}
+-
+-		if v.Priority != nil {
+-			t["priority"] = int(aws.Int64Value(v.Priority))
+-		}
+-
+-		if f := v.Filter; f != nil {
+-			m := map[string]interface{}{}
+-			if f.Prefix != nil {
+-				m["prefix"] = aws.StringValue(f.Prefix)
+-			}
+-			if t := f.Tag; t != nil {
+-				m["tags"] = KeyValueTags([]*s3.Tag{t}).IgnoreAWS().Map()
+-			}
+-			if a := f.And; a != nil {
+-				m["prefix"] = aws.StringValue(a.Prefix)
+-				m["tags"] = KeyValueTags(a.Tags).IgnoreAWS().Map()
+-			}
+-			t["filter"] = []interface{}{m}
+-
+-			if v.DeleteMarkerReplication != nil && v.DeleteMarkerReplication.Status != nil && aws.StringValue(v.DeleteMarkerReplication.Status) == s3.DeleteMarkerReplicationStatusEnabled {
+-				t["delete_marker_replication_status"] = aws.StringValue(v.DeleteMarkerReplication.Status)
+-			}
+-		}
+-
+-		rules = append(rules, t)
+-	}
+-	m["rules"] = schema.NewSet(rulesHashLegacy, rules)
+-
+-	replication_configuration = append(replication_configuration, m)
+-
+-	return replication_configuration
+-}
+-
+-func normalizeRoutingRulesLegacy(w []*s3.RoutingRule) (string, error) {
+-	withNulls, err := json.Marshal(w)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	var rules []map[string]interface{}
+-	if err := json.Unmarshal(withNulls, &rules); err != nil {
+-		return "", err
+-	}
+-
+-	var cleanRules []map[string]interface{}
+-	for _, rule := range rules {
+-		cleanRules = append(cleanRules, removeNilLegacy(rule))
+-	}
+-
+-	withoutNulls, err := json.Marshal(cleanRules)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	return string(withoutNulls), nil
+-}
+-
+-func removeNilLegacy(data map[string]interface{}) map[string]interface{} {
+-	withoutNil := make(map[string]interface{})
+-
+-	for k, v := range data {
+-		if v == nil {
+-			continue
+-		}
+-
+-		switch v := v.(type) {
+-		case map[string]interface{}:
+-			withoutNil[k] = removeNilLegacy(v)
+-		default:
+-			withoutNil[k] = v
+-		}
+-	}
+-
+-	return withoutNil
+-}
+-
+-func normalizeRegionLegacy(region string) string {
+-	// Default to us-east-1 if the bucket doesn't have a region:
+-	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+-	if region == "" {
+-		region = endpoints.UsEast1RegionID
+-	}
+-
+-	return region
+-}
+-
+-// ValidBucketName validates any S3 bucket name that is not inside the us-east-1 region.
+-// Buckets outside of this region have to be DNS-compliant. After the same restrictions are
+-// applied to buckets in the us-east-1 region, this function can be refactored as a SchemaValidateFunc
+-func ValidBucketNameLegacy(value string, region string) error {
+-	if region != endpoints.UsEast1RegionID {
+-		if (len(value) < 3) || (len(value) > 63) {
+-			return fmt.Errorf("%q must contain from 3 to 63 characters", value)
+-		}
+-		if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
+-			return fmt.Errorf("only lowercase alphanumeric characters and hyphens allowed in %q", value)
+-		}
+-		if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
+-			return fmt.Errorf("%q must not be formatted as an IP address", value)
+-		}
+-		if strings.HasPrefix(value, `.`) {
+-			return fmt.Errorf("%q cannot start with a period", value)
+-		}
+-		if strings.HasSuffix(value, `.`) {
+-			return fmt.Errorf("%q cannot end with a period", value)
+-		}
+-		if strings.Contains(value, `..`) {
+-			return fmt.Errorf("%q can be only one period between labels", value)
+-		}
+-	} else {
+-		if len(value) > 255 {
+-			return fmt.Errorf("%q must contain less than 256 characters", value)
+-		}
+-		if !regexp.MustCompile(`^[0-9a-zA-Z-._]+$`).MatchString(value) {
+-			return fmt.Errorf("only alphanumeric characters, hyphens, periods, and underscores allowed in %q", value)
+-		}
+-	}
+-	return nil
+-}
+-
+-func grantHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["id"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["type"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["uri"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if p, ok := m["permissions"]; ok {
+-		buf.WriteString(fmt.Sprintf("%v-", p.(*schema.Set).List()))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func transitionHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["date"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["days"]; ok {
+-		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+-	}
+-	if v, ok := m["storage_class"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func rulesHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["id"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["prefix"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["status"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["destination"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", destinationHashLegacy(v[0])))
+-	}
+-	if v, ok := m["source_selection_criteria"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", sourceSelectionCriteriaHashLegacy(v[0])))
+-	}
+-	if v, ok := m["priority"]; ok {
+-		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+-	}
+-	if v, ok := m["filter"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", replicationRuleFilterHashLegacy(v[0])))
+-
+-		if v, ok := m["delete_marker_replication_status"]; ok && v.(string) == s3.DeleteMarkerReplicationStatusEnabled {
+-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-		}
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func replicationRuleFilterHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["prefix"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["tags"]; ok {
+-		buf.WriteString(fmt.Sprintf("%d-", tftags.New(context.Background(), v).Hash()))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func destinationHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["bucket"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["storage_class"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["replica_kms_key_id"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["account"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	if v, ok := m["access_control_translation"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", accessControlTranslationHashLegacy(v[0])))
+-	}
+-	if v, ok := m["replication_time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", replicationTimeHashLegacy(v[0])))
+-	}
+-	if v, ok := m["metrics"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", metricsHashLegacy(v[0])))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func accessControlTranslationHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["owner"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func metricsHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["minutes"]; ok {
+-		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+-	}
+-	if v, ok := m["status"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func replicationTimeHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["minutes"]; ok {
+-		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+-	}
+-	if v, ok := m["status"]; ok {
+-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func sourceSelectionCriteriaHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["sse_kms_encrypted_objects"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+-		buf.WriteString(fmt.Sprintf("%d-", sourceSseKmsObjectsHashLegacy(v[0])))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-func sourceSseKmsObjectsHashLegacy(v interface{}) int {
+-	var buf bytes.Buffer
+-	m, ok := v.(map[string]interface{})
+-
+-	if !ok {
+-		return 0
+-	}
+-
+-	if v, ok := m["enabled"]; ok {
+-		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+-	}
+-	return create.StringHashcode(buf.String())
+-}
+-
+-type S3WebsiteLegacy struct {
+-	Endpoint, Domain string
+-}
+-
+-//
+-// S3 Object Lock functions.
+-//
+-
+-func readS3ObjectLockConfigurationLegacy(conn *s3.S3, bucket string) ([]interface{}, error) {
+-	resp, err := retryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+-		return conn.GetObjectLockConfiguration(&s3.GetObjectLockConfigurationInput{
+-			Bucket: aws.String(bucket),
+-		})
+-	})
+-	if err != nil {
+-		// Certain S3 implementations do not include this API
+-		if tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") {
+-			return nil, nil
+-		}
+-
+-		if tfawserr.ErrMessageContains(err, "ObjectLockConfigurationNotFoundError", "") {
+-			return nil, nil
+-		}
+-		return nil, err
+-	}
+-
+-	return flattenS3ObjectLockConfigurationLegacy(resp.(*s3.GetObjectLockConfigurationOutput).ObjectLockConfiguration), nil
+-}
+-
+-func expandS3ObjectLockConfigurationLegacy(vConf []interface{}) *s3.ObjectLockConfiguration {
+-	if len(vConf) == 0 || vConf[0] == nil {
+-		return nil
+-	}
+-
+-	mConf := vConf[0].(map[string]interface{})
+-
+-	conf := &s3.ObjectLockConfiguration{}
+-
+-	if vObjectLockEnabled, ok := mConf["object_lock_enabled"].(string); ok && vObjectLockEnabled != "" {
+-		conf.ObjectLockEnabled = aws.String(vObjectLockEnabled)
+-	}
+-
+-	if vRule, ok := mConf["rule"].([]interface{}); ok && len(vRule) > 0 {
+-		mRule := vRule[0].(map[string]interface{})
+-
+-		if vDefaultRetention, ok := mRule["default_retention"].([]interface{}); ok && len(vDefaultRetention) > 0 && vDefaultRetention[0] != nil {
+-			mDefaultRetention := vDefaultRetention[0].(map[string]interface{})
+-
+-			conf.Rule = &s3.ObjectLockRule{
+-				DefaultRetention: &s3.DefaultRetention{},
+-			}
+-
+-			if vMode, ok := mDefaultRetention["mode"].(string); ok && vMode != "" {
+-				conf.Rule.DefaultRetention.Mode = aws.String(vMode)
+-			}
+-			if vDays, ok := mDefaultRetention["days"].(int); ok && vDays > 0 {
+-				conf.Rule.DefaultRetention.Days = aws.Int64(int64(vDays))
+-			}
+-			if vYears, ok := mDefaultRetention["years"].(int); ok && vYears > 0 {
+-				conf.Rule.DefaultRetention.Years = aws.Int64(int64(vYears))
+-			}
+-		}
+-	}
+-
+-	return conf
+-}
+-
+-// Versioning functions
+-
+-func expandVersioningLegacy(l []interface{}) *s3.VersioningConfiguration {
+-	if len(l) == 0 || l[0] == nil {
+-		return nil
+-	}
+-
+-	tfMap, ok := l[0].(map[string]interface{})
+-
+-	if !ok {
+-		return nil
+-	}
+-
+-	output := &s3.VersioningConfiguration{}
+-
+-	if v, ok := tfMap["enabled"].(bool); ok {
+-		if v {
+-			output.Status = aws.String(s3.BucketVersioningStatusEnabled)
+-		} else {
+-			output.Status = aws.String(s3.BucketVersioningStatusSuspended)
+-		}
+-	}
+-
+-	if v, ok := tfMap["mfa_delete"].(bool); ok {
+-		if v {
+-			output.MFADelete = aws.String(s3.MFADeleteEnabled)
+-		} else {
+-			output.MFADelete = aws.String(s3.MFADeleteDisabled)
+-		}
+-	}
+-
+-	return output
+-}
+-
+-func expandVersioningWhenIsNewResourceLegacy(l []interface{}) *s3.VersioningConfiguration {
+-	if len(l) == 0 || l[0] == nil {
+-		return nil
+-	}
+-
+-	tfMap, ok := l[0].(map[string]interface{})
+-
+-	if !ok {
+-		return nil
+-	}
+-
+-	output := &s3.VersioningConfiguration{}
+-
+-	// Only set and return a non-nil VersioningConfiguration with at least one of
+-	// MFADelete or Status enabled as the PutBucketVersioning API request
+-	// does not need to be made for new buckets that don't require versioning.
+-	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4494
+-
+-	if v, ok := tfMap["enabled"].(bool); ok && v {
+-		output.Status = aws.String(s3.BucketVersioningStatusEnabled)
+-	}
+-
+-	if v, ok := tfMap["mfa_delete"].(bool); ok && v {
+-		output.MFADelete = aws.String(s3.MFADeleteEnabled)
+-	}
+-
+-	if output.MFADelete == nil && output.Status == nil {
+-		return nil
+-	}
+-
+-	return output
+-}
+-
+-func flattenVersioningLegacy(versioning *s3.GetBucketVersioningOutput) []interface{} {
+-	if versioning == nil {
+-		return []interface{}{}
+-	}
+-
+-	vc := make(map[string]interface{})
+-
+-	if aws.StringValue(versioning.Status) == s3.BucketVersioningStatusEnabled {
+-		vc["enabled"] = true
+-	} else {
+-		vc["enabled"] = false
+-	}
+-
+-	if aws.StringValue(versioning.MFADelete) == s3.MFADeleteEnabled {
+-		vc["mfa_delete"] = true
+-	} else {
+-		vc["mfa_delete"] = false
+-	}
+-
+-	return []interface{}{vc}
+-}
+-
+-func flattenS3ObjectLockConfigurationLegacy(conf *s3.ObjectLockConfiguration) []interface{} {
+-	if conf == nil {
+-		return []interface{}{}
+-	}
+-
+-	mConf := map[string]interface{}{
+-		"object_lock_enabled": aws.StringValue(conf.ObjectLockEnabled),
+-	}
+-
+-	if conf.Rule != nil && conf.Rule.DefaultRetention != nil {
+-		mRule := map[string]interface{}{
+-			"default_retention": []interface{}{
+-				map[string]interface{}{
+-					"mode":  aws.StringValue(conf.Rule.DefaultRetention.Mode),
+-					"days":  int(aws.Int64Value(conf.Rule.DefaultRetention.Days)),
+-					"years": int(aws.Int64Value(conf.Rule.DefaultRetention.Years)),
+-				},
+-			},
+-		}
+-
+-		mConf["rule"] = []interface{}{mRule}
+-	}
+-
+-	return []interface{}{mConf}
+-}
+-
+-func flattenGrantsLegacy(ap *s3.GetBucketAclOutput) []interface{} {
+-	//if ACL grants contains bucket owner FULL_CONTROL only - it is default "private" acl
+-	if len(ap.Grants) == 1 && aws.StringValue(ap.Grants[0].Grantee.ID) == aws.StringValue(ap.Owner.ID) &&
+-		aws.StringValue(ap.Grants[0].Permission) == s3.PermissionFullControl {
+-		return nil
+-	}
+-
+-	getGrant := func(grants []interface{}, grantee map[string]interface{}) (interface{}, bool) {
+-		for _, pg := range grants {
+-			pgt := pg.(map[string]interface{})
+-			if pgt["type"] == grantee["type"] && pgt["id"] == grantee["id"] && pgt["uri"] == grantee["uri"] &&
+-				pgt["permissions"].(*schema.Set).Len() > 0 {
+-				return pg, true
+-			}
+-		}
+-		return nil, false
+-	}
+-
+-	grants := make([]interface{}, 0, len(ap.Grants))
+-	for _, granteeObject := range ap.Grants {
+-		grantee := make(map[string]interface{})
+-		grantee["type"] = aws.StringValue(granteeObject.Grantee.Type)
+-
+-		if granteeObject.Grantee.ID != nil {
+-			grantee["id"] = aws.StringValue(granteeObject.Grantee.ID)
+-		}
+-		if granteeObject.Grantee.URI != nil {
+-			grantee["uri"] = aws.StringValue(granteeObject.Grantee.URI)
+-		}
+-		if pg, ok := getGrant(grants, grantee); ok {
+-			pg.(map[string]interface{})["permissions"].(*schema.Set).Add(aws.StringValue(granteeObject.Permission))
+-		} else {
+-			grantee["permissions"] = schema.NewSet(schema.HashString, []interface{}{aws.StringValue(granteeObject.Permission)})
+-			grants = append(grants, grantee)
+-		}
+-	}
+-
+-	return grants
+-}
+-
+-func validBucketLifecycleTimestampLegacy(v interface{}, k string) (ws []string, errors []error) {
+-	value := v.(string)
+-	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
+-	if err != nil {
+-		errors = append(errors, fmt.Errorf(
+-			"%q cannot be parsed as RFC3339 Timestamp Format", value))
+-	}
+-
+-	return
+-}
+diff --git a/internal/service/s3legacy/enum.go b/internal/service/s3legacy/enum.go
+deleted file mode 100644
+index 2e9caaae18..0000000000
+--- a/internal/service/s3legacy/enum.go
++++ /dev/null
+@@ -1,32 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"github.com/aws/aws-sdk-go/service/s3"
+-)
+-
+-const DefaultKmsKeyAlias = "alias/aws/s3"
+-
+-// These should be defined in the AWS SDK for Go. There is an open issue https://github.com/aws/aws-sdk-go/issues/2683
+-const (
+-	BucketCannedACLExecRead         = "aws-exec-read"
+-	BucketCannedACLLogDeliveryWrite = "log-delivery-write"
+-
+-	LifecycleRuleStatusEnabled  = "Enabled"
+-	LifecycleRuleStatusDisabled = "Disabled"
+-)
+-
+-func BucketCannedACL_Values() []string {
+-	result := s3.BucketCannedACL_Values()
+-	result = appendUniqueString(result, BucketCannedACLExecRead)
+-	result = appendUniqueString(result, BucketCannedACLLogDeliveryWrite)
+-	return result
+-}
+-
+-func appendUniqueString(slice []string, elem string) []string {
+-	for _, e := range slice {
+-		if e == elem {
+-			return slice
+-		}
+-	}
+-	return append(slice, elem)
+-}
+diff --git a/internal/service/s3legacy/errors.go b/internal/service/s3legacy/errors.go
+deleted file mode 100644
+index af03bdf5aa..0000000000
+--- a/internal/service/s3legacy/errors.go
++++ /dev/null
+@@ -1,8 +0,0 @@
+-package s3legacy
+-
+-// Error code constants missing from AWS Go SDK:
+-// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#pkg-constants
+-
+-const (
+-	ErrCodeOperationAborted = "OperationAborted"
+-)
+diff --git a/internal/service/s3legacy/generate.go b/internal/service/s3legacy/generate.go
+deleted file mode 100644
+index 8e0b62b3da..0000000000
+--- a/internal/service/s3legacy/generate.go
++++ /dev/null
+@@ -1,4 +0,0 @@
+-//go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
+-// ONLY generate directives and package declaration! Do not add anything else to this file.
+-
+-package s3legacy
+diff --git a/internal/service/s3legacy/hosted_zones.go b/internal/service/s3legacy/hosted_zones.go
+deleted file mode 100644
+index a94403b066..0000000000
+--- a/internal/service/s3legacy/hosted_zones.go
++++ /dev/null
+@@ -1,45 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"fmt"
+-
+-	"github.com/aws/aws-sdk-go/aws/endpoints"
+-)
+-
+-// See https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints.
+-var hostedZoneIDsMap = map[string]string{
+-	endpoints.AfSouth1RegionID:     "Z83WF9RJE8B12",
+-	endpoints.ApEast1RegionID:      "ZNB98KWMFR0R6",
+-	endpoints.ApNortheast1RegionID: "Z2M4EHUR26P7ZW",
+-	endpoints.ApNortheast2RegionID: "Z3W03O7B5YMIYP",
+-	endpoints.ApNortheast3RegionID: "Z2YQB5RD63NC85",
+-	endpoints.ApSouth1RegionID:     "Z11RGJOFQNVJUP",
+-	endpoints.ApSoutheast1RegionID: "Z3O0J2DXBE1FTB",
+-	endpoints.ApSoutheast2RegionID: "Z1WCIGYICN2BYD",
+-	endpoints.ApSoutheast3RegionID: "Z01613992JD795ZI93075",
+-	endpoints.CaCentral1RegionID:   "Z1QDHH18159H29",
+-	endpoints.CnNorthwest1RegionID: "Z282HJ1KT0DH03",
+-	endpoints.EuCentral1RegionID:   "Z21DNDUVLTQW6Q",
+-	endpoints.EuNorth1RegionID:     "Z3BAZG2TWCNX0D",
+-	endpoints.EuSouth1RegionID:     "Z30OZKI7KPW7MI",
+-	endpoints.EuWest1RegionID:      "Z1BKCTXD74EZPE",
+-	endpoints.EuWest2RegionID:      "Z3GKZC51ZF0DB4",
+-	endpoints.EuWest3RegionID:      "Z3R1K369G5AVDG",
+-	endpoints.MeSouth1RegionID:     "Z1MPMWCPA7YB62",
+-	endpoints.SaEast1RegionID:      "Z7KQH4QJS55SO",
+-	endpoints.UsEast1RegionID:      "Z3AQBSTGFYJSTF",
+-	endpoints.UsEast2RegionID:      "Z2O1EMRO9K5GLX",
+-	endpoints.UsGovEast1RegionID:   "Z2NIFVYYW2VKV1",
+-	endpoints.UsGovWest1RegionID:   "Z31GFT0UA1I2HV",
+-	endpoints.UsWest1RegionID:      "Z2F56UZL2M1ACD",
+-	endpoints.UsWest2RegionID:      "Z3BJ6K6RIION7M",
+-}
+-
+-// Returns the hosted zone ID for an S3 website endpoint region. This can be
+-// used as input to the aws_route53_record resource's zone_id argument.
+-func HostedZoneIDForRegion(region string) (string, error) {
+-	if v, ok := hostedZoneIDsMap[region]; ok {
+-		return v, nil
+-	}
+-	return "", fmt.Errorf("S3 hosted zone ID not found for region: %s", region)
+-}
+diff --git a/internal/service/s3legacy/object.go b/internal/service/s3legacy/object.go
+deleted file mode 100644
+index f44b435af6..0000000000
+--- a/internal/service/s3legacy/object.go
++++ /dev/null
+@@ -1,177 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"fmt"
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/service/s3"
+-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+-	"log"
+-)
+-
+-// DeleteAllObjectVersions deletes all versions of a specified key from an S3 bucket.
+-// If key is empty then all versions of all objects are deleted.
+-// Set force to true to override any S3 object lock protections on object lock enabled buckets.
+-func DeleteAllObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreObjectErrors bool) error {
+-	input := &s3.ListObjectVersionsInput{
+-		Bucket: aws.String(bucketName),
+-	}
+-	if key != "" {
+-		input.Prefix = aws.String(key)
+-	}
+-
+-	var lastErr error
+-	err := conn.ListObjectVersionsPages(input, func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
+-		if page == nil {
+-			return !lastPage
+-		}
+-
+-		for _, objectVersion := range page.Versions {
+-			objectKey := aws.StringValue(objectVersion.Key)
+-			objectVersionID := aws.StringValue(objectVersion.VersionId)
+-
+-			if key != "" && key != objectKey {
+-				continue
+-			}
+-
+-			err := deleteS3ObjectVersion(conn, bucketName, objectKey, objectVersionID, force)
+-			if tfawserr.ErrMessageContains(err, "AccessDenied", "") && force {
+-				// Remove any legal hold.
+-				resp, err := conn.HeadObject(&s3.HeadObjectInput{
+-					Bucket:    aws.String(bucketName),
+-					Key:       objectVersion.Key,
+-					VersionId: objectVersion.VersionId,
+-				})
+-
+-				if err != nil {
+-					log.Printf("[ERROR] Error getting S3 Bucket (%s) Object (%s) Version (%s) metadata: %s", bucketName, objectKey, objectVersionID, err)
+-					lastErr = err
+-					continue
+-				}
+-
+-				if aws.StringValue(resp.ObjectLockLegalHoldStatus) == s3.ObjectLockLegalHoldStatusOn {
+-					_, err := conn.PutObjectLegalHold(&s3.PutObjectLegalHoldInput{
+-						Bucket:    aws.String(bucketName),
+-						Key:       objectVersion.Key,
+-						VersionId: objectVersion.VersionId,
+-						LegalHold: &s3.ObjectLockLegalHold{
+-							Status: aws.String(s3.ObjectLockLegalHoldStatusOff),
+-						},
+-					})
+-
+-					if err != nil {
+-						log.Printf("[ERROR] Error putting S3 Bucket (%s) Object (%s) Version(%s) legal hold: %s", bucketName, objectKey, objectVersionID, err)
+-						lastErr = err
+-						continue
+-					}
+-
+-					// Attempt to delete again.
+-					err = deleteS3ObjectVersion(conn, bucketName, objectKey, objectVersionID, force)
+-
+-					if err != nil {
+-						lastErr = err
+-					}
+-
+-					continue
+-				}
+-
+-				// AccessDenied for another reason.
+-				lastErr = fmt.Errorf("AccessDenied deleting S3 Bucket (%s) Object (%s) Version: %s", bucketName, objectKey, objectVersionID)
+-				continue
+-			}
+-
+-			if err != nil {
+-				lastErr = err
+-			}
+-		}
+-
+-		return !lastPage
+-	})
+-
+-	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
+-		err = nil
+-	}
+-
+-	if err != nil {
+-		return err
+-	}
+-
+-	if lastErr != nil {
+-		if !ignoreObjectErrors {
+-			return fmt.Errorf("error deleting at least one object version, last error: %s", lastErr)
+-		}
+-
+-		lastErr = nil
+-	}
+-
+-	err = conn.ListObjectVersionsPages(input, func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
+-		if page == nil {
+-			return !lastPage
+-		}
+-
+-		for _, deleteMarker := range page.DeleteMarkers {
+-			deleteMarkerKey := aws.StringValue(deleteMarker.Key)
+-			deleteMarkerVersionID := aws.StringValue(deleteMarker.VersionId)
+-
+-			if key != "" && key != deleteMarkerKey {
+-				continue
+-			}
+-
+-			// Delete markers have no object lock protections.
+-			err := deleteS3ObjectVersion(conn, bucketName, deleteMarkerKey, deleteMarkerVersionID, false)
+-
+-			if err != nil {
+-				lastErr = err
+-			}
+-		}
+-
+-		return !lastPage
+-	})
+-
+-	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") {
+-		err = nil
+-	}
+-
+-	if err != nil {
+-		return err
+-	}
+-
+-	if lastErr != nil {
+-		if !ignoreObjectErrors {
+-			return fmt.Errorf("error deleting at least one object delete marker, last error: %s", lastErr)
+-		}
+-
+-		lastErr = nil
+-	}
+-
+-	return nil
+-}
+-
+-// deleteS3ObjectVersion deletes a specific object version.
+-// Set force to true to override any S3 object lock protections.
+-func deleteS3ObjectVersion(conn *s3.S3, b, k, v string, force bool) error {
+-	input := &s3.DeleteObjectInput{
+-		Bucket: aws.String(b),
+-		Key:    aws.String(k),
+-	}
+-
+-	if v != "" {
+-		input.VersionId = aws.String(v)
+-	}
+-
+-	if force {
+-		input.BypassGovernanceRetention = aws.Bool(true)
+-	}
+-
+-	log.Printf("[INFO] Deleting S3 Bucket (%s) Object (%s) Version: %s", b, k, v)
+-	_, err := conn.DeleteObject(input)
+-
+-	if err != nil {
+-		log.Printf("[WARN] Error deleting S3 Bucket (%s) Object (%s) Version (%s): %s", b, k, v, err)
+-	}
+-
+-	if tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchBucket, "") || tfawserr.ErrMessageContains(err, s3.ErrCodeNoSuchKey, "") {
+-		return nil
+-	}
+-
+-	return err
+-}
+diff --git a/internal/service/s3legacy/retry.go b/internal/service/s3legacy/retry.go
+deleted file mode 100644
+index dcf7e39759..0000000000
+--- a/internal/service/s3legacy/retry.go
++++ /dev/null
+@@ -1,30 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+-	"time"
+-)
+-
+-// FORK: Adding the retryOnAWSCode to the fork for the old AWS S3 Logic
+-func retryOnAWSCode(code string, f func() (interface{}, error)) (interface{}, error) {
+-	var resp interface{}
+-	err := retry.Retry(2*time.Minute, func() *retry.RetryError {
+-		var err error
+-		resp, err = f()
+-		if err != nil {
+-			if tfawserr.ErrCodeEquals(err, code) {
+-				return retry.RetryableError(err)
+-			}
+-			return retry.NonRetryableError(err)
+-		}
+-		return nil
+-	})
+-
+-	if tfresource.TimedOut(err) {
+-		resp, err = f()
+-	}
+-
+-	return resp, err
+-}
+diff --git a/internal/service/s3legacy/service_package.go b/internal/service/s3legacy/service_package.go
+deleted file mode 100644
+index 5d2ea27364..0000000000
+--- a/internal/service/s3legacy/service_package.go
++++ /dev/null
+@@ -1,78 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"context"
+-
+-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+-	"github.com/hashicorp/terraform-provider-aws/internal/types"
+-)
+-
+-type servicePackage struct{}
+-
+-func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
+-	return []*types.ServicePackageFrameworkDataSource{}
+-}
+-
+-func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
+-	return []*types.ServicePackageFrameworkResource{}
+-}
+-
+-func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
+-	return []*types.ServicePackageSDKDataSource{}
+-}
+-
+-func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
+-	return []*types.ServicePackageSDKResource{
+-		{
+-			Factory:  ResourceBucketLegacy,
+-			TypeName: "aws_s3_bucket_legacy",
+-			Name:     "BucketLegacy",
+-			Tags: &types.ServicePackageResourceTags{
+-				IdentifierAttribute: "bucket",
+-				ResourceType:        "Bucket",
+-			},
+-		},
+-	}
+-}
+-
+-func (p *servicePackage) ServicePackageName() string {
+-	return "s3legacy"
+-}
+-
+-func ServicePackage(ctx context.Context) conns.ServicePackage {
+-	return &servicePackage{}
+-}
+-
+-// import (
+-// 	"context"
+-
+-// 	"github.com/aws/aws-sdk-go-v2/aws"
+-// 	"github.com/aws/aws-sdk-go-v2/aws/retry"
+-// 	"github.com/aws/aws-sdk-go-v2/service/s3"
+-// 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+-// 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+-// 	"github.com/hashicorp/terraform-provider-aws/names"
+-// )
+-
+-// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+-// func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*s3.Client, error) {
+-// 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+-
+-// 	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+-// 		if endpoint := config["endpoint"].(string); endpoint != "" {
+-// 			o.BaseEndpoint = aws.String(endpoint)
+-// 		} else if o.Region == names.USEast1RegionID && config["s3_us_east_1_regional_endpoint"].(string) != "regional" {
+-// 			// Maintain the AWS SDK for Go v1 default of using the global endpoint in us-east-1.
+-// 			// See https://github.com/hashicorp/terraform-provider-aws/issues/33028.
+-// 			o.Region = names.GlobalRegionID
+-// 		}
+-// 		o.UsePathStyle = config["s3_use_path_style"].(bool)
+-
+-// 		o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+-// 			if tfawserr.ErrMessageContains(err, errCodeOperationAborted, "A conflicting conditional operation is currently in progress against this resource. Please try again.") {
+-// 				return aws.TrueTernary
+-// 			}
+-// 			return aws.UnknownTernary // Delegate to configured Retryer.
+-// 		}))
+-// 	}), nil
+-// }
+diff --git a/internal/service/s3legacy/tags.go b/internal/service/s3legacy/tags.go
+deleted file mode 100644
+index 669813747b..0000000000
+--- a/internal/service/s3legacy/tags.go
++++ /dev/null
+@@ -1,174 +0,0 @@
+-//go:build !generate
+-// +build !generate
+-
+-package s3legacy
+-
+-import (
+-	"context"
+-	"fmt"
+-	"time"
+-
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/aws/awserr"
+-	"github.com/aws/aws-sdk-go/service/s3"
+-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+-)
+-
+-const (
+-	ErrCodeNoSuchTagSet = "NoSuchTagSet"
+-)
+-
+-// Custom S3 tag service update functions using the same format as generated code.
+-
+-// BucketListTags lists S3 bucket tags.
+-// The identifier is the bucket name.
+-func BucketListTags(conn *s3.S3, identifier string) (tftags.KeyValueTags, error) {
+-	input := &s3.GetBucketTaggingInput{
+-		Bucket: aws.String(identifier),
+-	}
+-
+-	output, err := conn.GetBucketTagging(input)
+-
+-	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
+-	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
+-	// and the AWS Go SDK has neither as a constant.
+-	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet) {
+-		return tftags.New(context.Background(), nil), nil
+-	}
+-
+-	if err != nil {
+-		return tftags.New(context.Background(), nil), err
+-	}
+-
+-	return KeyValueTags(output.TagSet), nil
+-}
+-
+-// BucketUpdateTags updates S3 bucket tags.
+-// The identifier is the bucket name.
+-func BucketUpdateTags(conn *s3.S3, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+-	oldTags := tftags.New(context.Background(), oldTagsMap)
+-	newTags := tftags.New(context.Background(), newTagsMap)
+-
+-	// We need to also consider any existing ignored tags.
+-	allTags, err := BucketListTags(conn, identifier)
+-
+-	if err != nil {
+-		return fmt.Errorf("error listing resource tags (%s): %w", identifier, err)
+-	}
+-
+-	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
+-
+-	if len(newTags)+len(ignoredTags) > 0 {
+-		input := &s3.PutBucketTaggingInput{
+-			Bucket: aws.String(identifier),
+-			Tagging: &s3.Tagging{
+-				TagSet: Tags(newTags.Merge(ignoredTags)),
+-			},
+-		}
+-
+-		_, err := conn.PutBucketTagging(input)
+-
+-		if err != nil {
+-			return fmt.Errorf("error setting resource tags (%s): %w", identifier, err)
+-		}
+-	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
+-		input := &s3.DeleteBucketTaggingInput{
+-			Bucket: aws.String(identifier),
+-		}
+-
+-		_, err := conn.DeleteBucketTagging(input)
+-
+-		if err != nil {
+-			return fmt.Errorf("error deleting resource tags (%s): %w", identifier, err)
+-		}
+-	}
+-
+-	return nil
+-}
+-
+-// ObjectListTags lists S3 object tags.
+-func ObjectListTags(conn *s3.S3, bucket, key string) (tftags.KeyValueTags, error) {
+-	input := &s3.GetObjectTaggingInput{
+-		Bucket: aws.String(bucket),
+-		Key:    aws.String(key),
+-	}
+-
+-	var output *s3.GetObjectTaggingOutput
+-
+-	err := retry.Retry(1*time.Minute, func() *retry.RetryError {
+-		var err error
+-		output, err = conn.GetObjectTagging(input)
+-		if awsErr, ok := err.(awserr.Error); ok {
+-			if awsErr.Code() == "NoSuchKey" {
+-				return retry.RetryableError(
+-					fmt.Errorf("getting object tagging %s, retrying: %w", bucket, err),
+-				)
+-			}
+-		}
+-		if err != nil {
+-			return retry.NonRetryableError(err)
+-		}
+-
+-		return nil
+-	})
+-	if tfresource.TimedOut(err) {
+-		output, err = conn.GetObjectTagging(input)
+-	}
+-
+-	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet) {
+-		return tftags.New(context.Background(), nil), nil
+-	}
+-
+-	if err != nil {
+-		return tftags.New(context.Background(), nil), err
+-	}
+-
+-	return KeyValueTags(output.TagSet), nil
+-}
+-
+-// ObjectUpdateTags updates S3 object tags.
+-func ObjectUpdateTags(conn *s3.S3, bucket, key string, oldTagsMap interface{}, newTagsMap interface{}) error {
+-	oldTags := tftags.New(context.Background(), oldTagsMap)
+-	newTags := tftags.New(context.Background(), newTagsMap)
+-
+-	// We need to also consider any existing ignored tags.
+-	allTags, err := ObjectListTags(conn, bucket, key)
+-
+-	if err != nil {
+-		return fmt.Errorf("error listing resource tags (%s/%s): %w", bucket, key, err)
+-	}
+-
+-	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
+-
+-	if len(newTags)+len(ignoredTags) > 0 {
+-		input := &s3.PutObjectTaggingInput{
+-			Bucket: aws.String(bucket),
+-			Key:    aws.String(key),
+-			Tagging: &s3.Tagging{
+-				TagSet: Tags(newTags.Merge(ignoredTags).IgnoreAWS()),
+-			},
+-		}
+-
+-		_, err := conn.PutObjectTagging(input)
+-
+-		if err != nil {
+-			return fmt.Errorf("error setting resource tags (%s/%s): %w", bucket, key, err)
+-		}
+-	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
+-		input := &s3.DeleteObjectTaggingInput{
+-			Bucket: aws.String(bucket),
+-			Key:    aws.String(key),
+-		}
+-
+-		_, err := conn.DeleteObjectTagging(input)
+-
+-		if err != nil {
+-			return fmt.Errorf("error deleting resource tags (%s/%s): %w", bucket, key, err)
+-		}
+-	}
+-
+-	return nil
+-}
+diff --git a/internal/service/s3legacy/tags_gen.go b/internal/service/s3legacy/tags_gen.go
+deleted file mode 100644
+index c65bacf65d..0000000000
+--- a/internal/service/s3legacy/tags_gen.go
++++ /dev/null
+@@ -1,38 +0,0 @@
+-// Code generated by internal/generate/tags/main.go; DO NOT EDIT.
+-package s3legacy
+-
+-import (
+-	"context"
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/service/s3"
+-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+-)
+-
+-// []*SERVICE.Tag handling
+-
+-// Tags returns s3 service tags.
+-func Tags(tags tftags.KeyValueTags) []*s3.Tag {
+-	result := make([]*s3.Tag, 0, len(tags))
+-
+-	for k, v := range tags.Map() {
+-		tag := &s3.Tag{
+-			Key:   aws.String(k),
+-			Value: aws.String(v),
+-		}
+-
+-		result = append(result, tag)
+-	}
+-
+-	return result
+-}
+-
+-// KeyValueTags creates tftags.KeyValueTags from s3 service tags.
+-func KeyValueTags(tags []*s3.Tag) tftags.KeyValueTags {
+-	m := make(map[string]*string, len(tags))
+-
+-	for _, tag := range tags {
+-		m[aws.StringValue(tag.Key)] = tag.Value
+-	}
+-
+-	return tftags.New(context.Background(), m)
+-}
+diff --git a/internal/service/s3legacy/wait.go b/internal/service/s3legacy/wait.go
+deleted file mode 100644
+index 9031539c19..0000000000
+--- a/internal/service/s3legacy/wait.go
++++ /dev/null
+@@ -1,18 +0,0 @@
+-package s3legacy
+-
+-import (
+-	"context"
+-	"time"
+-
+-	"github.com/aws/aws-sdk-go/service/s3"
+-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+-)
+-
+-const (
+-	bucketCreatedTimeout = 2 * time.Minute
+-	propagationTimeout   = 1 * time.Minute
+-)
+-
+-func retryWhenBucketNotFound(ctx context.Context, f func() (interface{}, error)) (interface{}, error) {
+-	return tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, f, s3.ErrCodeNoSuchBucket)
+-}


### PR DESCRIPTION
BucketV2 and Bucket underlying schemata are still very close and almost identical, since they have a common ancestry, with BucketV2 continuing to evolve and Bucket lagging behind. This experiment attempts to exploit this by redirecting the implementation details of handling Bucket CRUD to the BucketV2 implementation.

This change is ideally a refactor invisible to the user but given a substantial API surface need to be careful not to regress.

- removed s3legacy and recreated the legacy bucket against v2 code
- encountering some bugs, we might need to remove default: "private" from "acl"

```
* putting S3 Bucket (my-bucket-eb276e3) ACL: operation error S3: PutBucketAcl, https response error StatusCode:
       400, RequestID: GMTPEW43STHM9DWM, HostID:
       /NJMasmaMuMN64OXgC+h58N1ozOYowaC0dP2I9rb2z7NPRZ83BWrabjNk0SIqYniyPCJe/iD/oI=, api error
       AccessControlListNotSupported: The bucket does not allow ACLs
```
   
- logging (loggings?) has changed from Set to List with MaxItems=1 there might be a slight change to compensate for
- there were a lot of custom TypeSet Set functions specified in the legacy, why were they removed in BucketV2, is it OK to match or we can roll without them
- generally might need to add lifecycle and provider upgrade tests targeting each attribute like "loggings"
- removes a fair bit of Pulumi-maintained custom code, need to itemize and ensure that was redundant