### PR TITLE
Increase timeout for TestRegress3196 test

### DIFF
--- a/provider/provider_python_test.go
+++ b/provider/provider_python_test.go
@@ -23,7 +23,7 @@ func TestRegress3196(t *testing.T) {
 		t.Skipf("Skipping test in -short mode because it needs cloud credentials")
 		return
 	}
-	maxDuration(3*time.Minute, t, func(t *testing.T) {
+	maxDuration(6*time.Minute, t, func(t *testing.T) {
 		test := getPythonBaseOptions(t).
 			With(integration.ProgramTestOptions{
 				Quick:         true,


### PR DESCRIPTION
The test flaked sometimes because it ran into the timeout.
The regression this test fixes had a wait time of hours, so changing the timeout to 6 minutes won't change the effectiveness of the regression test.

Fixes https://github.com/pulumi/pulumi-aws/issues/3945
