### PR TITLE
Enroll aws_wafv2_rule_group in PlanResourceChange

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -468,10 +468,6 @@ func TestAccWafV2(t *testing.T) {
 		})
 	skipRefresh(&test)
 
-	// TODO[pulumi/pulumi-aws#3190] there is a bug with non-empty diff after pulumi up.
-	test.AllowEmptyPreviewChanges = true
-	test.AllowEmptyUpdateChanges = true
-
 	integration.ProgramTest(t, &test)
 }
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -803,6 +803,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 			switch s {
 			case "aws_ssm_document",
 				"aws_wafv2_web_acl",
+				"aws_wafv2_rule_group",
 				"aws_batch_job_definition":
 				return true
 			default:


### PR DESCRIPTION
WAFv2 RuleGroups used to have a perma diff for the rules property.
Enrolling the resource in PlanResourceChange fixes that.

Fixes https://github.com/pulumi/pulumi-aws/issues/3306, https://github.com/pulumi/pulumi-aws/issues/3880, https://github.com/pulumi/pulumi-aws/issues/3190, https://github.com/pulumi/pulumi-aws/issues/3454