### PR TITLE
Upgrade instances for TestAccWebserverComp test

### DIFF
--- a/examples/webserver-comp/index.ts
+++ b/examples/webserver-comp/index.ts
@@ -3,4 +3,4 @@
 import * as webserver from "./webserver";
 
 let webServer = new webserver.Micro("www");
-let appServer = new webserver.Nano("app");
+let appServer = new webserver.Small("app");

--- a/examples/webserver-comp/webserver.ts
+++ b/examples/webserver-comp/webserver.ts
@@ -52,12 +52,12 @@ export class Server {
 
 export class Micro extends Server {
     constructor(name: string) {
-        super(name, aws.ec2.InstanceType.T2_Micro);
+        super(name, aws.ec2.InstanceType.T3_Micro);
     }
 }
 
-export class Nano extends Server {
+export class Small extends Server {
     constructor(name: string) {
-        super(name, aws.ec2.InstanceType.T2_Nano);
+        super(name, aws.ec2.InstanceType.T3_Small);
     }
 }


### PR DESCRIPTION
The TestAccWebserverComp still occasionally flaked after upgrading the AMI. This changes the instances to a newer generation and changes the `nano` instance to a `small` to ensure the long boot times aren't caused by running out of CPU credits

Fixes: https://github.com/pulumi/pulumi-aws/issues/3903