### PR TITLE
Do not skip metadata API check by default

### DIFF
--- a/provider/configure_test.go
+++ b/provider/configure_test.go
@@ -110,7 +110,6 @@ func TestCheckConfigFastWithCustomEndpoints(t *testing.T) {
 	      "s3UsePathStyle": "true",
 	      "secretKey": "*",
 	      "skipCredentialsValidation": "true",
-	      "skipMetadataApiCheck": "true",
 	      "skipRegionValidation": "true",
 	      "skipRequestingAccountId": "true",
 	      "version": "6.5.0"

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -6,12 +6,15 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -318,16 +321,44 @@ func TestRegress3674(t *testing.T) {
 
 // Ensure that pulumi-aws can authenticate using IMDS API when Pulumi is running in a context where that is made
 // available such as an EC2 instance.
-func TestIMSDAuth(t *testing.T) {
+func TestIMDSAuth(t *testing.T) {
+	var localProviderBuild string
 	actual := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 	expected := "linux/amd64"
-	if fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH) != "" {
-		t.Skipf("This test requires %q but running on %q", expected, actual)
-	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	localProviderBuild, err := filepath.Abs(filepath.Join(cwd, "..", "bin", "pulumi-resource-aws"))
-	require.NoError(t, err)
+	if actual == expected {
+		currentBinary, err := filepath.Abs(filepath.Join(cwd, "..", "bin", "pulumi-resource-aws"))
+		require.NoError(t, err)
+		t.Logf("Reusing prebuilt binary from %s to test %q", currentBinary, expected)
+		localProviderBuild = currentBinary
+	} else {
+		t.Logf("Cross-compiling provider-resource-aws under test to %q", expected)
+		localProviderBuild = filepath.Join(os.TempDir(), "pulumi-resource-aws")
+		ldFlags := []string{
+			"-X", "github.com/pulumi/pulumi-aws/provider/v6/pkg/version.Version=6.0.0-alpha.0+dev",
+			"-X", "github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=6.0.0-alpha.0+dev",
+		}
+		args := []string{
+			"build", "-o", localProviderBuild,
+			"-ldflags", strings.Join(ldFlags, " "),
+		}
+		cmd := exec.Command("go", args...)
+		cmd.Dir = filepath.Join(cwd, "cmd", "pulumi-resource-aws")
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env,
+			fmt.Sprintf("GOOS=linux"),
+			fmt.Sprintf("GOARCH=amd64"),
+		)
+		var stderr, stdout bytes.Buffer
+		cmd.Stderr = &stderr
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err != nil {
+			t.Logf("go %s failed\nStdout:\n%s\nStderr:\n%s\n", strings.Join(args, " "),
+				stdout.String(), stderr.String())
+			require.NoError(t, err)
+		}
+	}
 	t.Run("IDMSv2", func(t *testing.T) {
 		ptest := pulumiTest(t, filepath.Join("test-programs", "imds-auth", "imds-v2"), opttest.SkipInstall())
 		ptest.SetConfig("localProviderBuild", localProviderBuild)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -872,9 +872,6 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 			},
 			"skip_metadata_api_check": {
 				Type: "boolean",
-				Default: &tfbridge.DefaultInfo{
-					Value: true,
-				},
 			},
 			"access_key": {
 				Secret: tfbridge.True(),

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -642,14 +642,9 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 		config.AssumeRoleWithWebIdentity = &assumeRole
 	}
 
-	// By default `skipMetadataApiCheck` is true for Pulumi to speed operations
-	// if we want to authenticate against the AWS API Metadata Service then the user
-	// will specify that skipMetadataApiCheck: false
-	// therefore, if we have skipMetadataApiCheck false, then we are enabling the imds client
-	config.EC2MetadataServiceEnableState = imds.ClientDisabled
+	// Only set non-default EC2MetadataServiceEnableState if requested by skipMetadataApiCheck.
 	skipMetadataApiCheck, err := boolValue(vars, "skipMetadataApiCheck",
 		[]string{"AWS_SKIP_METADATA_API_CHECK"})
-
 	contract.AssertNoErrorf(err, "Failed to parse skipMetadataApiCheck configuration")
 	if skipMetadataApiCheck != nil {
 		if *skipMetadataApiCheck {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -522,22 +522,23 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 }
 
 // boolValue gets a bool value from a property map if present, else false
-func boolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) bool {
+func boolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) (*bool, error) {
 	val, ok := vars[prop]
 	if ok && val.IsBool() {
-		return val.BoolValue()
+		result := val.BoolValue()
+		return &result, nil
 	}
 	for _, env := range envs {
 		val, ok := os.LookupEnv(env)
 		if ok {
 			boolValue, err := strconv.ParseBool(val)
 			if err != nil {
-				return false
+				return nil, err
 			}
-			return boolValue
+			return &boolValue, nil
 		}
 	}
-	return false
+	return nil, nil
 }
 
 func arrayValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) []string {
@@ -646,10 +647,16 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 	// will specify that skipMetadataApiCheck: false
 	// therefore, if we have skipMetadataApiCheck false, then we are enabling the imds client
 	config.EC2MetadataServiceEnableState = imds.ClientDisabled
-	skipMetadataApiCheck := boolValue(vars, "skipMetadataApiCheck",
+	skipMetadataApiCheck, err := boolValue(vars, "skipMetadataApiCheck",
 		[]string{"AWS_SKIP_METADATA_API_CHECK"})
-	if !skipMetadataApiCheck {
-		config.EC2MetadataServiceEnableState = imds.ClientEnabled
+
+	contract.AssertNoErrorf(err, "Failed to parse skipMetadataApiCheck configuration")
+	if skipMetadataApiCheck != nil {
+		if *skipMetadataApiCheck {
+			config.EC2MetadataServiceEnableState = imds.ClientEnabled
+		} else {
+			config.EC2MetadataServiceEnableState = imds.ClientDisabled
+		}
 	}
 
 	// lastly let's set the sharedCreds and sharedConfig file. If these are not found then let's default to the
@@ -751,17 +758,21 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 // before passing control to the TF provider to ensure we can report actionable errors.
 func preConfigureCallback(alreadyRun *atomic.Bool) func(vars resource.PropertyMap, c shim.ResourceConfig) error {
 	return func(vars resource.PropertyMap, c shim.ResourceConfig) error {
-		skipCredentialsValidation := boolValue(vars, "skipCredentialsValidation",
+		var err error
+		skipCredentialsValidation, err := boolValue(vars, "skipCredentialsValidation",
 			[]string{"AWS_SKIP_CREDENTIALS_VALIDATION"})
+
+		if err != nil {
+			return err
+		}
 
 		// if we skipCredentialsValidation then we don't need to do anything in
 		// preConfigureCallback as this is an explicit operation
-		if skipCredentialsValidation {
+		if skipCredentialsValidation != nil && *skipCredentialsValidation {
 			log.Printf("[INFO] pulumi-aws: skip credentials validation")
 			return nil
 		}
 
-		var err error
 		if alreadyRun.CompareAndSwap(false, true) {
 			log.Printf("[INFO] pulumi-aws: starting to validate credentials. " +
 				"Disable this by AWS_SKIP_CREDENTIALS_VALIDATION or " +

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -647,7 +647,7 @@ func validateCredentials(vars resource.PropertyMap, c shim.ResourceConfig) error
 		[]string{"AWS_SKIP_METADATA_API_CHECK"})
 	contract.AssertNoErrorf(err, "Failed to parse skipMetadataApiCheck configuration")
 	if skipMetadataApiCheck != nil {
-		if *skipMetadataApiCheck {
+		if !*skipMetadataApiCheck {
 			config.EC2MetadataServiceEnableState = imds.ClientEnabled
 		} else {
 			config.EC2MetadataServiceEnableState = imds.ClientDisabled

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -6,6 +6,9 @@ backend:
   url: file://./pulumi-state
 
 config:
+  localProviderBuild:
+    type: string
+
   pulumi:tags:
     value:
       pulumi:template: aws-yaml
@@ -16,12 +19,16 @@ variables:
       function: aws:ec2:getAmi
       arguments:
         filters:
+          # TODO can get a better AMI that has AWS CLI v2 like al2023
           - name: name
             values: ["amzn2-ami-hvm-*-x86_64-*"]
         owners:
           - amazon
         mostRecent: true
       return: id
+
+  instanceType: t2.micro
+  policyArn: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess" # example policy
 
 resources:
 
@@ -45,6 +52,7 @@ resources:
             - 0.0.0.0/0
           ipv6CidrBlocks:
             - ::/0
+
   priv-key:
     type: tls:PrivateKey
     properties:
@@ -56,12 +64,41 @@ resources:
     properties:
       publicKey: ${priv-key.publicKeyOpenssh}
 
+  my-role:
+    type: aws:iam/role:Role
+    properties:
+      assumeRolePolicy: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Principal": {"Service": "ec2.amazonaws.com"},
+              "Effect": "Allow",
+              "Sid": ""
+            }
+          ]
+        }
+
+  my-role-policy-attachment:
+    type: aws:iam/rolePolicyAttachment:RolePolicyAttachment
+    properties:
+      role: ${my-role.name}
+      policyArn: ${policyArn}
+
+  my-instance-profile:
+    type: aws:iam/instanceProfile:InstanceProfile
+    properties:
+      role: ${my-role.name}
+
   inst:
     type: aws:ec2/instance:Instance
     properties:
       ami: ${ec2ami}
-      instanceType: t2.medium
+      instanceType: ${instanceType}
+      iamInstanceProfile: ${my-instance-profile.name}
       keyName: ${key-pair.keyName}
+      # Enable and enforce IMDSv2
       metadataOptions:
         httpTokens: required
         httpEndpoint: enabled
@@ -70,16 +107,12 @@ resources:
         - ${segroup}
       userData: |
         #!/bin/bash
-
-        # Reconfigure SSHD
+        # Reconfigure SSHD - workaround for pulumi Command issues
         cat /etc/ssh/ssh_config >/tmp/sshd_config
         echo "AcceptEnv PULUMI_COMMAND_STDOUT" >> /tmp/sshd_config
         echo "AcceptEnv PULUMI_COMMAND_STDERR" >> /tmp/sshd_config
         sudo cp /tmp/sshd_config /etc/ssh/sshd_config || echo "FAILED to set sshd_config"
         rm /tmp/sshd_config
-
-
-        # sudo systemctl restart sshd.service
 
   file-copy:
     type: command:remote:CopyFile
@@ -88,38 +121,53 @@ resources:
         host: ${inst.publicIp}
         user: ec2-user # The default user for Amazon Linux AMI
         privateKey: ${priv-key.privateKeyOpenssh}
-      localPath: ./Pulumi.yaml
+      localPath: remote-program/Pulumi.yaml
       remotePath: "/tmp/Pulumi.yaml"
+    options:
+      ignoreChanges:
+        - connection
+
+  provider-copy:
+    type: command:remote:CopyFile
+    properties:
+      connection:
+        host: ${inst.publicIp}
+        user: ec2-user # The default user for Amazon Linux AMI
+        privateKey: ${priv-key.privateKeyOpenssh}
+      localPath: ${localProviderBuild}
+      remotePath: "/tmp/pulumi-resource-aws"
+    options:
+      ignoreChanges:
+        - connection
 
   install-cmd:
     type: command:remote:Command
     properties:
       create: |
-
-        echo "===="
-
         # Upgrade from AWS CLI v1 to AWS CLI v2
+        echo "========"
         sudo yum remove awscli
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
         unzip awscliv2.zip
         sudo ./aws/install
-
-        echo "====="
+        echo "========"
+        aws --version
+        echo "========"
 
         # Install Pulumi
+        echo "========"
         curl -fsSL https://get.pulumi.com | sh
         export PATH="/home/ec2-user/.pulumi/bin:$PATH"
-
-        echo "======"
+        echo "========"
         pulumi version
-        echo "======"
-        aws --version
-        echo "======"
+        echo "========"
       connection:
         host: ${inst.publicIp}
         user: ec2-user # The default user for Amazon Linux AMI
         privateKey: ${priv-key.privateKeyOpenssh}
     options:
+      ignoreChanges:
+        - connection
       dependsOn:
         - ${file-copy}
 
@@ -127,16 +175,16 @@ resources:
     type: command:remote:Command
     properties:
       create: |
-        echo "+++++"
-        aws --version
-        aws s3 ls
-        echo "+++++"
         cd /tmp
         mkdir ./pulumi-state
         export PULUMI_CONFIG_PASSPHRASE=123456
+        export PATH="/tmp:$PATH"
+        export PATH="/home/ec2-user/.pulumi/bin:$PATH"
+        pulumi version # ensure in PATH
+        pulumi-resource-aws --help # ensure in PATH
+
         pulumi stack init dev
         pulumi stack select dev
-        pulumi config set aws:skipMetadataApiCheck false
         pulumi config
         pulumi preview
       # SSH connection details to the remote machine
@@ -147,9 +195,9 @@ resources:
     options:
       dependsOn:
         - ${install-cmd}
+        - ${provider-copy}
 
 outputs:
   instanceId: ${inst.id}
   publicIp: ${inst.publicIp}
-  installOut: ${install-cmd.stdout}
   commandOut: ${init-cmd.stdout}

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -1,0 +1,92 @@
+name: imds-v2
+runtime: yaml
+description: Test the ability of pulumi-aws to authenticate on an EC2 instance with IMDSv2 enabled
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-yaml
+
+variables:
+  ec2ami:
+    fn::invoke:
+      function: aws:ec2:getAmi
+      arguments:
+        filters:
+          - name: name
+            values: ["amzn2-ami-hvm-*-x86_64-*"]
+        owners:
+          - amazon
+        mostRecent: true
+      return: id
+
+resources:
+
+  segroup:
+    type: aws:ec2:SecurityGroup
+    properties:
+      ingress:
+        - protocol: tcp
+          fromPort: 80
+          toPort: 80
+          cidrBlocks: ["0.0.0.0/0"]
+        - protocol: tcp
+          fromPort: 22
+          toPort: 22
+          cidrBlocks: ["0.0.0.0/0"]
+      egress:
+        - fromPort: 0
+          toPort: 0
+          protocol: '-1'
+          cidrBlocks:
+            - 0.0.0.0/0
+          ipv6CidrBlocks:
+            - ::/0
+  priv-key:
+    type: tls:PrivateKey
+    properties:
+      algorithm: RSA
+      rsaBits: 2048
+
+  key-pair:
+    type: aws:ec2/keyPair:KeyPair
+    properties:
+      publicKey: ${priv-key.publicKeyOpenssh}
+
+  inst:
+    type: aws:ec2/instance:Instance
+    properties:
+      ami: ${ec2ami}
+      instanceType: t2.micro
+      keyName: ${key-pair.keyName}
+      metadataOptions:
+        httpTokens: required
+        httpEndpoint: enabled
+        httpPutResponseHopLimit: 1
+      vpcSecurityGroupIds:
+        - ${segroup}
+      userData: |
+        #!/bin/bash
+        cat /etc/ssh/ssh_config >/tmp/sshd_config
+        echo "AcceptEnv PULUMI_COMMAND_STDOUT" >> /tmp/sshd_config
+        echo "AcceptEnv PULUMI_COMMAND_STDERR" >> /tmp/sshd_config
+        sudo cp /tmp/sshd_config /etc/ssh/sshd_config || echo "FAILED to set sshd_config"
+        rm /tmp/sshd_config
+        # sudo systemctl restart sshd.service
+
+  init-cmd:
+    type: command:remote:Command
+    properties:
+      create: |
+        curl -fsSL https://get.pulumi.com | sh
+        export PATH="/home/ec2-user/.pulumi/bin:$PATH"
+        pulumi version
+      # SSH connection details to the remote machine
+      connection:
+        host: ${inst.publicIp}
+        user: ec2-user # The default user for Amazon Linux AMI
+        privateKey: ${priv-key.privateKeyOpenssh}
+
+outputs:
+  instanceId: ${inst.id}
+  publicIp: ${inst.publicIp}
+  commandOut: ${init-cmd.stdout}

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -181,6 +181,8 @@ resources:
         user: ec2-user # The default user for Amazon Linux AMI
         privateKey: ${priv-key.privateKeyOpenssh}
     options:
+      ignoreChanges:
+        - connection
       dependsOn:
         - ${install-cmd}
         - ${provider-copy}

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -1,6 +1,10 @@
 name: imds-v2
 runtime: yaml
 description: Test the ability of pulumi-aws to authenticate on an EC2 instance with IMDSv2 enabled
+
+backend:
+  url: file://./pulumi-state
+
 config:
   pulumi:tags:
     value:
@@ -73,18 +77,36 @@ resources:
         rm /tmp/sshd_config
         # sudo systemctl restart sshd.service
 
+  file-copy:
+    type: command:remote:CopyFile
+    properties:
+      connection:
+        host: ${inst.publicIp}
+        user: ec2-user # The default user for Amazon Linux AMI
+        privateKey: ${priv-key.privateKeyOpenssh}
+      localPath: ./Pulumi.yaml
+      remotePath: "/tmp/Pulumi.yaml"
+
   init-cmd:
     type: command:remote:Command
     properties:
       create: |
         curl -fsSL https://get.pulumi.com | sh
         export PATH="/home/ec2-user/.pulumi/bin:$PATH"
-        pulumi version
+        cd /tmp
+        mkdir ./pulumi-state
+        export PULUMI_CONFIG_PASSPHRASE=123456
+        pulumi stack init dev
+        pulumi stack select dev
+        pulumi preview
       # SSH connection details to the remote machine
       connection:
         host: ${inst.publicIp}
         user: ec2-user # The default user for Amazon Linux AMI
         privateKey: ${priv-key.privateKeyOpenssh}
+    options:
+      dependsOn:
+        - ${file-copy}
 
 outputs:
   instanceId: ${inst.id}

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -180,9 +180,9 @@ resources:
         export PULUMI_CONFIG_PASSPHRASE=123456
         export PATH="/tmp:$PATH"
         export PATH="/home/ec2-user/.pulumi/bin:$PATH"
+        chmod a+x /tmp/pulumi-resource-aws
         pulumi version # ensure in PATH
         pulumi-resource-aws --help # ensure in PATH
-
         pulumi stack init dev
         pulumi stack select dev
         pulumi config

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -60,7 +60,7 @@ resources:
     type: aws:ec2/instance:Instance
     properties:
       ami: ${ec2ami}
-      instanceType: t2.micro
+      instanceType: t2.medium
       keyName: ${key-pair.keyName}
       metadataOptions:
         httpTokens: required
@@ -70,11 +70,15 @@ resources:
         - ${segroup}
       userData: |
         #!/bin/bash
+
+        # Reconfigure SSHD
         cat /etc/ssh/ssh_config >/tmp/sshd_config
         echo "AcceptEnv PULUMI_COMMAND_STDOUT" >> /tmp/sshd_config
         echo "AcceptEnv PULUMI_COMMAND_STDERR" >> /tmp/sshd_config
         sudo cp /tmp/sshd_config /etc/ssh/sshd_config || echo "FAILED to set sshd_config"
         rm /tmp/sshd_config
+
+
         # sudo systemctl restart sshd.service
 
   file-copy:
@@ -87,19 +91,30 @@ resources:
       localPath: ./Pulumi.yaml
       remotePath: "/tmp/Pulumi.yaml"
 
-  init-cmd:
+  install-cmd:
     type: command:remote:Command
     properties:
       create: |
+
+        echo "===="
+
+        # Upgrade from AWS CLI v1 to AWS CLI v2
+        sudo yum remove awscli
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+
+        echo "====="
+
+        # Install Pulumi
         curl -fsSL https://get.pulumi.com | sh
         export PATH="/home/ec2-user/.pulumi/bin:$PATH"
-        cd /tmp
-        mkdir ./pulumi-state
-        export PULUMI_CONFIG_PASSPHRASE=123456
-        pulumi stack init dev
-        pulumi stack select dev
-        pulumi preview
-      # SSH connection details to the remote machine
+
+        echo "======"
+        pulumi version
+        echo "======"
+        aws --version
+        echo "======"
       connection:
         host: ${inst.publicIp}
         user: ec2-user # The default user for Amazon Linux AMI
@@ -108,7 +123,33 @@ resources:
       dependsOn:
         - ${file-copy}
 
+  init-cmd:
+    type: command:remote:Command
+    properties:
+      create: |
+        echo "+++++"
+        aws --version
+        aws s3 ls
+        echo "+++++"
+        cd /tmp
+        mkdir ./pulumi-state
+        export PULUMI_CONFIG_PASSPHRASE=123456
+        pulumi stack init dev
+        pulumi stack select dev
+        pulumi config set aws:skipMetadataApiCheck false
+        pulumi config
+        pulumi preview
+      # SSH connection details to the remote machine
+      connection:
+        host: ${inst.publicIp}
+        user: ec2-user # The default user for Amazon Linux AMI
+        privateKey: ${priv-key.privateKeyOpenssh}
+    options:
+      dependsOn:
+        - ${install-cmd}
+
 outputs:
   instanceId: ${inst.id}
   publicIp: ${inst.publicIp}
+  installOut: ${install-cmd.stdout}
   commandOut: ${init-cmd.stdout}

--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -19,15 +19,14 @@ variables:
       function: aws:ec2:getAmi
       arguments:
         filters:
-          # TODO can get a better AMI that has AWS CLI v2 like al2023
           - name: name
-            values: ["amzn2-ami-hvm-*-x86_64-*"]
+            values: ["al2023*x86_64*"]
         owners:
           - amazon
         mostRecent: true
       return: id
 
-  instanceType: t2.micro
+  instanceType: t2.medium
   policyArn: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess" # example policy
 
 resources:
@@ -144,17 +143,6 @@ resources:
     type: command:remote:Command
     properties:
       create: |
-        # Upgrade from AWS CLI v1 to AWS CLI v2
-        echo "========"
-        sudo yum remove awscli
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
-        echo "========"
-        aws --version
-        echo "========"
-
-        # Install Pulumi
         echo "========"
         curl -fsSL https://get.pulumi.com | sh
         export PATH="/home/ec2-user/.pulumi/bin:$PATH"

--- a/provider/test-programs/imds-auth/imds-v2/remote-program/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/remote-program/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: remote-program
+runtime: yaml
+description: A minimal AWS Pulumi YAML program
+backend:
+  url: file://./pulumi-state
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-yaml
+outputs:
+  # Export the name of the bucket
+  bucketName: ${my-bucket.id}
+resources:
+  # Create an AWS resource (S3 Bucket)
+  my-bucket:
+    type: aws:s3:Bucket

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -279,7 +279,7 @@ namespace Pulumi.Aws
             set => _skipCredentialsValidation.Set(value);
         }
 
-        private static readonly __Value<bool?> _skipMetadataApiCheck = new __Value<bool?>(() => __config.GetBoolean("skipMetadataApiCheck") ?? true);
+        private static readonly __Value<bool?> _skipMetadataApiCheck = new __Value<bool?>(() => __config.GetBoolean("skipMetadataApiCheck"));
         /// <summary>
         /// Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.
         /// </summary>

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -402,7 +402,6 @@ namespace Pulumi.Aws
         {
             Region = Utilities.GetEnv("AWS_REGION", "AWS_DEFAULT_REGION");
             SkipCredentialsValidation = false;
-            SkipMetadataApiCheck = true;
             SkipRegionValidation = true;
         }
         public static new ProviderArgs Empty => new ProviderArgs();

--- a/sdk/go/aws/config/config.go
+++ b/sdk/go/aws/config/config.go
@@ -154,13 +154,7 @@ func GetSkipCredentialsValidation(ctx *pulumi.Context) bool {
 
 // Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.
 func GetSkipMetadataApiCheck(ctx *pulumi.Context) bool {
-	v, err := config.TryBool(ctx, "aws:skipMetadataApiCheck")
-	if err == nil {
-		return v
-	}
-	var value bool
-	value = true
-	return value
+	return config.GetBool(ctx, "aws:skipMetadataApiCheck")
 }
 
 // Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are

--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -72,9 +72,6 @@ func NewProvider(ctx *pulumi.Context,
 	if args.SkipCredentialsValidation == nil {
 		args.SkipCredentialsValidation = pulumi.BoolPtr(false)
 	}
-	if args.SkipMetadataApiCheck == nil {
-		args.SkipMetadataApiCheck = pulumi.BoolPtr(true)
-	}
 	if args.SkipRegionValidation == nil {
 		args.SkipRegionValidation = pulumi.BoolPtr(true)
 	}

--- a/sdk/java/src/main/java/com/pulumi/aws/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/Config.java
@@ -191,7 +191,7 @@ public final class Config {
  * 
  */
     public Optional<Boolean> skipMetadataApiCheck() {
-        return Codegen.booleanProp("skipMetadataApiCheck").config(config).def(true).get();
+        return Codegen.booleanProp("skipMetadataApiCheck").config(config).get();
     }
 /**
  * Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are

--- a/sdk/java/src/main/java/com/pulumi/aws/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ProviderArgs.java
@@ -1255,7 +1255,6 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         public ProviderArgs build() {
             $.region = Codegen.stringProp("region").output().arg($.region).env("AWS_REGION", "AWS_DEFAULT_REGION").getNullable();
             $.skipCredentialsValidation = Codegen.booleanProp("skipCredentialsValidation").output().arg($.skipCredentialsValidation).def(false).getNullable();
-            $.skipMetadataApiCheck = Codegen.booleanProp("skipMetadataApiCheck").output().arg($.skipMetadataApiCheck).def(true).getNullable();
             $.skipRegionValidation = Codegen.booleanProp("skipRegionValidation").output().arg($.skipRegionValidation).def(true).getNullable();
             return $;
         }

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -287,10 +287,10 @@ Object.defineProperty(exports, "skipCredentialsValidation", {
 /**
  * Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.
  */
-export declare const skipMetadataApiCheck: boolean;
+export declare const skipMetadataApiCheck: boolean | undefined;
 Object.defineProperty(exports, "skipMetadataApiCheck", {
     get() {
-        return __config.getObject<boolean>("skipMetadataApiCheck") ?? true;
+        return __config.getObject<boolean>("skipMetadataApiCheck");
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -132,7 +132,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["sharedConfigFiles"] = pulumi.output(args ? args.sharedConfigFiles : undefined).apply(JSON.stringify);
             resourceInputs["sharedCredentialsFiles"] = pulumi.output(args ? args.sharedCredentialsFiles : undefined).apply(JSON.stringify);
             resourceInputs["skipCredentialsValidation"] = pulumi.output((args ? args.skipCredentialsValidation : undefined) ?? false).apply(JSON.stringify);
-            resourceInputs["skipMetadataApiCheck"] = pulumi.output((args ? args.skipMetadataApiCheck : undefined) ?? true).apply(JSON.stringify);
+            resourceInputs["skipMetadataApiCheck"] = pulumi.output(args ? args.skipMetadataApiCheck : undefined).apply(JSON.stringify);
             resourceInputs["skipRegionValidation"] = pulumi.output((args ? args.skipRegionValidation : undefined) ?? true).apply(JSON.stringify);
             resourceInputs["skipRequestingAccountId"] = pulumi.output(args ? args.skipRequestingAccountId : undefined).apply(JSON.stringify);
             resourceInputs["stsRegion"] = args ? args.stsRegion : undefined;

--- a/sdk/python/pulumi_aws/config/__init__.pyi
+++ b/sdk/python/pulumi_aws/config/__init__.pyi
@@ -132,7 +132,7 @@ Skip the credentials validation via STS API. Used for AWS API implementations th
 available/implemented.
 """
 
-skipMetadataApiCheck: bool
+skipMetadataApiCheck: Optional[bool]
 """
 Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.
 """

--- a/sdk/python/pulumi_aws/config/vars.py
+++ b/sdk/python/pulumi_aws/config/vars.py
@@ -189,11 +189,11 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get_bool('skipCredentialsValidation') or False
 
     @property
-    def skip_metadata_api_check(self) -> bool:
+    def skip_metadata_api_check(self) -> Optional[bool]:
         """
         Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.
         """
-        return __config__.get_bool('skipMetadataApiCheck') or True
+        return __config__.get_bool('skipMetadataApiCheck')
 
     @property
     def skip_region_validation(self) -> bool:

--- a/sdk/python/pulumi_aws/provider.py
+++ b/sdk/python/pulumi_aws/provider.py
@@ -146,8 +146,6 @@ class ProviderArgs:
             skip_credentials_validation = False
         if skip_credentials_validation is not None:
             pulumi.set(__self__, "skip_credentials_validation", skip_credentials_validation)
-        if skip_metadata_api_check is None:
-            skip_metadata_api_check = True
         if skip_metadata_api_check is not None:
             pulumi.set(__self__, "skip_metadata_api_check", skip_metadata_api_check)
         if skip_region_validation is None:
@@ -749,8 +747,6 @@ class Provider(pulumi.ProviderResource):
             if skip_credentials_validation is None:
                 skip_credentials_validation = False
             __props__.__dict__["skip_credentials_validation"] = pulumi.Output.from_input(skip_credentials_validation).apply(pulumi.runtime.to_json) if skip_credentials_validation is not None else None
-            if skip_metadata_api_check is None:
-                skip_metadata_api_check = True
             __props__.__dict__["skip_metadata_api_check"] = pulumi.Output.from_input(skip_metadata_api_check).apply(pulumi.runtime.to_json) if skip_metadata_api_check is not None else None
             if skip_region_validation is None:
                 skip_region_validation = True


### PR DESCRIPTION
This PR explores reverting the default `aws:skipMetadataApiCheck=false` setting to enable the provider to be able to seamlessly authenticate against an IMDS(v2) endpoints in the AWS environment. It appears that doing so no longer slows down the provider startup time perceptibly.  The way I tested the speed delta was by measuring local empty preview of an AWS s3 Bucket using AWS_PROFILE authentication with local <-> us-east-1 there is no perceptible difference.

Fixes: https://github.com/pulumi/pulumi-aws/issues/1692

An integration test is added that exercises `pulumi preview` on an EC2 instance with IMDSv2 and asserts that the provider can authenticate successfully. 

Background:

- https://github.com/pulumi/pulumi-aws/issues/873
- https://github.com/pulumi/pulumi-aws/pull/1288





