### PR TITLE
Replace resources when the AWS region changes

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -89,12 +89,24 @@ func TestChangingRegion(t *testing.T) {
 		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
 		opttest.YarnLink("@pulumi/aws"),
 	}
-	test := pulumitest.NewPulumiTest(t, dir, options...)
-	for _, region := range []string{"us-east-1", "us-west-1"} {
-		test.SetConfig("desired-region", region)
-		res := test.Up()
-		require.Equal(t, region, res.Outputs["actualRegion"].Value)
-	}
+
+	t.Run("default provider", func(t *testing.T) {
+		test := pulumitest.NewPulumiTest(t, dir, options...)
+		for _, region := range []string{"us-east-1", "us-west-1"} {
+			test.SetConfig("aws:region", region)
+			res := test.Up()
+			require.Equal(t, region, res.Outputs["actualRegion"].Value)
+		}
+	})
+
+	t.Run("explicit provider", func(t *testing.T) {
+		test := pulumitest.NewPulumiTest(t, dir, options...)
+		for _, region := range []string{"us-east-1", "us-west-1"} {
+			test.SetConfig("desired-region", region)
+			res := test.Up()
+			require.Equal(t, region, res.Outputs["actualRegion"].Value)
+		}
+	})
 }
 
 func TestRegressAttributeMustBeWholeNumber(t *testing.T) {

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -79,6 +79,24 @@ func TestRegress3835(t *testing.T) {
 	t.Logf("#%v", result.ChangeSummary)
 }
 
+func TestChangingRegion(t *testing.T) {
+	skipIfShort(t)
+	dir := filepath.Join("test-programs", "changing-region")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	providerName := "aws"
+	options := []opttest.Option{
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+		opttest.YarnLink("@pulumi/aws"),
+	}
+	test := pulumitest.NewPulumiTest(t, dir, options...)
+	for _, region := range []string{"us-east-1", "us-west-1"} {
+		test.SetConfig("desired-region", region)
+		res := test.Up()
+		require.Equal(t, region, res.Outputs["actualRegion"].Value)
+	}
+}
+
 func TestRegressAttributeMustBeWholeNumber(t *testing.T) {
 	// pulumi/pulumi-terraform-bridge#1940
 	skipIfShort(t)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -851,6 +851,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				Default: &tfbridge.DefaultInfo{
 					EnvVars: []string{"AWS_REGION", "AWS_DEFAULT_REGION"},
 				},
+				ForcesProviderReplace: tfbridge.True(),
 			},
 			"skip_region_validation": {
 				Default: &tfbridge.DefaultInfo{

--- a/provider/test-programs/changing-region/.gitignore
+++ b/provider/test-programs/changing-region/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/provider/test-programs/changing-region/Pulumi.yaml
+++ b/provider/test-programs/changing-region/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: changing-region
+runtime: nodejs
+description: A test program to try changing AWS region
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/provider/test-programs/changing-region/index.ts
+++ b/provider/test-programs/changing-region/index.ts
@@ -2,13 +2,22 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
 const cfg = new pulumi.Config();
-const reg: aws.Region = cfg.require("desired-region");
 
-const awsProvider = new aws.Provider("myprovider", {
-    region: reg,
-});
+export const desiredRegion: string|undefined = cfg.get("desired-region");
 
-const queue = new aws.sqs.Queue("my-queue", {}, { provider: awsProvider })
+function parseRegion(region: string|undefined): aws.Region|undefined {
+    if (region === undefined) {
+        return undefined;
+    }
+    var r: any = region;
+    return r;
+}
 
-export const desiredRegion = reg;
+const opts: pulumi.ResourceOptions =
+    desiredRegion
+    ? {provider: new aws.Provider("myprovider", {region: parseRegion(desiredRegion)})}
+    : {};
+
+const queue = new aws.sqs.Queue("my-queue", {}, opts)
+
 export const actualRegion = queue.arn.apply(x => x.split(":")[3]);

--- a/provider/test-programs/changing-region/index.ts
+++ b/provider/test-programs/changing-region/index.ts
@@ -1,0 +1,14 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const cfg = new pulumi.Config();
+const reg: aws.Region = cfg.require("desired-region");
+
+const awsProvider = new aws.Provider("myprovider", {
+    region: reg,
+});
+
+const queue = new aws.sqs.Queue("my-queue", {}, { provider: awsProvider })
+
+export const desiredRegion = reg;
+export const actualRegion = queue.arn.apply(x => x.split(":")[3]);

--- a/provider/test-programs/changing-region/package.json
+++ b/provider/test-programs/changing-region/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "changing-region",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/provider/test-programs/changing-region/tsconfig.json
+++ b/provider/test-programs/changing-region/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Enable `pulumi up` to do the right thing when AWS region changes in the program. It will now execute a cascading replace plan for all resources associated with a provider to delete resources in the old region and re-provision them in the new desired region.

Fixes https://github.com/pulumi/pulumi-aws/issues/3777 https://github.com/pulumi/pulumi-aws/issues/879

