### PR TITLE
Add ComputedID for resources that need it

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -6053,7 +6053,11 @@ func setupComputedIDs(prov *tfbridge.ProviderInfo) {
 				}
 			}
 		}
-		return resource.ID(strings.Join(parts, "__"))
+		s := strings.Join(parts, "__")
+		if s == "" {
+			s = "id"
+		}
+		return resource.ID(s)
 	}
 	prov.Resources["aws_lambda_runtime_management_config"].ComputeID = func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
 		return attr(state, "functionName", "qualifier"), nil

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -6048,7 +6048,7 @@ func setupComputedIDs(prov *tfbridge.ProviderInfo) {
 		parts := []string{}
 		for _, a := range attrs {
 			if v, ok := state[a]; ok {
-				if v.IsString() {
+				if v.IsString() && v.StringValue() != "" {
 					parts = append(parts, v.StringValue())
 				}
 			}
@@ -6063,7 +6063,7 @@ func setupComputedIDs(prov *tfbridge.ProviderInfo) {
 		return attr(state, "functionName", "qualifier"), nil
 	}
 	prov.Resources["aws_datazone_environment_blueprint_configuration"].ComputeID = func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
-		return attr(state, "domainId", "EnvironmentBlueprintId"), nil
+		return attr(state, "domainId", "environmentBlueprintId"), nil
 	}
 	prov.Resources["aws_vpc_endpoint_service_private_dns_verification"].ComputeID = func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
 		return attr(state, "serviceId"), nil


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/4008

The TF bridge currently requires a notion of ID for resources based on the Plugin Framework. Before these change the following resource used to panic, now they provision correctly:

- aws_lambda_runtime_management_config
- aws_datazone_environment_blueprint_configuration
- aws_vpc_endpoint_service_private_dns_verification
- aws_vpc_endpoint_private_dns