### PR TITLE
Fix migrating batch.ComputeEnvironment from v5 to v6 of the provider

### DIFF
--- a/provider/pkg/batch/compute_environment.go
+++ b/provider/pkg/batch/compute_environment.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+func ComputeEnvironment(token tokens.Type) *info.Resource {
+	return &info.Resource{
+		Tok: token,
+		TransformFromState: func(ctx context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
+			// computeResources.ec2Configurations should be a list
+			// older versions of the provider like 5.42.0 used to write it out as an object
+			r := pm.Copy()
+			cr, ok := r["computeResources"]
+			if !ok || !cr.IsObject() {
+				return pm, nil
+			}
+			ec2c, ok := cr.ObjectValue()["ec2Configuration"]
+			if !ok || !ec2c.IsObject() {
+				return pm, nil
+			}
+			replacement := resource.NewArrayProperty([]resource.PropertyValue{ec2c})
+			tfbridge.GetLogger(ctx).Debug(fmt.Sprintf(
+				"batch.ComputeEnvironment is wrapping old computeResources.ec2Configurations state in an array"))
+			cr.ObjectValue()["ec2Configuration"] = replacement
+			r["computeResources"] = cr
+			return r, nil
+		},
+	}
+}

--- a/provider/pkg/batch/compute_environment_test.go
+++ b/provider/pkg/batch/compute_environment_test.go
@@ -1,0 +1,36 @@
+package batch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeEnvironmentTransformFromState(t *testing.T) {
+	ctx := context.Background()
+	ctx = logging.InitLogging(ctx, logging.LogOptions{})
+	pm := resource.PropertyMap{
+		"computeResources": resource.NewObjectProperty(resource.PropertyMap{
+			"ec2Configuration": resource.NewObjectProperty(resource.PropertyMap{
+				"imageIdOverride": resource.NewStringProperty(""),
+				"imageType":       resource.NewStringProperty("ECS_AL2"),
+			}),
+		}),
+	}
+	expect := resource.PropertyMap{
+		"computeResources": resource.NewObjectProperty(resource.PropertyMap{
+			"ec2Configuration": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"imageIdOverride": resource.NewStringProperty(""),
+					"imageType":       resource.NewStringProperty("ECS_AL2"),
+				}),
+			}),
+		}),
+	}
+	actual, err := ComputeEnvironment("").TransformFromState(ctx, pm)
+	require.NoError(t, err)
+	require.Equal(t, expect, actual)
+}

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -38,6 +38,10 @@ func TestRoute53Upgrade(t *testing.T) {
 func TestJobQueueUpgrade(t *testing.T) {
 	opts := nodeProviderUpgradeOpts()
 	opts.setEnvRegion = false
+	opts.region = "us-west-2" // has to match the snapshot-recorded region
+	opts.extraOpts = []opttest.Option{
+		opttest.Env("PULUMI_ENABLE_PLAN_RESOURCE_CHANGE", "true"),
+	}
 	testProviderUpgrade(t, filepath.Join("test-programs", "job-queue"), opts)
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -31,6 +31,8 @@ type testProviderUpgradeOptions struct {
 	linkNodeSDK     bool
 	installDeps     bool
 	setEnvRegion    bool
+	region          string
+	extraOpts       []opttest.Option
 }
 
 func skipIfShort(t *testing.T) {
@@ -62,10 +64,14 @@ func testProviderUpgrade(t *testing.T, dir string, opts *testProviderUpgradeOpti
 	if opts != nil && opts.linkNodeSDK {
 		options = append(options, opttest.YarnLink("@pulumi/aws"))
 	}
+	options = append(options, opts.extraOpts...)
 	test := pulumitest.NewPulumiTest(t, dir, options...)
 	if opts != nil && opts.setEnvRegion {
 		test.SetConfig("aws:region", "INVALID_REGION")
 		test.SetConfig("aws:envRegion", getEnvRegion(t))
+	}
+	if opts.region != "" {
+		test.SetConfig("aws:region", opts.region)
 	}
 	result := providertest.PreviewProviderUpgrade(
 		test, providerName, baselineVersion, optproviderupgrade.DisableAttach(),

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -64,7 +64,9 @@ func testProviderUpgrade(t *testing.T, dir string, opts *testProviderUpgradeOpti
 	if opts != nil && opts.linkNodeSDK {
 		options = append(options, opttest.YarnLink("@pulumi/aws"))
 	}
-	options = append(options, opts.extraOpts...)
+	if opts != nil {
+		options = append(options, opts.extraOpts...)
+	}
 	test := pulumitest.NewPulumiTest(t, dir, options...)
 	if opts != nil && opts.setEnvRegion {
 		test.SetConfig("aws:region", "INVALID_REGION")

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -72,7 +72,7 @@ func testProviderUpgrade(t *testing.T, dir string, opts *testProviderUpgradeOpti
 		test.SetConfig("aws:region", "INVALID_REGION")
 		test.SetConfig("aws:envRegion", getEnvRegion(t))
 	}
-	if opts.region != "" {
+	if opts != nil && opts.region != "" {
 		test.SetConfig("aws:region", opts.region)
 	}
 	result := providertest.PreviewProviderUpgrade(

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -31,6 +31,7 @@ import (
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
+	"github.com/pulumi/pulumi-aws/provider/v6/pkg/batch"
 	"github.com/pulumi/pulumi-aws/provider/v6/pkg/rds"
 	"github.com/pulumi/pulumi-aws/provider/v6/pkg/version"
 
@@ -1259,7 +1260,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				},
 			},
 			// Batch
-			"aws_batch_compute_environment": {Tok: awsResource(batchMod, "ComputeEnvironment")},
+			"aws_batch_compute_environment": batch.ComputeEnvironment(awsResource(batchMod, "ComputeEnvironment")),
 			"aws_batch_job_definition":      {Tok: awsResource(batchMod, "JobDefinition")},
 			"aws_batch_job_queue":           {Tok: awsResource(batchMod, "JobQueue")},
 			"aws_batch_scheduling_policy":   {Tok: awsResource(batchMod, "SchedulingPolicy")},


### PR DESCRIPTION
Although the upstream schema of batch.ComputeEnvironment did not change between v5 and v6 of pulumi-aws, the Pulumi schema did, and computeResources.ec2Configuration is now an array. Prior to this change pulumi-aws v6 was not able to read the states written by the v5 of the provider correctly, if those states did involve a non-nil  computeResources.ec2Configuration.

In some of the recent bridge work this also interacted poorly with the new PlanResourceChange machinery causing panics. 

The change makes the provider automatically apply `x -> [x]` conversions to computeResources.ec2Configuration state.

Fixes #4015 