### PR TITLE
Simplify CI hooks

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -80,8 +80,9 @@ extraTests:
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
         submodules: true
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
+    - uses: pulumi/provider-version-action@v1
+      with:
+        set-env: 'PROVIDER_VERSION'
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -122,13 +123,9 @@ extraTests:
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
         submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
+    - uses: pulumi/provider-version-action@v1
       with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
+        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -221,14 +218,9 @@ extraTests:
         with:
           ref: ${{ env.PR_COMMIT_SHA }}
           submodules: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
+      - uses: pulumi/provider-version-action@v1
         with:
-          path: ci-scripts
-          repository: pulumi/scripts
-          ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
+          set-env: 'PROVIDER_VERSION'
       - name: Make upstream
         run: make upstream
       - name: Install Go

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -68,7 +68,6 @@ actions:
       with:
         tool-cache: false
         swap-storage: false
-        dotnet: ${{ matrix.language != 'dotnet' }}
 
 extraTests:
   go_test_shim:

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -211,6 +211,11 @@ extraTests:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          swap-storage: false
+          tool-cache: false
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
@@ -298,16 +303,6 @@ extraTests:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: v2.5.0
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          swap-storage: false
-          tool-cache: false
-      - if: ${{ matrix.language == 'dotnet' }}
-        name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "6.0.x"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -371,6 +371,11 @@ jobs:
           id-token: write
       runs-on: ubuntu-latest
       steps:
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
           - name: Checkout Repo
             uses: actions/checkout@v4
             with:
@@ -455,16 +460,6 @@ jobs:
             with:
               token: ${{ secrets.GITHUB_TOKEN }}
               version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - if: ${{ matrix.language == 'dotnet' }}
-            name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -340,8 +340,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+          - uses: pulumi/provider-version-action@v1
+            with:
+              set-env: PROVIDER_VERSION
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
             with:
@@ -381,14 +382,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Make upstream
             run: make upstream
           - name: Install Go
@@ -507,13 +503,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Install Go
             uses: actions/setup-go@v5
             with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -305,8 +305,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+          - uses: pulumi/provider-version-action@v1
+            with:
+              set-env: PROVIDER_VERSION
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
             with:
@@ -346,14 +347,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Make upstream
             run: make upstream
           - name: Install Go
@@ -472,13 +468,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Install Go
             uses: actions/setup-go@v5
             with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -336,6 +336,11 @@ jobs:
           id-token: write
       runs-on: ubuntu-latest
       steps:
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
           - name: Checkout Repo
             uses: actions/checkout@v4
             with:
@@ -420,16 +425,6 @@ jobs:
             with:
               token: ${{ secrets.GITHUB_TOKEN }}
               version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - if: ${{ matrix.language == 'dotnet' }}
-            name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -57,7 +57,6 @@ jobs:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
-        dotnet: ${{ matrix.language != 'dotnet' }}
         swap-storage: false
         tool-cache: false
     - name: Build schema generator binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,11 @@ jobs:
           id-token: write
       runs-on: ubuntu-latest
       steps:
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
           - name: Checkout Repo
             uses: actions/checkout@v4
             with:
@@ -453,16 +458,6 @@ jobs:
             with:
               token: ${{ secrets.GITHUB_TOKEN }}
               version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - if: ${{ matrix.language == 'dotnet' }}
-            name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,8 +338,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+          - uses: pulumi/provider-version-action@v1
+            with:
+              set-env: PROVIDER_VERSION
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
             with:
@@ -379,14 +380,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Make upstream
             run: make upstream
           - name: Install Go
@@ -505,13 +501,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Install Go
             uses: actions/setup-go@v5
             with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -270,6 +270,11 @@ jobs:
           id-token: write
       runs-on: ubuntu-latest
       steps:
+          - name: Free Disk Space (Ubuntu)
+            uses: jlumbroso/free-disk-space@main
+            with:
+              swap-storage: false
+              tool-cache: false
           - name: Checkout Repo
             uses: actions/checkout@v4
             with:
@@ -354,16 +359,6 @@ jobs:
             with:
               token: ${{ secrets.GITHUB_TOKEN }}
               version: v2.5.0
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - if: ${{ matrix.language == 'dotnet' }}
-            name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -239,8 +239,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+          - uses: pulumi/provider-version-action@v1
+            with:
+              set-env: PROVIDER_VERSION
           - name: Install pulumictl
             uses: jaxxstorm/action-install-gh-release@v1.11.0
             with:
@@ -280,14 +281,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Make upstream
             run: make upstream
           - name: Install Go
@@ -406,13 +402,9 @@ jobs:
             with:
               ref: ${{ env.PR_COMMIT_SHA }}
               submodules: true
-          - name: Checkout Scripts Repo
-            uses: actions/checkout@v4
+          - uses: pulumi/provider-version-action@v1
             with:
-              path: ci-scripts
-              repository: pulumi/scripts
-          - name: Unshallow clone for tags
-            run: git fetch --prune --unshallow --tags
+              set-env: PROVIDER_VERSION
           - name: Install Go
             uses: actions/setup-go@v5
             with:


### PR DESCRIPTION
Broken into 3 smaller commits for review.

## 1. Fix invalid matrix condition in prerequisites

Prerequisites does not run in a matrix, so there's no need to check for dotnet.

## 2. Move clearing disk space in custom provider_test job

Removes the need to install dotnet for a second time.

## 3.Remove scripts & unshallow

- Set version for consistency with other jobs even though we likely won't use it.
- We're not running anything from the scripts repo in these test jobs. The only previous use of the scripts was for working tree clean checks, which we only perform during the build_sdk step, and should now use the `pulumi/git-status-check-action@v1` action for instead.
- Remove unshallow clone as we no longer need to fetch all tags to calculate the version via pulumictl.