### PR TITLE
Simplify custom CI

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -69,16 +69,12 @@ extraTests:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        repo: pulumi/pulumictl
+        tools: pulumictl, pulumi, go
     - name: Make upstream
       run: make upstream
-    - uses: actions/setup-go@v5
-      with:
-       go-version-file: 'provider/go.mod'
-       cache-dependency-path: 'provider/go.sum'
     - name: go test
       run: |
         cd upstream
@@ -112,25 +108,10 @@ extraTests:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.77.1
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
+        tools: pulumictl, pulumi, go, node
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:
@@ -207,47 +188,12 @@ extraTests:
       - uses: pulumi/provider-version-action@v1
         with:
           set-env: 'PROVIDER_VERSION'
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumi, go, node, dotnet, python, java
       - name: Make upstream
         run: make upstream
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-          go-version: 1.21.x
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
-        with:
-          tag: v0.0.46
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/actions@v5
-        with:
-          pulumi-version: ^3
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.x"
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "6.0.x"
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11.8"
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: "11"
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: "7.6"
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -11,6 +11,8 @@ env:
   OIDC_ROLE_ARN: ${{ secrets.OIDC_ROLE_ARN }}
 makeTemplate: bridged
 checkoutSubmodules: true
+freeDiskSpaceBeforeBuild: true
+freeDiskSpaceBeforeTest: true
 # TODO: remove XrunUpstreamTools flag after work to add docs replacement strategies to resources.go is completed
 # Tracked in in https://github.com/pulumi/pulumi-aws/issues/2757
 XrunUpstreamTools: true
@@ -41,16 +43,6 @@ pulumiConvert: 1
 goBuildParallelism: 2
 actions:
   preTest:
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        swap-storage: false
-    - name: Setup DotNet
-      if: ${{ matrix.language == 'dotnet' }}
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '6.0.x'
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -62,12 +54,6 @@ actions:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Make upstream
       run: make upstream
-  preBuild:
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        swap-storage: false
 
 extraTests:
   go_test_shim:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -213,6 +213,12 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -291,16 +297,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - if: ${{ matrix.language == 'dotnet' }}
-      name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -339,16 +339,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              repo: pulumi/pulumictl
+              tools: pulumictl, pulumi, go
           - name: Make upstream
             run: make upstream
-          - uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: provider/go.sum
-              go-version-file: provider/go.mod
           - name: go test
             run: |
               cd upstream
@@ -381,47 +377,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
+            with:
+              tools: pulumictl, pulumi, go, node, dotnet, python, java
           - name: Make upstream
             run: make upstream
-          - name: Install Go
-            uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: |
-                  provider/*.sum
-                  upstream/*.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
-          - name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: 3.11.8
-          - name: Setup Java
-            uses: actions/setup-java@v4
-            with:
-              cache: gradle
-              distribution: temurin
-              java-version: "11"
-          - name: Setup Gradle
-            uses: gradle/gradle-build-action@v3
-            with:
-              gradle-version: "7.6"
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:
@@ -502,25 +463,10 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install Go
-            uses: actions/setup-go@v5
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              cache-dependency-path: |
-                  sdk/go.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: v3.77.1
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
+              tools: pulumictl, pulumi, go, node
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -44,6 +44,12 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -122,16 +128,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - if: ${{ matrix.language == 'dotnet' }}
-      name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -178,6 +178,12 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -256,16 +262,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - if: ${{ matrix.language == 'dotnet' }}
-      name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -304,16 +304,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              repo: pulumi/pulumictl
+              tools: pulumictl, pulumi, go
           - name: Make upstream
             run: make upstream
-          - uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: provider/go.sum
-              go-version-file: provider/go.mod
           - name: go test
             run: |
               cd upstream
@@ -346,47 +342,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
+            with:
+              tools: pulumictl, pulumi, go, node, dotnet, python, java
           - name: Make upstream
             run: make upstream
-          - name: Install Go
-            uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: |
-                  provider/*.sum
-                  upstream/*.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
-          - name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: 3.11.8
-          - name: Setup Java
-            uses: actions/setup-java@v4
-            with:
-              cache: gradle
-              distribution: temurin
-              java-version: "11"
-          - name: Setup Gradle
-            uses: gradle/gradle-build-action@v3
-            with:
-              gradle-version: "7.6"
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:
@@ -467,25 +428,10 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install Go
-            uses: actions/setup-go@v5
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              cache-dependency-path: |
-                  sdk/go.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: v3.77.1
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
+              tools: pulumictl, pulumi, go, node
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -18,6 +18,12 @@ jobs:
     name: prerequisites
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -37,11 +43,6 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
     - name: Build schema generator binary
       run: make tfgen_build_only
     - name: Install plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,16 +337,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              repo: pulumi/pulumictl
+              tools: pulumictl, pulumi, go
           - name: Make upstream
             run: make upstream
-          - uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: provider/go.sum
-              go-version-file: provider/go.mod
           - name: go test
             run: |
               cd upstream
@@ -379,47 +375,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
+            with:
+              tools: pulumictl, pulumi, go, node, dotnet, python, java
           - name: Make upstream
             run: make upstream
-          - name: Install Go
-            uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: |
-                  provider/*.sum
-                  upstream/*.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
-          - name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: 3.11.8
-          - name: Setup Java
-            uses: actions/setup-java@v4
-            with:
-              cache: gradle
-              distribution: temurin
-              java-version: "11"
-          - name: Setup Gradle
-            uses: gradle/gradle-build-action@v3
-            with:
-              gradle-version: "7.6"
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:
@@ -500,25 +461,10 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install Go
-            uses: actions/setup-go@v5
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              cache-dependency-path: |
-                  sdk/go.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: v3.77.1
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
+              tools: pulumictl, pulumi, go, node
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,12 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -289,16 +295,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - if: ${{ matrix.language == 'dotnet' }}
-      name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -204,16 +204,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              repo: pulumi/pulumictl
+              tools: pulumictl, pulumi, go
           - name: Make upstream
             run: make upstream
-          - uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: provider/go.sum
-              go-version-file: provider/go.mod
           - name: go test
             run: |
               cd upstream
@@ -246,47 +242,12 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
+            with:
+              tools: pulumictl, pulumi, go, node, dotnet, python, java
           - name: Make upstream
             run: make upstream
-          - name: Install Go
-            uses: actions/setup-go@v5
-            with:
-              cache-dependency-path: |
-                  provider/*.sum
-                  upstream/*.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-              tag: v0.0.46
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: ^3
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
-          - name: Setup DotNet
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: 6.0.x
-          - name: Setup Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: 3.11.8
-          - name: Setup Java
-            uses: actions/setup-java@v4
-            with:
-              cache: gradle
-              distribution: temurin
-              java-version: "11"
-          - name: Setup Gradle
-            uses: gradle/gradle-build-action@v3
-            with:
-              gradle-version: "7.6"
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:
@@ -367,25 +328,10 @@ jobs:
           - uses: pulumi/provider-version-action@v1
             with:
               set-env: PROVIDER_VERSION
-          - name: Install Go
-            uses: actions/setup-go@v5
+          - name: Setup tools
+            uses: ./.github/actions/setup-tools
             with:
-              cache-dependency-path: |
-                  sdk/go.sum
-              go-version: 1.21.x
-          - name: Install pulumictl
-            uses: jaxxstorm/action-install-gh-release@v1.11.0
-            with:
-              repo: pulumi/pulumictl
-          - name: Install Pulumi CLI
-            uses: pulumi/actions@v5
-            with:
-              pulumi-version: v3.77.1
-          - name: Setup Node
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20.x
-              registry-url: https://registry.npmjs.org
+              tools: pulumictl, pulumi, go, node
           - name: Download provider + tfgen binaries
             uses: actions/download-artifact@v4
             with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -95,6 +95,12 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -146,16 +152,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - if: ${{ matrix.language == 'dotnet' }}
-      name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:


### PR DESCRIPTION
1. [Use built-in freeDiskSpace options instead of hooks](https://github.com/pulumi/pulumi-aws/pull/4061/commits/2c62884d93d8ec0652e44963b4ba483ff3afda7d)
   - This runs the cleaning at the beginning of the job, avoiding deleting the tools we've just installed.
2. [Use new setup-tools action](https://github.com/pulumi/pulumi-aws/pull/4061/commits/1548cf853b774abd6ee4b1937b455257c445e2ab)
   - Reduce duplication and ensure we're using a consistent version between jobs. 
   - The tool versions are currently hard-coded and this removes that hard-coding so they're automatically upgraded.