### PR TITLE
Directly inject `aws:rds:Instance.name` into the schema

### DIFF
--- a/provider/cmd/pulumi-tfgen-aws/main.go
+++ b/provider/cmd/pulumi-tfgen-aws/main.go
@@ -29,7 +29,9 @@ import (
 func main() {
 	info := aws.ProviderFromMeta(tfbridge.NewProviderMetadata(locateMetadata()))
 
+	postProcessor := info.SchemaPostProcessor
 	info.SchemaPostProcessor = func(spec *schema.PackageSpec) {
+		postProcessor(spec)
 		replaceWafV2TypesWithRecursive(spec)
 	}
 


### PR DESCRIPTION
This bypasses the need to call `shim.SchemaMap.Set` which has been removed in the latest version of the bridge. Since `"name"` is *never* witnessed by the underlying provider, it should not matter that the provider doesn't have the phony "name" field in it's map anymore.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2101