### PR TITLE
Extend ecs.TaskDefinition containerDefinitions normalization

### DIFF
--- a/patches/0061-Normalize-ecs.TaskDefinition-containerDefinitions-he.patch
+++ b/patches/0061-Normalize-ecs.TaskDefinition-containerDefinitions-he.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Tayanovskyy <anton@pulumi.com>
+Date: Thu, 27 Jun 2024 16:20:44 -0400
+Subject: [PATCH] Normalize ecs.TaskDefinition containerDefinitions
+ healthCheck.timeout
+
+
+diff --git a/internal/service/ecs/task_definition_equivalency.go b/internal/service/ecs/task_definition_equivalency.go
+index 3d757997b5..efd649fbdc 100644
+--- a/internal/service/ecs/task_definition_equivalency.go
++++ b/internal/service/ecs/task_definition_equivalency.go
+@@ -72,6 +72,10 @@ func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
+ 		if def.Essential == nil {
+ 			def.Essential = aws.Bool(true)
+ 		}
++		if def.HealthCheck != nil && def.HealthCheck.Timeout == nil {
++			five := int64(5)
++			def.HealthCheck.Timeout = &five
++		}
+ 		for j, pm := range def.PortMappings {
+ 			if pm.Protocol != nil && aws.StringValue(pm.Protocol) == "tcp" {
+ 				cd[i].PortMappings[j].Protocol = nil

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -283,6 +283,8 @@ func cleanPlan(t *testing.T, plan map[string]interface{}) map[string]interface{}
 	if val, exists := plan["manifest"]; exists {
 		manifest := val.(map[string]interface{})
 		delete(manifest, "time")
+		delete(manifest, "version")
+		delete(manifest, "magic")
 	}
 
 	return plan


### PR DESCRIPTION
Fixes #1738 
Fixes #1985

containerDefinitions expects a raw JSON which may lead to spurious diff on insignificant changes. The was pre-existing code for normalizing environment variable order and default values. This code is patched to extend it to handle normalizing the default value of healthCheck.timeout=5.