### PR TITLE
Fix ListenerRule panic if no forward parameter is missing in defaultActions

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -226,6 +226,11 @@ func TestParallelLambdaCreation(t *testing.T) {
 }
 
 func TestRegress4128(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping test in -short mode because it needs cloud credentials")
+		return
+	}
+
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:         filepath.Join("test-programs", "regress-4128"),

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -225,6 +225,18 @@ func TestParallelLambdaCreation(t *testing.T) {
 	})
 }
 
+func TestRegress4128(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         filepath.Join("test-programs", "regress-4128"),
+			SkipRefresh: true,
+		},
+		)
+	// Disable envRegion mangling
+	test.Config = nil
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	envRegion := getEnvRegion(t)
 	baseJS := integration.ProgramTestOptions{

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -283,6 +283,8 @@ func cleanPlan(t *testing.T, plan map[string]interface{}) map[string]interface{}
 	if val, exists := plan["manifest"]; exists {
 		manifest := val.(map[string]interface{})
 		delete(manifest, "time")
+		delete(manifest, "version")
+		delete(manifest, "magic")
 	}
 
 	return plan

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -821,7 +821,9 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 				"aws_wafv2_rule_group",
 				"aws_batch_job_definition",
 				"aws_lb_listener",
-				"aws_alb_listener":
+				"aws_lb_listener_rule",
+				"aws_alb_listener",
+				"aws_alb_listener_rule":
 				return true
 			default:
 				return false

--- a/provider/test-programs/regress-4128/Pulumi.yaml
+++ b/provider/test-programs/regress-4128/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: regress-4128
+runtime: nodejs
+description: A minimal AWS TypeScript Pulumi program
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/provider/test-programs/regress-4128/index.ts
+++ b/provider/test-programs/regress-4128/index.ts
@@ -1,0 +1,99 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+const vpc = new awsx.ec2.Vpc("lb-vpc", {
+    cidrBlock: "10.0.0.0/16",
+    subnetStrategy: "Auto",
+    subnetSpecs: [
+      {
+        type: "Public",
+        name: "public-subnet",
+      },
+    ],
+    numberOfAvailabilityZones: 3,
+    natGateways: {
+      strategy: "None"
+    }
+  });
+
+const secGroup = new aws.ec2.SecurityGroup("allowTls", {
+    description: "Allow TLS inbound traffic and all outbound traffic",
+    vpcId: vpc.vpcId,
+    tags: {
+        Name: "allow_tls",
+    },
+});
+
+const loadbalancer = new aws.lb.LoadBalancer("my-lb", {
+    loadBalancerType: "application",
+    securityGroups: [secGroup.id],
+    subnets: vpc.publicSubnetIds,
+    internal: true,
+});
+
+const targetGroup = new aws.lb.TargetGroup("my-tg", {
+    port: 80,
+    protocol: "HTTP",
+    targetType: "ip",
+    vpcId: vpc.vpcId,
+});
+
+const listener = new aws.lb.Listener("my-listener", {
+    loadBalancerArn: loadbalancer.arn,
+    port: 80,
+    defaultActions: [{
+        type: "forward",
+        targetGroupArn: targetGroup.arn,
+    }],
+});
+
+const listenerRule = new aws.lb.ListenerRule("my-listener-rule", {
+    listenerArn: listener.arn,
+    priority: 100,
+    actions: [{
+        type: "forward",
+        targetGroupArn: targetGroup.arn,
+    }],
+    conditions: [{
+        pathPattern: {
+            values: ["/path/*"],
+        },
+    }],
+});
+
+const alb = new aws.alb.LoadBalancer("my-alb", {
+    securityGroups: [secGroup.id],
+    subnets: vpc.publicSubnetIds,
+    internal: true,
+});
+
+const albTg = new aws.alb.TargetGroup("my-alb-tg", {
+    port: 80,
+    protocol: "HTTP",
+    targetType: "ip",
+    vpcId: vpc.vpcId,
+});
+
+const albListener = new aws.lb.Listener("my-alb-listener", {
+    loadBalancerArn: alb.arn,
+    port: 80,
+    defaultActions: [{
+        type: "forward",
+        targetGroupArn: albTg.arn,
+    }],
+});
+
+const albRule = new aws.alb.ListenerRule("my-alb-listener-rule", {
+    listenerArn: albListener.arn,
+    priority: 100,
+    actions: [{
+        type: "forward",
+        targetGroupArn: albTg.arn,
+    }],
+    conditions: [{
+        pathPattern: {
+            values: ["/path/*"],
+        },
+    }],
+});

--- a/provider/test-programs/regress-4128/package.json
+++ b/provider/test-programs/regress-4128/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "regress-4128",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2"
+    }
+}

--- a/provider/test-programs/regress-4128/tsconfig.json
+++ b/provider/test-programs/regress-4128/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
In #4083 we removed two patches fixing panics for `Listener` and `ListenerRule` resources and instead enrolled the resources in `PlanResourceChange`.

The ListenerRule (`lb.ListenerRule` and `alb.ListenerRule`) resources were missed to be enrolled in `PlanResourceChange`, which caused the original panic to surface again.

This change enrolls the ListenerRule resources in PlanResourceChange and adds a regression test covering those resources.

fixes #4128 