### PR TITLE
Fix flake in regress-4011 test

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -677,6 +677,8 @@ func TestRegress4011(t *testing.T) {
 		})
 
 	// Disable envRegion mangling
-	test.Config = nil
+	test.Config = map[string]string{
+		"parameterName": "regress-4011-" + randomString(10),
+	}
 	integration.ProgramTest(t, &test)
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -5,6 +5,7 @@ package examples
 import (
 	"context"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"testing"
@@ -90,6 +91,16 @@ func replay(t *testing.T, sequence string) {
 	)(nil)
 	require.NoError(t, err)
 	testutils.ReplaySequence(t, p, sequence)
+}
+
+var letterRunes = []rune("1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randomString(length int) string {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }
 
 // This replicates the diff when running `pulumi preview` on a aws.rds.Instance with

--- a/examples/regress-4011/index.ts
+++ b/examples/regress-4011/index.ts
@@ -15,8 +15,11 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+const cfg = new pulumi.Config();
+const parameterName = cfg.require("parameterName");
+
 const param = new aws.ssm.Parameter('regress-4011-test-secret', {
-  name: 'regress-4011-test-secret',
+  name: parameterName,
   type: 'SecureString',
   value: "test",
 });

--- a/examples/regress-4011/step1/index.ts
+++ b/examples/regress-4011/step1/index.ts
@@ -15,13 +15,16 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+const cfg = new pulumi.Config();
+const parameterName = cfg.require("parameterName");
+
 const param = new aws.ssm.Parameter('regress-4011-test-secret', {
-  name: 'regress-4011-test-secret',
+  name: parameterName,
   type: 'SecureString',
   value: "test",
 });
 
-const retrievedParam = aws.ssm.Parameter.get('retrieved-parameter', 'regress-4011-test-secret:1');
+const retrievedParam = aws.ssm.Parameter.get('retrieved-parameter', `${parameterName}:1`);
 
 export const secret = pulumi.output(param).arn;
 export const retrievedSecret = pulumi.output(retrievedParam).arn;


### PR DESCRIPTION
The test for regress-4011 is using a static name because it needs to import a created resource. This can clash with other parallel test runs.

To fix it I added some randomness to the name.