### PR TITLE
Adjust TestRegress2868 to ignore birthdate drift

### DIFF
--- a/examples/regress-2868/index.ts
+++ b/examples/regress-2868/index.ts
@@ -42,6 +42,15 @@ export const AppUsersPool = new aws.cognito.UserPool("test-user-pool", {
             maxLength: "2048",
             minLength: "0",
         },
+    },{
+        attributeDataType: "String",
+        mutable: true,
+        name: "birthdate",
+        required: false,
+        stringAttributeConstraints: {
+            maxLength: "2048",
+            minLength: "0",
+        },
     }],
     softwareTokenMfaConfiguration: {
         enabled: true,


### PR DESCRIPTION
Some changes in the AWS cloud invalidated TestRegress2868:

   https://github.com/pulumi/pulumi-aws/issues/4158

This change works around the problem to continue using TestRegress2868 for its original purposes (see #2868).

Fixes https://github.com/pulumi/pulumi-aws/issues/4152
