### PR TITLE
fix: CVE-2024-24791

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-aws/examples/v6
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/aws/aws-sdk-go v1.54.8

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-aws/provider/v6
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.21

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-aws/sdk/v6
 
-go 1.21
+go 1.21.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/4163

Upgrades minimally required Go versions to those unaffected by CVE-2024-24791.