### PR TITLE
chore: fix flaky test

### DIFF
--- a/examples/regress-2555/index.ts
+++ b/examples/regress-2555/index.ts
@@ -42,7 +42,6 @@ let content = doc.replace("{STEP}", String(step));
 
 // Create the SSM Automation Runbook
 const nodeBuildRunbookDoc = new aws.ssm.Document('nodeBuildRunbook-doc', {
-    name: 'nodeBuildRunbook',
     content: content,
     documentType: 'Automation',
     documentFormat: 'YAML',

--- a/examples/regress-2555/step1/index.ts
+++ b/examples/regress-2555/step1/index.ts
@@ -42,7 +42,6 @@ let content = doc.replace("{STEP}", String(step));
 
 // Create the SSM Automation Runbook
 const nodeBuildRunbookDoc = new aws.ssm.Document('nodeBuildRunbook-doc', {
-    name: 'nodeBuildRunbook',
     content: content,
     documentType: 'Automation',
     documentFormat: 'YAML',


### PR DESCRIPTION
This test has been failing recently due to a resource with the same name
already existing. I think we have been running into a race condition
between different jobs.

Remove the hardcoded name.