### PR TITLE
Deprecate gamelift Matchmaking* resources

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2308,14 +2308,24 @@ compatibility shim in favor of the new "name" field.`)
 
 			// GameLift
 
-			"aws_gamelift_alias":                     {Tok: awsResource(gameliftMod, "Alias")},
-			"aws_gamelift_build":                     {Tok: awsResource(gameliftMod, "Build")},
-			"aws_gamelift_fleet":                     {Tok: awsResource(gameliftMod, "Fleet")},
-			"aws_gamelift_game_session_queue":        {Tok: awsResource(gameliftMod, "GameSessionQueue")},
-			"aws_gamelift_game_server_group":         {Tok: awsResource(gameliftMod, "GameServerGroup")},
-			"aws_gamelift_script":                    {Tok: awsResource(gameliftMod, "Script")},
-			"aws_gamelift_matchmaking_configuration": {Tok: awsResource(gameliftMod, "MatchmakingConfiguration")},
-			"aws_gamelift_matchmaking_rule_set":      {Tok: awsResource(gameliftMod, "MatchmakingRuleSet")},
+			"aws_gamelift_alias":              {Tok: awsResource(gameliftMod, "Alias")},
+			"aws_gamelift_build":              {Tok: awsResource(gameliftMod, "Build")},
+			"aws_gamelift_fleet":              {Tok: awsResource(gameliftMod, "Fleet")},
+			"aws_gamelift_game_session_queue": {Tok: awsResource(gameliftMod, "GameSessionQueue")},
+			"aws_gamelift_game_server_group":  {Tok: awsResource(gameliftMod, "GameServerGroup")},
+			"aws_gamelift_script":             {Tok: awsResource(gameliftMod, "Script")},
+
+			"aws_gamelift_matchmaking_configuration": {
+				Tok: awsResource(gameliftMod, "MatchmakingConfiguration"),
+				DeprecationMessage: "This resource will be removed in the next major version. " +
+					"Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead",
+			},
+
+			"aws_gamelift_matchmaking_rule_set": {
+				Tok: awsResource(gameliftMod, "MatchmakingRuleSet"),
+				DeprecationMessage: "This resource will be removed in the next major version." +
+					"Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead",
+			},
 
 			// Glacier
 			"aws_glacier_vault":      {Tok: awsResource(glacierMod, "Vault")},

--- a/sdk/dotnet/GameLift/MatchmakingConfiguration.cs
+++ b/sdk/dotnet/GameLift/MatchmakingConfiguration.cs
@@ -20,6 +20,7 @@ namespace Pulumi.Aws.GameLift
     /// $ pulumi import aws:gamelift/matchmakingConfiguration:MatchmakingConfiguration example &lt;matchmakingconfiguration-id&gt;
     /// ```
     /// </summary>
+    [Obsolete(@"This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead")]
     [AwsResourceType("aws:gamelift/matchmakingConfiguration:MatchmakingConfiguration")]
     public partial class MatchmakingConfiguration : global::Pulumi.CustomResource
     {

--- a/sdk/dotnet/GameLift/MatchmakingRuleSet.cs
+++ b/sdk/dotnet/GameLift/MatchmakingRuleSet.cs
@@ -20,6 +20,7 @@ namespace Pulumi.Aws.GameLift
     /// $ pulumi import aws:gamelift/matchmakingRuleSet:MatchmakingRuleSet example &lt;ruleset-id&gt;
     /// ```
     /// </summary>
+    [Obsolete(@"This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead")]
     [AwsResourceType("aws:gamelift/matchmakingRuleSet:MatchmakingRuleSet")]
     public partial class MatchmakingRuleSet : global::Pulumi.CustomResource
     {

--- a/sdk/go/aws/gamelift/matchmakingConfiguration.go
+++ b/sdk/go/aws/gamelift/matchmakingConfiguration.go
@@ -21,6 +21,8 @@ import (
 // ```sh
 // $ pulumi import aws:gamelift/matchmakingConfiguration:MatchmakingConfiguration example <matchmakingconfiguration-id>
 // ```
+//
+// Deprecated: This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead
 type MatchmakingConfiguration struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/aws/gamelift/matchmakingRuleSet.go
+++ b/sdk/go/aws/gamelift/matchmakingRuleSet.go
@@ -21,6 +21,8 @@ import (
 // ```sh
 // $ pulumi import aws:gamelift/matchmakingRuleSet:MatchmakingRuleSet example <ruleset-id>
 // ```
+//
+// Deprecated: This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead
 type MatchmakingRuleSet struct {
 	pulumi.CustomResourceState
 

--- a/sdk/java/src/main/java/com/pulumi/aws/gamelift/MatchmakingConfiguration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/gamelift/MatchmakingConfiguration.java
@@ -30,7 +30,11 @@ import javax.annotation.Nullable;
  * $ pulumi import aws:gamelift/matchmakingConfiguration:MatchmakingConfiguration example &lt;matchmakingconfiguration-id&gt;
  * ```
  * 
+ * @deprecated
+ * This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead
+ * 
  */
+@Deprecated /* This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead */
 @ResourceType(type="aws:gamelift/matchmakingConfiguration:MatchmakingConfiguration")
 public class MatchmakingConfiguration extends com.pulumi.resources.CustomResource {
     /**

--- a/sdk/java/src/main/java/com/pulumi/aws/gamelift/MatchmakingRuleSet.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/gamelift/MatchmakingRuleSet.java
@@ -26,7 +26,11 @@ import javax.annotation.Nullable;
  * $ pulumi import aws:gamelift/matchmakingRuleSet:MatchmakingRuleSet example &lt;ruleset-id&gt;
  * ```
  * 
+ * @deprecated
+ * This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead
+ * 
  */
+@Deprecated /* This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead */
 @ResourceType(type="aws:gamelift/matchmakingRuleSet:MatchmakingRuleSet")
 public class MatchmakingRuleSet extends com.pulumi.resources.CustomResource {
     /**

--- a/sdk/nodejs/gamelift/matchmakingConfiguration.ts
+++ b/sdk/nodejs/gamelift/matchmakingConfiguration.ts
@@ -17,6 +17,8 @@ import * as utilities from "../utilities";
  * ```sh
  * $ pulumi import aws:gamelift/matchmakingConfiguration:MatchmakingConfiguration example <matchmakingconfiguration-id>
  * ```
+ *
+ * @deprecated This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead
  */
 export class MatchmakingConfiguration extends pulumi.CustomResource {
     /**
@@ -29,6 +31,7 @@ export class MatchmakingConfiguration extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: MatchmakingConfigurationState, opts?: pulumi.CustomResourceOptions): MatchmakingConfiguration {
+        pulumi.log.warn("MatchmakingConfiguration is deprecated: This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead")
         return new MatchmakingConfiguration(name, <any>state, { ...opts, id: id });
     }
 
@@ -129,8 +132,11 @@ export class MatchmakingConfiguration extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
+    /** @deprecated This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead */
     constructor(name: string, args: MatchmakingConfigurationArgs, opts?: pulumi.CustomResourceOptions)
+    /** @deprecated This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead */
     constructor(name: string, argsOrState?: MatchmakingConfigurationArgs | MatchmakingConfigurationState, opts?: pulumi.CustomResourceOptions) {
+        pulumi.log.warn("MatchmakingConfiguration is deprecated: This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead")
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (opts.id) {

--- a/sdk/nodejs/gamelift/matchmakingRuleSet.ts
+++ b/sdk/nodejs/gamelift/matchmakingRuleSet.ts
@@ -14,6 +14,8 @@ import * as utilities from "../utilities";
  * ```sh
  * $ pulumi import aws:gamelift/matchmakingRuleSet:MatchmakingRuleSet example <ruleset-id>
  * ```
+ *
+ * @deprecated This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead
  */
 export class MatchmakingRuleSet extends pulumi.CustomResource {
     /**
@@ -26,6 +28,7 @@ export class MatchmakingRuleSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: MatchmakingRuleSetState, opts?: pulumi.CustomResourceOptions): MatchmakingRuleSet {
+        pulumi.log.warn("MatchmakingRuleSet is deprecated: This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead")
         return new MatchmakingRuleSet(name, <any>state, { ...opts, id: id });
     }
 
@@ -70,8 +73,11 @@ export class MatchmakingRuleSet extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
+    /** @deprecated This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead */
     constructor(name: string, args: MatchmakingRuleSetArgs, opts?: pulumi.CustomResourceOptions)
+    /** @deprecated This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead */
     constructor(name: string, argsOrState?: MatchmakingRuleSetArgs | MatchmakingRuleSetState, opts?: pulumi.CustomResourceOptions) {
+        pulumi.log.warn("MatchmakingRuleSet is deprecated: This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead")
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (opts.id) {

--- a/sdk/python/pulumi_aws/gamelift/matchmaking_configuration.py
+++ b/sdk/python/pulumi_aws/gamelift/matchmaking_configuration.py
@@ -576,7 +576,12 @@ class _MatchmakingConfigurationState:
         pulumi.set(self, "tags_all", value)
 
 
+warnings.warn("""This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead""", DeprecationWarning)
+
+
 class MatchmakingConfiguration(pulumi.CustomResource):
+    warnings.warn("""This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead""", DeprecationWarning)
+
     @overload
     def __init__(__self__,
                  resource_name: str,
@@ -674,6 +679,7 @@ class MatchmakingConfiguration(pulumi.CustomResource):
                  rule_set_name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  __props__=None):
+        pulumi.log.warn("""MatchmakingConfiguration is deprecated: This resource will be removed in the next major version. Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingconfiguration/ instead""")
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')

--- a/sdk/python/pulumi_aws/gamelift/matchmaking_rule_set.py
+++ b/sdk/python/pulumi_aws/gamelift/matchmaking_rule_set.py
@@ -155,7 +155,12 @@ class _MatchmakingRuleSetState:
         pulumi.set(self, "tags_all", value)
 
 
+warnings.warn("""This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead""", DeprecationWarning)
+
+
 class MatchmakingRuleSet(pulumi.CustomResource):
+    warnings.warn("""This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead""", DeprecationWarning)
+
     @overload
     def __init__(__self__,
                  resource_name: str,
@@ -216,6 +221,7 @@ class MatchmakingRuleSet(pulumi.CustomResource):
                  rule_set_body: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  __props__=None):
+        pulumi.log.warn("""MatchmakingRuleSet is deprecated: This resource will be removed in the next major version.Consider using https://www.pulumi.com/registry/packages/aws-native/api-docs/gamelift/matchmakingruleset/ instead""")
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')


### PR DESCRIPTION
GameLift module has MatchmakingConfiguration and MatchmakingRuleSet resources that are implemented using patches and not maintained upstream. With this PR these resources are deprecated and are to be removed in the next major version. These resources have very modest usage numbers and have alternatives in the aws-native provider.