### PR TITLE
chore: SkipInstall for tests that do not need it

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -308,7 +308,7 @@ func randSeq(n int) string {
 
 func TestNonIdempotentSnsTopic(t *testing.T) {
 	t.Parallel()
-	ptest := pulumiTest(t, filepath.Join("test-programs", "non-idempotent-sns-topic"))
+	ptest := pulumiTest(t, filepath.Join("test-programs", "non-idempotent-sns-topic"), opttest.SkipInstall())
 
 	ptest.InstallStack("test")
 	// generate random name
@@ -772,7 +772,7 @@ func testTagsPulumiLifecycle(t *testing.T, step tagsTestStep) {
 	fpath := filepath.Join(stepDir, "Pulumi.yaml")
 
 	generateTagsTest(t, step, fpath, "")
-	ptest := pulumiTest(t, stepDir, opttest.TestInPlace())
+	ptest := pulumiTest(t, stepDir, opttest.TestInPlace(), opttest.SkipInstall())
 	stack := ptest.CurrentStack()
 
 	t.Log("Initial deployment...")


### PR DESCRIPTION
Some of the YAML tests only need the AWS provider. Unless the SkipInstall option is specified, they will attempt to download the latest version of the provider before realizing there is an ambient in-process version to test with. This can cause sporadic CI failures unrelated to the test. Specifying SkipInstall optimizes away this redundant step.

Example failure log addressed here:

    pulumiTest.go:103: failed to install packages and plugins: exit status 255
          resource plugin aws installing
          warning: Error downloading plugin: unknown version for plugin aws
          Will retry in 80ms [1/5]
          warning: Error downloading plugin: unknown version for plugin aws
          Will retry in 160ms [2/5]