### PR TITLE
Fix type-checking booleans

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.34.3
 	github.com/pulumi/providertest v0.0.14
 	github.com/pulumi/pulumi-aws/provider/v6 v6.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.42.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.42.1-0.20240813180400-e4682154f173
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3
 	github.com/pulumi/pulumi/pkg/v3 v3.128.0
 	github.com/stretchr/testify v1.9.0
@@ -408,7 +408,7 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.9.1 // indirect
 	github.com/pulumi/inflector v0.1.1 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.1-0.20240813180400-e4682154f173 // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 // indirect
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2385,12 +2385,12 @@ github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+Sob
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/providertest v0.0.14 h1:5QlAPAAs82jkQraHsJvq1xgVfC7xtW8sFJwv2pHgxQ8=
 github.com/pulumi/providertest v0.0.14/go.mod h1:GcsqEGgSngwaNOD+kICJPIUQlnA911fGBU8HDlJvVL0=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.42.0 h1:+nuhPROS9Dl8EatzGqtYxmXipAGBTDD7ICowpGMFxf8=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.42.0/go.mod h1:aK6RyeNLjmEHeMuwAbDgUXlAD8BTv+rK3HCs02JopSw=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.42.1-0.20240813180400-e4682154f173 h1:dh/1lnHozXhvCMzfm3wmYp+i4i0NIkdYa1nbJaO7Sfw=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.42.1-0.20240813180400-e4682154f173/go.mod h1:sJ1KJ/jTG5Jj+vTnnT3Jt5J8XyWPscNHBLiBrV3xubg=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3 h1:bBWWeAtSPPYpKYlPZr2h0BiYgWQpHRIk0HO/MQmB+jc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.2-0.20230927165309-e3fd9503f2d3/go.mod h1:vAQ7DeddebQ7FHdRaSG6ijuS28FS9PC4j8Y9wUuue0c=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0 h1:Om0Yw07/5dVABB2ou8+XBCmbp9TUUtDZJEh2B5jPGgI=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0/go.mod h1:EWGqRo+ogMPty23b6rVUajgJXUDSNXU+WqcZTPlzyEI=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.1-0.20240813180400-e4682154f173 h1:txMk4LQN4Vg3Kkc9mMaCo6t4nMKS/Cp/EyRHPNuc9Cc=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.1-0.20240813180400-e4682154f173/go.mod h1:nMXMI6J+tKZjpGG/abixyGi82fJavA/CttpHA8pqaZY=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKgepHyYsMzwaTm4cvp0dcTMYw=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi/pkg/v3 v3.128.0 h1:K3qtJYjHg4DkA7LxknY/MoQZ+QHdHQDh/k2njjmjHXM=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220923175450-ca71523cdc36
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pulumi/providertest v0.0.14
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.42.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.42.1-0.20240813180400-e4682154f173
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.1-0.20240813180400-e4682154f173
 	github.com/pulumi/pulumi/pkg/v3 v3.128.0
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 	github.com/stretchr/testify v1.9.0
@@ -448,6 +448,7 @@ require (
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/teekennedy/goldmark-markdown v0.3.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2401,10 +2401,10 @@ github.com/pulumi/providertest v0.0.14 h1:5QlAPAAs82jkQraHsJvq1xgVfC7xtW8sFJwv2p
 github.com/pulumi/providertest v0.0.14/go.mod h1:GcsqEGgSngwaNOD+kICJPIUQlnA911fGBU8HDlJvVL0=
 github.com/pulumi/pulumi-java/pkg v0.11.0 h1:Jw9gBvyfmfOMq/EkYDm9+zGPxsDAA8jfeMpHmtZ+1oA=
 github.com/pulumi/pulumi-java/pkg v0.11.0/go.mod h1:sXAk25P47AQVQL6ilAbFmRNgZykC7og/+87ihnqzFTc=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.42.0 h1:+nuhPROS9Dl8EatzGqtYxmXipAGBTDD7ICowpGMFxf8=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.42.0/go.mod h1:aK6RyeNLjmEHeMuwAbDgUXlAD8BTv+rK3HCs02JopSw=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0 h1:Om0Yw07/5dVABB2ou8+XBCmbp9TUUtDZJEh2B5jPGgI=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0/go.mod h1:EWGqRo+ogMPty23b6rVUajgJXUDSNXU+WqcZTPlzyEI=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.42.1-0.20240813180400-e4682154f173 h1:dh/1lnHozXhvCMzfm3wmYp+i4i0NIkdYa1nbJaO7Sfw=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.42.1-0.20240813180400-e4682154f173/go.mod h1:sJ1KJ/jTG5Jj+vTnnT3Jt5J8XyWPscNHBLiBrV3xubg=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.1-0.20240813180400-e4682154f173 h1:txMk4LQN4Vg3Kkc9mMaCo6t4nMKS/Cp/EyRHPNuc9Cc=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.1-0.20240813180400-e4682154f173/go.mod h1:nMXMI6J+tKZjpGG/abixyGi82fJavA/CttpHA8pqaZY=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKgepHyYsMzwaTm4cvp0dcTMYw=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi-yaml v1.9.1 h1:JPeI80M23SPactxgnCFS1casZlSr7ZhAXwSx4H55QQ4=
@@ -2421,6 +2421,8 @@ github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10 h1:
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10/go.mod h1:H+8tjs9TjV2w57QFVSMBQacf8k/E1XwLXGCARgViC6A=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rhysd/go-fakeio v1.0.0 h1:+TjiKCOs32dONY7DaoVz/VPOdvRkPfBkEyUDIpM8FQY=
+github.com/rhysd/go-fakeio v1.0.0/go.mod h1:joYxF906trVwp2JLrE4jlN7A0z6wrz8O6o1UjarbFzE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
@@ -2497,6 +2499,8 @@ github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/teekennedy/goldmark-markdown v0.3.0 h1:ik9/biVGCwGWFg8dQ3KVm2pQ/wiiG0whYiUcz9xH0W8=
+github.com/teekennedy/goldmark-markdown v0.3.0/go.mod h1:kMhDz8La77A9UHvJGsxejd0QUflN9sS+QXCqnhmxmNo=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
 github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=


### PR DESCRIPTION
Fixes #4342 

The fix is inherited through the https://github.com/pulumi/pulumi-terraform-bridge/commit/e4682154f1735880a1376774ccb593b4523410fe commit

This change bypasses our normal process of waiting for the next pulumi-terraform-bridge release to accelerate landing the fix. The changes between 3.89.0 and e4682154f1735880a1376774ccb593b4523410fe appear to be low-risk:

- https://github.com/pulumi/pulumi-terraform-bridge/pull/2306
- https://github.com/pulumi/pulumi-terraform-bridge/pull/2292


