### PR TITLE
Add example for deploying an application from the serverless app repository

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -724,3 +724,12 @@ func TestRegress4011(t *testing.T) {
 	}
 	integration.ProgramTest(t, &test)
 }
+
+func TestServerlessAppRepositoryApplication(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "serverless-app-repository-application"),
+		})
+
+	integration.ProgramTest(t, &test)
+}

--- a/examples/serverless-app-repository-application/Pulumi.yaml
+++ b/examples/serverless-app-repository-application/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: serverless-app-repository-application
+runtime: nodejs
+description: Basic example of deploying an application from the serverless app repository.

--- a/examples/serverless-app-repository-application/README.md
+++ b/examples/serverless-app-repository-application/README.md
@@ -1,0 +1,4 @@
+# examples/serverless-app-repository-application
+
+Basic example of deploying an application from the serverless app repository.
+This deploys the [`AthenaCloudwatchConnector`](https://serverlessrepo.aws.amazon.com/applications/ap-south-1/313922868085/AthenaCloudwatchConnector) from the Serverless Application Repository and sets it up as a data source in Athena. This allows you to query CloudWatch Logs using Athena.

--- a/examples/serverless-app-repository-application/index.ts
+++ b/examples/serverless-app-repository-application/index.ts
@@ -1,0 +1,39 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const athenaConnectorApp = aws.serverlessrepository.getApplication({
+    applicationId: "arn:aws:serverlessrepo:us-east-1:292517598671:applications/AthenaCloudwatchConnector",
+}, providerOpts);
+
+const spillBucket = new aws.s3.BucketV2("spill-bucket", {
+    bucketPrefix: "spill-bucket",
+    forceDestroy: true,
+}, providerOpts);
+
+const functionName = "athena-cloudwatch-connector"
+const athenaConnector = new aws.serverlessrepository.CloudFormationStack("athena-connector", {
+    applicationId: athenaConnectorApp.then(app => app.applicationId),
+    semanticVersion: athenaConnectorApp.then(app => app.semanticVersion),
+    capabilities: athenaConnectorApp.then(app => app.requiredCapabilities),
+
+    parameters: {
+        AthenaCatalogName: functionName,
+        SpillBucket: spillBucket.bucket,
+    },
+}, providerOpts);
+
+const region = aws.getRegionOutput({}, providerOpts);
+const identity = aws.getCallerIdentityOutput({}, providerOpts);
+const partition = aws.getPartitionOutput({}, providerOpts);
+
+const catalog = new aws.athena.DataCatalog("cloudwatch-catalog", {
+    name: "cloudwatch-catalog",
+    description: "Example CloudWatch data catalog",
+    type: "LAMBDA",
+    parameters: {
+        "function": pulumi.interpolate`arn:${partition.id}:lambda:${region.name}:${identity.accountId}:function:${functionName}`,
+    },
+}, { ...providerOpts, dependsOn: athenaConnector });

--- a/examples/serverless-app-repository-application/package.json
+++ b/examples/serverless-app-repository-application/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "serverless-app-repository-application",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.2",
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/examples/serverless-app-repository-application/tsconfig.json
+++ b/examples/serverless-app-repository-application/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This deploys the [AthenaCloudwatchConnector](https://serverlessrepo.aws.amazon.com/applications/ap-south-1/313922868085/AthenaCloudwatchConnector) from the Serverless Application Repository
and sets it up as a data source in Athena. This allows users to query CloudWatch Logs using Athena.

Relates to #4393
