### PR TITLE
Annotate Node runtime constants with @deprecated

### DIFF
--- a/sdk/nodejs/lambda/runtimes.ts
+++ b/sdk/nodejs/lambda/runtimes.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,33 +19,33 @@
 
 import {Runtime} from ".";
 
-/** The DotnetCore2d1Runtime constant is deprecated, use Runtime.DotnetCore2d1 instead. */
+/** @deprecated The DotnetCore2d1Runtime constant is deprecated, use Runtime.DotnetCore2d1 instead. */
 export let DotnetCore2d1Runtime: Runtime = "dotnetcore2.1";
-/** The DotnetCore3d1Runtime constant is deprecated, use Runtime.DotnetCore3d1 instead. */
+/** @deprecated The DotnetCore3d1Runtime constant is deprecated, use Runtime.DotnetCore3d1 instead. */
 export let DotnetCore3d1Runtime: Runtime = "dotnetcore3.1";
-/** The Go1dxRuntime constant is deprecated, use Runtime.Go1dx instead. */
+/** @deprecated The Go1dxRuntime constant is deprecated, use Runtime.Go1dx instead. */
 export let Go1dxRuntime:         Runtime = "go1.x";
-/** The Java8Runtime constant is deprecated, use Runtime.Java8 instead. */
+/** @deprecated The Java8Runtime constant is deprecated, use Runtime.Java8 instead. */
 export let Java8Runtime:         Runtime = "java8";
-/** The Java11Runtime constant is deprecated, use Runtime.Java11 instead. */
+/** @deprecated The Java11Runtime constant is deprecated, use Runtime.Java11 instead. */
 export let Java11Runtime:        Runtime = "java11";
-/** The Ruby2d5Runtime constant is deprecated, use Runtime.Ruby2d5 instead. */
+/** @deprecated The Ruby2d5Runtime constant is deprecated, use Runtime.Ruby2d5 instead. */
 export let Ruby2d5Runtime:       Runtime = "ruby2.5";
-/** The Ruby2d7Runtime constant is deprecated, use Runtime.Ruby2d7 instead. */
+/** @deprecated The Ruby2d7Runtime constant is deprecated, use Runtime.Ruby2d7 instead. */
 export let Ruby2d7Runtime:       Runtime = "ruby2.7";
-/** The NodeJS10dXRuntime constant is deprecated, use Runtime.NodeJS10dX instead. */
+/** @deprecated The NodeJS10dXRuntime constant is deprecated, use Runtime.NodeJS10dX instead. */
 export let NodeJS10dXRuntime:    Runtime = "nodejs10.x";
-/** The NodeJS12dXRuntime constant is deprecated, use Runtime.NodeJS12dX instead. */
+/** @deprecated The NodeJS12dXRuntime constant is deprecated, use Runtime.NodeJS12dX instead. */
 export let NodeJS12dXRuntime:    Runtime = "nodejs12.x";
-/** The Python2d7Runtime constant is deprecated, use Runtime.Python2d7 instead. */
+/** @deprecated The Python2d7Runtime constant is deprecated, use Runtime.Python2d7 instead. */
 export let Python2d7Runtime:     Runtime = "python2.7";
-/** The Python3d6Runtime constant is deprecated, use Runtime.Python3d6 instead. */
+/** @deprecated The Python3d6Runtime constant is deprecated, use Runtime.Python3d6 instead. */
 export let Python3d6Runtime:     Runtime = "python3.6";
-/** The Python3d7Runtime constant is deprecated, use Runtime.Python3d7 instead. */
+/** @deprecated The Python3d7Runtime constant is deprecated, use Runtime.Python3d7 instead. */
 export let Python3d7Runtime:     Runtime = "python3.7";
-/** The Python3d8Runtime constant is deprecated, use Runtime.Python3d8 instead. */
+/** @deprecated The Python3d8Runtime constant is deprecated, use Runtime.Python3d8 instead. */
 export let Python3d8Runtime:     Runtime = "python3.8";
-/** The CustomRuntime constant is deprecated, use Runtime.Custom instead. */
+/** @deprecated The CustomRuntime constant is deprecated, use Runtime.Custom instead. */
 export let CustomRuntime:        Runtime = "provided";
 
 /** @deprecated No longer supported. New lambda functions created using this runtime will fail */


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/4424

Literals like lambda.Java8Runtime are marked formally @deprecated with this change. While they do work, the preferred form is lambda.Runtime.Java8. The preferred form also has the up-to-date literals.