### PR TITLE
chore: introduce stale issue workflow

### DIFF
--- a/.github/workflows/aws-close-stale-issues.yml
+++ b/.github/workflows/aws-close-stale-issues.yml
@@ -53,4 +53,5 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
         # Set dry-run to true to not perform label or close actions.
-        dry-run: false
+        # TODO: switch to false after some testing
+        dry-run: true

--- a/.github/workflows/aws-close-stale-issues.yml
+++ b/.github/workflows/aws-close-stale-issues.yml
@@ -1,0 +1,62 @@
+name: "Close Stale Issues"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # runs every day at midnight
+  - cron: "0 0 * * *"
+
+# This job currently has two workflows
+# 1. Stale issue workflow
+# - If an issue has the `response-requested-label` for `days-before-stale`
+#   then add the `stale-issue-label` and comment with the `stale-issue-message`
+# - If an issue has the `stale-issue-label` for `days-before-close` then close the issue
+# 2. Ancient issue workflow (currently disabled)
+# - If an issue has been open for `days-before-ancient` then add then `ancient-issue-message`
+#   and add the `stale-issue-label` (which starts the Stale issue workflow)
+jobs:
+  cleanup:
+    # this workflow will always fail in forks; bail if this isn't running in the upstream
+    if: github.repository == 'pulumi/pulumi-aws'
+    permissions:
+      issues: write
+      contents: read
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v6
+      with:
+        # Types of issues that will be processed
+        issue-types: issues
+
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+
+        # TODO: turn on ancient-issue workflow once we are ready
+        # ancient-issue-message: This issue has not received any attention in 1 year. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-labels: no-autoclose
+        response-requested-label: awaiting-feedback
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 5
+        days-before-close: 10
+        days-before-ancient: 365
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 5
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: false

--- a/.github/workflows/aws-close-stale-issues.yml
+++ b/.github/workflows/aws-close-stale-issues.yml
@@ -11,9 +11,6 @@ on:
 # - If an issue has the `response-requested-label` for `days-before-stale`
 #   then add the `stale-issue-label` and comment with the `stale-issue-message`
 # - If an issue has the `stale-issue-label` for `days-before-close` then close the issue
-# 2. Ancient issue workflow (currently disabled)
-# - If an issue has been open for `days-before-ancient` then add then `ancient-issue-message`
-#   and add the `stale-issue-label` (which starts the Stale issue workflow)
 jobs:
   cleanup:
     # this workflow will always fail in forks; bail if this isn't running in the upstream
@@ -31,10 +28,7 @@ jobs:
 
         # Setting messages to an empty string will cause the automation to skip
         # that category
-        stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
-
-        # TODO: turn on ancient-issue workflow once we are ready
-        # ancient-issue-message: This issue has not received any attention in 1 year. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-issue-message: This issue has not received a response in 5 days. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
 
         # These labels are required
         stale-issue-label: closing-soon

--- a/.github/workflows/aws-close-stale-issues.yml
+++ b/.github/workflows/aws-close-stale-issues.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Don't set closed-for-staleness label to skip closing very old issues
         # regardless of label
-        closed-for-staleness-label: closed-for-staleness
+        closed-for-staleness-label: resolution/stale
 
         # Issue timing
         days-before-stale: 5


### PR DESCRIPTION
There are two workflows that we want to implement

1. Stale issue workflow
- If an issue has the `response-requested-label` for `days-before-stale`
  then add the `stale-issue-label` and comment with the `stale-issue-message`
- If an issue has the `stale-issue-label` for `days-before-close` then close the issue

2. Ancient issue workflow (currently disabled)
- If an issue has been open for `days-before-ancient` then add then `ancient-issue-message`
  and add the `stale-issue-label` (which starts the Stale issue workflow)

The workflow introduced in this PR is the stale issue workflow. A separate ancient issue workflow will be introduced in a separate PR.