### PR TITLE
Remove explicit dependency on core SDK

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5233,7 +5233,6 @@ compatibility shim in favor of the new "name" field.`)
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":  "^3.0.0",
 				"mime":            "^2.0.0",
 				"builtin-modules": "3.0.0",
 				"resolve":         "^1.7.1",
@@ -5364,11 +5363,8 @@ compatibility shim in favor of the new "name" field.`)
 		},
 		Python: &tfbridge.PythonInfo{
 			RespectSchemaVersion: true,
-			Requires: map[string]string{
-				"pulumi": ">=3.0.0,<4.0.0",
-			},
-			PyProject:  struct{ Enabled bool }{true},
-			InputTypes: tfbridge.PythonInputTypeClassesAndDicts,
+			PyProject:            struct{ Enabled bool }{true},
+			InputTypes:           tfbridge.PythonInputTypeClassesAndDicts,
 		},
 		Golang: &tfbridge.GolangInfo{
 			ImportBasePath: filepath.Join(
@@ -5382,10 +5378,7 @@ compatibility shim in favor of the new "name" field.`)
 		},
 		CSharp: &tfbridge.CSharpInfo{
 			RespectSchemaVersion: true,
-			PackageReferences: map[string]string{
-				"Pulumi": "3.*",
-			},
-			Namespaces: namespaceMap,
+			Namespaces:           namespaceMap,
 		},
 	}
 

--- a/sdk/dotnet/Pulumi.Aws.csproj
+++ b/sdk/dotnet/Pulumi.Aws.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/pulumi": "^3.42.0",
         "builtin-modules": "3.0.0",
         "mime": "^2.0.0",
         "resolve": "^1.7.1"


### PR DESCRIPTION
This change removes the explicitly specified dependency on the core SDK from the schema so that the SDK generator can emit the minimum required version that's actually required for the generated provider SDK.