### PR TITLE
Update aws.s3.Bucket notes to point to aws.s3.BucketV2

### DIFF
--- a/docs/resource/aws_s3_bucket_legacy.md
+++ b/docs/resource/aws_s3_bucket_legacy.md
@@ -6,13 +6,14 @@ description: |-
 Provides a S3 bucket resource.
 ---
 
-# Resource: aws_s3_bucket
+# Resource: aws.s3.Bucket
 
 Provides a S3 bucket resource.
 
--> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the `aws_s3control_bucket` resource.
-
--> **NOTE:** This resource might not work well if using an alternative s3-compatible provider. Please use `aws.s3.BucketV2` instead.
+-> **NOTE:** Please use [aws.s3.BucketV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketv2) instead.
+This resource is maintained for backwards compatibility only. Please see [BucketV2 Migration
+Guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/bucketv2-migration/) for instructions on migrating
+existing Bucket resources to BucketV2.
 
 ## Example Usage
 

--- a/provider/doc_edits.go
+++ b/provider/doc_edits.go
@@ -250,3 +250,13 @@ func findLine(src []byte, i int) (int, int) {
 	}
 	return start, end + 1
 }
+
+// Attempts to read the contents of a given file but returns an empty array in case of failure. This is useful for
+// overriding documentation files at generation time only.
+func maybeReadFile(filePath string) []byte {
+	fileBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+	return fileBytes
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -3756,7 +3756,7 @@ compatibility shim in favor of the new "name" field.`)
 						Transform: tfbridge.TransformJSONDocument,
 					},
 				},
-				Docs: &tfbridge.DocInfo{Source: "../../../../docs/resource/aws_s3_bucket_legacy.md"},
+				Docs: &tfbridge.DocInfo{Markdown: maybeReadFile("docs/resource/aws_s3_bucket_legacy.md")},
 			},
 			"aws_s3_bucket_inventory":    {Tok: awsResource(s3Mod, "Inventory")},
 			"aws_s3_bucket_metric":       {Tok: awsResource(s3Mod, "BucketMetric")},

--- a/sdk/dotnet/S3/Inputs/BucketCorsRuleArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketCorsRuleArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _allowedHeaders;
 
         /// <summary>
-        /// List of headers allowed.
+        /// Specifies which headers are allowed.
         /// </summary>
         public InputList<string> AllowedHeaders
         {
@@ -28,7 +28,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _allowedMethods;
 
         /// <summary>
-        /// One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        /// Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
         /// </summary>
         public InputList<string> AllowedMethods
         {
@@ -40,7 +40,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _allowedOrigins;
 
         /// <summary>
-        /// One or more origins you want customers to be able to access the bucket from.
+        /// Specifies which origins are allowed.
         /// </summary>
         public InputList<string> AllowedOrigins
         {
@@ -52,7 +52,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _exposeHeaders;
 
         /// <summary>
-        /// One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        /// Specifies expose header in the response.
         /// </summary>
         public InputList<string> ExposeHeaders
         {

--- a/sdk/dotnet/S3/Inputs/BucketCorsRuleGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketCorsRuleGetArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _allowedHeaders;
 
         /// <summary>
-        /// List of headers allowed.
+        /// Specifies which headers are allowed.
         /// </summary>
         public InputList<string> AllowedHeaders
         {
@@ -28,7 +28,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _allowedMethods;
 
         /// <summary>
-        /// One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        /// Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
         /// </summary>
         public InputList<string> AllowedMethods
         {
@@ -40,7 +40,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _allowedOrigins;
 
         /// <summary>
-        /// One or more origins you want customers to be able to access the bucket from.
+        /// Specifies which origins are allowed.
         /// </summary>
         public InputList<string> AllowedOrigins
         {
@@ -52,7 +52,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<string>? _exposeHeaders;
 
         /// <summary>
-        /// One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        /// Specifies expose header in the response.
         /// </summary>
         public InputList<string> ExposeHeaders
         {

--- a/sdk/dotnet/S3/Inputs/BucketLifecycleRuleArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketLifecycleRuleArgs.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<bool> Enabled { get; set; } = null!;
 
         /// <summary>
-        /// Specifies a period in the object's expire. See Expiration below for details.
+        /// Specifies a period in the object's expire (documented below).
         /// </summary>
         [Input("expiration")]
         public Input<Inputs.BucketLifecycleRuleExpirationArgs>? Expiration { get; set; }
@@ -37,7 +37,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<string>? Id { get; set; }
 
         /// <summary>
-        /// Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+        /// Specifies when noncurrent object versions expire (documented below).
         /// </summary>
         [Input("noncurrentVersionExpiration")]
         public Input<Inputs.BucketLifecycleRuleNoncurrentVersionExpirationArgs>? NoncurrentVersionExpiration { get; set; }
@@ -46,7 +46,9 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<Inputs.BucketLifecycleRuleNoncurrentVersionTransitionArgs>? _noncurrentVersionTransitions;
 
         /// <summary>
-        /// Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        /// Specifies when noncurrent object versions transitions (documented below).
+        /// 
+        /// At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         /// </summary>
         public InputList<Inputs.BucketLifecycleRuleNoncurrentVersionTransitionArgs> NoncurrentVersionTransitions
         {
@@ -76,7 +78,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<Inputs.BucketLifecycleRuleTransitionArgs>? _transitions;
 
         /// <summary>
-        /// Specifies a period in the object's transitions. See Transition below for details.
+        /// Specifies a period in the object's transitions (documented below).
         /// </summary>
         public InputList<Inputs.BucketLifecycleRuleTransitionArgs> Transitions
         {

--- a/sdk/dotnet/S3/Inputs/BucketLifecycleRuleGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketLifecycleRuleGetArgs.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<bool> Enabled { get; set; } = null!;
 
         /// <summary>
-        /// Specifies a period in the object's expire. See Expiration below for details.
+        /// Specifies a period in the object's expire (documented below).
         /// </summary>
         [Input("expiration")]
         public Input<Inputs.BucketLifecycleRuleExpirationGetArgs>? Expiration { get; set; }
@@ -37,7 +37,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<string>? Id { get; set; }
 
         /// <summary>
-        /// Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+        /// Specifies when noncurrent object versions expire (documented below).
         /// </summary>
         [Input("noncurrentVersionExpiration")]
         public Input<Inputs.BucketLifecycleRuleNoncurrentVersionExpirationGetArgs>? NoncurrentVersionExpiration { get; set; }
@@ -46,7 +46,9 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<Inputs.BucketLifecycleRuleNoncurrentVersionTransitionGetArgs>? _noncurrentVersionTransitions;
 
         /// <summary>
-        /// Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        /// Specifies when noncurrent object versions transitions (documented below).
+        /// 
+        /// At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         /// </summary>
         public InputList<Inputs.BucketLifecycleRuleNoncurrentVersionTransitionGetArgs> NoncurrentVersionTransitions
         {
@@ -76,7 +78,7 @@ namespace Pulumi.Aws.S3.Inputs
         private InputList<Inputs.BucketLifecycleRuleTransitionGetArgs>? _transitions;
 
         /// <summary>
-        /// Specifies a period in the object's transitions. See Transition below for details.
+        /// Specifies a period in the object's transitions (documented below).
         /// </summary>
         public InputList<Inputs.BucketLifecycleRuleTransitionGetArgs> Transitions
         {

--- a/sdk/dotnet/S3/Inputs/BucketLoggingArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketLoggingArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketLoggingArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Name of the bucket that will receive the log objects.
+        /// The name of the bucket that will receive the log objects.
         /// </summary>
         [Input("targetBucket", required: true)]
         public Input<string> TargetBucket { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketLoggingGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketLoggingGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketLoggingGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Name of the bucket that will receive the log objects.
+        /// The name of the bucket that will receive the log objects.
         /// </summary>
         [Input("targetBucket", required: true)]
         public Input<string> TargetBucket { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationArgs.cs
@@ -13,13 +13,13 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketObjectLockConfigurationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+        /// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
         /// </summary>
         [Input("objectLockEnabled", required: true)]
         public Input<string> ObjectLockEnabled { get; set; } = null!;
 
         /// <summary>
-        /// Object Lock rule in place for this bucket (documented below).
+        /// The Object Lock rule in place for this bucket.
         /// </summary>
         [Input("rule")]
         public Input<Inputs.BucketObjectLockConfigurationRuleArgs>? Rule { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationGetArgs.cs
@@ -13,13 +13,13 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketObjectLockConfigurationGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+        /// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
         /// </summary>
         [Input("objectLockEnabled", required: true)]
         public Input<string> ObjectLockEnabled { get; set; } = null!;
 
         /// <summary>
-        /// Object Lock rule in place for this bucket (documented below).
+        /// The Object Lock rule in place for this bucket.
         /// </summary>
         [Input("rule")]
         public Input<Inputs.BucketObjectLockConfigurationRuleGetArgs>? Rule { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketObjectLockConfigurationRuleArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        /// The default retention period that you want to apply to new objects placed in this bucket.
         /// </summary>
         [Input("defaultRetention", required: true)]
         public Input<Inputs.BucketObjectLockConfigurationRuleDefaultRetentionArgs> DefaultRetention { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleDefaultRetentionArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleDefaultRetentionArgs.cs
@@ -13,19 +13,25 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketObjectLockConfigurationRuleDefaultRetentionArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Number of days that you want to specify for the default retention period.
+        /// The number of days that you want to specify for the default retention period.
         /// </summary>
         [Input("days")]
         public Input<int>? Days { get; set; }
 
         /// <summary>
-        /// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        /// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
         /// </summary>
         [Input("mode", required: true)]
         public Input<string> Mode { get; set; } = null!;
 
         /// <summary>
-        /// Number of years that you want to specify for the default retention period.
+        /// The number of years that you want to specify for the default retention period.
+        /// 
+        /// Either `days` or `years` must be specified, but not both.
+        /// 
+        /// &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+        /// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+        /// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         /// </summary>
         [Input("years")]
         public Input<int>? Years { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleDefaultRetentionGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleDefaultRetentionGetArgs.cs
@@ -13,19 +13,25 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketObjectLockConfigurationRuleDefaultRetentionGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Number of days that you want to specify for the default retention period.
+        /// The number of days that you want to specify for the default retention period.
         /// </summary>
         [Input("days")]
         public Input<int>? Days { get; set; }
 
         /// <summary>
-        /// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        /// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
         /// </summary>
         [Input("mode", required: true)]
         public Input<string> Mode { get; set; } = null!;
 
         /// <summary>
-        /// Number of years that you want to specify for the default retention period.
+        /// The number of years that you want to specify for the default retention period.
+        /// 
+        /// Either `days` or `years` must be specified, but not both.
+        /// 
+        /// &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+        /// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+        /// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         /// </summary>
         [Input("years")]
         public Input<int>? Years { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketObjectLockConfigurationRuleGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketObjectLockConfigurationRuleGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        /// The default retention period that you want to apply to new objects placed in this bucket.
         /// </summary>
         [Input("defaultRetention", required: true)]
         public Input<Inputs.BucketObjectLockConfigurationRuleDefaultRetentionGetArgs> DefaultRetention { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketReplicationConfigurationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        /// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         /// </summary>
         [Input("role", required: true)]
         public Input<string> Role { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketReplicationConfigurationGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        /// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         /// </summary>
         [Input("role", required: true)]
         public Input<string> Role { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleArgs.cs
@@ -43,7 +43,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<string>? Prefix { get; set; }
 
         /// <summary>
-        /// Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        /// The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         /// </summary>
         [Input("priority")]
         public Input<int>? Priority { get; set; }
@@ -55,7 +55,9 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<Inputs.BucketReplicationConfigurationRuleSourceSelectionCriteriaArgs>? SourceSelectionCriteria { get; set; }
 
         /// <summary>
-        /// Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        /// The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        /// 
+        /// &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         /// </summary>
         [Input("status", required: true)]
         public Input<string> Status { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        /// The override value for the owner on replicated objects. Currently only `Destination` is supported.
         /// </summary>
         [Input("owner", required: true)]
         public Input<string> Owner { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslationGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslationGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketReplicationConfigurationRuleDestinationAccessControlTranslationGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        /// The override value for the owner on replicated objects. Currently only `Destination` is supported.
         /// </summary>
         [Input("owner", required: true)]
         public Input<string> Owner { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationArgs.cs
@@ -13,19 +13,19 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketReplicationConfigurationRuleDestinationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+        /// Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
         /// </summary>
         [Input("accessControlTranslation")]
         public Input<Inputs.BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs>? AccessControlTranslation { get; set; }
 
         /// <summary>
-        /// Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        /// The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         /// </summary>
         [Input("accountId")]
         public Input<string>? AccountId { get; set; }
 
         /// <summary>
-        /// ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        /// The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
         /// </summary>
         [Input("bucket", required: true)]
         public Input<string> Bucket { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationGetArgs.cs
@@ -13,19 +13,19 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketReplicationConfigurationRuleDestinationGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+        /// Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
         /// </summary>
         [Input("accessControlTranslation")]
         public Input<Inputs.BucketReplicationConfigurationRuleDestinationAccessControlTranslationGetArgs>? AccessControlTranslation { get; set; }
 
         /// <summary>
-        /// Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        /// The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         /// </summary>
         [Input("accountId")]
         public Input<string>? AccountId { get; set; }
 
         /// <summary>
-        /// ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        /// The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
         /// </summary>
         [Input("bucket", required: true)]
         public Input<string> Bucket { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationMetricsArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationMetricsArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<int>? Minutes { get; set; }
 
         /// <summary>
-        /// Status of replication metrics. Either `Enabled` or `Disabled`.
+        /// The status of replication metrics. Either `Enabled` or `Disabled`.
         /// </summary>
         [Input("status")]
         public Input<string>? Status { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationMetricsGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationMetricsGetArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<int>? Minutes { get; set; }
 
         /// <summary>
-        /// Status of replication metrics. Either `Enabled` or `Disabled`.
+        /// The status of replication metrics. Either `Enabled` or `Disabled`.
         /// </summary>
         [Input("status")]
         public Input<string>? Status { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationReplicationTimeArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationReplicationTimeArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<int>? Minutes { get; set; }
 
         /// <summary>
-        /// Status of RTC. Either `Enabled` or `Disabled`.
+        /// The status of RTC. Either `Enabled` or `Disabled`.
         /// </summary>
         [Input("status")]
         public Input<string>? Status { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationReplicationTimeGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleDestinationReplicationTimeGetArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<int>? Minutes { get; set; }
 
         /// <summary>
-        /// Status of RTC. Either `Enabled` or `Disabled`.
+        /// The status of RTC. Either `Enabled` or `Disabled`.
         /// </summary>
         [Input("status")]
         public Input<string>? Status { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketReplicationConfigurationRuleGetArgs.cs
@@ -43,7 +43,7 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<string>? Prefix { get; set; }
 
         /// <summary>
-        /// Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        /// The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         /// </summary>
         [Input("priority")]
         public Input<int>? Priority { get; set; }
@@ -55,7 +55,9 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<Inputs.BucketReplicationConfigurationRuleSourceSelectionCriteriaGetArgs>? SourceSelectionCriteria { get; set; }
 
         /// <summary>
-        /// Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        /// The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        /// 
+        /// &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         /// </summary>
         [Input("status", required: true)]
         public Input<string> Status { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketServerSideEncryptionConfigurationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Single object for server-side encryption by default configuration. (documented below)
+        /// A single object for server-side encryption by default configuration. (documented below)
         /// </summary>
         [Input("rule", required: true)]
         public Input<Inputs.BucketServerSideEncryptionConfigurationRuleArgs> Rule { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketServerSideEncryptionConfigurationGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Single object for server-side encryption by default configuration. (documented below)
+        /// A single object for server-side encryption by default configuration. (documented below)
         /// </summary>
         [Input("rule", required: true)]
         public Input<Inputs.BucketServerSideEncryptionConfigurationRuleGetArgs> Rule { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs.cs
@@ -13,13 +13,13 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        /// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         /// </summary>
         [Input("kmsMasterKeyId")]
         public Input<string>? KmsMasterKeyId { get; set; }
 
         /// <summary>
-        /// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        /// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
         /// </summary>
         [Input("sseAlgorithm", required: true)]
         public Input<string> SseAlgorithm { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultGetArgs.cs
@@ -13,13 +13,13 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        /// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         /// </summary>
         [Input("kmsMasterKeyId")]
         public Input<string>? KmsMasterKeyId { get; set; }
 
         /// <summary>
-        /// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        /// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
         /// </summary>
         [Input("sseAlgorithm", required: true)]
         public Input<string> SseAlgorithm { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketServerSideEncryptionConfigurationRuleArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Single object for setting server-side encryption by default. (documented below)
+        /// A single object for setting server-side encryption by default. (documented below)
         /// </summary>
         [Input("applyServerSideEncryptionByDefault", required: true)]
         public Input<Inputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs> ApplyServerSideEncryptionByDefault { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketServerSideEncryptionConfigurationRuleGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketServerSideEncryptionConfigurationRuleGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Single object for setting server-side encryption by default. (documented below)
+        /// A single object for setting server-side encryption by default. (documented below)
         /// </summary>
         [Input("applyServerSideEncryptionByDefault", required: true)]
         public Input<Inputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultGetArgs> ApplyServerSideEncryptionByDefault { get; set; } = null!;

--- a/sdk/dotnet/S3/Inputs/BucketWebsiteArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketWebsiteArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketWebsiteArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Absolute path to the document to return in case of a 4XX error.
+        /// An absolute path to the document to return in case of a 4XX error.
         /// </summary>
         [Input("errorDocument")]
         public Input<string>? ErrorDocument { get; set; }
@@ -25,14 +25,16 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<string>? IndexDocument { get; set; }
 
         /// <summary>
-        /// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        /// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
         /// </summary>
         [Input("redirectAllRequestsTo")]
         public Input<string>? RedirectAllRequestsTo { get; set; }
 
         /// <summary>
-        /// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        /// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
         /// describing redirect behavior and when redirects are applied.
+        /// 
+        /// The `CORS` object supports the following:
         /// </summary>
         [Input("routingRules")]
         public InputUnion<string, ImmutableArray<string>>? RoutingRules { get; set; }

--- a/sdk/dotnet/S3/Inputs/BucketWebsiteGetArgs.cs
+++ b/sdk/dotnet/S3/Inputs/BucketWebsiteGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Aws.S3.Inputs
     public sealed class BucketWebsiteGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Absolute path to the document to return in case of a 4XX error.
+        /// An absolute path to the document to return in case of a 4XX error.
         /// </summary>
         [Input("errorDocument")]
         public Input<string>? ErrorDocument { get; set; }
@@ -25,14 +25,16 @@ namespace Pulumi.Aws.S3.Inputs
         public Input<string>? IndexDocument { get; set; }
 
         /// <summary>
-        /// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        /// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
         /// </summary>
         [Input("redirectAllRequestsTo")]
         public Input<string>? RedirectAllRequestsTo { get; set; }
 
         /// <summary>
-        /// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        /// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
         /// describing redirect behavior and when redirects are applied.
+        /// 
+        /// The `CORS` object supports the following:
         /// </summary>
         [Input("routingRules")]
         public InputUnion<string, ImmutableArray<string>>? RoutingRules { get; set; }

--- a/sdk/dotnet/S3/Outputs/BucketCorsRule.cs
+++ b/sdk/dotnet/S3/Outputs/BucketCorsRule.cs
@@ -14,19 +14,19 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketCorsRule
     {
         /// <summary>
-        /// List of headers allowed.
+        /// Specifies which headers are allowed.
         /// </summary>
         public readonly ImmutableArray<string> AllowedHeaders;
         /// <summary>
-        /// One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        /// Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
         /// </summary>
         public readonly ImmutableArray<string> AllowedMethods;
         /// <summary>
-        /// One or more origins you want customers to be able to access the bucket from.
+        /// Specifies which origins are allowed.
         /// </summary>
         public readonly ImmutableArray<string> AllowedOrigins;
         /// <summary>
-        /// One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        /// Specifies expose header in the response.
         /// </summary>
         public readonly ImmutableArray<string> ExposeHeaders;
         /// <summary>

--- a/sdk/dotnet/S3/Outputs/BucketLifecycleRule.cs
+++ b/sdk/dotnet/S3/Outputs/BucketLifecycleRule.cs
@@ -22,7 +22,7 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly bool Enabled;
         /// <summary>
-        /// Specifies a period in the object's expire. See Expiration below for details.
+        /// Specifies a period in the object's expire (documented below).
         /// </summary>
         public readonly Outputs.BucketLifecycleRuleExpiration? Expiration;
         /// <summary>
@@ -30,11 +30,13 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly string? Id;
         /// <summary>
-        /// Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+        /// Specifies when noncurrent object versions expire (documented below).
         /// </summary>
         public readonly Outputs.BucketLifecycleRuleNoncurrentVersionExpiration? NoncurrentVersionExpiration;
         /// <summary>
-        /// Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        /// Specifies when noncurrent object versions transitions (documented below).
+        /// 
+        /// At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         /// </summary>
         public readonly ImmutableArray<Outputs.BucketLifecycleRuleNoncurrentVersionTransition> NoncurrentVersionTransitions;
         /// <summary>
@@ -46,7 +48,7 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
-        /// Specifies a period in the object's transitions. See Transition below for details.
+        /// Specifies a period in the object's transitions (documented below).
         /// </summary>
         public readonly ImmutableArray<Outputs.BucketLifecycleRuleTransition> Transitions;
 

--- a/sdk/dotnet/S3/Outputs/BucketLogging.cs
+++ b/sdk/dotnet/S3/Outputs/BucketLogging.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketLogging
     {
         /// <summary>
-        /// Name of the bucket that will receive the log objects.
+        /// The name of the bucket that will receive the log objects.
         /// </summary>
         public readonly string TargetBucket;
         /// <summary>

--- a/sdk/dotnet/S3/Outputs/BucketObjectLockConfiguration.cs
+++ b/sdk/dotnet/S3/Outputs/BucketObjectLockConfiguration.cs
@@ -14,11 +14,11 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketObjectLockConfiguration
     {
         /// <summary>
-        /// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+        /// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
         /// </summary>
         public readonly string ObjectLockEnabled;
         /// <summary>
-        /// Object Lock rule in place for this bucket (documented below).
+        /// The Object Lock rule in place for this bucket.
         /// </summary>
         public readonly Outputs.BucketObjectLockConfigurationRule? Rule;
 

--- a/sdk/dotnet/S3/Outputs/BucketObjectLockConfigurationRule.cs
+++ b/sdk/dotnet/S3/Outputs/BucketObjectLockConfigurationRule.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketObjectLockConfigurationRule
     {
         /// <summary>
-        /// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        /// The default retention period that you want to apply to new objects placed in this bucket.
         /// </summary>
         public readonly Outputs.BucketObjectLockConfigurationRuleDefaultRetention DefaultRetention;
 

--- a/sdk/dotnet/S3/Outputs/BucketObjectLockConfigurationRuleDefaultRetention.cs
+++ b/sdk/dotnet/S3/Outputs/BucketObjectLockConfigurationRuleDefaultRetention.cs
@@ -14,15 +14,21 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketObjectLockConfigurationRuleDefaultRetention
     {
         /// <summary>
-        /// Number of days that you want to specify for the default retention period.
+        /// The number of days that you want to specify for the default retention period.
         /// </summary>
         public readonly int? Days;
         /// <summary>
-        /// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        /// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
         /// </summary>
         public readonly string Mode;
         /// <summary>
-        /// Number of years that you want to specify for the default retention period.
+        /// The number of years that you want to specify for the default retention period.
+        /// 
+        /// Either `days` or `years` must be specified, but not both.
+        /// 
+        /// &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+        /// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+        /// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         /// </summary>
         public readonly int? Years;
 

--- a/sdk/dotnet/S3/Outputs/BucketReplicationConfiguration.cs
+++ b/sdk/dotnet/S3/Outputs/BucketReplicationConfiguration.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketReplicationConfiguration
     {
         /// <summary>
-        /// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        /// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         /// </summary>
         public readonly string Role;
         /// <summary>

--- a/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRule.cs
+++ b/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRule.cs
@@ -34,7 +34,7 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly string? Prefix;
         /// <summary>
-        /// Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        /// The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         /// </summary>
         public readonly int? Priority;
         /// <summary>
@@ -42,7 +42,9 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly Outputs.BucketReplicationConfigurationRuleSourceSelectionCriteria? SourceSelectionCriteria;
         /// <summary>
-        /// Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        /// The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        /// 
+        /// &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         /// </summary>
         public readonly string Status;
 

--- a/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestination.cs
+++ b/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestination.cs
@@ -14,15 +14,15 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketReplicationConfigurationRuleDestination
     {
         /// <summary>
-        /// Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+        /// Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
         /// </summary>
         public readonly Outputs.BucketReplicationConfigurationRuleDestinationAccessControlTranslation? AccessControlTranslation;
         /// <summary>
-        /// Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        /// The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         /// </summary>
         public readonly string? AccountId;
         /// <summary>
-        /// ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        /// The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
         /// </summary>
         public readonly string Bucket;
         /// <summary>

--- a/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslation.cs
+++ b/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslation.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketReplicationConfigurationRuleDestinationAccessControlTranslation
     {
         /// <summary>
-        /// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        /// The override value for the owner on replicated objects. Currently only `Destination` is supported.
         /// </summary>
         public readonly string Owner;
 

--- a/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestinationMetrics.cs
+++ b/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestinationMetrics.cs
@@ -18,7 +18,7 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly int? Minutes;
         /// <summary>
-        /// Status of replication metrics. Either `Enabled` or `Disabled`.
+        /// The status of replication metrics. Either `Enabled` or `Disabled`.
         /// </summary>
         public readonly string? Status;
 

--- a/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestinationReplicationTime.cs
+++ b/sdk/dotnet/S3/Outputs/BucketReplicationConfigurationRuleDestinationReplicationTime.cs
@@ -18,7 +18,7 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly int? Minutes;
         /// <summary>
-        /// Status of RTC. Either `Enabled` or `Disabled`.
+        /// The status of RTC. Either `Enabled` or `Disabled`.
         /// </summary>
         public readonly string? Status;
 

--- a/sdk/dotnet/S3/Outputs/BucketServerSideEncryptionConfiguration.cs
+++ b/sdk/dotnet/S3/Outputs/BucketServerSideEncryptionConfiguration.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketServerSideEncryptionConfiguration
     {
         /// <summary>
-        /// Single object for server-side encryption by default configuration. (documented below)
+        /// A single object for server-side encryption by default configuration. (documented below)
         /// </summary>
         public readonly Outputs.BucketServerSideEncryptionConfigurationRule Rule;
 

--- a/sdk/dotnet/S3/Outputs/BucketServerSideEncryptionConfigurationRule.cs
+++ b/sdk/dotnet/S3/Outputs/BucketServerSideEncryptionConfigurationRule.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketServerSideEncryptionConfigurationRule
     {
         /// <summary>
-        /// Single object for setting server-side encryption by default. (documented below)
+        /// A single object for setting server-side encryption by default. (documented below)
         /// </summary>
         public readonly Outputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault ApplyServerSideEncryptionByDefault;
         /// <summary>

--- a/sdk/dotnet/S3/Outputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault.cs
+++ b/sdk/dotnet/S3/Outputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault.cs
@@ -14,11 +14,11 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault
     {
         /// <summary>
-        /// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        /// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         /// </summary>
         public readonly string? KmsMasterKeyId;
         /// <summary>
-        /// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        /// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
         /// </summary>
         public readonly string SseAlgorithm;
 

--- a/sdk/dotnet/S3/Outputs/BucketWebsite.cs
+++ b/sdk/dotnet/S3/Outputs/BucketWebsite.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Aws.S3.Outputs
     public sealed class BucketWebsite
     {
         /// <summary>
-        /// Absolute path to the document to return in case of a 4XX error.
+        /// An absolute path to the document to return in case of a 4XX error.
         /// </summary>
         public readonly string? ErrorDocument;
         /// <summary>
@@ -22,12 +22,14 @@ namespace Pulumi.Aws.S3.Outputs
         /// </summary>
         public readonly string? IndexDocument;
         /// <summary>
-        /// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        /// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
         /// </summary>
         public readonly string? RedirectAllRequestsTo;
         /// <summary>
-        /// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        /// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
         /// describing redirect behavior and when redirects are applied.
+        /// 
+        /// The `CORS` object supports the following:
         /// </summary>
         public readonly Union<string, ImmutableArray<string>>? RoutingRules;
 

--- a/sdk/go/aws/s3/bucket.go
+++ b/sdk/go/aws/s3/bucket.go
@@ -13,13 +13,14 @@ import (
 
 // Provides a S3 bucket resource.
 //
-// > This resource provides functionality for managing S3 general purpose buckets in an AWS Partition. To manage Amazon S3 Express directory buckets, use the `awsDirectoryBucket` resource. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), use the `s3control.Bucket` resource.
-//
-// > Object Lock can be enabled by using the `objectLockEnable` attribute or by using the `s3.BucketObjectLockConfigurationV2` resource. Please note, that by using the resource, Object Lock can be enabled/disabled without destroying and recreating the bucket.
+// > **NOTE:** Please use [aws.s3.BucketV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketv2) instead.
+// This resource is maintained for backwards compatibility only. Please see [BucketV2 Migration
+// Guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/bucketv2-migration/) for instructions on migrating
+// existing Bucket resources to BucketV2.
 //
 // ## Example Usage
 //
-// ### Private Bucket With Tags
+// ### Private Bucket w/ Tags
 //
 // ```go
 // package main
@@ -33,8 +34,9 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			_, err := s3.NewBucketV2(ctx, "example", &s3.BucketV2Args{
+//			_, err := s3.NewBucket(ctx, "b", &s3.BucketArgs{
 //				Bucket: pulumi.String("my-tf-test-bucket"),
+//				Acl:    pulumi.String(s3.CannedAclPrivate),
 //				Tags: pulumi.StringMap{
 //					"Name":        pulumi.String("My bucket"),
 //					"Environment": pulumi.String("Dev"),
@@ -49,84 +51,562 @@ import (
 //
 // ```
 //
+// ### Static Website Hosting
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi-std/sdk/go/std"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			invokeFile, err := std.File(ctx, &std.FileArgs{
+//				Input: "policy.json",
+//			}, nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = s3.NewBucket(ctx, "b", &s3.BucketArgs{
+//				Bucket: pulumi.String("s3-website-test.mydomain.com"),
+//				Acl:    pulumi.String(s3.CannedAclPublicRead),
+//				Policy: pulumi.String(invokeFile.Result),
+//				Website: &s3.BucketWebsiteArgs{
+//					IndexDocument: pulumi.String("index.html"),
+//					ErrorDocument: pulumi.String("error.html"),
+//					RoutingRules: pulumi.Any(`[{
+//	    "Condition": {
+//	        "KeyPrefixEquals": "docs/"
+//	    },
+//	    "Redirect": {
+//	        "ReplaceKeyPrefixWith": "documents/"
+//	    }
+//	}]
+//
+// `),
+//
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Using CORS
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := s3.NewBucket(ctx, "b", &s3.BucketArgs{
+//				Bucket: pulumi.String("s3-website-test.mydomain.com"),
+//				Acl:    pulumi.String(s3.CannedAclPublicRead),
+//				CorsRules: s3.BucketCorsRuleArray{
+//					&s3.BucketCorsRuleArgs{
+//						AllowedHeaders: pulumi.StringArray{
+//							pulumi.String("*"),
+//						},
+//						AllowedMethods: pulumi.StringArray{
+//							pulumi.String("PUT"),
+//							pulumi.String("POST"),
+//						},
+//						AllowedOrigins: pulumi.StringArray{
+//							pulumi.String("https://s3-website-test.mydomain.com"),
+//						},
+//						ExposeHeaders: pulumi.StringArray{
+//							pulumi.String("ETag"),
+//						},
+//						MaxAgeSeconds: pulumi.Int(3000),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Using versioning
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := s3.NewBucket(ctx, "b", &s3.BucketArgs{
+//				Bucket: pulumi.String("my-tf-test-bucket"),
+//				Acl:    pulumi.String(s3.CannedAclPrivate),
+//				Versioning: &s3.BucketVersioningArgs{
+//					Enabled: pulumi.Bool(true),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Enable Logging
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			logBucket, err := s3.NewBucket(ctx, "log_bucket", &s3.BucketArgs{
+//				Bucket: pulumi.String("my-tf-log-bucket"),
+//				Acl:    pulumi.String(s3.CannedAclLogDeliveryWrite),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = s3.NewBucket(ctx, "b", &s3.BucketArgs{
+//				Bucket: pulumi.String("my-tf-test-bucket"),
+//				Acl:    pulumi.String(s3.CannedAclPrivate),
+//				Loggings: s3.BucketLoggingArray{
+//					&s3.BucketLoggingArgs{
+//						TargetBucket: logBucket.ID(),
+//						TargetPrefix: pulumi.String("log/"),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Using object lifecycle
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := s3.NewBucket(ctx, "bucket", &s3.BucketArgs{
+//				Bucket: pulumi.String("my-bucket"),
+//				Acl:    pulumi.String(s3.CannedAclPrivate),
+//				LifecycleRules: s3.BucketLifecycleRuleArray{
+//					&s3.BucketLifecycleRuleArgs{
+//						Id:      pulumi.String("log"),
+//						Enabled: pulumi.Bool(true),
+//						Prefix:  pulumi.String("log/"),
+//						Tags: pulumi.StringMap{
+//							"rule":      pulumi.String("log"),
+//							"autoclean": pulumi.String("true"),
+//						},
+//						Transitions: s3.BucketLifecycleRuleTransitionArray{
+//							&s3.BucketLifecycleRuleTransitionArgs{
+//								Days:         pulumi.Int(30),
+//								StorageClass: pulumi.String("STANDARD_IA"),
+//							},
+//							&s3.BucketLifecycleRuleTransitionArgs{
+//								Days:         pulumi.Int(60),
+//								StorageClass: pulumi.String("GLACIER"),
+//							},
+//						},
+//						Expiration: &s3.BucketLifecycleRuleExpirationArgs{
+//							Days: pulumi.Int(90),
+//						},
+//					},
+//					&s3.BucketLifecycleRuleArgs{
+//						Id:      pulumi.String("tmp"),
+//						Prefix:  pulumi.String("tmp/"),
+//						Enabled: pulumi.Bool(true),
+//						Expiration: &s3.BucketLifecycleRuleExpirationArgs{
+//							Date: pulumi.String("2016-01-12"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = s3.NewBucket(ctx, "versioning_bucket", &s3.BucketArgs{
+//				Bucket: pulumi.String("my-versioning-bucket"),
+//				Acl:    pulumi.String(s3.CannedAclPrivate),
+//				Versioning: &s3.BucketVersioningArgs{
+//					Enabled: pulumi.Bool(true),
+//				},
+//				LifecycleRules: s3.BucketLifecycleRuleArray{
+//					&s3.BucketLifecycleRuleArgs{
+//						Prefix:  pulumi.String("config/"),
+//						Enabled: pulumi.Bool(true),
+//						NoncurrentVersionTransitions: s3.BucketLifecycleRuleNoncurrentVersionTransitionArray{
+//							&s3.BucketLifecycleRuleNoncurrentVersionTransitionArgs{
+//								Days:         pulumi.Int(30),
+//								StorageClass: pulumi.String("STANDARD_IA"),
+//							},
+//							&s3.BucketLifecycleRuleNoncurrentVersionTransitionArgs{
+//								Days:         pulumi.Int(60),
+//								StorageClass: pulumi.String("GLACIER"),
+//							},
+//						},
+//						NoncurrentVersionExpiration: &s3.BucketLifecycleRuleNoncurrentVersionExpirationArgs{
+//							Days: pulumi.Int(90),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Using replication configuration
+//
+// > **NOTE:** See the `s3.BucketReplicationConfig` resource to support bi-directional replication configuration and additional features.
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"fmt"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			replication, err := iam.NewRole(ctx, "replication", &iam.RoleArgs{
+//				Name: pulumi.String("tf-iam-role-replication-12345"),
+//				AssumeRolePolicy: pulumi.Any(`{
+//	  "Version": "2012-10-17",
+//	  "Statement": [
+//	    {
+//	      "Action": "sts:AssumeRole",
+//	      "Principal": {
+//	        "Service": "s3.amazonaws.com"
+//	      },
+//	      "Effect": "Allow",
+//	      "Sid": ""
+//	    }
+//	  ]
+//	}
+//
+// `),
+//
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			destination, err := s3.NewBucket(ctx, "destination", &s3.BucketArgs{
+//				Bucket: pulumi.String("tf-test-bucket-destination-12345"),
+//				Versioning: &s3.BucketVersioningArgs{
+//					Enabled: pulumi.Bool(true),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			source, err := s3.NewBucket(ctx, "source", &s3.BucketArgs{
+//				Bucket: pulumi.String("tf-test-bucket-source-12345"),
+//				Acl:    pulumi.String(s3.CannedAclPrivate),
+//				Versioning: &s3.BucketVersioningArgs{
+//					Enabled: pulumi.Bool(true),
+//				},
+//				ReplicationConfiguration: &s3.BucketReplicationConfigurationArgs{
+//					Role: replication.Arn,
+//					Rules: s3.BucketReplicationConfigurationRuleArray{
+//						&s3.BucketReplicationConfigurationRuleArgs{
+//							Id:     pulumi.String("foobar"),
+//							Status: pulumi.String("Enabled"),
+//							Filter: &s3.BucketReplicationConfigurationRuleFilterArgs{
+//								Tags: pulumi.StringMap{},
+//							},
+//							Destination: &s3.BucketReplicationConfigurationRuleDestinationArgs{
+//								Bucket:       destination.Arn,
+//								StorageClass: pulumi.String("STANDARD"),
+//								ReplicationTime: &s3.BucketReplicationConfigurationRuleDestinationReplicationTimeArgs{
+//									Status:  pulumi.String("Enabled"),
+//									Minutes: pulumi.Int(15),
+//								},
+//								Metrics: &s3.BucketReplicationConfigurationRuleDestinationMetricsArgs{
+//									Status:  pulumi.String("Enabled"),
+//									Minutes: pulumi.Int(15),
+//								},
+//							},
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			replicationPolicy, err := iam.NewPolicy(ctx, "replication", &iam.PolicyArgs{
+//				Name: pulumi.String("tf-iam-role-policy-replication-12345"),
+//				Policy: pulumi.All(source.Arn, source.Arn, destination.Arn).ApplyT(func(_args []interface{}) (string, error) {
+//					sourceArn := _args[0].(string)
+//					sourceArn1 := _args[1].(string)
+//					destinationArn := _args[2].(string)
+//					return fmt.Sprintf(`{
+//	  "Version": "2012-10-17",
+//	  "Statement": [
+//	    {
+//	      "Action": [
+//	        "s3:GetReplicationConfiguration",
+//	        "s3:ListBucket"
+//	      ],
+//	      "Effect": "Allow",
+//	      "Resource": [
+//	        "%v"
+//	      ]
+//	    },
+//	    {
+//	      "Action": [
+//	        "s3:GetObjectVersionForReplication",
+//	        "s3:GetObjectVersionAcl",
+//	         "s3:GetObjectVersionTagging"
+//	      ],
+//	      "Effect": "Allow",
+//	      "Resource": [
+//	        "%v/*"
+//	      ]
+//	    },
+//	    {
+//	      "Action": [
+//	        "s3:ReplicateObject",
+//	        "s3:ReplicateDelete",
+//	        "s3:ReplicateTags"
+//	      ],
+//	      "Effect": "Allow",
+//	      "Resource": "%v/*"
+//	    }
+//	  ]
+//	}
+//
+// `, sourceArn, sourceArn1, destinationArn), nil
+//
+//				}).(pulumi.StringOutput),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = iam.NewRolePolicyAttachment(ctx, "replication", &iam.RolePolicyAttachmentArgs{
+//				Role:      replication.Name,
+//				PolicyArn: replicationPolicy.Arn,
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Enable Default Server Side Encryption
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/kms"
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			mykey, err := kms.NewKey(ctx, "mykey", &kms.KeyArgs{
+//				Description:          pulumi.String("This key is used to encrypt bucket objects"),
+//				DeletionWindowInDays: pulumi.Int(10),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = s3.NewBucket(ctx, "mybucket", &s3.BucketArgs{
+//				Bucket: pulumi.String("mybucket"),
+//				ServerSideEncryptionConfiguration: &s3.BucketServerSideEncryptionConfigurationArgs{
+//					Rule: &s3.BucketServerSideEncryptionConfigurationRuleArgs{
+//						ApplyServerSideEncryptionByDefault: &s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs{
+//							KmsMasterKeyId: mykey.Arn,
+//							SseAlgorithm:   pulumi.String("aws:kms"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
+// ### Using ACL policy grants
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			currentUser, err := s3.GetCanonicalUserId(ctx, map[string]interface{}{}, nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = s3.NewBucket(ctx, "bucket", &s3.BucketArgs{
+//				Bucket: pulumi.String("mybucket"),
+//				Grants: s3.BucketGrantArray{
+//					&s3.BucketGrantArgs{
+//						Id:   pulumi.String(currentUser.Id),
+//						Type: pulumi.String("CanonicalUser"),
+//						Permissions: pulumi.StringArray{
+//							pulumi.String("FULL_CONTROL"),
+//						},
+//					},
+//					&s3.BucketGrantArgs{
+//						Type: pulumi.String("Group"),
+//						Permissions: pulumi.StringArray{
+//							pulumi.String("READ_ACP"),
+//							pulumi.String("WRITE"),
+//						},
+//						Uri: pulumi.String("http://acs.amazonaws.com/groups/s3/LogDelivery"),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
 // ## Import
 //
-// Using `pulumi import`, import S3 bucket using the `bucket`. For example:
+// S3 bucket can be imported using the `bucket`, e.g.,
 //
 // ```sh
 // $ pulumi import aws:s3/bucket:Bucket bucket bucket-name
 // ```
+// The `policy` argument is not imported and will be deprecated in a future version of the provider. Use the `aws_s3_bucket_policy` resource to manage the S3 Bucket Policy instead.
 type Bucket struct {
 	pulumi.CustomResourceState
 
-	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 	AccelerationStatus pulumi.StringOutput `pulumi:"accelerationStatus"`
-	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 	Acl pulumi.StringPtrOutput `pulumi:"acl"`
-	// ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+	// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 	Arn pulumi.StringOutput `pulumi:"arn"`
-	// Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucketName]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+	// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	Bucket pulumi.StringOutput `pulumi:"bucket"`
-	// Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+	// The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 	BucketDomainName pulumi.StringOutput `pulumi:"bucketDomainName"`
 	// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	BucketPrefix pulumi.StringPtrOutput `pulumi:"bucketPrefix"`
-	// The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+	// The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
 	BucketRegionalDomainName pulumi.StringOutput `pulumi:"bucketRegionalDomainName"`
-	// Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+	// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 	CorsRules BucketCorsRuleArrayOutput `pulumi:"corsRules"`
-	// Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+	// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 	ForceDestroy pulumi.BoolPtrOutput `pulumi:"forceDestroy"`
-	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 	Grants BucketGrantArrayOutput `pulumi:"grants"`
-	// [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+	// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 	HostedZoneId pulumi.StringOutput `pulumi:"hostedZoneId"`
-	// Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+	// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 	LifecycleRules BucketLifecycleRuleArrayOutput `pulumi:"lifecycleRules"`
-	// Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLoggingV2` instead.
+	// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 	Loggings BucketLoggingArrayOutput `pulumi:"loggings"`
-	// Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-	// The provider wil only perform drift detection if a configuration value is provided.
-	// Use the `objectLockEnabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+	// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+	//
+	// > **NOTE:** You cannot use `accelerationStatus` in `cn-north-1` or `us-gov-west-1`
 	ObjectLockConfiguration BucketObjectLockConfigurationPtrOutput `pulumi:"objectLockConfiguration"`
-	// Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketPolicy` instead.
+	// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
 	Policy pulumi.StringPtrOutput `pulumi:"policy"`
-	// AWS region this bucket resides in.
+	// The AWS region this bucket resides in.
 	Region pulumi.StringOutput `pulumi:"region"`
-	// Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketReplicationConfig` instead.
+	// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 	ReplicationConfiguration BucketReplicationConfigurationPtrOutput `pulumi:"replicationConfiguration"`
 	// Specifies who should bear the cost of Amazon S3 data transfer.
-	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-	// See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+	// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+	// developer guide for more information.
 	RequestPayer pulumi.StringOutput `pulumi:"requestPayer"`
-	// Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+	// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 	ServerSideEncryptionConfiguration BucketServerSideEncryptionConfigurationOutput `pulumi:"serverSideEncryptionConfiguration"`
-	// Map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-	//
-	// The following arguments are deprecated, and will be removed in a future major version:
+	// A map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapOutput `pulumi:"tags"`
-	// Map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
+	// A map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
 	//
 	// Deprecated: Please use `tags` instead.
 	TagsAll pulumi.StringMapOutput `pulumi:"tagsAll"`
-	// Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+	// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 	Versioning BucketVersioningOutput `pulumi:"versioning"`
-	// Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// A website object (documented below).
 	Website BucketWebsitePtrOutput `pulumi:"website"`
-	// (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
 	WebsiteDomain pulumi.StringOutput `pulumi:"websiteDomain"`
-	// (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 	WebsiteEndpoint pulumi.StringOutput `pulumi:"websiteEndpoint"`
 }
 
@@ -160,146 +640,122 @@ func GetBucket(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering Bucket resources.
 type bucketState struct {
-	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 	AccelerationStatus *string `pulumi:"accelerationStatus"`
-	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 	Acl *string `pulumi:"acl"`
-	// ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+	// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 	Arn *string `pulumi:"arn"`
-	// Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucketName]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+	// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	Bucket *string `pulumi:"bucket"`
-	// Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+	// The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 	BucketDomainName *string `pulumi:"bucketDomainName"`
 	// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	BucketPrefix *string `pulumi:"bucketPrefix"`
-	// The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+	// The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
 	BucketRegionalDomainName *string `pulumi:"bucketRegionalDomainName"`
-	// Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+	// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 	CorsRules []BucketCorsRule `pulumi:"corsRules"`
-	// Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+	// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 	ForceDestroy *bool `pulumi:"forceDestroy"`
-	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 	Grants []BucketGrant `pulumi:"grants"`
-	// [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+	// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 	HostedZoneId *string `pulumi:"hostedZoneId"`
-	// Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+	// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 	LifecycleRules []BucketLifecycleRule `pulumi:"lifecycleRules"`
-	// Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLoggingV2` instead.
+	// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 	Loggings []BucketLogging `pulumi:"loggings"`
-	// Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-	// The provider wil only perform drift detection if a configuration value is provided.
-	// Use the `objectLockEnabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+	// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+	//
+	// > **NOTE:** You cannot use `accelerationStatus` in `cn-north-1` or `us-gov-west-1`
 	ObjectLockConfiguration *BucketObjectLockConfiguration `pulumi:"objectLockConfiguration"`
-	// Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketPolicy` instead.
+	// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
 	Policy interface{} `pulumi:"policy"`
-	// AWS region this bucket resides in.
+	// The AWS region this bucket resides in.
 	Region *string `pulumi:"region"`
-	// Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketReplicationConfig` instead.
+	// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 	ReplicationConfiguration *BucketReplicationConfiguration `pulumi:"replicationConfiguration"`
 	// Specifies who should bear the cost of Amazon S3 data transfer.
-	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-	// See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+	// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+	// developer guide for more information.
 	RequestPayer *string `pulumi:"requestPayer"`
-	// Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+	// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 	ServerSideEncryptionConfiguration *BucketServerSideEncryptionConfiguration `pulumi:"serverSideEncryptionConfiguration"`
-	// Map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-	//
-	// The following arguments are deprecated, and will be removed in a future major version:
+	// A map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
-	// Map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
+	// A map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
 	//
 	// Deprecated: Please use `tags` instead.
 	TagsAll map[string]string `pulumi:"tagsAll"`
-	// Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+	// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 	Versioning *BucketVersioning `pulumi:"versioning"`
-	// Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// A website object (documented below).
 	Website *BucketWebsite `pulumi:"website"`
-	// (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
 	WebsiteDomain *string `pulumi:"websiteDomain"`
-	// (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 	WebsiteEndpoint *string `pulumi:"websiteEndpoint"`
 }
 
 type BucketState struct {
-	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 	AccelerationStatus pulumi.StringPtrInput
-	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 	Acl pulumi.StringPtrInput
-	// ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+	// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 	Arn pulumi.StringPtrInput
-	// Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucketName]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+	// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	Bucket pulumi.StringPtrInput
-	// Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+	// The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 	BucketDomainName pulumi.StringPtrInput
 	// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	BucketPrefix pulumi.StringPtrInput
-	// The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+	// The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
 	BucketRegionalDomainName pulumi.StringPtrInput
-	// Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+	// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 	CorsRules BucketCorsRuleArrayInput
-	// Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+	// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 	ForceDestroy pulumi.BoolPtrInput
-	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 	Grants BucketGrantArrayInput
-	// [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+	// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 	HostedZoneId pulumi.StringPtrInput
-	// Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+	// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 	LifecycleRules BucketLifecycleRuleArrayInput
-	// Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLoggingV2` instead.
+	// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 	Loggings BucketLoggingArrayInput
-	// Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-	// The provider wil only perform drift detection if a configuration value is provided.
-	// Use the `objectLockEnabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+	// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+	//
+	// > **NOTE:** You cannot use `accelerationStatus` in `cn-north-1` or `us-gov-west-1`
 	ObjectLockConfiguration BucketObjectLockConfigurationPtrInput
-	// Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketPolicy` instead.
+	// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
 	Policy pulumi.Input
-	// AWS region this bucket resides in.
+	// The AWS region this bucket resides in.
 	Region pulumi.StringPtrInput
-	// Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketReplicationConfig` instead.
+	// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 	ReplicationConfiguration BucketReplicationConfigurationPtrInput
 	// Specifies who should bear the cost of Amazon S3 data transfer.
-	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-	// See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+	// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+	// developer guide for more information.
 	RequestPayer pulumi.StringPtrInput
-	// Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+	// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 	ServerSideEncryptionConfiguration BucketServerSideEncryptionConfigurationPtrInput
-	// Map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-	//
-	// The following arguments are deprecated, and will be removed in a future major version:
+	// A map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
-	// Map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
+	// A map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
 	//
 	// Deprecated: Please use `tags` instead.
 	TagsAll pulumi.StringMapInput
-	// Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+	// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 	Versioning BucketVersioningPtrInput
-	// Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// A website object (documented below).
 	Website BucketWebsitePtrInput
-	// (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
 	WebsiteDomain pulumi.StringPtrInput
-	// (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 	WebsiteEndpoint pulumi.StringPtrInput
 }
 
@@ -308,127 +764,103 @@ func (BucketState) ElementType() reflect.Type {
 }
 
 type bucketArgs struct {
-	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 	AccelerationStatus *string `pulumi:"accelerationStatus"`
-	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 	Acl *string `pulumi:"acl"`
-	// ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+	// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 	Arn *string `pulumi:"arn"`
-	// Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucketName]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+	// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	Bucket *string `pulumi:"bucket"`
 	// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	BucketPrefix *string `pulumi:"bucketPrefix"`
-	// Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+	// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 	CorsRules []BucketCorsRule `pulumi:"corsRules"`
-	// Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+	// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 	ForceDestroy *bool `pulumi:"forceDestroy"`
-	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 	Grants []BucketGrant `pulumi:"grants"`
-	// [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+	// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 	HostedZoneId *string `pulumi:"hostedZoneId"`
-	// Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+	// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 	LifecycleRules []BucketLifecycleRule `pulumi:"lifecycleRules"`
-	// Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLoggingV2` instead.
+	// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 	Loggings []BucketLogging `pulumi:"loggings"`
-	// Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-	// The provider wil only perform drift detection if a configuration value is provided.
-	// Use the `objectLockEnabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+	// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+	//
+	// > **NOTE:** You cannot use `accelerationStatus` in `cn-north-1` or `us-gov-west-1`
 	ObjectLockConfiguration *BucketObjectLockConfiguration `pulumi:"objectLockConfiguration"`
-	// Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketPolicy` instead.
+	// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
 	Policy interface{} `pulumi:"policy"`
-	// Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketReplicationConfig` instead.
+	// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 	ReplicationConfiguration *BucketReplicationConfiguration `pulumi:"replicationConfiguration"`
 	// Specifies who should bear the cost of Amazon S3 data transfer.
-	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-	// See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+	// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+	// developer guide for more information.
 	RequestPayer *string `pulumi:"requestPayer"`
-	// Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+	// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 	ServerSideEncryptionConfiguration *BucketServerSideEncryptionConfiguration `pulumi:"serverSideEncryptionConfiguration"`
-	// Map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-	//
-	// The following arguments are deprecated, and will be removed in a future major version:
+	// A map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
-	// Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+	// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 	Versioning *BucketVersioning `pulumi:"versioning"`
-	// Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// A website object (documented below).
 	Website *BucketWebsite `pulumi:"website"`
-	// (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
 	WebsiteDomain *string `pulumi:"websiteDomain"`
-	// (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 	WebsiteEndpoint *string `pulumi:"websiteEndpoint"`
 }
 
 // The set of arguments for constructing a Bucket resource.
 type BucketArgs struct {
-	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 	AccelerationStatus pulumi.StringPtrInput
-	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 	Acl pulumi.StringPtrInput
-	// ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+	// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 	Arn pulumi.StringPtrInput
-	// Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucketName]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+	// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	Bucket pulumi.StringPtrInput
 	// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 	BucketPrefix pulumi.StringPtrInput
-	// Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+	// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 	CorsRules BucketCorsRuleArrayInput
-	// Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+	// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 	ForceDestroy pulumi.BoolPtrInput
-	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 	Grants BucketGrantArrayInput
-	// [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+	// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 	HostedZoneId pulumi.StringPtrInput
-	// Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+	// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 	LifecycleRules BucketLifecycleRuleArrayInput
-	// Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketLoggingV2` instead.
+	// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 	Loggings BucketLoggingArrayInput
-	// Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-	// The provider wil only perform drift detection if a configuration value is provided.
-	// Use the `objectLockEnabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+	// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+	//
+	// > **NOTE:** You cannot use `accelerationStatus` in `cn-north-1` or `us-gov-west-1`
 	ObjectLockConfiguration BucketObjectLockConfigurationPtrInput
-	// Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketPolicy` instead.
+	// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
 	Policy pulumi.Input
-	// Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketReplicationConfig` instead.
+	// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 	ReplicationConfiguration BucketReplicationConfigurationPtrInput
 	// Specifies who should bear the cost of Amazon S3 data transfer.
-	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-	// See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+	// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+	// developer guide for more information.
 	RequestPayer pulumi.StringPtrInput
-	// Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-	// The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+	// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 	ServerSideEncryptionConfiguration BucketServerSideEncryptionConfigurationPtrInput
-	// Map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-	//
-	// The following arguments are deprecated, and will be removed in a future major version:
+	// A map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
-	// Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+	// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 	Versioning BucketVersioningPtrInput
-	// Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-	// Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// A website object (documented below).
 	Website BucketWebsitePtrInput
-	// (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
 	WebsiteDomain pulumi.StringPtrInput
-	// (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+	// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 	WebsiteEndpoint pulumi.StringPtrInput
 }
 
@@ -519,28 +951,27 @@ func (o BucketOutput) ToBucketOutputWithContext(ctx context.Context) BucketOutpu
 	return o
 }
 
-// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 func (o BucketOutput) AccelerationStatus() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.AccelerationStatus }).(pulumi.StringOutput)
 }
 
-// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 func (o BucketOutput) Acl() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringPtrOutput { return v.Acl }).(pulumi.StringPtrOutput)
 }
 
-// ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 func (o BucketOutput) Arn() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.Arn }).(pulumi.StringOutput)
 }
 
-// Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucketName]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 func (o BucketOutput) Bucket() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.Bucket }).(pulumi.StringOutput)
 }
 
-// Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+// The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 func (o BucketOutput) BucketDomainName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.BucketDomainName }).(pulumi.StringOutput)
 }
@@ -550,117 +981,106 @@ func (o BucketOutput) BucketPrefix() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringPtrOutput { return v.BucketPrefix }).(pulumi.StringPtrOutput)
 }
 
-// The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+// The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
 func (o BucketOutput) BucketRegionalDomainName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.BucketRegionalDomainName }).(pulumi.StringOutput)
 }
 
-// Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 func (o BucketOutput) CorsRules() BucketCorsRuleArrayOutput {
 	return o.ApplyT(func(v *Bucket) BucketCorsRuleArrayOutput { return v.CorsRules }).(BucketCorsRuleArrayOutput)
 }
 
-// Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 func (o BucketOutput) ForceDestroy() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.BoolPtrOutput { return v.ForceDestroy }).(pulumi.BoolPtrOutput)
 }
 
-// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 func (o BucketOutput) Grants() BucketGrantArrayOutput {
 	return o.ApplyT(func(v *Bucket) BucketGrantArrayOutput { return v.Grants }).(BucketGrantArrayOutput)
 }
 
-// [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 func (o BucketOutput) HostedZoneId() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.HostedZoneId }).(pulumi.StringOutput)
 }
 
-// Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 func (o BucketOutput) LifecycleRules() BucketLifecycleRuleArrayOutput {
 	return o.ApplyT(func(v *Bucket) BucketLifecycleRuleArrayOutput { return v.LifecycleRules }).(BucketLifecycleRuleArrayOutput)
 }
 
-// Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketLoggingV2` instead.
+// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 func (o BucketOutput) Loggings() BucketLoggingArrayOutput {
 	return o.ApplyT(func(v *Bucket) BucketLoggingArrayOutput { return v.Loggings }).(BucketLoggingArrayOutput)
 }
 
-// Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-// The provider wil only perform drift detection if a configuration value is provided.
-// Use the `objectLockEnabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+//
+// > **NOTE:** You cannot use `accelerationStatus` in `cn-north-1` or `us-gov-west-1`
 func (o BucketOutput) ObjectLockConfiguration() BucketObjectLockConfigurationPtrOutput {
 	return o.ApplyT(func(v *Bucket) BucketObjectLockConfigurationPtrOutput { return v.ObjectLockConfiguration }).(BucketObjectLockConfigurationPtrOutput)
 }
 
-// Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-// The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketPolicy` instead.
+// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
 func (o BucketOutput) Policy() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringPtrOutput { return v.Policy }).(pulumi.StringPtrOutput)
 }
 
-// AWS region this bucket resides in.
+// The AWS region this bucket resides in.
 func (o BucketOutput) Region() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.Region }).(pulumi.StringOutput)
 }
 
-// Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketReplicationConfig` instead.
+// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 func (o BucketOutput) ReplicationConfiguration() BucketReplicationConfigurationPtrOutput {
 	return o.ApplyT(func(v *Bucket) BucketReplicationConfigurationPtrOutput { return v.ReplicationConfiguration }).(BucketReplicationConfigurationPtrOutput)
 }
 
 // Specifies who should bear the cost of Amazon S3 data transfer.
-// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-// See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-// The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+// developer guide for more information.
 func (o BucketOutput) RequestPayer() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.RequestPayer }).(pulumi.StringOutput)
 }
 
-// Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-// The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 func (o BucketOutput) ServerSideEncryptionConfiguration() BucketServerSideEncryptionConfigurationOutput {
 	return o.ApplyT(func(v *Bucket) BucketServerSideEncryptionConfigurationOutput {
 		return v.ServerSideEncryptionConfiguration
 	}).(BucketServerSideEncryptionConfigurationOutput)
 }
 
-// Map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-//
-// The following arguments are deprecated, and will be removed in a future major version:
+// A map of tags to assign to the bucket. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 func (o BucketOutput) Tags() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringMapOutput { return v.Tags }).(pulumi.StringMapOutput)
 }
 
-// Map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
+// A map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
 //
 // Deprecated: Please use `tags` instead.
 func (o BucketOutput) TagsAll() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringMapOutput { return v.TagsAll }).(pulumi.StringMapOutput)
 }
 
-// Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 func (o BucketOutput) Versioning() BucketVersioningOutput {
 	return o.ApplyT(func(v *Bucket) BucketVersioningOutput { return v.Versioning }).(BucketVersioningOutput)
 }
 
-// Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-// Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+// A website object (documented below).
 func (o BucketOutput) Website() BucketWebsitePtrOutput {
 	return o.ApplyT(func(v *Bucket) BucketWebsitePtrOutput { return v.Website }).(BucketWebsitePtrOutput)
 }
 
-// (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
 func (o BucketOutput) WebsiteDomain() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.WebsiteDomain }).(pulumi.StringOutput)
 }
 
-// (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 func (o BucketOutput) WebsiteEndpoint() pulumi.StringOutput {
 	return o.ApplyT(func(v *Bucket) pulumi.StringOutput { return v.WebsiteEndpoint }).(pulumi.StringOutput)
 }

--- a/sdk/go/aws/s3/pulumiTypes.go
+++ b/sdk/go/aws/s3/pulumiTypes.go
@@ -1938,13 +1938,13 @@ func (o BucketCorsConfigurationV2CorsRuleArrayOutput) Index(i pulumi.IntInput) B
 }
 
 type BucketCorsRule struct {
-	// List of headers allowed.
+	// Specifies which headers are allowed.
 	AllowedHeaders []string `pulumi:"allowedHeaders"`
-	// One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+	// Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
 	AllowedMethods []string `pulumi:"allowedMethods"`
-	// One or more origins you want customers to be able to access the bucket from.
+	// Specifies which origins are allowed.
 	AllowedOrigins []string `pulumi:"allowedOrigins"`
-	// One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+	// Specifies expose header in the response.
 	ExposeHeaders []string `pulumi:"exposeHeaders"`
 	// Specifies time in seconds that browser can cache the response for a preflight request.
 	MaxAgeSeconds *int `pulumi:"maxAgeSeconds"`
@@ -1962,13 +1962,13 @@ type BucketCorsRuleInput interface {
 }
 
 type BucketCorsRuleArgs struct {
-	// List of headers allowed.
+	// Specifies which headers are allowed.
 	AllowedHeaders pulumi.StringArrayInput `pulumi:"allowedHeaders"`
-	// One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+	// Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
 	AllowedMethods pulumi.StringArrayInput `pulumi:"allowedMethods"`
-	// One or more origins you want customers to be able to access the bucket from.
+	// Specifies which origins are allowed.
 	AllowedOrigins pulumi.StringArrayInput `pulumi:"allowedOrigins"`
-	// One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+	// Specifies expose header in the response.
 	ExposeHeaders pulumi.StringArrayInput `pulumi:"exposeHeaders"`
 	// Specifies time in seconds that browser can cache the response for a preflight request.
 	MaxAgeSeconds pulumi.IntPtrInput `pulumi:"maxAgeSeconds"`
@@ -2025,22 +2025,22 @@ func (o BucketCorsRuleOutput) ToBucketCorsRuleOutputWithContext(ctx context.Cont
 	return o
 }
 
-// List of headers allowed.
+// Specifies which headers are allowed.
 func (o BucketCorsRuleOutput) AllowedHeaders() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v BucketCorsRule) []string { return v.AllowedHeaders }).(pulumi.StringArrayOutput)
 }
 
-// One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+// Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
 func (o BucketCorsRuleOutput) AllowedMethods() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v BucketCorsRule) []string { return v.AllowedMethods }).(pulumi.StringArrayOutput)
 }
 
-// One or more origins you want customers to be able to access the bucket from.
+// Specifies which origins are allowed.
 func (o BucketCorsRuleOutput) AllowedOrigins() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v BucketCorsRule) []string { return v.AllowedOrigins }).(pulumi.StringArrayOutput)
 }
 
-// One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+// Specifies expose header in the response.
 func (o BucketCorsRuleOutput) ExposeHeaders() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v BucketCorsRule) []string { return v.ExposeHeaders }).(pulumi.StringArrayOutput)
 }
@@ -3917,19 +3917,21 @@ type BucketLifecycleRule struct {
 	AbortIncompleteMultipartUploadDays *int `pulumi:"abortIncompleteMultipartUploadDays"`
 	// Specifies lifecycle rule status.
 	Enabled bool `pulumi:"enabled"`
-	// Specifies a period in the object's expire. See Expiration below for details.
+	// Specifies a period in the object's expire (documented below).
 	Expiration *BucketLifecycleRuleExpiration `pulumi:"expiration"`
 	// Unique identifier for the rule. Must be less than or equal to 255 characters in length.
 	Id *string `pulumi:"id"`
-	// Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+	// Specifies when noncurrent object versions expire (documented below).
 	NoncurrentVersionExpiration *BucketLifecycleRuleNoncurrentVersionExpiration `pulumi:"noncurrentVersionExpiration"`
-	// Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+	// Specifies when noncurrent object versions transitions (documented below).
+	//
+	// At least one of `abortIncompleteMultipartUploadDays`, `expiration`, `transition`, `noncurrentVersionExpiration`, `noncurrentVersionTransition` must be specified.
 	NoncurrentVersionTransitions []BucketLifecycleRuleNoncurrentVersionTransition `pulumi:"noncurrentVersionTransitions"`
 	// Object key prefix identifying one or more objects to which the rule applies.
 	Prefix *string `pulumi:"prefix"`
 	// Specifies object tags key and value.
 	Tags map[string]string `pulumi:"tags"`
-	// Specifies a period in the object's transitions. See Transition below for details.
+	// Specifies a period in the object's transitions (documented below).
 	Transitions []BucketLifecycleRuleTransition `pulumi:"transitions"`
 }
 
@@ -3949,19 +3951,21 @@ type BucketLifecycleRuleArgs struct {
 	AbortIncompleteMultipartUploadDays pulumi.IntPtrInput `pulumi:"abortIncompleteMultipartUploadDays"`
 	// Specifies lifecycle rule status.
 	Enabled pulumi.BoolInput `pulumi:"enabled"`
-	// Specifies a period in the object's expire. See Expiration below for details.
+	// Specifies a period in the object's expire (documented below).
 	Expiration BucketLifecycleRuleExpirationPtrInput `pulumi:"expiration"`
 	// Unique identifier for the rule. Must be less than or equal to 255 characters in length.
 	Id pulumi.StringPtrInput `pulumi:"id"`
-	// Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+	// Specifies when noncurrent object versions expire (documented below).
 	NoncurrentVersionExpiration BucketLifecycleRuleNoncurrentVersionExpirationPtrInput `pulumi:"noncurrentVersionExpiration"`
-	// Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+	// Specifies when noncurrent object versions transitions (documented below).
+	//
+	// At least one of `abortIncompleteMultipartUploadDays`, `expiration`, `transition`, `noncurrentVersionExpiration`, `noncurrentVersionTransition` must be specified.
 	NoncurrentVersionTransitions BucketLifecycleRuleNoncurrentVersionTransitionArrayInput `pulumi:"noncurrentVersionTransitions"`
 	// Object key prefix identifying one or more objects to which the rule applies.
 	Prefix pulumi.StringPtrInput `pulumi:"prefix"`
 	// Specifies object tags key and value.
 	Tags pulumi.StringMapInput `pulumi:"tags"`
-	// Specifies a period in the object's transitions. See Transition below for details.
+	// Specifies a period in the object's transitions (documented below).
 	Transitions BucketLifecycleRuleTransitionArrayInput `pulumi:"transitions"`
 }
 
@@ -4026,7 +4030,7 @@ func (o BucketLifecycleRuleOutput) Enabled() pulumi.BoolOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) bool { return v.Enabled }).(pulumi.BoolOutput)
 }
 
-// Specifies a period in the object's expire. See Expiration below for details.
+// Specifies a period in the object's expire (documented below).
 func (o BucketLifecycleRuleOutput) Expiration() BucketLifecycleRuleExpirationPtrOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) *BucketLifecycleRuleExpiration { return v.Expiration }).(BucketLifecycleRuleExpirationPtrOutput)
 }
@@ -4036,14 +4040,16 @@ func (o BucketLifecycleRuleOutput) Id() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) *string { return v.Id }).(pulumi.StringPtrOutput)
 }
 
-// Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+// Specifies when noncurrent object versions expire (documented below).
 func (o BucketLifecycleRuleOutput) NoncurrentVersionExpiration() BucketLifecycleRuleNoncurrentVersionExpirationPtrOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) *BucketLifecycleRuleNoncurrentVersionExpiration {
 		return v.NoncurrentVersionExpiration
 	}).(BucketLifecycleRuleNoncurrentVersionExpirationPtrOutput)
 }
 
-// Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+// Specifies when noncurrent object versions transitions (documented below).
+//
+// At least one of `abortIncompleteMultipartUploadDays`, `expiration`, `transition`, `noncurrentVersionExpiration`, `noncurrentVersionTransition` must be specified.
 func (o BucketLifecycleRuleOutput) NoncurrentVersionTransitions() BucketLifecycleRuleNoncurrentVersionTransitionArrayOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) []BucketLifecycleRuleNoncurrentVersionTransition {
 		return v.NoncurrentVersionTransitions
@@ -4060,7 +4066,7 @@ func (o BucketLifecycleRuleOutput) Tags() pulumi.StringMapOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
 }
 
-// Specifies a period in the object's transitions. See Transition below for details.
+// Specifies a period in the object's transitions (documented below).
 func (o BucketLifecycleRuleOutput) Transitions() BucketLifecycleRuleTransitionArrayOutput {
 	return o.ApplyT(func(v BucketLifecycleRule) []BucketLifecycleRuleTransition { return v.Transitions }).(BucketLifecycleRuleTransitionArrayOutput)
 }
@@ -4619,7 +4625,7 @@ func (o BucketLifecycleRuleTransitionArrayOutput) Index(i pulumi.IntInput) Bucke
 }
 
 type BucketLogging struct {
-	// Name of the bucket that will receive the log objects.
+	// The name of the bucket that will receive the log objects.
 	TargetBucket string `pulumi:"targetBucket"`
 	// To specify a key prefix for log objects.
 	TargetPrefix *string `pulumi:"targetPrefix"`
@@ -4637,7 +4643,7 @@ type BucketLoggingInput interface {
 }
 
 type BucketLoggingArgs struct {
-	// Name of the bucket that will receive the log objects.
+	// The name of the bucket that will receive the log objects.
 	TargetBucket pulumi.StringInput `pulumi:"targetBucket"`
 	// To specify a key prefix for log objects.
 	TargetPrefix pulumi.StringPtrInput `pulumi:"targetPrefix"`
@@ -4694,7 +4700,7 @@ func (o BucketLoggingOutput) ToBucketLoggingOutputWithContext(ctx context.Contex
 	return o
 }
 
-// Name of the bucket that will receive the log objects.
+// The name of the bucket that will receive the log objects.
 func (o BucketLoggingOutput) TargetBucket() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketLogging) string { return v.TargetBucket }).(pulumi.StringOutput)
 }
@@ -5905,9 +5911,9 @@ func (o BucketNotificationTopicArrayOutput) Index(i pulumi.IntInput) BucketNotif
 }
 
 type BucketObjectLockConfiguration struct {
-	// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+	// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
 	ObjectLockEnabled string `pulumi:"objectLockEnabled"`
-	// Object Lock rule in place for this bucket (documented below).
+	// The Object Lock rule in place for this bucket.
 	Rule *BucketObjectLockConfigurationRule `pulumi:"rule"`
 }
 
@@ -5923,9 +5929,9 @@ type BucketObjectLockConfigurationInput interface {
 }
 
 type BucketObjectLockConfigurationArgs struct {
-	// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+	// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
 	ObjectLockEnabled pulumi.StringInput `pulumi:"objectLockEnabled"`
-	// Object Lock rule in place for this bucket (documented below).
+	// The Object Lock rule in place for this bucket.
 	Rule BucketObjectLockConfigurationRulePtrInput `pulumi:"rule"`
 }
 
@@ -6006,12 +6012,12 @@ func (o BucketObjectLockConfigurationOutput) ToBucketObjectLockConfigurationPtrO
 	}).(BucketObjectLockConfigurationPtrOutput)
 }
 
-// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
 func (o BucketObjectLockConfigurationOutput) ObjectLockEnabled() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketObjectLockConfiguration) string { return v.ObjectLockEnabled }).(pulumi.StringOutput)
 }
 
-// Object Lock rule in place for this bucket (documented below).
+// The Object Lock rule in place for this bucket.
 func (o BucketObjectLockConfigurationOutput) Rule() BucketObjectLockConfigurationRulePtrOutput {
 	return o.ApplyT(func(v BucketObjectLockConfiguration) *BucketObjectLockConfigurationRule { return v.Rule }).(BucketObjectLockConfigurationRulePtrOutput)
 }
@@ -6040,7 +6046,7 @@ func (o BucketObjectLockConfigurationPtrOutput) Elem() BucketObjectLockConfigura
 	}).(BucketObjectLockConfigurationOutput)
 }
 
-// Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+// Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
 func (o BucketObjectLockConfigurationPtrOutput) ObjectLockEnabled() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketObjectLockConfiguration) *string {
 		if v == nil {
@@ -6050,7 +6056,7 @@ func (o BucketObjectLockConfigurationPtrOutput) ObjectLockEnabled() pulumi.Strin
 	}).(pulumi.StringPtrOutput)
 }
 
-// Object Lock rule in place for this bucket (documented below).
+// The Object Lock rule in place for this bucket.
 func (o BucketObjectLockConfigurationPtrOutput) Rule() BucketObjectLockConfigurationRulePtrOutput {
 	return o.ApplyT(func(v *BucketObjectLockConfiguration) *BucketObjectLockConfigurationRule {
 		if v == nil {
@@ -6061,7 +6067,7 @@ func (o BucketObjectLockConfigurationPtrOutput) Rule() BucketObjectLockConfigura
 }
 
 type BucketObjectLockConfigurationRule struct {
-	// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+	// The default retention period that you want to apply to new objects placed in this bucket.
 	DefaultRetention BucketObjectLockConfigurationRuleDefaultRetention `pulumi:"defaultRetention"`
 }
 
@@ -6077,7 +6083,7 @@ type BucketObjectLockConfigurationRuleInput interface {
 }
 
 type BucketObjectLockConfigurationRuleArgs struct {
-	// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+	// The default retention period that you want to apply to new objects placed in this bucket.
 	DefaultRetention BucketObjectLockConfigurationRuleDefaultRetentionInput `pulumi:"defaultRetention"`
 }
 
@@ -6158,7 +6164,7 @@ func (o BucketObjectLockConfigurationRuleOutput) ToBucketObjectLockConfiguration
 	}).(BucketObjectLockConfigurationRulePtrOutput)
 }
 
-// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+// The default retention period that you want to apply to new objects placed in this bucket.
 func (o BucketObjectLockConfigurationRuleOutput) DefaultRetention() BucketObjectLockConfigurationRuleDefaultRetentionOutput {
 	return o.ApplyT(func(v BucketObjectLockConfigurationRule) BucketObjectLockConfigurationRuleDefaultRetention {
 		return v.DefaultRetention
@@ -6189,7 +6195,7 @@ func (o BucketObjectLockConfigurationRulePtrOutput) Elem() BucketObjectLockConfi
 	}).(BucketObjectLockConfigurationRuleOutput)
 }
 
-// Default retention period that you want to apply to new objects placed in this bucket (documented below).
+// The default retention period that you want to apply to new objects placed in this bucket.
 func (o BucketObjectLockConfigurationRulePtrOutput) DefaultRetention() BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput {
 	return o.ApplyT(func(v *BucketObjectLockConfigurationRule) *BucketObjectLockConfigurationRuleDefaultRetention {
 		if v == nil {
@@ -6200,11 +6206,17 @@ func (o BucketObjectLockConfigurationRulePtrOutput) DefaultRetention() BucketObj
 }
 
 type BucketObjectLockConfigurationRuleDefaultRetention struct {
-	// Number of days that you want to specify for the default retention period.
+	// The number of days that you want to specify for the default retention period.
 	Days *int `pulumi:"days"`
-	// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+	// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
 	Mode string `pulumi:"mode"`
-	// Number of years that you want to specify for the default retention period.
+	// The number of years that you want to specify for the default retention period.
+	//
+	// Either `days` or `years` must be specified, but not both.
+	//
+	// > **NOTE on `objectLockConfiguration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+	// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+	// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
 	Years *int `pulumi:"years"`
 }
 
@@ -6220,11 +6232,17 @@ type BucketObjectLockConfigurationRuleDefaultRetentionInput interface {
 }
 
 type BucketObjectLockConfigurationRuleDefaultRetentionArgs struct {
-	// Number of days that you want to specify for the default retention period.
+	// The number of days that you want to specify for the default retention period.
 	Days pulumi.IntPtrInput `pulumi:"days"`
-	// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+	// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
 	Mode pulumi.StringInput `pulumi:"mode"`
-	// Number of years that you want to specify for the default retention period.
+	// The number of years that you want to specify for the default retention period.
+	//
+	// Either `days` or `years` must be specified, but not both.
+	//
+	// > **NOTE on `objectLockConfiguration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+	// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+	// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
 	Years pulumi.IntPtrInput `pulumi:"years"`
 }
 
@@ -6305,17 +6323,23 @@ func (o BucketObjectLockConfigurationRuleDefaultRetentionOutput) ToBucketObjectL
 	}).(BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput)
 }
 
-// Number of days that you want to specify for the default retention period.
+// The number of days that you want to specify for the default retention period.
 func (o BucketObjectLockConfigurationRuleDefaultRetentionOutput) Days() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v BucketObjectLockConfigurationRuleDefaultRetention) *int { return v.Days }).(pulumi.IntPtrOutput)
 }
 
-// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
 func (o BucketObjectLockConfigurationRuleDefaultRetentionOutput) Mode() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketObjectLockConfigurationRuleDefaultRetention) string { return v.Mode }).(pulumi.StringOutput)
 }
 
-// Number of years that you want to specify for the default retention period.
+// The number of years that you want to specify for the default retention period.
+//
+// Either `days` or `years` must be specified, but not both.
+//
+// > **NOTE on `objectLockConfiguration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
 func (o BucketObjectLockConfigurationRuleDefaultRetentionOutput) Years() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v BucketObjectLockConfigurationRuleDefaultRetention) *int { return v.Years }).(pulumi.IntPtrOutput)
 }
@@ -6344,7 +6368,7 @@ func (o BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput) Elem() Bucke
 	}).(BucketObjectLockConfigurationRuleDefaultRetentionOutput)
 }
 
-// Number of days that you want to specify for the default retention period.
+// The number of days that you want to specify for the default retention period.
 func (o BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput) Days() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *BucketObjectLockConfigurationRuleDefaultRetention) *int {
 		if v == nil {
@@ -6354,7 +6378,7 @@ func (o BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput) Days() pulum
 	}).(pulumi.IntPtrOutput)
 }
 
-// Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+// The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
 func (o BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput) Mode() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketObjectLockConfigurationRuleDefaultRetention) *string {
 		if v == nil {
@@ -6364,7 +6388,13 @@ func (o BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput) Mode() pulum
 	}).(pulumi.StringPtrOutput)
 }
 
-// Number of years that you want to specify for the default retention period.
+// The number of years that you want to specify for the default retention period.
+//
+// Either `days` or `years` must be specified, but not both.
+//
+// > **NOTE on `objectLockConfiguration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+// When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+// Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
 func (o BucketObjectLockConfigurationRuleDefaultRetentionPtrOutput) Years() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *BucketObjectLockConfigurationRuleDefaultRetention) *int {
 		if v == nil {
@@ -9470,7 +9500,7 @@ func (o BucketReplicationConfigRuleSourceSelectionCriteriaSseKmsEncryptedObjects
 }
 
 type BucketReplicationConfiguration struct {
-	// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+	// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
 	Role string `pulumi:"role"`
 	// Specifies the rules managing the replication (documented below).
 	Rules []BucketReplicationConfigurationRule `pulumi:"rules"`
@@ -9488,7 +9518,7 @@ type BucketReplicationConfigurationInput interface {
 }
 
 type BucketReplicationConfigurationArgs struct {
-	// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+	// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
 	Role pulumi.StringInput `pulumi:"role"`
 	// Specifies the rules managing the replication (documented below).
 	Rules BucketReplicationConfigurationRuleArrayInput `pulumi:"rules"`
@@ -9571,7 +9601,7 @@ func (o BucketReplicationConfigurationOutput) ToBucketReplicationConfigurationPt
 	}).(BucketReplicationConfigurationPtrOutput)
 }
 
-// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
 func (o BucketReplicationConfigurationOutput) Role() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketReplicationConfiguration) string { return v.Role }).(pulumi.StringOutput)
 }
@@ -9605,7 +9635,7 @@ func (o BucketReplicationConfigurationPtrOutput) Elem() BucketReplicationConfigu
 	}).(BucketReplicationConfigurationOutput)
 }
 
-// ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+// The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
 func (o BucketReplicationConfigurationPtrOutput) Role() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketReplicationConfiguration) *string {
 		if v == nil {
@@ -9636,11 +9666,13 @@ type BucketReplicationConfigurationRule struct {
 	Id *string `pulumi:"id"`
 	// Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
 	Prefix *string `pulumi:"prefix"`
-	// Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+	// The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
 	Priority *int `pulumi:"priority"`
 	// Specifies special object selection criteria (documented below).
 	SourceSelectionCriteria *BucketReplicationConfigurationRuleSourceSelectionCriteria `pulumi:"sourceSelectionCriteria"`
-	// Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+	// The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+	//
+	// > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
 	Status string `pulumi:"status"`
 }
 
@@ -9666,11 +9698,13 @@ type BucketReplicationConfigurationRuleArgs struct {
 	Id pulumi.StringPtrInput `pulumi:"id"`
 	// Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
 	Prefix pulumi.StringPtrInput `pulumi:"prefix"`
-	// Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+	// The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
 	Priority pulumi.IntPtrInput `pulumi:"priority"`
 	// Specifies special object selection criteria (documented below).
 	SourceSelectionCriteria BucketReplicationConfigurationRuleSourceSelectionCriteriaPtrInput `pulumi:"sourceSelectionCriteria"`
-	// Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+	// The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+	//
+	// > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
 	Status pulumi.StringInput `pulumi:"status"`
 }
 
@@ -9752,7 +9786,7 @@ func (o BucketReplicationConfigurationRuleOutput) Prefix() pulumi.StringPtrOutpu
 	return o.ApplyT(func(v BucketReplicationConfigurationRule) *string { return v.Prefix }).(pulumi.StringPtrOutput)
 }
 
-// Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+// The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
 func (o BucketReplicationConfigurationRuleOutput) Priority() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRule) *int { return v.Priority }).(pulumi.IntPtrOutput)
 }
@@ -9764,7 +9798,9 @@ func (o BucketReplicationConfigurationRuleOutput) SourceSelectionCriteria() Buck
 	}).(BucketReplicationConfigurationRuleSourceSelectionCriteriaPtrOutput)
 }
 
-// Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+// The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+//
+// > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
 func (o BucketReplicationConfigurationRuleOutput) Status() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRule) string { return v.Status }).(pulumi.StringOutput)
 }
@@ -9790,11 +9826,11 @@ func (o BucketReplicationConfigurationRuleArrayOutput) Index(i pulumi.IntInput) 
 }
 
 type BucketReplicationConfigurationRuleDestination struct {
-	// Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `accountId` owner override configuration.
+	// Specifies the overrides to use for object owners on replication. Must be used in conjunction with `accountId` owner override configuration.
 	AccessControlTranslation *BucketReplicationConfigurationRuleDestinationAccessControlTranslation `pulumi:"accessControlTranslation"`
-	// Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
+	// The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
 	AccountId *string `pulumi:"accountId"`
-	// ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+	// The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
 	Bucket string `pulumi:"bucket"`
 	// Enables replication metrics (required for S3 RTC) (documented below).
 	Metrics *BucketReplicationConfigurationRuleDestinationMetrics `pulumi:"metrics"`
@@ -9819,11 +9855,11 @@ type BucketReplicationConfigurationRuleDestinationInput interface {
 }
 
 type BucketReplicationConfigurationRuleDestinationArgs struct {
-	// Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `accountId` owner override configuration.
+	// Specifies the overrides to use for object owners on replication. Must be used in conjunction with `accountId` owner override configuration.
 	AccessControlTranslation BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtrInput `pulumi:"accessControlTranslation"`
-	// Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
+	// The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
 	AccountId pulumi.StringPtrInput `pulumi:"accountId"`
-	// ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+	// The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
 	Bucket pulumi.StringInput `pulumi:"bucket"`
 	// Enables replication metrics (required for S3 RTC) (documented below).
 	Metrics BucketReplicationConfigurationRuleDestinationMetricsPtrInput `pulumi:"metrics"`
@@ -9862,19 +9898,19 @@ func (o BucketReplicationConfigurationRuleDestinationOutput) ToBucketReplication
 	return o
 }
 
-// Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `accountId` owner override configuration.
+// Specifies the overrides to use for object owners on replication. Must be used in conjunction with `accountId` owner override configuration.
 func (o BucketReplicationConfigurationRuleDestinationOutput) AccessControlTranslation() BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtrOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestination) *BucketReplicationConfigurationRuleDestinationAccessControlTranslation {
 		return v.AccessControlTranslation
 	}).(BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtrOutput)
 }
 
-// Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
+// The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
 func (o BucketReplicationConfigurationRuleDestinationOutput) AccountId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestination) *string { return v.AccountId }).(pulumi.StringPtrOutput)
 }
 
-// ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+// The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
 func (o BucketReplicationConfigurationRuleDestinationOutput) Bucket() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestination) string { return v.Bucket }).(pulumi.StringOutput)
 }
@@ -9905,7 +9941,7 @@ func (o BucketReplicationConfigurationRuleDestinationOutput) StorageClass() pulu
 }
 
 type BucketReplicationConfigurationRuleDestinationAccessControlTranslation struct {
-	// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+	// The override value for the owner on replicated objects. Currently only `Destination` is supported.
 	Owner string `pulumi:"owner"`
 }
 
@@ -9921,7 +9957,7 @@ type BucketReplicationConfigurationRuleDestinationAccessControlTranslationInput 
 }
 
 type BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs struct {
-	// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+	// The override value for the owner on replicated objects. Currently only `Destination` is supported.
 	Owner pulumi.StringInput `pulumi:"owner"`
 }
 
@@ -10002,7 +10038,7 @@ func (o BucketReplicationConfigurationRuleDestinationAccessControlTranslationOut
 	}).(BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtrOutput)
 }
 
-// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+// The override value for the owner on replicated objects. Currently only `Destination` is supported.
 func (o BucketReplicationConfigurationRuleDestinationAccessControlTranslationOutput) Owner() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestinationAccessControlTranslation) string { return v.Owner }).(pulumi.StringOutput)
 }
@@ -10031,7 +10067,7 @@ func (o BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtr
 	}).(BucketReplicationConfigurationRuleDestinationAccessControlTranslationOutput)
 }
 
-// Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+// The override value for the owner on replicated objects. Currently only `Destination` is supported.
 func (o BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtrOutput) Owner() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketReplicationConfigurationRuleDestinationAccessControlTranslation) *string {
 		if v == nil {
@@ -10044,7 +10080,7 @@ func (o BucketReplicationConfigurationRuleDestinationAccessControlTranslationPtr
 type BucketReplicationConfigurationRuleDestinationMetrics struct {
 	// Threshold within which objects are to be replicated. The only valid value is `15`.
 	Minutes *int `pulumi:"minutes"`
-	// Status of replication metrics. Either `Enabled` or `Disabled`.
+	// The status of replication metrics. Either `Enabled` or `Disabled`.
 	Status *string `pulumi:"status"`
 }
 
@@ -10062,7 +10098,7 @@ type BucketReplicationConfigurationRuleDestinationMetricsInput interface {
 type BucketReplicationConfigurationRuleDestinationMetricsArgs struct {
 	// Threshold within which objects are to be replicated. The only valid value is `15`.
 	Minutes pulumi.IntPtrInput `pulumi:"minutes"`
-	// Status of replication metrics. Either `Enabled` or `Disabled`.
+	// The status of replication metrics. Either `Enabled` or `Disabled`.
 	Status pulumi.StringPtrInput `pulumi:"status"`
 }
 
@@ -10148,7 +10184,7 @@ func (o BucketReplicationConfigurationRuleDestinationMetricsOutput) Minutes() pu
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestinationMetrics) *int { return v.Minutes }).(pulumi.IntPtrOutput)
 }
 
-// Status of replication metrics. Either `Enabled` or `Disabled`.
+// The status of replication metrics. Either `Enabled` or `Disabled`.
 func (o BucketReplicationConfigurationRuleDestinationMetricsOutput) Status() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestinationMetrics) *string { return v.Status }).(pulumi.StringPtrOutput)
 }
@@ -10187,7 +10223,7 @@ func (o BucketReplicationConfigurationRuleDestinationMetricsPtrOutput) Minutes()
 	}).(pulumi.IntPtrOutput)
 }
 
-// Status of replication metrics. Either `Enabled` or `Disabled`.
+// The status of replication metrics. Either `Enabled` or `Disabled`.
 func (o BucketReplicationConfigurationRuleDestinationMetricsPtrOutput) Status() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketReplicationConfigurationRuleDestinationMetrics) *string {
 		if v == nil {
@@ -10200,7 +10236,7 @@ func (o BucketReplicationConfigurationRuleDestinationMetricsPtrOutput) Status() 
 type BucketReplicationConfigurationRuleDestinationReplicationTime struct {
 	// Threshold within which objects are to be replicated. The only valid value is `15`.
 	Minutes *int `pulumi:"minutes"`
-	// Status of RTC. Either `Enabled` or `Disabled`.
+	// The status of RTC. Either `Enabled` or `Disabled`.
 	Status *string `pulumi:"status"`
 }
 
@@ -10218,7 +10254,7 @@ type BucketReplicationConfigurationRuleDestinationReplicationTimeInput interface
 type BucketReplicationConfigurationRuleDestinationReplicationTimeArgs struct {
 	// Threshold within which objects are to be replicated. The only valid value is `15`.
 	Minutes pulumi.IntPtrInput `pulumi:"minutes"`
-	// Status of RTC. Either `Enabled` or `Disabled`.
+	// The status of RTC. Either `Enabled` or `Disabled`.
 	Status pulumi.StringPtrInput `pulumi:"status"`
 }
 
@@ -10304,7 +10340,7 @@ func (o BucketReplicationConfigurationRuleDestinationReplicationTimeOutput) Minu
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestinationReplicationTime) *int { return v.Minutes }).(pulumi.IntPtrOutput)
 }
 
-// Status of RTC. Either `Enabled` or `Disabled`.
+// The status of RTC. Either `Enabled` or `Disabled`.
 func (o BucketReplicationConfigurationRuleDestinationReplicationTimeOutput) Status() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketReplicationConfigurationRuleDestinationReplicationTime) *string { return v.Status }).(pulumi.StringPtrOutput)
 }
@@ -10343,7 +10379,7 @@ func (o BucketReplicationConfigurationRuleDestinationReplicationTimePtrOutput) M
 	}).(pulumi.IntPtrOutput)
 }
 
-// Status of RTC. Either `Enabled` or `Disabled`.
+// The status of RTC. Either `Enabled` or `Disabled`.
 func (o BucketReplicationConfigurationRuleDestinationReplicationTimePtrOutput) Status() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketReplicationConfigurationRuleDestinationReplicationTime) *string {
 		if v == nil {
@@ -10796,7 +10832,7 @@ func (o BucketReplicationConfigurationRuleSourceSelectionCriteriaSseKmsEncrypted
 }
 
 type BucketServerSideEncryptionConfiguration struct {
-	// Single object for server-side encryption by default configuration. (documented below)
+	// A single object for server-side encryption by default configuration. (documented below)
 	Rule BucketServerSideEncryptionConfigurationRule `pulumi:"rule"`
 }
 
@@ -10812,7 +10848,7 @@ type BucketServerSideEncryptionConfigurationInput interface {
 }
 
 type BucketServerSideEncryptionConfigurationArgs struct {
-	// Single object for server-side encryption by default configuration. (documented below)
+	// A single object for server-side encryption by default configuration. (documented below)
 	Rule BucketServerSideEncryptionConfigurationRuleInput `pulumi:"rule"`
 }
 
@@ -10893,7 +10929,7 @@ func (o BucketServerSideEncryptionConfigurationOutput) ToBucketServerSideEncrypt
 	}).(BucketServerSideEncryptionConfigurationPtrOutput)
 }
 
-// Single object for server-side encryption by default configuration. (documented below)
+// A single object for server-side encryption by default configuration. (documented below)
 func (o BucketServerSideEncryptionConfigurationOutput) Rule() BucketServerSideEncryptionConfigurationRuleOutput {
 	return o.ApplyT(func(v BucketServerSideEncryptionConfiguration) BucketServerSideEncryptionConfigurationRule {
 		return v.Rule
@@ -10924,7 +10960,7 @@ func (o BucketServerSideEncryptionConfigurationPtrOutput) Elem() BucketServerSid
 	}).(BucketServerSideEncryptionConfigurationOutput)
 }
 
-// Single object for server-side encryption by default configuration. (documented below)
+// A single object for server-side encryption by default configuration. (documented below)
 func (o BucketServerSideEncryptionConfigurationPtrOutput) Rule() BucketServerSideEncryptionConfigurationRulePtrOutput {
 	return o.ApplyT(func(v *BucketServerSideEncryptionConfiguration) *BucketServerSideEncryptionConfigurationRule {
 		if v == nil {
@@ -10935,7 +10971,7 @@ func (o BucketServerSideEncryptionConfigurationPtrOutput) Rule() BucketServerSid
 }
 
 type BucketServerSideEncryptionConfigurationRule struct {
-	// Single object for setting server-side encryption by default. (documented below)
+	// A single object for setting server-side encryption by default. (documented below)
 	ApplyServerSideEncryptionByDefault BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault `pulumi:"applyServerSideEncryptionByDefault"`
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled *bool `pulumi:"bucketKeyEnabled"`
@@ -10953,7 +10989,7 @@ type BucketServerSideEncryptionConfigurationRuleInput interface {
 }
 
 type BucketServerSideEncryptionConfigurationRuleArgs struct {
-	// Single object for setting server-side encryption by default. (documented below)
+	// A single object for setting server-side encryption by default. (documented below)
 	ApplyServerSideEncryptionByDefault BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultInput `pulumi:"applyServerSideEncryptionByDefault"`
 	// Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 	BucketKeyEnabled pulumi.BoolPtrInput `pulumi:"bucketKeyEnabled"`
@@ -11036,7 +11072,7 @@ func (o BucketServerSideEncryptionConfigurationRuleOutput) ToBucketServerSideEnc
 	}).(BucketServerSideEncryptionConfigurationRulePtrOutput)
 }
 
-// Single object for setting server-side encryption by default. (documented below)
+// A single object for setting server-side encryption by default. (documented below)
 func (o BucketServerSideEncryptionConfigurationRuleOutput) ApplyServerSideEncryptionByDefault() BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultOutput {
 	return o.ApplyT(func(v BucketServerSideEncryptionConfigurationRule) BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault {
 		return v.ApplyServerSideEncryptionByDefault
@@ -11072,7 +11108,7 @@ func (o BucketServerSideEncryptionConfigurationRulePtrOutput) Elem() BucketServe
 	}).(BucketServerSideEncryptionConfigurationRuleOutput)
 }
 
-// Single object for setting server-side encryption by default. (documented below)
+// A single object for setting server-side encryption by default. (documented below)
 func (o BucketServerSideEncryptionConfigurationRulePtrOutput) ApplyServerSideEncryptionByDefault() BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultPtrOutput {
 	return o.ApplyT(func(v *BucketServerSideEncryptionConfigurationRule) *BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault {
 		if v == nil {
@@ -11093,9 +11129,9 @@ func (o BucketServerSideEncryptionConfigurationRulePtrOutput) BucketKeyEnabled()
 }
 
 type BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault struct {
-	// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
+	// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
 	KmsMasterKeyId *string `pulumi:"kmsMasterKeyId"`
-	// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+	// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
 	SseAlgorithm string `pulumi:"sseAlgorithm"`
 }
 
@@ -11111,9 +11147,9 @@ type BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefau
 }
 
 type BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs struct {
-	// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
+	// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
 	KmsMasterKeyId pulumi.StringPtrInput `pulumi:"kmsMasterKeyId"`
-	// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+	// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
 	SseAlgorithm pulumi.StringInput `pulumi:"sseAlgorithm"`
 }
 
@@ -11194,14 +11230,14 @@ func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDe
 	}).(BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultPtrOutput)
 }
 
-// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
+// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
 func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultOutput) KmsMasterKeyId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault) *string {
 		return v.KmsMasterKeyId
 	}).(pulumi.StringPtrOutput)
 }
 
-// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
 func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultOutput) SseAlgorithm() pulumi.StringOutput {
 	return o.ApplyT(func(v BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault) string {
 		return v.SseAlgorithm
@@ -11232,7 +11268,7 @@ func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDe
 	}).(BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultOutput)
 }
 
-// AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
+// The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
 func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultPtrOutput) KmsMasterKeyId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault) *string {
 		if v == nil {
@@ -11242,7 +11278,7 @@ func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDe
 	}).(pulumi.StringPtrOutput)
 }
 
-// Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+// The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
 func (o BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultPtrOutput) SseAlgorithm() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault) *string {
 		if v == nil {
@@ -14789,14 +14825,16 @@ func (o BucketVersioningV2VersioningConfigurationPtrOutput) Status() pulumi.Stri
 }
 
 type BucketWebsite struct {
-	// Absolute path to the document to return in case of a 4XX error.
+	// An absolute path to the document to return in case of a 4XX error.
 	ErrorDocument *string `pulumi:"errorDocument"`
 	// Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
 	IndexDocument *string `pulumi:"indexDocument"`
-	// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+	// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
 	RedirectAllRequestsTo *string `pulumi:"redirectAllRequestsTo"`
-	// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+	// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
 	// describing redirect behavior and when redirects are applied.
+	//
+	// The `CORS` object supports the following:
 	RoutingRules interface{} `pulumi:"routingRules"`
 }
 
@@ -14812,14 +14850,16 @@ type BucketWebsiteInput interface {
 }
 
 type BucketWebsiteArgs struct {
-	// Absolute path to the document to return in case of a 4XX error.
+	// An absolute path to the document to return in case of a 4XX error.
 	ErrorDocument pulumi.StringPtrInput `pulumi:"errorDocument"`
 	// Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
 	IndexDocument pulumi.StringPtrInput `pulumi:"indexDocument"`
-	// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+	// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
 	RedirectAllRequestsTo pulumi.StringPtrInput `pulumi:"redirectAllRequestsTo"`
-	// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+	// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
 	// describing redirect behavior and when redirects are applied.
+	//
+	// The `CORS` object supports the following:
 	RoutingRules pulumi.Input `pulumi:"routingRules"`
 }
 
@@ -14900,7 +14940,7 @@ func (o BucketWebsiteOutput) ToBucketWebsitePtrOutputWithContext(ctx context.Con
 	}).(BucketWebsitePtrOutput)
 }
 
-// Absolute path to the document to return in case of a 4XX error.
+// An absolute path to the document to return in case of a 4XX error.
 func (o BucketWebsiteOutput) ErrorDocument() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketWebsite) *string { return v.ErrorDocument }).(pulumi.StringPtrOutput)
 }
@@ -14910,13 +14950,15 @@ func (o BucketWebsiteOutput) IndexDocument() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketWebsite) *string { return v.IndexDocument }).(pulumi.StringPtrOutput)
 }
 
-// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
 func (o BucketWebsiteOutput) RedirectAllRequestsTo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BucketWebsite) *string { return v.RedirectAllRequestsTo }).(pulumi.StringPtrOutput)
 }
 
-// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
 // describing redirect behavior and when redirects are applied.
+//
+// The `CORS` object supports the following:
 func (o BucketWebsiteOutput) RoutingRules() pulumi.AnyOutput {
 	return o.ApplyT(func(v BucketWebsite) interface{} { return v.RoutingRules }).(pulumi.AnyOutput)
 }
@@ -14945,7 +14987,7 @@ func (o BucketWebsitePtrOutput) Elem() BucketWebsiteOutput {
 	}).(BucketWebsiteOutput)
 }
 
-// Absolute path to the document to return in case of a 4XX error.
+// An absolute path to the document to return in case of a 4XX error.
 func (o BucketWebsitePtrOutput) ErrorDocument() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketWebsite) *string {
 		if v == nil {
@@ -14965,7 +15007,7 @@ func (o BucketWebsitePtrOutput) IndexDocument() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+// A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
 func (o BucketWebsitePtrOutput) RedirectAllRequestsTo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BucketWebsite) *string {
 		if v == nil {
@@ -14975,8 +15017,10 @@ func (o BucketWebsitePtrOutput) RedirectAllRequestsTo() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+// A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
 // describing redirect behavior and when redirects are applied.
+//
+// The `CORS` object supports the following:
 func (o BucketWebsitePtrOutput) RoutingRules() pulumi.AnyOutput {
 	return o.ApplyT(func(v *BucketWebsite) interface{} {
 		if v == nil {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/Bucket.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/Bucket.java
@@ -29,13 +29,14 @@ import javax.annotation.Nullable;
 /**
  * Provides a S3 bucket resource.
  * 
- * &gt; This resource provides functionality for managing S3 general purpose buckets in an AWS Partition. To manage Amazon S3 Express directory buckets, use the `aws_directory_bucket` resource. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), use the `aws.s3control.Bucket` resource.
- * 
- * &gt; Object Lock can be enabled by using the `object_lock_enable` attribute or by using the `aws.s3.BucketObjectLockConfigurationV2` resource. Please note, that by using the resource, Object Lock can be enabled/disabled without destroying and recreating the bucket.
+ * &gt; **NOTE:** Please use [aws.s3.BucketV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketv2) instead.
+ * This resource is maintained for backwards compatibility only. Please see [BucketV2 Migration
+ * Guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/bucketv2-migration/) for instructions on migrating
+ * existing Bucket resources to BucketV2.
  * 
  * ## Example Usage
  * 
- * ### Private Bucket With Tags
+ * ### Private Bucket w/ Tags
  * 
  * &lt;!--Start PulumiCodeChooser --&gt;
  * <pre>
@@ -45,8 +46,8 @@ import javax.annotation.Nullable;
  * import com.pulumi.Context;
  * import com.pulumi.Pulumi;
  * import com.pulumi.core.Output;
- * import com.pulumi.aws.s3.BucketV2;
- * import com.pulumi.aws.s3.BucketV2Args;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
  * import java.util.List;
  * import java.util.ArrayList;
  * import java.util.Map;
@@ -60,8 +61,9 @@ import javax.annotation.Nullable;
  *     }
  * 
  *     public static void stack(Context ctx) {
- *         var example = new BucketV2("example", BucketV2Args.builder()
+ *         var b = new Bucket("b", BucketArgs.builder()
  *             .bucket("my-tf-test-bucket")
+ *             .acl("private")
  *             .tags(Map.ofEntries(
  *                 Map.entry("Name", "My bucket"),
  *                 Map.entry("Environment", "Dev")
@@ -74,84 +76,616 @@ import javax.annotation.Nullable;
  * </pre>
  * &lt;!--End PulumiCodeChooser --&gt;
  * 
+ * ### Static Website Hosting
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketWebsiteArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var b = new Bucket("b", BucketArgs.builder()
+ *             .bucket("s3-website-test.mydomain.com")
+ *             .acl("public-read")
+ *             .policy(StdFunctions.file(FileArgs.builder()
+ *                 .input("policy.json")
+ *                 .build()).result())
+ *             .website(BucketWebsiteArgs.builder()
+ *                 .indexDocument("index.html")
+ *                 .errorDocument("error.html")
+ *                 .routingRules("""
+ * [{
+ *     "Condition": {
+ *         "KeyPrefixEquals": "docs/"
+ *     },
+ *     "Redirect": {
+ *         "ReplaceKeyPrefixWith": "documents/"
+ *     }
+ * }]
+ *                 """)
+ *                 .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Using CORS
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketCorsRuleArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var b = new Bucket("b", BucketArgs.builder()
+ *             .bucket("s3-website-test.mydomain.com")
+ *             .acl("public-read")
+ *             .corsRules(BucketCorsRuleArgs.builder()
+ *                 .allowedHeaders("*")
+ *                 .allowedMethods(                
+ *                     "PUT",
+ *                     "POST")
+ *                 .allowedOrigins("https://s3-website-test.mydomain.com")
+ *                 .exposeHeaders("ETag")
+ *                 .maxAgeSeconds(3000)
+ *                 .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Using versioning
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketVersioningArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var b = new Bucket("b", BucketArgs.builder()
+ *             .bucket("my-tf-test-bucket")
+ *             .acl("private")
+ *             .versioning(BucketVersioningArgs.builder()
+ *                 .enabled(true)
+ *                 .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Enable Logging
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketLoggingArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var logBucket = new Bucket("logBucket", BucketArgs.builder()
+ *             .bucket("my-tf-log-bucket")
+ *             .acl("log-delivery-write")
+ *             .build());
+ * 
+ *         var b = new Bucket("b", BucketArgs.builder()
+ *             .bucket("my-tf-test-bucket")
+ *             .acl("private")
+ *             .loggings(BucketLoggingArgs.builder()
+ *                 .targetBucket(logBucket.id())
+ *                 .targetPrefix("log/")
+ *                 .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Using object lifecycle
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketLifecycleRuleArgs;
+ * import com.pulumi.aws.s3.inputs.BucketLifecycleRuleExpirationArgs;
+ * import com.pulumi.aws.s3.inputs.BucketVersioningArgs;
+ * import com.pulumi.aws.s3.inputs.BucketLifecycleRuleNoncurrentVersionExpirationArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var bucket = new Bucket("bucket", BucketArgs.builder()
+ *             .bucket("my-bucket")
+ *             .acl("private")
+ *             .lifecycleRules(            
+ *                 BucketLifecycleRuleArgs.builder()
+ *                     .id("log")
+ *                     .enabled(true)
+ *                     .prefix("log/")
+ *                     .tags(Map.ofEntries(
+ *                         Map.entry("rule", "log"),
+ *                         Map.entry("autoclean", "true")
+ *                     ))
+ *                     .transitions(                    
+ *                         BucketLifecycleRuleTransitionArgs.builder()
+ *                             .days(30)
+ *                             .storageClass("STANDARD_IA")
+ *                             .build(),
+ *                         BucketLifecycleRuleTransitionArgs.builder()
+ *                             .days(60)
+ *                             .storageClass("GLACIER")
+ *                             .build())
+ *                     .expiration(BucketLifecycleRuleExpirationArgs.builder()
+ *                         .days(90)
+ *                         .build())
+ *                     .build(),
+ *                 BucketLifecycleRuleArgs.builder()
+ *                     .id("tmp")
+ *                     .prefix("tmp/")
+ *                     .enabled(true)
+ *                     .expiration(BucketLifecycleRuleExpirationArgs.builder()
+ *                         .date("2016-01-12")
+ *                         .build())
+ *                     .build())
+ *             .build());
+ * 
+ *         var versioningBucket = new Bucket("versioningBucket", BucketArgs.builder()
+ *             .bucket("my-versioning-bucket")
+ *             .acl("private")
+ *             .versioning(BucketVersioningArgs.builder()
+ *                 .enabled(true)
+ *                 .build())
+ *             .lifecycleRules(BucketLifecycleRuleArgs.builder()
+ *                 .prefix("config/")
+ *                 .enabled(true)
+ *                 .noncurrentVersionTransitions(                
+ *                     BucketLifecycleRuleNoncurrentVersionTransitionArgs.builder()
+ *                         .days(30)
+ *                         .storageClass("STANDARD_IA")
+ *                         .build(),
+ *                     BucketLifecycleRuleNoncurrentVersionTransitionArgs.builder()
+ *                         .days(60)
+ *                         .storageClass("GLACIER")
+ *                         .build())
+ *                 .noncurrentVersionExpiration(BucketLifecycleRuleNoncurrentVersionExpirationArgs.builder()
+ *                     .days(90)
+ *                     .build())
+ *                 .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Using replication configuration
+ * 
+ * &gt; **NOTE:** See the `aws.s3.BucketReplicationConfig` resource to support bi-directional replication configuration and additional features.
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.iam.Role;
+ * import com.pulumi.aws.iam.RoleArgs;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketVersioningArgs;
+ * import com.pulumi.aws.s3.inputs.BucketReplicationConfigurationArgs;
+ * import com.pulumi.aws.iam.Policy;
+ * import com.pulumi.aws.iam.PolicyArgs;
+ * import com.pulumi.aws.iam.RolePolicyAttachment;
+ * import com.pulumi.aws.iam.RolePolicyAttachmentArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var replication = new Role("replication", RoleArgs.builder()
+ *             .name("tf-iam-role-replication-12345")
+ *             .assumeRolePolicy("""
+ * {
+ *   "Version": "2012-10-17",
+ *   "Statement": [
+ *     {
+ *       "Action": "sts:AssumeRole",
+ *       "Principal": {
+ *         "Service": "s3.amazonaws.com"
+ *       },
+ *       "Effect": "Allow",
+ *       "Sid": ""
+ *     }
+ *   ]
+ * }
+ *             """)
+ *             .build());
+ * 
+ *         var destination = new Bucket("destination", BucketArgs.builder()
+ *             .bucket("tf-test-bucket-destination-12345")
+ *             .versioning(BucketVersioningArgs.builder()
+ *                 .enabled(true)
+ *                 .build())
+ *             .build());
+ * 
+ *         var source = new Bucket("source", BucketArgs.builder()
+ *             .bucket("tf-test-bucket-source-12345")
+ *             .acl("private")
+ *             .versioning(BucketVersioningArgs.builder()
+ *                 .enabled(true)
+ *                 .build())
+ *             .replicationConfiguration(BucketReplicationConfigurationArgs.builder()
+ *                 .role(replication.arn())
+ *                 .rules(BucketReplicationConfigurationRuleArgs.builder()
+ *                     .id("foobar")
+ *                     .status("Enabled")
+ *                     .filter(BucketReplicationConfigurationRuleFilterArgs.builder()
+ *                         .tags()
+ *                         .build())
+ *                     .destination(BucketReplicationConfigurationRuleDestinationArgs.builder()
+ *                         .bucket(destination.arn())
+ *                         .storageClass("STANDARD")
+ *                         .replicationTime(BucketReplicationConfigurationRuleDestinationReplicationTimeArgs.builder()
+ *                             .status("Enabled")
+ *                             .minutes(15)
+ *                             .build())
+ *                         .metrics(BucketReplicationConfigurationRuleDestinationMetricsArgs.builder()
+ *                             .status("Enabled")
+ *                             .minutes(15)
+ *                             .build())
+ *                         .build())
+ *                     .build())
+ *                 .build())
+ *             .build());
+ * 
+ *         var replicationPolicy = new Policy("replicationPolicy", PolicyArgs.builder()
+ *             .name("tf-iam-role-policy-replication-12345")
+ *             .policy(Output.tuple(source.arn(), source.arn(), destination.arn()).applyValue(values -> {
+ *                 var sourceArn = values.t1;
+ *                 var sourceArn1 = values.t2;
+ *                 var destinationArn = values.t3;
+ *                 return """
+ * {
+ *   "Version": "2012-10-17",
+ *   "Statement": [
+ *     {
+ *       "Action": [
+ *         "s3:GetReplicationConfiguration",
+ *         "s3:ListBucket"
+ *       ],
+ *       "Effect": "Allow",
+ *       "Resource": [
+ *         "%s"
+ *       ]
+ *     },
+ *     {
+ *       "Action": [
+ *         "s3:GetObjectVersionForReplication",
+ *         "s3:GetObjectVersionAcl",
+ *          "s3:GetObjectVersionTagging"
+ *       ],
+ *       "Effect": "Allow",
+ *       "Resource": [
+ *         "%s/*"
+ *       ]
+ *     },
+ *     {
+ *       "Action": [
+ *         "s3:ReplicateObject",
+ *         "s3:ReplicateDelete",
+ *         "s3:ReplicateTags"
+ *       ],
+ *       "Effect": "Allow",
+ *       "Resource": "%s/*"
+ *     }
+ *   ]
+ * }
+ * ", sourceArn,sourceArn1,destinationArn);
+ *             }))
+ *             .build());
+ * 
+ *         var replicationRolePolicyAttachment = new RolePolicyAttachment("replicationRolePolicyAttachment", RolePolicyAttachmentArgs.builder()
+ *             .role(replication.name())
+ *             .policyArn(replicationPolicy.arn())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Enable Default Server Side Encryption
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.kms.Key;
+ * import com.pulumi.aws.kms.KeyArgs;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketServerSideEncryptionConfigurationArgs;
+ * import com.pulumi.aws.s3.inputs.BucketServerSideEncryptionConfigurationRuleArgs;
+ * import com.pulumi.aws.s3.inputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var mykey = new Key("mykey", KeyArgs.builder()
+ *             .description("This key is used to encrypt bucket objects")
+ *             .deletionWindowInDays(10)
+ *             .build());
+ * 
+ *         var mybucket = new Bucket("mybucket", BucketArgs.builder()
+ *             .bucket("mybucket")
+ *             .serverSideEncryptionConfiguration(BucketServerSideEncryptionConfigurationArgs.builder()
+ *                 .rule(BucketServerSideEncryptionConfigurationRuleArgs.builder()
+ *                     .applyServerSideEncryptionByDefault(BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs.builder()
+ *                         .kmsMasterKeyId(mykey.arn())
+ *                         .sseAlgorithm("aws:kms")
+ *                         .build())
+ *                     .build())
+ *                 .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
+ * ### Using ACL policy grants
+ * 
+ * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.aws.s3.S3Functions;
+ * import com.pulumi.aws.s3.Bucket;
+ * import com.pulumi.aws.s3.BucketArgs;
+ * import com.pulumi.aws.s3.inputs.BucketGrantArgs;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         final var currentUser = S3Functions.getCanonicalUserId();
+ * 
+ *         var bucket = new Bucket("bucket", BucketArgs.builder()
+ *             .bucket("mybucket")
+ *             .grants(            
+ *                 BucketGrantArgs.builder()
+ *                     .id(currentUser.applyValue(getCanonicalUserIdResult -> getCanonicalUserIdResult.id()))
+ *                     .type("CanonicalUser")
+ *                     .permissions("FULL_CONTROL")
+ *                     .build(),
+ *                 BucketGrantArgs.builder()
+ *                     .type("Group")
+ *                     .permissions(                    
+ *                         "READ_ACP",
+ *                         "WRITE")
+ *                     .uri("http://acs.amazonaws.com/groups/s3/LogDelivery")
+ *                     .build())
+ *             .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
+ * &lt;!--End PulumiCodeChooser --&gt;
+ * 
  * ## Import
  * 
- * Using `pulumi import`, import S3 bucket using the `bucket`. For example:
+ * S3 bucket can be imported using the `bucket`, e.g.,
  * 
  * ```sh
  * $ pulumi import aws:s3/bucket:Bucket bucket bucket-name
  * ```
+ * The `policy` argument is not imported and will be deprecated in a future version of the provider. Use the `aws_s3_bucket_policy` resource to manage the S3 Bucket Policy instead.
  * 
  */
 @ResourceType(type="aws:s3/bucket:Bucket")
 public class Bucket extends com.pulumi.resources.CustomResource {
     /**
-     * Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+     * Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
      * 
      */
     @Export(name="accelerationStatus", refs={String.class}, tree="[0]")
     private Output<String> accelerationStatus;
 
     /**
-     * @return Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+     * @return Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
      * 
      */
     public Output<String> accelerationStatus() {
         return this.accelerationStatus;
     }
     /**
-     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
      * 
      */
     @Export(name="acl", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> acl;
 
     /**
-     * @return The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * @return The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
      * 
      */
     public Output<Optional<String>> acl() {
         return Codegen.optional(this.acl);
     }
     /**
-     * ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+     * The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      * 
      */
     @Export(name="arn", refs={String.class}, tree="[0]")
     private Output<String> arn;
 
     /**
-     * @return ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+     * @return The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      * 
      */
     public Output<String> arn() {
         return this.arn;
     }
     /**
-     * Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+     * The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
      * 
      */
     @Export(name="bucket", refs={String.class}, tree="[0]")
     private Output<String> bucket;
 
     /**
-     * @return Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+     * @return The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
      * 
      */
     public Output<String> bucket() {
         return this.bucket;
     }
     /**
-     * Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+     * The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
      * 
      */
     @Export(name="bucketDomainName", refs={String.class}, tree="[0]")
     private Output<String> bucketDomainName;
 
     /**
-     * @return Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+     * @return The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
      * 
      */
     public Output<String> bucketDomainName() {
@@ -172,168 +706,158 @@ public class Bucket extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.bucketPrefix);
     }
     /**
-     * The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+     * The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
      * 
      */
     @Export(name="bucketRegionalDomainName", refs={String.class}, tree="[0]")
     private Output<String> bucketRegionalDomainName;
 
     /**
-     * @return The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+     * @return The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
      * 
      */
     public Output<String> bucketRegionalDomainName() {
         return this.bucketRegionalDomainName;
     }
     /**
-     * Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+     * A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
      * 
      */
     @Export(name="corsRules", refs={List.class,BucketCorsRule.class}, tree="[0,1]")
     private Output</* @Nullable */ List<BucketCorsRule>> corsRules;
 
     /**
-     * @return Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+     * @return A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
      * 
      */
     public Output<Optional<List<BucketCorsRule>>> corsRules() {
         return Codegen.optional(this.corsRules);
     }
     /**
-     * Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+     * A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
      * 
      */
     @Export(name="forceDestroy", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> forceDestroy;
 
     /**
-     * @return Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+     * @return A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
      * 
      */
     public Output<Optional<Boolean>> forceDestroy() {
         return Codegen.optional(this.forceDestroy);
     }
     /**
-     * An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
      * 
      */
     @Export(name="grants", refs={List.class,BucketGrant.class}, tree="[0,1]")
     private Output</* @Nullable */ List<BucketGrant>> grants;
 
     /**
-     * @return An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * @return An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
      * 
      */
     public Output<Optional<List<BucketGrant>>> grants() {
         return Codegen.optional(this.grants);
     }
     /**
-     * [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+     * The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
      * 
      */
     @Export(name="hostedZoneId", refs={String.class}, tree="[0]")
     private Output<String> hostedZoneId;
 
     /**
-     * @return [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+     * @return The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
      * 
      */
     public Output<String> hostedZoneId() {
         return this.hostedZoneId;
     }
     /**
-     * Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+     * A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
      * 
      */
     @Export(name="lifecycleRules", refs={List.class,BucketLifecycleRule.class}, tree="[0,1]")
     private Output</* @Nullable */ List<BucketLifecycleRule>> lifecycleRules;
 
     /**
-     * @return Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+     * @return A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
      * 
      */
     public Output<Optional<List<BucketLifecycleRule>>> lifecycleRules() {
         return Codegen.optional(this.lifecycleRules);
     }
     /**
-     * Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLoggingV2` instead.
+     * A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
      * 
      */
     @Export(name="loggings", refs={List.class,BucketLogging.class}, tree="[0,1]")
     private Output</* @Nullable */ List<BucketLogging>> loggings;
 
     /**
-     * @return Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLoggingV2` instead.
+     * @return A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
      * 
      */
     public Output<Optional<List<BucketLogging>>> loggings() {
         return Codegen.optional(this.loggings);
     }
     /**
-     * Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-     * The provider wil only perform drift detection if a configuration value is provided.
-     * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+     * A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+     * 
+     * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
      * 
      */
     @Export(name="objectLockConfiguration", refs={BucketObjectLockConfiguration.class}, tree="[0]")
     private Output</* @Nullable */ BucketObjectLockConfiguration> objectLockConfiguration;
 
     /**
-     * @return Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-     * The provider wil only perform drift detection if a configuration value is provided.
-     * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+     * @return A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+     * 
+     * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
      * 
      */
     public Output<Optional<BucketObjectLockConfiguration>> objectLockConfiguration() {
         return Codegen.optional(this.objectLockConfiguration);
     }
     /**
-     * Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketPolicy` instead.
+     * A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
      * 
      */
     @Export(name="policy", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> policy;
 
     /**
-     * @return Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketPolicy` instead.
+     * @return A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
      * 
      */
     public Output<Optional<String>> policy() {
         return Codegen.optional(this.policy);
     }
     /**
-     * AWS region this bucket resides in.
+     * The AWS region this bucket resides in.
      * 
      */
     @Export(name="region", refs={String.class}, tree="[0]")
     private Output<String> region;
 
     /**
-     * @return AWS region this bucket resides in.
+     * @return The AWS region this bucket resides in.
      * 
      */
     public Output<String> region() {
         return this.region;
     }
     /**
-     * Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketReplicationConfig` instead.
+     * A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
      * 
      */
     @Export(name="replicationConfiguration", refs={BucketReplicationConfiguration.class}, tree="[0]")
     private Output</* @Nullable */ BucketReplicationConfiguration> replicationConfiguration;
 
     /**
-     * @return Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketReplicationConfig` instead.
+     * @return A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
      * 
      */
     public Output<Optional<BucketReplicationConfiguration>> replicationConfiguration() {
@@ -341,10 +865,9 @@ public class Bucket extends com.pulumi.resources.CustomResource {
     }
     /**
      * Specifies who should bear the cost of Amazon S3 data transfer.
-     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-     * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+     * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+     * developer guide for more information.
      * 
      */
     @Export(name="requestPayer", refs={String.class}, tree="[0]")
@@ -352,53 +875,44 @@ public class Bucket extends com.pulumi.resources.CustomResource {
 
     /**
      * @return Specifies who should bear the cost of Amazon S3 data transfer.
-     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-     * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+     * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+     * developer guide for more information.
      * 
      */
     public Output<String> requestPayer() {
         return this.requestPayer;
     }
     /**
-     * Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+     * A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
      * 
      */
     @Export(name="serverSideEncryptionConfiguration", refs={BucketServerSideEncryptionConfiguration.class}, tree="[0]")
     private Output<BucketServerSideEncryptionConfiguration> serverSideEncryptionConfiguration;
 
     /**
-     * @return Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+     * @return A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
      * 
      */
     public Output<BucketServerSideEncryptionConfiguration> serverSideEncryptionConfiguration() {
         return this.serverSideEncryptionConfiguration;
     }
     /**
-     * Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-     * 
-     * The following arguments are deprecated, and will be removed in a future major version:
+     * A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      * 
      */
     @Export(name="tags", refs={Map.class,String.class}, tree="[0,1,1]")
     private Output</* @Nullable */ Map<String,String>> tags;
 
     /**
-     * @return Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-     * 
-     * The following arguments are deprecated, and will be removed in a future major version:
+     * @return A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      * 
      */
     public Output<Optional<Map<String,String>>> tags() {
         return Codegen.optional(this.tags);
     }
     /**
-     * Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+     * A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
      * 
      * @deprecated
      * Please use `tags` instead.
@@ -409,65 +923,63 @@ public class Bucket extends com.pulumi.resources.CustomResource {
     private Output<Map<String,String>> tagsAll;
 
     /**
-     * @return Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+     * @return A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
      * 
      */
     public Output<Map<String,String>> tagsAll() {
         return this.tagsAll;
     }
     /**
-     * Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+     * A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      * 
      */
     @Export(name="versioning", refs={BucketVersioning.class}, tree="[0]")
     private Output<BucketVersioning> versioning;
 
     /**
-     * @return Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+     * @return A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      * 
      */
     public Output<BucketVersioning> versioning() {
         return this.versioning;
     }
     /**
-     * Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * A website object (documented below).
      * 
      */
     @Export(name="website", refs={BucketWebsite.class}, tree="[0]")
     private Output</* @Nullable */ BucketWebsite> website;
 
     /**
-     * @return Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return A website object (documented below).
      * 
      */
     public Output<Optional<BucketWebsite>> website() {
         return Codegen.optional(this.website);
     }
     /**
-     * (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      * 
      */
     @Export(name="websiteDomain", refs={String.class}, tree="[0]")
     private Output<String> websiteDomain;
 
     /**
-     * @return (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      * 
      */
     public Output<String> websiteDomain() {
         return this.websiteDomain;
     }
     /**
-     * (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
      * 
      */
     @Export(name="websiteEndpoint", refs={String.class}, tree="[0]")
     private Output<String> websiteEndpoint;
 
     /**
-     * @return (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
      * 
      */
     public Output<String> websiteEndpoint() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/BucketArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/BucketArgs.java
@@ -30,16 +30,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     public static final BucketArgs Empty = new BucketArgs();
 
     /**
-     * Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+     * Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
      * 
      */
     @Import(name="accelerationStatus")
     private @Nullable Output<String> accelerationStatus;
 
     /**
-     * @return Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+     * @return Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
      * 
      */
     public Optional<Output<String>> accelerationStatus() {
@@ -47,14 +45,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
      * 
      */
     @Import(name="acl")
     private @Nullable Output<Either<String,CannedAcl>> acl;
 
     /**
-     * @return The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * @return The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
      * 
      */
     public Optional<Output<Either<String,CannedAcl>>> acl() {
@@ -62,14 +60,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+     * The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      * 
      */
     @Import(name="arn")
     private @Nullable Output<String> arn;
 
     /**
-     * @return ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+     * @return The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      * 
      */
     public Optional<Output<String>> arn() {
@@ -77,14 +75,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+     * The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
      * 
      */
     @Import(name="bucket")
     private @Nullable Output<String> bucket;
 
     /**
-     * @return Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+     * @return The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
      * 
      */
     public Optional<Output<String>> bucket() {
@@ -107,14 +105,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+     * A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
      * 
      */
     @Import(name="corsRules")
     private @Nullable Output<List<BucketCorsRuleArgs>> corsRules;
 
     /**
-     * @return Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+     * @return A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
      * 
      */
     public Optional<Output<List<BucketCorsRuleArgs>>> corsRules() {
@@ -122,14 +120,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+     * A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
      * 
      */
     @Import(name="forceDestroy")
     private @Nullable Output<Boolean> forceDestroy;
 
     /**
-     * @return Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+     * @return A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
      * 
      */
     public Optional<Output<Boolean>> forceDestroy() {
@@ -137,14 +135,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
      * 
      */
     @Import(name="grants")
     private @Nullable Output<List<BucketGrantArgs>> grants;
 
     /**
-     * @return An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * @return An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
      * 
      */
     public Optional<Output<List<BucketGrantArgs>>> grants() {
@@ -152,14 +150,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+     * The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
      * 
      */
     @Import(name="hostedZoneId")
     private @Nullable Output<String> hostedZoneId;
 
     /**
-     * @return [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+     * @return The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
      * 
      */
     public Optional<Output<String>> hostedZoneId() {
@@ -167,16 +165,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+     * A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
      * 
      */
     @Import(name="lifecycleRules")
     private @Nullable Output<List<BucketLifecycleRuleArgs>> lifecycleRules;
 
     /**
-     * @return Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+     * @return A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
      * 
      */
     public Optional<Output<List<BucketLifecycleRuleArgs>>> lifecycleRules() {
@@ -184,16 +180,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLoggingV2` instead.
+     * A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
      * 
      */
     @Import(name="loggings")
     private @Nullable Output<List<BucketLoggingArgs>> loggings;
 
     /**
-     * @return Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLoggingV2` instead.
+     * @return A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
      * 
      */
     public Optional<Output<List<BucketLoggingArgs>>> loggings() {
@@ -201,18 +195,18 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-     * The provider wil only perform drift detection if a configuration value is provided.
-     * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+     * A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+     * 
+     * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
      * 
      */
     @Import(name="objectLockConfiguration")
     private @Nullable Output<BucketObjectLockConfigurationArgs> objectLockConfiguration;
 
     /**
-     * @return Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-     * The provider wil only perform drift detection if a configuration value is provided.
-     * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+     * @return A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+     * 
+     * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
      * 
      */
     public Optional<Output<BucketObjectLockConfigurationArgs>> objectLockConfiguration() {
@@ -220,18 +214,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketPolicy` instead.
+     * A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
      * 
      */
     @Import(name="policy")
     private @Nullable Output<String> policy;
 
     /**
-     * @return Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketPolicy` instead.
+     * @return A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
      * 
      */
     public Optional<Output<String>> policy() {
@@ -239,16 +229,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketReplicationConfig` instead.
+     * A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
      * 
      */
     @Import(name="replicationConfiguration")
     private @Nullable Output<BucketReplicationConfigurationArgs> replicationConfiguration;
 
     /**
-     * @return Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketReplicationConfig` instead.
+     * @return A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
      * 
      */
     public Optional<Output<BucketReplicationConfigurationArgs>> replicationConfiguration() {
@@ -257,10 +245,9 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Specifies who should bear the cost of Amazon S3 data transfer.
-     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-     * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+     * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+     * developer guide for more information.
      * 
      */
     @Import(name="requestPayer")
@@ -268,10 +255,9 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * @return Specifies who should bear the cost of Amazon S3 data transfer.
-     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-     * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+     * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+     * developer guide for more information.
      * 
      */
     public Optional<Output<String>> requestPayer() {
@@ -279,18 +265,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+     * A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
      * 
      */
     @Import(name="serverSideEncryptionConfiguration")
     private @Nullable Output<BucketServerSideEncryptionConfigurationArgs> serverSideEncryptionConfiguration;
 
     /**
-     * @return Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+     * @return A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
      * 
      */
     public Optional<Output<BucketServerSideEncryptionConfigurationArgs>> serverSideEncryptionConfiguration() {
@@ -298,18 +280,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-     * 
-     * The following arguments are deprecated, and will be removed in a future major version:
+     * A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      * 
      */
     @Import(name="tags")
     private @Nullable Output<Map<String,String>> tags;
 
     /**
-     * @return Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-     * 
-     * The following arguments are deprecated, and will be removed in a future major version:
+     * @return A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      * 
      */
     public Optional<Output<Map<String,String>>> tags() {
@@ -317,14 +295,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+     * A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      * 
      */
     @Import(name="versioning")
     private @Nullable Output<BucketVersioningArgs> versioning;
 
     /**
-     * @return Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+     * @return A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      * 
      */
     public Optional<Output<BucketVersioningArgs>> versioning() {
@@ -332,16 +310,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * A website object (documented below).
      * 
      */
     @Import(name="website")
     private @Nullable Output<BucketWebsiteArgs> website;
 
     /**
-     * @return Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return A website object (documented below).
      * 
      */
     public Optional<Output<BucketWebsiteArgs>> website() {
@@ -349,14 +325,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      * 
      */
     @Import(name="websiteDomain")
     private @Nullable Output<String> websiteDomain;
 
     /**
-     * @return (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      * 
      */
     public Optional<Output<String>> websiteDomain() {
@@ -364,14 +340,14 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
      * 
      */
     @Import(name="websiteEndpoint")
     private @Nullable Output<String> websiteEndpoint;
 
     /**
-     * @return (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
      * 
      */
     public Optional<Output<String>> websiteEndpoint() {
@@ -423,8 +399,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
          * 
          * @return builder
          * 
@@ -435,8 +410,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
          * 
          * @return builder
          * 
@@ -446,7 +420,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -457,7 +431,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -467,7 +441,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -477,7 +451,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -487,7 +461,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param arn ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+         * @param arn The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
          * 
          * @return builder
          * 
@@ -498,7 +472,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param arn ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+         * @param arn The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
          * 
          * @return builder
          * 
@@ -508,7 +482,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucket Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+         * @param bucket The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
          * 
          * @return builder
          * 
@@ -519,7 +493,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucket Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+         * @param bucket The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
          * 
          * @return builder
          * 
@@ -550,7 +524,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param corsRules Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+         * @param corsRules A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
          * 
          * @return builder
          * 
@@ -561,7 +535,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param corsRules Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+         * @param corsRules A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
          * 
          * @return builder
          * 
@@ -571,7 +545,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param corsRules Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+         * @param corsRules A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
          * 
          * @return builder
          * 
@@ -581,7 +555,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+         * @param forceDestroy A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
          * 
          * @return builder
          * 
@@ -592,7 +566,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+         * @param forceDestroy A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
          * 
          * @return builder
          * 
@@ -602,7 +576,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
          * 
          * @return builder
          * 
@@ -613,7 +587,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
          * 
          * @return builder
          * 
@@ -623,7 +597,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
          * 
          * @return builder
          * 
@@ -633,7 +607,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param hostedZoneId [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+         * @param hostedZoneId The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
          * 
          * @return builder
          * 
@@ -644,7 +618,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param hostedZoneId [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+         * @param hostedZoneId The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
          * 
          * @return builder
          * 
@@ -654,8 +628,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param lifecycleRules Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+         * @param lifecycleRules A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
          * 
          * @return builder
          * 
@@ -666,8 +639,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param lifecycleRules Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+         * @param lifecycleRules A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
          * 
          * @return builder
          * 
@@ -677,8 +649,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param lifecycleRules Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+         * @param lifecycleRules A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
          * 
          * @return builder
          * 
@@ -688,8 +659,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param loggings Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLoggingV2` instead.
+         * @param loggings A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
          * 
          * @return builder
          * 
@@ -700,8 +670,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param loggings Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLoggingV2` instead.
+         * @param loggings A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
          * 
          * @return builder
          * 
@@ -711,8 +680,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param loggings Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLoggingV2` instead.
+         * @param loggings A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
          * 
          * @return builder
          * 
@@ -722,9 +690,9 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param objectLockConfiguration Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-         * The provider wil only perform drift detection if a configuration value is provided.
-         * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+         * @param objectLockConfiguration A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+         * 
+         * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
          * 
          * @return builder
          * 
@@ -735,9 +703,9 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param objectLockConfiguration Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-         * The provider wil only perform drift detection if a configuration value is provided.
-         * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+         * @param objectLockConfiguration A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+         * 
+         * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
          * 
          * @return builder
          * 
@@ -747,9 +715,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param policy Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketPolicy` instead.
+         * @param policy A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
          * 
          * @return builder
          * 
@@ -760,9 +726,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param policy Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketPolicy` instead.
+         * @param policy A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
          * 
          * @return builder
          * 
@@ -772,8 +736,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param replicationConfiguration Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketReplicationConfig` instead.
+         * @param replicationConfiguration A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
          * 
          * @return builder
          * 
@@ -784,8 +747,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param replicationConfiguration Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketReplicationConfig` instead.
+         * @param replicationConfiguration A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
          * 
          * @return builder
          * 
@@ -796,10 +758,9 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param requestPayer Specifies who should bear the cost of Amazon S3 data transfer.
-         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-         * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+         * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+         * developer guide for more information.
          * 
          * @return builder
          * 
@@ -811,10 +772,9 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param requestPayer Specifies who should bear the cost of Amazon S3 data transfer.
-         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-         * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+         * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+         * developer guide for more information.
          * 
          * @return builder
          * 
@@ -824,9 +784,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param serverSideEncryptionConfiguration Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+         * @param serverSideEncryptionConfiguration A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
          * 
          * @return builder
          * 
@@ -837,9 +795,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param serverSideEncryptionConfiguration Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+         * @param serverSideEncryptionConfiguration A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
          * 
          * @return builder
          * 
@@ -849,9 +805,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tags Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-         * 
-         * The following arguments are deprecated, and will be removed in a future major version:
+         * @param tags A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
          * 
          * @return builder
          * 
@@ -862,9 +816,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tags Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-         * 
-         * The following arguments are deprecated, and will be removed in a future major version:
+         * @param tags A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
          * 
          * @return builder
          * 
@@ -874,7 +826,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param versioning Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+         * @param versioning A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
          * 
          * @return builder
          * 
@@ -885,7 +837,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param versioning Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+         * @param versioning A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
          * 
          * @return builder
          * 
@@ -895,8 +847,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param website Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param website A website object (documented below).
          * 
          * @return builder
          * 
@@ -907,8 +858,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param website Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param website A website object (documented below).
          * 
          * @return builder
          * 
@@ -918,7 +868,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteDomain (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteDomain The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
          * 
          * @return builder
          * 
@@ -929,7 +879,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteDomain (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteDomain The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
          * 
          * @return builder
          * 
@@ -939,7 +889,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteEndpoint (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteEndpoint The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
          * 
          * @return builder
          * 
@@ -950,7 +900,7 @@ public final class BucketArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteEndpoint (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteEndpoint The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketCorsRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketCorsRuleArgs.java
@@ -19,14 +19,14 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
     public static final BucketCorsRuleArgs Empty = new BucketCorsRuleArgs();
 
     /**
-     * List of headers allowed.
+     * Specifies which headers are allowed.
      * 
      */
     @Import(name="allowedHeaders")
     private @Nullable Output<List<String>> allowedHeaders;
 
     /**
-     * @return List of headers allowed.
+     * @return Specifies which headers are allowed.
      * 
      */
     public Optional<Output<List<String>>> allowedHeaders() {
@@ -34,14 +34,14 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
     }
 
     /**
-     * One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+     * Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
      * 
      */
     @Import(name="allowedMethods", required=true)
     private Output<List<String>> allowedMethods;
 
     /**
-     * @return One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+     * @return Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
      * 
      */
     public Output<List<String>> allowedMethods() {
@@ -49,14 +49,14 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
     }
 
     /**
-     * One or more origins you want customers to be able to access the bucket from.
+     * Specifies which origins are allowed.
      * 
      */
     @Import(name="allowedOrigins", required=true)
     private Output<List<String>> allowedOrigins;
 
     /**
-     * @return One or more origins you want customers to be able to access the bucket from.
+     * @return Specifies which origins are allowed.
      * 
      */
     public Output<List<String>> allowedOrigins() {
@@ -64,14 +64,14 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
     }
 
     /**
-     * One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+     * Specifies expose header in the response.
      * 
      */
     @Import(name="exposeHeaders")
     private @Nullable Output<List<String>> exposeHeaders;
 
     /**
-     * @return One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+     * @return Specifies expose header in the response.
      * 
      */
     public Optional<Output<List<String>>> exposeHeaders() {
@@ -122,7 +122,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedHeaders List of headers allowed.
+         * @param allowedHeaders Specifies which headers are allowed.
          * 
          * @return builder
          * 
@@ -133,7 +133,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedHeaders List of headers allowed.
+         * @param allowedHeaders Specifies which headers are allowed.
          * 
          * @return builder
          * 
@@ -143,7 +143,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedHeaders List of headers allowed.
+         * @param allowedHeaders Specifies which headers are allowed.
          * 
          * @return builder
          * 
@@ -153,7 +153,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedMethods One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+         * @param allowedMethods Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
          * 
          * @return builder
          * 
@@ -164,7 +164,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedMethods One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+         * @param allowedMethods Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
          * 
          * @return builder
          * 
@@ -174,7 +174,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedMethods One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+         * @param allowedMethods Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
          * 
          * @return builder
          * 
@@ -184,7 +184,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedOrigins One or more origins you want customers to be able to access the bucket from.
+         * @param allowedOrigins Specifies which origins are allowed.
          * 
          * @return builder
          * 
@@ -195,7 +195,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedOrigins One or more origins you want customers to be able to access the bucket from.
+         * @param allowedOrigins Specifies which origins are allowed.
          * 
          * @return builder
          * 
@@ -205,7 +205,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param allowedOrigins One or more origins you want customers to be able to access the bucket from.
+         * @param allowedOrigins Specifies which origins are allowed.
          * 
          * @return builder
          * 
@@ -215,7 +215,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param exposeHeaders One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+         * @param exposeHeaders Specifies expose header in the response.
          * 
          * @return builder
          * 
@@ -226,7 +226,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param exposeHeaders One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+         * @param exposeHeaders Specifies expose header in the response.
          * 
          * @return builder
          * 
@@ -236,7 +236,7 @@ public final class BucketCorsRuleArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param exposeHeaders One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+         * @param exposeHeaders Specifies expose header in the response.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketLifecycleRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketLifecycleRuleArgs.java
@@ -55,14 +55,14 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
     }
 
     /**
-     * Specifies a period in the object&#39;s expire. See Expiration below for details.
+     * Specifies a period in the object&#39;s expire (documented below).
      * 
      */
     @Import(name="expiration")
     private @Nullable Output<BucketLifecycleRuleExpirationArgs> expiration;
 
     /**
-     * @return Specifies a period in the object&#39;s expire. See Expiration below for details.
+     * @return Specifies a period in the object&#39;s expire (documented below).
      * 
      */
     public Optional<Output<BucketLifecycleRuleExpirationArgs>> expiration() {
@@ -85,14 +85,14 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
     }
 
     /**
-     * Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+     * Specifies when noncurrent object versions expire (documented below).
      * 
      */
     @Import(name="noncurrentVersionExpiration")
     private @Nullable Output<BucketLifecycleRuleNoncurrentVersionExpirationArgs> noncurrentVersionExpiration;
 
     /**
-     * @return Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+     * @return Specifies when noncurrent object versions expire (documented below).
      * 
      */
     public Optional<Output<BucketLifecycleRuleNoncurrentVersionExpirationArgs>> noncurrentVersionExpiration() {
@@ -100,14 +100,18 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
     }
 
     /**
-     * Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+     * Specifies when noncurrent object versions transitions (documented below).
+     * 
+     * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
      * 
      */
     @Import(name="noncurrentVersionTransitions")
     private @Nullable Output<List<BucketLifecycleRuleNoncurrentVersionTransitionArgs>> noncurrentVersionTransitions;
 
     /**
-     * @return Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+     * @return Specifies when noncurrent object versions transitions (documented below).
+     * 
+     * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
      * 
      */
     public Optional<Output<List<BucketLifecycleRuleNoncurrentVersionTransitionArgs>>> noncurrentVersionTransitions() {
@@ -145,14 +149,14 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
     }
 
     /**
-     * Specifies a period in the object&#39;s transitions. See Transition below for details.
+     * Specifies a period in the object&#39;s transitions (documented below).
      * 
      */
     @Import(name="transitions")
     private @Nullable Output<List<BucketLifecycleRuleTransitionArgs>> transitions;
 
     /**
-     * @return Specifies a period in the object&#39;s transitions. See Transition below for details.
+     * @return Specifies a period in the object&#39;s transitions (documented below).
      * 
      */
     public Optional<Output<List<BucketLifecycleRuleTransitionArgs>>> transitions() {
@@ -234,7 +238,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param expiration Specifies a period in the object&#39;s expire. See Expiration below for details.
+         * @param expiration Specifies a period in the object&#39;s expire (documented below).
          * 
          * @return builder
          * 
@@ -245,7 +249,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param expiration Specifies a period in the object&#39;s expire. See Expiration below for details.
+         * @param expiration Specifies a period in the object&#39;s expire (documented below).
          * 
          * @return builder
          * 
@@ -276,7 +280,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param noncurrentVersionExpiration Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+         * @param noncurrentVersionExpiration Specifies when noncurrent object versions expire (documented below).
          * 
          * @return builder
          * 
@@ -287,7 +291,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param noncurrentVersionExpiration Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+         * @param noncurrentVersionExpiration Specifies when noncurrent object versions expire (documented below).
          * 
          * @return builder
          * 
@@ -297,7 +301,9 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param noncurrentVersionTransitions Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+         * @param noncurrentVersionTransitions Specifies when noncurrent object versions transitions (documented below).
+         * 
+         * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
          * 
          * @return builder
          * 
@@ -308,7 +314,9 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param noncurrentVersionTransitions Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+         * @param noncurrentVersionTransitions Specifies when noncurrent object versions transitions (documented below).
+         * 
+         * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
          * 
          * @return builder
          * 
@@ -318,7 +326,9 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param noncurrentVersionTransitions Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+         * @param noncurrentVersionTransitions Specifies when noncurrent object versions transitions (documented below).
+         * 
+         * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
          * 
          * @return builder
          * 
@@ -370,7 +380,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param transitions Specifies a period in the object&#39;s transitions. See Transition below for details.
+         * @param transitions Specifies a period in the object&#39;s transitions (documented below).
          * 
          * @return builder
          * 
@@ -381,7 +391,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param transitions Specifies a period in the object&#39;s transitions. See Transition below for details.
+         * @param transitions Specifies a period in the object&#39;s transitions (documented below).
          * 
          * @return builder
          * 
@@ -391,7 +401,7 @@ public final class BucketLifecycleRuleArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param transitions Specifies a period in the object&#39;s transitions. See Transition below for details.
+         * @param transitions Specifies a period in the object&#39;s transitions (documented below).
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketLoggingArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketLoggingArgs.java
@@ -17,14 +17,14 @@ public final class BucketLoggingArgs extends com.pulumi.resources.ResourceArgs {
     public static final BucketLoggingArgs Empty = new BucketLoggingArgs();
 
     /**
-     * Name of the bucket that will receive the log objects.
+     * The name of the bucket that will receive the log objects.
      * 
      */
     @Import(name="targetBucket", required=true)
     private Output<String> targetBucket;
 
     /**
-     * @return Name of the bucket that will receive the log objects.
+     * @return The name of the bucket that will receive the log objects.
      * 
      */
     public Output<String> targetBucket() {
@@ -72,7 +72,7 @@ public final class BucketLoggingArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param targetBucket Name of the bucket that will receive the log objects.
+         * @param targetBucket The name of the bucket that will receive the log objects.
          * 
          * @return builder
          * 
@@ -83,7 +83,7 @@ public final class BucketLoggingArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param targetBucket Name of the bucket that will receive the log objects.
+         * @param targetBucket The name of the bucket that will receive the log objects.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketObjectLockConfigurationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketObjectLockConfigurationArgs.java
@@ -18,14 +18,14 @@ public final class BucketObjectLockConfigurationArgs extends com.pulumi.resource
     public static final BucketObjectLockConfigurationArgs Empty = new BucketObjectLockConfigurationArgs();
 
     /**
-     * Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+     * Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
      * 
      */
     @Import(name="objectLockEnabled", required=true)
     private Output<String> objectLockEnabled;
 
     /**
-     * @return Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+     * @return Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
      * 
      */
     public Output<String> objectLockEnabled() {
@@ -33,14 +33,14 @@ public final class BucketObjectLockConfigurationArgs extends com.pulumi.resource
     }
 
     /**
-     * Object Lock rule in place for this bucket (documented below).
+     * The Object Lock rule in place for this bucket.
      * 
      */
     @Import(name="rule")
     private @Nullable Output<BucketObjectLockConfigurationRuleArgs> rule;
 
     /**
-     * @return Object Lock rule in place for this bucket (documented below).
+     * @return The Object Lock rule in place for this bucket.
      * 
      */
     public Optional<Output<BucketObjectLockConfigurationRuleArgs>> rule() {
@@ -73,7 +73,7 @@ public final class BucketObjectLockConfigurationArgs extends com.pulumi.resource
         }
 
         /**
-         * @param objectLockEnabled Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+         * @param objectLockEnabled Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
          * 
          * @return builder
          * 
@@ -84,7 +84,7 @@ public final class BucketObjectLockConfigurationArgs extends com.pulumi.resource
         }
 
         /**
-         * @param objectLockEnabled Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+         * @param objectLockEnabled Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
          * 
          * @return builder
          * 
@@ -94,7 +94,7 @@ public final class BucketObjectLockConfigurationArgs extends com.pulumi.resource
         }
 
         /**
-         * @param rule Object Lock rule in place for this bucket (documented below).
+         * @param rule The Object Lock rule in place for this bucket.
          * 
          * @return builder
          * 
@@ -105,7 +105,7 @@ public final class BucketObjectLockConfigurationArgs extends com.pulumi.resource
         }
 
         /**
-         * @param rule Object Lock rule in place for this bucket (documented below).
+         * @param rule The Object Lock rule in place for this bucket.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketObjectLockConfigurationRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketObjectLockConfigurationRuleArgs.java
@@ -15,14 +15,14 @@ public final class BucketObjectLockConfigurationRuleArgs extends com.pulumi.reso
     public static final BucketObjectLockConfigurationRuleArgs Empty = new BucketObjectLockConfigurationRuleArgs();
 
     /**
-     * Default retention period that you want to apply to new objects placed in this bucket (documented below).
+     * The default retention period that you want to apply to new objects placed in this bucket.
      * 
      */
     @Import(name="defaultRetention", required=true)
     private Output<BucketObjectLockConfigurationRuleDefaultRetentionArgs> defaultRetention;
 
     /**
-     * @return Default retention period that you want to apply to new objects placed in this bucket (documented below).
+     * @return The default retention period that you want to apply to new objects placed in this bucket.
      * 
      */
     public Output<BucketObjectLockConfigurationRuleDefaultRetentionArgs> defaultRetention() {
@@ -54,7 +54,7 @@ public final class BucketObjectLockConfigurationRuleArgs extends com.pulumi.reso
         }
 
         /**
-         * @param defaultRetention Default retention period that you want to apply to new objects placed in this bucket (documented below).
+         * @param defaultRetention The default retention period that you want to apply to new objects placed in this bucket.
          * 
          * @return builder
          * 
@@ -65,7 +65,7 @@ public final class BucketObjectLockConfigurationRuleArgs extends com.pulumi.reso
         }
 
         /**
-         * @param defaultRetention Default retention period that you want to apply to new objects placed in this bucket (documented below).
+         * @param defaultRetention The default retention period that you want to apply to new objects placed in this bucket.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketObjectLockConfigurationRuleDefaultRetentionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketObjectLockConfigurationRuleDefaultRetentionArgs.java
@@ -18,14 +18,14 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
     public static final BucketObjectLockConfigurationRuleDefaultRetentionArgs Empty = new BucketObjectLockConfigurationRuleDefaultRetentionArgs();
 
     /**
-     * Number of days that you want to specify for the default retention period.
+     * The number of days that you want to specify for the default retention period.
      * 
      */
     @Import(name="days")
     private @Nullable Output<Integer> days;
 
     /**
-     * @return Number of days that you want to specify for the default retention period.
+     * @return The number of days that you want to specify for the default retention period.
      * 
      */
     public Optional<Output<Integer>> days() {
@@ -33,14 +33,14 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
     }
 
     /**
-     * Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+     * The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
      * 
      */
     @Import(name="mode", required=true)
     private Output<String> mode;
 
     /**
-     * @return Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+     * @return The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
      * 
      */
     public Output<String> mode() {
@@ -48,14 +48,26 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
     }
 
     /**
-     * Number of years that you want to specify for the default retention period.
+     * The number of years that you want to specify for the default retention period.
+     * 
+     * Either `days` or `years` must be specified, but not both.
+     * 
+     * &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+     * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+     * Once you create a bucket with S3 Object Lock enabled, you can&#39;t disable Object Lock or suspend versioning for the bucket.
      * 
      */
     @Import(name="years")
     private @Nullable Output<Integer> years;
 
     /**
-     * @return Number of years that you want to specify for the default retention period.
+     * @return The number of years that you want to specify for the default retention period.
+     * 
+     * Either `days` or `years` must be specified, but not both.
+     * 
+     * &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+     * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+     * Once you create a bucket with S3 Object Lock enabled, you can&#39;t disable Object Lock or suspend versioning for the bucket.
      * 
      */
     public Optional<Output<Integer>> years() {
@@ -89,7 +101,7 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
         }
 
         /**
-         * @param days Number of days that you want to specify for the default retention period.
+         * @param days The number of days that you want to specify for the default retention period.
          * 
          * @return builder
          * 
@@ -100,7 +112,7 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
         }
 
         /**
-         * @param days Number of days that you want to specify for the default retention period.
+         * @param days The number of days that you want to specify for the default retention period.
          * 
          * @return builder
          * 
@@ -110,7 +122,7 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
         }
 
         /**
-         * @param mode Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+         * @param mode The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
          * 
          * @return builder
          * 
@@ -121,7 +133,7 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
         }
 
         /**
-         * @param mode Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+         * @param mode The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
          * 
          * @return builder
          * 
@@ -131,7 +143,13 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
         }
 
         /**
-         * @param years Number of years that you want to specify for the default retention period.
+         * @param years The number of years that you want to specify for the default retention period.
+         * 
+         * Either `days` or `years` must be specified, but not both.
+         * 
+         * &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+         * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+         * Once you create a bucket with S3 Object Lock enabled, you can&#39;t disable Object Lock or suspend versioning for the bucket.
          * 
          * @return builder
          * 
@@ -142,7 +160,13 @@ public final class BucketObjectLockConfigurationRuleDefaultRetentionArgs extends
         }
 
         /**
-         * @param years Number of years that you want to specify for the default retention period.
+         * @param years The number of years that you want to specify for the default retention period.
+         * 
+         * Either `days` or `years` must be specified, but not both.
+         * 
+         * &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+         * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+         * Once you create a bucket with S3 Object Lock enabled, you can&#39;t disable Object Lock or suspend versioning for the bucket.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationArgs.java
@@ -17,14 +17,14 @@ public final class BucketReplicationConfigurationArgs extends com.pulumi.resourc
     public static final BucketReplicationConfigurationArgs Empty = new BucketReplicationConfigurationArgs();
 
     /**
-     * ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+     * The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
      * 
      */
     @Import(name="role", required=true)
     private Output<String> role;
 
     /**
-     * @return ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+     * @return The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
      * 
      */
     public Output<String> role() {
@@ -72,7 +72,7 @@ public final class BucketReplicationConfigurationArgs extends com.pulumi.resourc
         }
 
         /**
-         * @param role ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+         * @param role The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
          * 
          * @return builder
          * 
@@ -83,7 +83,7 @@ public final class BucketReplicationConfigurationArgs extends com.pulumi.resourc
         }
 
         /**
-         * @param role ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+         * @param role The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleArgs.java
@@ -96,14 +96,14 @@ public final class BucketReplicationConfigurationRuleArgs extends com.pulumi.res
     }
 
     /**
-     * Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+     * The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
      * 
      */
     @Import(name="priority")
     private @Nullable Output<Integer> priority;
 
     /**
-     * @return Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+     * @return The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
      * 
      */
     public Optional<Output<Integer>> priority() {
@@ -126,14 +126,18 @@ public final class BucketReplicationConfigurationRuleArgs extends com.pulumi.res
     }
 
     /**
-     * Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * 
+     * &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
      * 
      */
     @Import(name="status", required=true)
     private Output<String> status;
 
     /**
-     * @return Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * @return The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * 
+     * &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
      * 
      */
     public Output<String> status() {
@@ -277,7 +281,7 @@ public final class BucketReplicationConfigurationRuleArgs extends com.pulumi.res
         }
 
         /**
-         * @param priority Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+         * @param priority The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
          * 
          * @return builder
          * 
@@ -288,7 +292,7 @@ public final class BucketReplicationConfigurationRuleArgs extends com.pulumi.res
         }
 
         /**
-         * @param priority Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+         * @param priority The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
          * 
          * @return builder
          * 
@@ -319,7 +323,9 @@ public final class BucketReplicationConfigurationRuleArgs extends com.pulumi.res
         }
 
         /**
-         * @param status Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         * @param status The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         * 
+         * &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
          * 
          * @return builder
          * 
@@ -330,7 +336,9 @@ public final class BucketReplicationConfigurationRuleArgs extends com.pulumi.res
         }
 
         /**
-         * @param status Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         * @param status The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         * 
+         * &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs.java
@@ -15,14 +15,14 @@ public final class BucketReplicationConfigurationRuleDestinationAccessControlTra
     public static final BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs Empty = new BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs();
 
     /**
-     * Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+     * The override value for the owner on replicated objects. Currently only `Destination` is supported.
      * 
      */
     @Import(name="owner", required=true)
     private Output<String> owner;
 
     /**
-     * @return Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+     * @return The override value for the owner on replicated objects. Currently only `Destination` is supported.
      * 
      */
     public Output<String> owner() {
@@ -54,7 +54,7 @@ public final class BucketReplicationConfigurationRuleDestinationAccessControlTra
         }
 
         /**
-         * @param owner Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+         * @param owner The override value for the owner on replicated objects. Currently only `Destination` is supported.
          * 
          * @return builder
          * 
@@ -65,7 +65,7 @@ public final class BucketReplicationConfigurationRuleDestinationAccessControlTra
         }
 
         /**
-         * @param owner Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+         * @param owner The override value for the owner on replicated objects. Currently only `Destination` is supported.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationArgs.java
@@ -20,14 +20,14 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
     public static final BucketReplicationConfigurationRuleDestinationArgs Empty = new BucketReplicationConfigurationRuleDestinationArgs();
 
     /**
-     * Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+     * Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
      * 
      */
     @Import(name="accessControlTranslation")
     private @Nullable Output<BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs> accessControlTranslation;
 
     /**
-     * @return Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+     * @return Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
      * 
      */
     public Optional<Output<BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs>> accessControlTranslation() {
@@ -35,14 +35,14 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
     }
 
     /**
-     * Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+     * The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
      * 
      */
     @Import(name="accountId")
     private @Nullable Output<String> accountId;
 
     /**
-     * @return Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+     * @return The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
      * 
      */
     public Optional<Output<String>> accountId() {
@@ -50,14 +50,14 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
     }
 
     /**
-     * ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+     * The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
      * 
      */
     @Import(name="bucket", required=true)
     private Output<String> bucket;
 
     /**
-     * @return ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+     * @return The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
      * 
      */
     public Output<String> bucket() {
@@ -157,7 +157,7 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
         }
 
         /**
-         * @param accessControlTranslation Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+         * @param accessControlTranslation Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
          * 
          * @return builder
          * 
@@ -168,7 +168,7 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
         }
 
         /**
-         * @param accessControlTranslation Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+         * @param accessControlTranslation Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
          * 
          * @return builder
          * 
@@ -178,7 +178,7 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
         }
 
         /**
-         * @param accountId Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+         * @param accountId The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
          * 
          * @return builder
          * 
@@ -189,7 +189,7 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
         }
 
         /**
-         * @param accountId Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+         * @param accountId The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
          * 
          * @return builder
          * 
@@ -199,7 +199,7 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
         }
 
         /**
-         * @param bucket ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+         * @param bucket The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
          * 
          * @return builder
          * 
@@ -210,7 +210,7 @@ public final class BucketReplicationConfigurationRuleDestinationArgs extends com
         }
 
         /**
-         * @param bucket ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+         * @param bucket The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationMetricsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationMetricsArgs.java
@@ -32,14 +32,14 @@ public final class BucketReplicationConfigurationRuleDestinationMetricsArgs exte
     }
 
     /**
-     * Status of replication metrics. Either `Enabled` or `Disabled`.
+     * The status of replication metrics. Either `Enabled` or `Disabled`.
      * 
      */
     @Import(name="status")
     private @Nullable Output<String> status;
 
     /**
-     * @return Status of replication metrics. Either `Enabled` or `Disabled`.
+     * @return The status of replication metrics. Either `Enabled` or `Disabled`.
      * 
      */
     public Optional<Output<String>> status() {
@@ -93,7 +93,7 @@ public final class BucketReplicationConfigurationRuleDestinationMetricsArgs exte
         }
 
         /**
-         * @param status Status of replication metrics. Either `Enabled` or `Disabled`.
+         * @param status The status of replication metrics. Either `Enabled` or `Disabled`.
          * 
          * @return builder
          * 
@@ -104,7 +104,7 @@ public final class BucketReplicationConfigurationRuleDestinationMetricsArgs exte
         }
 
         /**
-         * @param status Status of replication metrics. Either `Enabled` or `Disabled`.
+         * @param status The status of replication metrics. Either `Enabled` or `Disabled`.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationReplicationTimeArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketReplicationConfigurationRuleDestinationReplicationTimeArgs.java
@@ -32,14 +32,14 @@ public final class BucketReplicationConfigurationRuleDestinationReplicationTimeA
     }
 
     /**
-     * Status of RTC. Either `Enabled` or `Disabled`.
+     * The status of RTC. Either `Enabled` or `Disabled`.
      * 
      */
     @Import(name="status")
     private @Nullable Output<String> status;
 
     /**
-     * @return Status of RTC. Either `Enabled` or `Disabled`.
+     * @return The status of RTC. Either `Enabled` or `Disabled`.
      * 
      */
     public Optional<Output<String>> status() {
@@ -93,7 +93,7 @@ public final class BucketReplicationConfigurationRuleDestinationReplicationTimeA
         }
 
         /**
-         * @param status Status of RTC. Either `Enabled` or `Disabled`.
+         * @param status The status of RTC. Either `Enabled` or `Disabled`.
          * 
          * @return builder
          * 
@@ -104,7 +104,7 @@ public final class BucketReplicationConfigurationRuleDestinationReplicationTimeA
         }
 
         /**
-         * @param status Status of RTC. Either `Enabled` or `Disabled`.
+         * @param status The status of RTC. Either `Enabled` or `Disabled`.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketServerSideEncryptionConfigurationArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketServerSideEncryptionConfigurationArgs.java
@@ -15,14 +15,14 @@ public final class BucketServerSideEncryptionConfigurationArgs extends com.pulum
     public static final BucketServerSideEncryptionConfigurationArgs Empty = new BucketServerSideEncryptionConfigurationArgs();
 
     /**
-     * Single object for server-side encryption by default configuration. (documented below)
+     * A single object for server-side encryption by default configuration. (documented below)
      * 
      */
     @Import(name="rule", required=true)
     private Output<BucketServerSideEncryptionConfigurationRuleArgs> rule;
 
     /**
-     * @return Single object for server-side encryption by default configuration. (documented below)
+     * @return A single object for server-side encryption by default configuration. (documented below)
      * 
      */
     public Output<BucketServerSideEncryptionConfigurationRuleArgs> rule() {
@@ -54,7 +54,7 @@ public final class BucketServerSideEncryptionConfigurationArgs extends com.pulum
         }
 
         /**
-         * @param rule Single object for server-side encryption by default configuration. (documented below)
+         * @param rule A single object for server-side encryption by default configuration. (documented below)
          * 
          * @return builder
          * 
@@ -65,7 +65,7 @@ public final class BucketServerSideEncryptionConfigurationArgs extends com.pulum
         }
 
         /**
-         * @param rule Single object for server-side encryption by default configuration. (documented below)
+         * @param rule A single object for server-side encryption by default configuration. (documented below)
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs.java
@@ -17,14 +17,14 @@ public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEnc
     public static final BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs Empty = new BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs();
 
     /**
-     * AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+     * The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
      * 
      */
     @Import(name="kmsMasterKeyId")
     private @Nullable Output<String> kmsMasterKeyId;
 
     /**
-     * @return AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+     * @return The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
      * 
      */
     public Optional<Output<String>> kmsMasterKeyId() {
@@ -32,14 +32,14 @@ public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEnc
     }
 
     /**
-     * Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+     * The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
      * 
      */
     @Import(name="sseAlgorithm", required=true)
     private Output<String> sseAlgorithm;
 
     /**
-     * @return Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+     * @return The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
      * 
      */
     public Output<String> sseAlgorithm() {
@@ -72,7 +72,7 @@ public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEnc
         }
 
         /**
-         * @param kmsMasterKeyId AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+         * @param kmsMasterKeyId The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
          * 
          * @return builder
          * 
@@ -83,7 +83,7 @@ public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEnc
         }
 
         /**
-         * @param kmsMasterKeyId AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+         * @param kmsMasterKeyId The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
          * 
          * @return builder
          * 
@@ -93,7 +93,7 @@ public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEnc
         }
 
         /**
-         * @param sseAlgorithm Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+         * @param sseAlgorithm The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
          * 
          * @return builder
          * 
@@ -104,7 +104,7 @@ public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEnc
         }
 
         /**
-         * @param sseAlgorithm Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+         * @param sseAlgorithm The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketServerSideEncryptionConfigurationRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketServerSideEncryptionConfigurationRuleArgs.java
@@ -18,14 +18,14 @@ public final class BucketServerSideEncryptionConfigurationRuleArgs extends com.p
     public static final BucketServerSideEncryptionConfigurationRuleArgs Empty = new BucketServerSideEncryptionConfigurationRuleArgs();
 
     /**
-     * Single object for setting server-side encryption by default. (documented below)
+     * A single object for setting server-side encryption by default. (documented below)
      * 
      */
     @Import(name="applyServerSideEncryptionByDefault", required=true)
     private Output<BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs> applyServerSideEncryptionByDefault;
 
     /**
-     * @return Single object for setting server-side encryption by default. (documented below)
+     * @return A single object for setting server-side encryption by default. (documented below)
      * 
      */
     public Output<BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs> applyServerSideEncryptionByDefault() {
@@ -73,7 +73,7 @@ public final class BucketServerSideEncryptionConfigurationRuleArgs extends com.p
         }
 
         /**
-         * @param applyServerSideEncryptionByDefault Single object for setting server-side encryption by default. (documented below)
+         * @param applyServerSideEncryptionByDefault A single object for setting server-side encryption by default. (documented below)
          * 
          * @return builder
          * 
@@ -84,7 +84,7 @@ public final class BucketServerSideEncryptionConfigurationRuleArgs extends com.p
         }
 
         /**
-         * @param applyServerSideEncryptionByDefault Single object for setting server-side encryption by default. (documented below)
+         * @param applyServerSideEncryptionByDefault A single object for setting server-side encryption by default. (documented below)
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketState.java
@@ -30,16 +30,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     public static final BucketState Empty = new BucketState();
 
     /**
-     * Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+     * Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
      * 
      */
     @Import(name="accelerationStatus")
     private @Nullable Output<String> accelerationStatus;
 
     /**
-     * @return Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+     * @return Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
      * 
      */
     public Optional<Output<String>> accelerationStatus() {
@@ -47,14 +45,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
      * 
      */
     @Import(name="acl")
     private @Nullable Output<Either<String,CannedAcl>> acl;
 
     /**
-     * @return The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * @return The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
      * 
      */
     public Optional<Output<Either<String,CannedAcl>>> acl() {
@@ -62,14 +60,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+     * The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      * 
      */
     @Import(name="arn")
     private @Nullable Output<String> arn;
 
     /**
-     * @return ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+     * @return The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
      * 
      */
     public Optional<Output<String>> arn() {
@@ -77,14 +75,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+     * The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
      * 
      */
     @Import(name="bucket")
     private @Nullable Output<String> bucket;
 
     /**
-     * @return Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+     * @return The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
      * 
      */
     public Optional<Output<String>> bucket() {
@@ -92,14 +90,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+     * The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
      * 
      */
     @Import(name="bucketDomainName")
     private @Nullable Output<String> bucketDomainName;
 
     /**
-     * @return Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+     * @return The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
      * 
      */
     public Optional<Output<String>> bucketDomainName() {
@@ -122,14 +120,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+     * The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
      * 
      */
     @Import(name="bucketRegionalDomainName")
     private @Nullable Output<String> bucketRegionalDomainName;
 
     /**
-     * @return The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+     * @return The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
      * 
      */
     public Optional<Output<String>> bucketRegionalDomainName() {
@@ -137,14 +135,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+     * A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
      * 
      */
     @Import(name="corsRules")
     private @Nullable Output<List<BucketCorsRuleArgs>> corsRules;
 
     /**
-     * @return Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+     * @return A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
      * 
      */
     public Optional<Output<List<BucketCorsRuleArgs>>> corsRules() {
@@ -152,14 +150,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+     * A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
      * 
      */
     @Import(name="forceDestroy")
     private @Nullable Output<Boolean> forceDestroy;
 
     /**
-     * @return Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+     * @return A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
      * 
      */
     public Optional<Output<Boolean>> forceDestroy() {
@@ -167,14 +165,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
      * 
      */
     @Import(name="grants")
     private @Nullable Output<List<BucketGrantArgs>> grants;
 
     /**
-     * @return An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+     * @return An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
      * 
      */
     public Optional<Output<List<BucketGrantArgs>>> grants() {
@@ -182,14 +180,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+     * The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
      * 
      */
     @Import(name="hostedZoneId")
     private @Nullable Output<String> hostedZoneId;
 
     /**
-     * @return [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+     * @return The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
      * 
      */
     public Optional<Output<String>> hostedZoneId() {
@@ -197,16 +195,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+     * A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
      * 
      */
     @Import(name="lifecycleRules")
     private @Nullable Output<List<BucketLifecycleRuleArgs>> lifecycleRules;
 
     /**
-     * @return Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+     * @return A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
      * 
      */
     public Optional<Output<List<BucketLifecycleRuleArgs>>> lifecycleRules() {
@@ -214,16 +210,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLoggingV2` instead.
+     * A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
      * 
      */
     @Import(name="loggings")
     private @Nullable Output<List<BucketLoggingArgs>> loggings;
 
     /**
-     * @return Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketLoggingV2` instead.
+     * @return A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
      * 
      */
     public Optional<Output<List<BucketLoggingArgs>>> loggings() {
@@ -231,18 +225,18 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-     * The provider wil only perform drift detection if a configuration value is provided.
-     * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+     * A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+     * 
+     * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
      * 
      */
     @Import(name="objectLockConfiguration")
     private @Nullable Output<BucketObjectLockConfigurationArgs> objectLockConfiguration;
 
     /**
-     * @return Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-     * The provider wil only perform drift detection if a configuration value is provided.
-     * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+     * @return A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+     * 
+     * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
      * 
      */
     public Optional<Output<BucketObjectLockConfigurationArgs>> objectLockConfiguration() {
@@ -250,18 +244,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketPolicy` instead.
+     * A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
      * 
      */
     @Import(name="policy")
     private @Nullable Output<String> policy;
 
     /**
-     * @return Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketPolicy` instead.
+     * @return A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
      * 
      */
     public Optional<Output<String>> policy() {
@@ -269,14 +259,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * AWS region this bucket resides in.
+     * The AWS region this bucket resides in.
      * 
      */
     @Import(name="region")
     private @Nullable Output<String> region;
 
     /**
-     * @return AWS region this bucket resides in.
+     * @return The AWS region this bucket resides in.
      * 
      */
     public Optional<Output<String>> region() {
@@ -284,16 +274,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketReplicationConfig` instead.
+     * A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
      * 
      */
     @Import(name="replicationConfiguration")
     private @Nullable Output<BucketReplicationConfigurationArgs> replicationConfiguration;
 
     /**
-     * @return Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketReplicationConfig` instead.
+     * @return A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
      * 
      */
     public Optional<Output<BucketReplicationConfigurationArgs>> replicationConfiguration() {
@@ -302,10 +290,9 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Specifies who should bear the cost of Amazon S3 data transfer.
-     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-     * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+     * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+     * developer guide for more information.
      * 
      */
     @Import(name="requestPayer")
@@ -313,10 +300,9 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * @return Specifies who should bear the cost of Amazon S3 data transfer.
-     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-     * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+     * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+     * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+     * developer guide for more information.
      * 
      */
     public Optional<Output<String>> requestPayer() {
@@ -324,18 +310,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+     * A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
      * 
      */
     @Import(name="serverSideEncryptionConfiguration")
     private @Nullable Output<BucketServerSideEncryptionConfigurationArgs> serverSideEncryptionConfiguration;
 
     /**
-     * @return Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-     * The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+     * @return A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
      * 
      */
     public Optional<Output<BucketServerSideEncryptionConfigurationArgs>> serverSideEncryptionConfiguration() {
@@ -343,18 +325,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-     * 
-     * The following arguments are deprecated, and will be removed in a future major version:
+     * A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      * 
      */
     @Import(name="tags")
     private @Nullable Output<Map<String,String>> tags;
 
     /**
-     * @return Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-     * 
-     * The following arguments are deprecated, and will be removed in a future major version:
+     * @return A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      * 
      */
     public Optional<Output<Map<String,String>>> tags() {
@@ -362,7 +340,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+     * A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
      * 
      * @deprecated
      * Please use `tags` instead.
@@ -373,7 +351,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<Map<String,String>> tagsAll;
 
     /**
-     * @return Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+     * @return A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
      * 
      * @deprecated
      * Please use `tags` instead.
@@ -385,14 +363,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+     * A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      * 
      */
     @Import(name="versioning")
     private @Nullable Output<BucketVersioningArgs> versioning;
 
     /**
-     * @return Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+     * @return A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
      * 
      */
     public Optional<Output<BucketVersioningArgs>> versioning() {
@@ -400,16 +378,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * A website object (documented below).
      * 
      */
     @Import(name="website")
     private @Nullable Output<BucketWebsiteArgs> website;
 
     /**
-     * @return Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-     * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return A website object (documented below).
      * 
      */
     public Optional<Output<BucketWebsiteArgs>> website() {
@@ -417,14 +393,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      * 
      */
     @Import(name="websiteDomain")
     private @Nullable Output<String> websiteDomain;
 
     /**
-     * @return (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
      * 
      */
     public Optional<Output<String>> websiteDomain() {
@@ -432,14 +408,14 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
      * 
      */
     @Import(name="websiteEndpoint")
     private @Nullable Output<String> websiteEndpoint;
 
     /**
-     * @return (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+     * @return The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
      * 
      */
     public Optional<Output<String>> websiteEndpoint() {
@@ -495,8 +471,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
          * 
          * @return builder
          * 
@@ -507,8 +482,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketAccelerateConfigurationV2` instead.
+         * @param accelerationStatus Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
          * 
          * @return builder
          * 
@@ -518,7 +492,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -529,7 +503,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -539,7 +513,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -549,7 +523,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param acl The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
          * 
          * @return builder
          * 
@@ -559,7 +533,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param arn ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+         * @param arn The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
          * 
          * @return builder
          * 
@@ -570,7 +544,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param arn ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+         * @param arn The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
          * 
          * @return builder
          * 
@@ -580,7 +554,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucket Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+         * @param bucket The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
          * 
          * @return builder
          * 
@@ -591,7 +565,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucket Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws.s3.DirectoryBucket` resource to manage S3 Express buckets.
+         * @param bucket The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
          * 
          * @return builder
          * 
@@ -601,7 +575,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucketDomainName Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+         * @param bucketDomainName The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
          * 
          * @return builder
          * 
@@ -612,7 +586,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucketDomainName Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+         * @param bucketDomainName The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
          * 
          * @return builder
          * 
@@ -643,7 +617,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucketRegionalDomainName The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+         * @param bucketRegionalDomainName The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
          * 
          * @return builder
          * 
@@ -654,7 +628,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param bucketRegionalDomainName The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+         * @param bucketRegionalDomainName The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
          * 
          * @return builder
          * 
@@ -664,7 +638,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param corsRules Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+         * @param corsRules A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
          * 
          * @return builder
          * 
@@ -675,7 +649,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param corsRules Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+         * @param corsRules A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
          * 
          * @return builder
          * 
@@ -685,7 +659,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param corsRules Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketCorsConfigurationV2` instead.
+         * @param corsRules A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
          * 
          * @return builder
          * 
@@ -695,7 +669,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+         * @param forceDestroy A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
          * 
          * @return builder
          * 
@@ -706,7 +680,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+         * @param forceDestroy A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
          * 
          * @return builder
          * 
@@ -716,7 +690,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
          * 
          * @return builder
          * 
@@ -727,7 +701,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
          * 
          * @return builder
          * 
@@ -737,7 +711,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.
+         * @param grants An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
          * 
          * @return builder
          * 
@@ -747,7 +721,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param hostedZoneId [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+         * @param hostedZoneId The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
          * 
          * @return builder
          * 
@@ -758,7 +732,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param hostedZoneId [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
+         * @param hostedZoneId The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket&#39;s region.
          * 
          * @return builder
          * 
@@ -768,8 +742,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param lifecycleRules Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+         * @param lifecycleRules A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
          * 
          * @return builder
          * 
@@ -780,8 +753,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param lifecycleRules Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+         * @param lifecycleRules A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
          * 
          * @return builder
          * 
@@ -791,8 +763,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param lifecycleRules Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLifecycleConfigurationV2` instead.
+         * @param lifecycleRules A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
          * 
          * @return builder
          * 
@@ -802,8 +773,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param loggings Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLoggingV2` instead.
+         * @param loggings A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
          * 
          * @return builder
          * 
@@ -814,8 +784,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param loggings Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLoggingV2` instead.
+         * @param loggings A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
          * 
          * @return builder
          * 
@@ -825,8 +794,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param loggings Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketLoggingV2` instead.
+         * @param loggings A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
          * 
          * @return builder
          * 
@@ -836,9 +804,9 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param objectLockConfiguration Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-         * The provider wil only perform drift detection if a configuration value is provided.
-         * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+         * @param objectLockConfiguration A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+         * 
+         * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
          * 
          * @return builder
          * 
@@ -849,9 +817,9 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param objectLockConfiguration Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-         * The provider wil only perform drift detection if a configuration value is provided.
-         * Use the `object_lock_enabled` parameter and the resource `aws.s3.BucketObjectLockConfigurationV2` instead.
+         * @param objectLockConfiguration A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+         * 
+         * &gt; **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
          * 
          * @return builder
          * 
@@ -861,9 +829,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param policy Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketPolicy` instead.
+         * @param policy A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
          * 
          * @return builder
          * 
@@ -874,9 +840,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param policy Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketPolicy` instead.
+         * @param policy A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
          * 
          * @return builder
          * 
@@ -886,7 +850,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param region AWS region this bucket resides in.
+         * @param region The AWS region this bucket resides in.
          * 
          * @return builder
          * 
@@ -897,7 +861,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param region AWS region this bucket resides in.
+         * @param region The AWS region this bucket resides in.
          * 
          * @return builder
          * 
@@ -907,8 +871,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param replicationConfiguration Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketReplicationConfig` instead.
+         * @param replicationConfiguration A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
          * 
          * @return builder
          * 
@@ -919,8 +882,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param replicationConfiguration Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketReplicationConfig` instead.
+         * @param replicationConfiguration A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
          * 
          * @return builder
          * 
@@ -931,10 +893,9 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param requestPayer Specifies who should bear the cost of Amazon S3 data transfer.
-         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-         * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+         * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+         * developer guide for more information.
          * 
          * @return builder
          * 
@@ -946,10 +907,9 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param requestPayer Specifies who should bear the cost of Amazon S3 data transfer.
-         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-         * See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketRequestPaymentConfigurationV2` instead.
+         * Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+         * the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+         * developer guide for more information.
          * 
          * @return builder
          * 
@@ -959,9 +919,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param serverSideEncryptionConfiguration Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+         * @param serverSideEncryptionConfiguration A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
          * 
          * @return builder
          * 
@@ -972,9 +930,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param serverSideEncryptionConfiguration Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-         * The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketServerSideEncryptionConfigurationV2` instead.
+         * @param serverSideEncryptionConfiguration A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
          * 
          * @return builder
          * 
@@ -984,9 +940,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tags Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-         * 
-         * The following arguments are deprecated, and will be removed in a future major version:
+         * @param tags A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
          * 
          * @return builder
          * 
@@ -997,9 +951,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tags Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-         * 
-         * The following arguments are deprecated, and will be removed in a future major version:
+         * @param tags A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
          * 
          * @return builder
          * 
@@ -1009,7 +961,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tagsAll Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+         * @param tagsAll A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
          * 
          * @return builder
          * 
@@ -1024,7 +976,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tagsAll Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+         * @param tagsAll A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
          * 
          * @return builder
          * 
@@ -1038,7 +990,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param versioning Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+         * @param versioning A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
          * 
          * @return builder
          * 
@@ -1049,7 +1001,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param versioning Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketVersioningV2` instead.
+         * @param versioning A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
          * 
          * @return builder
          * 
@@ -1059,8 +1011,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param website Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param website A website object (documented below).
          * 
          * @return builder
          * 
@@ -1071,8 +1022,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param website Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-         * Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param website A website object (documented below).
          * 
          * @return builder
          * 
@@ -1082,7 +1032,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteDomain (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteDomain The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
          * 
          * @return builder
          * 
@@ -1093,7 +1043,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteDomain (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteDomain The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
          * 
          * @return builder
          * 
@@ -1103,7 +1053,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteEndpoint (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteEndpoint The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
          * 
          * @return builder
          * 
@@ -1114,7 +1064,7 @@ public final class BucketState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param websiteEndpoint (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `aws.s3.BucketWebsiteConfigurationV2` instead.
+         * @param websiteEndpoint The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketWebsiteArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/inputs/BucketWebsiteArgs.java
@@ -18,14 +18,14 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
     public static final BucketWebsiteArgs Empty = new BucketWebsiteArgs();
 
     /**
-     * Absolute path to the document to return in case of a 4XX error.
+     * An absolute path to the document to return in case of a 4XX error.
      * 
      */
     @Import(name="errorDocument")
     private @Nullable Output<String> errorDocument;
 
     /**
-     * @return Absolute path to the document to return in case of a 4XX error.
+     * @return An absolute path to the document to return in case of a 4XX error.
      * 
      */
     public Optional<Output<String>> errorDocument() {
@@ -48,14 +48,14 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+     * A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
      * 
      */
     @Import(name="redirectAllRequestsTo")
     private @Nullable Output<String> redirectAllRequestsTo;
 
     /**
-     * @return Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+     * @return A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
      * 
      */
     public Optional<Output<String>> redirectAllRequestsTo() {
@@ -63,16 +63,20 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+     * A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
      * describing redirect behavior and when redirects are applied.
+     * 
+     * The `CORS` object supports the following:
      * 
      */
     @Import(name="routingRules")
     private @Nullable Output<Either<String,List<String>>> routingRules;
 
     /**
-     * @return JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+     * @return A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
      * describing redirect behavior and when redirects are applied.
+     * 
+     * The `CORS` object supports the following:
      * 
      */
     public Optional<Output<Either<String,List<String>>>> routingRules() {
@@ -107,7 +111,7 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param errorDocument Absolute path to the document to return in case of a 4XX error.
+         * @param errorDocument An absolute path to the document to return in case of a 4XX error.
          * 
          * @return builder
          * 
@@ -118,7 +122,7 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param errorDocument Absolute path to the document to return in case of a 4XX error.
+         * @param errorDocument An absolute path to the document to return in case of a 4XX error.
          * 
          * @return builder
          * 
@@ -149,7 +153,7 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param redirectAllRequestsTo Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+         * @param redirectAllRequestsTo A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
          * 
          * @return builder
          * 
@@ -160,7 +164,7 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param redirectAllRequestsTo Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+         * @param redirectAllRequestsTo A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
          * 
          * @return builder
          * 
@@ -170,8 +174,10 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param routingRules JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+         * @param routingRules A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
          * describing redirect behavior and when redirects are applied.
+         * 
+         * The `CORS` object supports the following:
          * 
          * @return builder
          * 
@@ -182,8 +188,10 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param routingRules JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+         * @param routingRules A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
          * describing redirect behavior and when redirects are applied.
+         * 
+         * The `CORS` object supports the following:
          * 
          * @return builder
          * 
@@ -193,8 +201,10 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param routingRules JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+         * @param routingRules A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
          * describing redirect behavior and when redirects are applied.
+         * 
+         * The `CORS` object supports the following:
          * 
          * @return builder
          * 
@@ -204,8 +214,10 @@ public final class BucketWebsiteArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param routingRules JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+         * @param routingRules A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
          * describing redirect behavior and when redirects are applied.
+         * 
+         * The `CORS` object supports the following:
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketCorsRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketCorsRule.java
@@ -15,22 +15,22 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketCorsRule {
     /**
-     * @return List of headers allowed.
+     * @return Specifies which headers are allowed.
      * 
      */
     private @Nullable List<String> allowedHeaders;
     /**
-     * @return One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+     * @return Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
      * 
      */
     private List<String> allowedMethods;
     /**
-     * @return One or more origins you want customers to be able to access the bucket from.
+     * @return Specifies which origins are allowed.
      * 
      */
     private List<String> allowedOrigins;
     /**
-     * @return One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+     * @return Specifies expose header in the response.
      * 
      */
     private @Nullable List<String> exposeHeaders;
@@ -42,28 +42,28 @@ public final class BucketCorsRule {
 
     private BucketCorsRule() {}
     /**
-     * @return List of headers allowed.
+     * @return Specifies which headers are allowed.
      * 
      */
     public List<String> allowedHeaders() {
         return this.allowedHeaders == null ? List.of() : this.allowedHeaders;
     }
     /**
-     * @return One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+     * @return Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
      * 
      */
     public List<String> allowedMethods() {
         return this.allowedMethods;
     }
     /**
-     * @return One or more origins you want customers to be able to access the bucket from.
+     * @return Specifies which origins are allowed.
      * 
      */
     public List<String> allowedOrigins() {
         return this.allowedOrigins;
     }
     /**
-     * @return One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+     * @return Specifies expose header in the response.
      * 
      */
     public List<String> exposeHeaders() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketLifecycleRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketLifecycleRule.java
@@ -31,7 +31,7 @@ public final class BucketLifecycleRule {
      */
     private Boolean enabled;
     /**
-     * @return Specifies a period in the object&#39;s expire. See Expiration below for details.
+     * @return Specifies a period in the object&#39;s expire (documented below).
      * 
      */
     private @Nullable BucketLifecycleRuleExpiration expiration;
@@ -41,12 +41,14 @@ public final class BucketLifecycleRule {
      */
     private @Nullable String id;
     /**
-     * @return Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+     * @return Specifies when noncurrent object versions expire (documented below).
      * 
      */
     private @Nullable BucketLifecycleRuleNoncurrentVersionExpiration noncurrentVersionExpiration;
     /**
-     * @return Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+     * @return Specifies when noncurrent object versions transitions (documented below).
+     * 
+     * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
      * 
      */
     private @Nullable List<BucketLifecycleRuleNoncurrentVersionTransition> noncurrentVersionTransitions;
@@ -61,7 +63,7 @@ public final class BucketLifecycleRule {
      */
     private @Nullable Map<String,String> tags;
     /**
-     * @return Specifies a period in the object&#39;s transitions. See Transition below for details.
+     * @return Specifies a period in the object&#39;s transitions (documented below).
      * 
      */
     private @Nullable List<BucketLifecycleRuleTransition> transitions;
@@ -82,7 +84,7 @@ public final class BucketLifecycleRule {
         return this.enabled;
     }
     /**
-     * @return Specifies a period in the object&#39;s expire. See Expiration below for details.
+     * @return Specifies a period in the object&#39;s expire (documented below).
      * 
      */
     public Optional<BucketLifecycleRuleExpiration> expiration() {
@@ -96,14 +98,16 @@ public final class BucketLifecycleRule {
         return Optional.ofNullable(this.id);
     }
     /**
-     * @return Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+     * @return Specifies when noncurrent object versions expire (documented below).
      * 
      */
     public Optional<BucketLifecycleRuleNoncurrentVersionExpiration> noncurrentVersionExpiration() {
         return Optional.ofNullable(this.noncurrentVersionExpiration);
     }
     /**
-     * @return Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+     * @return Specifies when noncurrent object versions transitions (documented below).
+     * 
+     * At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
      * 
      */
     public List<BucketLifecycleRuleNoncurrentVersionTransition> noncurrentVersionTransitions() {
@@ -124,7 +128,7 @@ public final class BucketLifecycleRule {
         return this.tags == null ? Map.of() : this.tags;
     }
     /**
-     * @return Specifies a period in the object&#39;s transitions. See Transition below for details.
+     * @return Specifies a period in the object&#39;s transitions (documented below).
      * 
      */
     public List<BucketLifecycleRuleTransition> transitions() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketLogging.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketLogging.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketLogging {
     /**
-     * @return Name of the bucket that will receive the log objects.
+     * @return The name of the bucket that will receive the log objects.
      * 
      */
     private String targetBucket;
@@ -25,7 +25,7 @@ public final class BucketLogging {
 
     private BucketLogging() {}
     /**
-     * @return Name of the bucket that will receive the log objects.
+     * @return The name of the bucket that will receive the log objects.
      * 
      */
     public String targetBucket() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketObjectLockConfiguration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketObjectLockConfiguration.java
@@ -14,26 +14,26 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketObjectLockConfiguration {
     /**
-     * @return Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+     * @return Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
      * 
      */
     private String objectLockEnabled;
     /**
-     * @return Object Lock rule in place for this bucket (documented below).
+     * @return The Object Lock rule in place for this bucket.
      * 
      */
     private @Nullable BucketObjectLockConfigurationRule rule;
 
     private BucketObjectLockConfiguration() {}
     /**
-     * @return Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+     * @return Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
      * 
      */
     public String objectLockEnabled() {
         return this.objectLockEnabled;
     }
     /**
-     * @return Object Lock rule in place for this bucket (documented below).
+     * @return The Object Lock rule in place for this bucket.
      * 
      */
     public Optional<BucketObjectLockConfigurationRule> rule() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketObjectLockConfigurationRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketObjectLockConfigurationRule.java
@@ -11,14 +11,14 @@ import java.util.Objects;
 @CustomType
 public final class BucketObjectLockConfigurationRule {
     /**
-     * @return Default retention period that you want to apply to new objects placed in this bucket (documented below).
+     * @return The default retention period that you want to apply to new objects placed in this bucket.
      * 
      */
     private BucketObjectLockConfigurationRuleDefaultRetention defaultRetention;
 
     private BucketObjectLockConfigurationRule() {}
     /**
-     * @return Default retention period that you want to apply to new objects placed in this bucket (documented below).
+     * @return The default retention period that you want to apply to new objects placed in this bucket.
      * 
      */
     public BucketObjectLockConfigurationRuleDefaultRetention defaultRetention() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketObjectLockConfigurationRuleDefaultRetention.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketObjectLockConfigurationRuleDefaultRetention.java
@@ -14,38 +14,50 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketObjectLockConfigurationRuleDefaultRetention {
     /**
-     * @return Number of days that you want to specify for the default retention period.
+     * @return The number of days that you want to specify for the default retention period.
      * 
      */
     private @Nullable Integer days;
     /**
-     * @return Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+     * @return The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
      * 
      */
     private String mode;
     /**
-     * @return Number of years that you want to specify for the default retention period.
+     * @return The number of years that you want to specify for the default retention period.
+     * 
+     * Either `days` or `years` must be specified, but not both.
+     * 
+     * &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+     * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+     * Once you create a bucket with S3 Object Lock enabled, you can&#39;t disable Object Lock or suspend versioning for the bucket.
      * 
      */
     private @Nullable Integer years;
 
     private BucketObjectLockConfigurationRuleDefaultRetention() {}
     /**
-     * @return Number of days that you want to specify for the default retention period.
+     * @return The number of days that you want to specify for the default retention period.
      * 
      */
     public Optional<Integer> days() {
         return Optional.ofNullable(this.days);
     }
     /**
-     * @return Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+     * @return The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
      * 
      */
     public String mode() {
         return this.mode;
     }
     /**
-     * @return Number of years that you want to specify for the default retention period.
+     * @return The number of years that you want to specify for the default retention period.
+     * 
+     * Either `days` or `years` must be specified, but not both.
+     * 
+     * &gt; **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+     * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+     * Once you create a bucket with S3 Object Lock enabled, you can&#39;t disable Object Lock or suspend versioning for the bucket.
      * 
      */
     public Optional<Integer> years() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfiguration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfiguration.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 @CustomType
 public final class BucketReplicationConfiguration {
     /**
-     * @return ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+     * @return The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
      * 
      */
     private String role;
@@ -25,7 +25,7 @@ public final class BucketReplicationConfiguration {
 
     private BucketReplicationConfiguration() {}
     /**
-     * @return ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+     * @return The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
      * 
      */
     public String role() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRule.java
@@ -42,7 +42,7 @@ public final class BucketReplicationConfigurationRule {
      */
     private @Nullable String prefix;
     /**
-     * @return Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+     * @return The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
      * 
      */
     private @Nullable Integer priority;
@@ -52,7 +52,9 @@ public final class BucketReplicationConfigurationRule {
      */
     private @Nullable BucketReplicationConfigurationRuleSourceSelectionCriteria sourceSelectionCriteria;
     /**
-     * @return Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * @return The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * 
+     * &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
      * 
      */
     private String status;
@@ -94,7 +96,7 @@ public final class BucketReplicationConfigurationRule {
         return Optional.ofNullable(this.prefix);
     }
     /**
-     * @return Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+     * @return The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
      * 
      */
     public Optional<Integer> priority() {
@@ -108,7 +110,9 @@ public final class BucketReplicationConfigurationRule {
         return Optional.ofNullable(this.sourceSelectionCriteria);
     }
     /**
-     * @return Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * @return The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+     * 
+     * &gt; **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
      * 
      */
     public String status() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestination.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestination.java
@@ -16,17 +16,17 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketReplicationConfigurationRuleDestination {
     /**
-     * @return Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+     * @return Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
      * 
      */
     private @Nullable BucketReplicationConfigurationRuleDestinationAccessControlTranslation accessControlTranslation;
     /**
-     * @return Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+     * @return The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
      * 
      */
     private @Nullable String accountId;
     /**
-     * @return ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+     * @return The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
      * 
      */
     private String bucket;
@@ -54,21 +54,21 @@ public final class BucketReplicationConfigurationRuleDestination {
 
     private BucketReplicationConfigurationRuleDestination() {}
     /**
-     * @return Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+     * @return Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
      * 
      */
     public Optional<BucketReplicationConfigurationRuleDestinationAccessControlTranslation> accessControlTranslation() {
         return Optional.ofNullable(this.accessControlTranslation);
     }
     /**
-     * @return Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+     * @return The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
      * 
      */
     public Optional<String> accountId() {
         return Optional.ofNullable(this.accountId);
     }
     /**
-     * @return ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+     * @return The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
      * 
      */
     public String bucket() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslation.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestinationAccessControlTranslation.java
@@ -11,14 +11,14 @@ import java.util.Objects;
 @CustomType
 public final class BucketReplicationConfigurationRuleDestinationAccessControlTranslation {
     /**
-     * @return Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+     * @return The override value for the owner on replicated objects. Currently only `Destination` is supported.
      * 
      */
     private String owner;
 
     private BucketReplicationConfigurationRuleDestinationAccessControlTranslation() {}
     /**
-     * @return Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+     * @return The override value for the owner on replicated objects. Currently only `Destination` is supported.
      * 
      */
     public String owner() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestinationMetrics.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestinationMetrics.java
@@ -18,7 +18,7 @@ public final class BucketReplicationConfigurationRuleDestinationMetrics {
      */
     private @Nullable Integer minutes;
     /**
-     * @return Status of replication metrics. Either `Enabled` or `Disabled`.
+     * @return The status of replication metrics. Either `Enabled` or `Disabled`.
      * 
      */
     private @Nullable String status;
@@ -32,7 +32,7 @@ public final class BucketReplicationConfigurationRuleDestinationMetrics {
         return Optional.ofNullable(this.minutes);
     }
     /**
-     * @return Status of replication metrics. Either `Enabled` or `Disabled`.
+     * @return The status of replication metrics. Either `Enabled` or `Disabled`.
      * 
      */
     public Optional<String> status() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestinationReplicationTime.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketReplicationConfigurationRuleDestinationReplicationTime.java
@@ -18,7 +18,7 @@ public final class BucketReplicationConfigurationRuleDestinationReplicationTime 
      */
     private @Nullable Integer minutes;
     /**
-     * @return Status of RTC. Either `Enabled` or `Disabled`.
+     * @return The status of RTC. Either `Enabled` or `Disabled`.
      * 
      */
     private @Nullable String status;
@@ -32,7 +32,7 @@ public final class BucketReplicationConfigurationRuleDestinationReplicationTime 
         return Optional.ofNullable(this.minutes);
     }
     /**
-     * @return Status of RTC. Either `Enabled` or `Disabled`.
+     * @return The status of RTC. Either `Enabled` or `Disabled`.
      * 
      */
     public Optional<String> status() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketServerSideEncryptionConfiguration.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketServerSideEncryptionConfiguration.java
@@ -11,14 +11,14 @@ import java.util.Objects;
 @CustomType
 public final class BucketServerSideEncryptionConfiguration {
     /**
-     * @return Single object for server-side encryption by default configuration. (documented below)
+     * @return A single object for server-side encryption by default configuration. (documented below)
      * 
      */
     private BucketServerSideEncryptionConfigurationRule rule;
 
     private BucketServerSideEncryptionConfiguration() {}
     /**
-     * @return Single object for server-side encryption by default configuration. (documented below)
+     * @return A single object for server-side encryption by default configuration. (documented below)
      * 
      */
     public BucketServerSideEncryptionConfigurationRule rule() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketServerSideEncryptionConfigurationRule.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketServerSideEncryptionConfigurationRule.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketServerSideEncryptionConfigurationRule {
     /**
-     * @return Single object for setting server-side encryption by default. (documented below)
+     * @return A single object for setting server-side encryption by default. (documented below)
      * 
      */
     private BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault applyServerSideEncryptionByDefault;
@@ -26,7 +26,7 @@ public final class BucketServerSideEncryptionConfigurationRule {
 
     private BucketServerSideEncryptionConfigurationRule() {}
     /**
-     * @return Single object for setting server-side encryption by default. (documented below)
+     * @return A single object for setting server-side encryption by default. (documented below)
      * 
      */
     public BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault applyServerSideEncryptionByDefault() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault.java
@@ -13,26 +13,26 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault {
     /**
-     * @return AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+     * @return The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
      * 
      */
     private @Nullable String kmsMasterKeyId;
     /**
-     * @return Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+     * @return The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
      * 
      */
     private String sseAlgorithm;
 
     private BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault() {}
     /**
-     * @return AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+     * @return The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
      * 
      */
     public Optional<String> kmsMasterKeyId() {
         return Optional.ofNullable(this.kmsMasterKeyId);
     }
     /**
-     * @return Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+     * @return The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
      * 
      */
     public String sseAlgorithm() {

--- a/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketWebsite.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/s3/outputs/BucketWebsite.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class BucketWebsite {
     /**
-     * @return Absolute path to the document to return in case of a 4XX error.
+     * @return An absolute path to the document to return in case of a 4XX error.
      * 
      */
     private @Nullable String errorDocument;
@@ -24,20 +24,22 @@ public final class BucketWebsite {
      */
     private @Nullable String indexDocument;
     /**
-     * @return Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+     * @return A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
      * 
      */
     private @Nullable String redirectAllRequestsTo;
     /**
-     * @return JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+     * @return A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
      * describing redirect behavior and when redirects are applied.
+     * 
+     * The `CORS` object supports the following:
      * 
      */
     private @Nullable Either<String,List<String>> routingRules;
 
     private BucketWebsite() {}
     /**
-     * @return Absolute path to the document to return in case of a 4XX error.
+     * @return An absolute path to the document to return in case of a 4XX error.
      * 
      */
     public Optional<String> errorDocument() {
@@ -51,15 +53,17 @@ public final class BucketWebsite {
         return Optional.ofNullable(this.indexDocument);
     }
     /**
-     * @return Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+     * @return A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
      * 
      */
     public Optional<String> redirectAllRequestsTo() {
         return Optional.ofNullable(this.redirectAllRequestsTo);
     }
     /**
-     * @return JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+     * @return A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
      * describing redirect behavior and when redirects are applied.
+     * 
+     * The `CORS` object supports the following:
      * 
      */
     public Optional<Either<String,List<String>>> routingRules() {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -65400,19 +65400,19 @@ export namespace s3 {
 
     export interface BucketCorsRule {
         /**
-         * List of headers allowed.
+         * Specifies which headers are allowed.
          */
         allowedHeaders?: pulumi.Input<pulumi.Input<string>[]>;
         /**
-         * One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+         * Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
          */
         allowedMethods: pulumi.Input<pulumi.Input<string>[]>;
         /**
-         * One or more origins you want customers to be able to access the bucket from.
+         * Specifies which origins are allowed.
          */
         allowedOrigins: pulumi.Input<pulumi.Input<string>[]>;
         /**
-         * One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+         * Specifies expose header in the response.
          */
         exposeHeaders?: pulumi.Input<pulumi.Input<string>[]>;
         /**
@@ -65629,7 +65629,7 @@ export namespace s3 {
          */
         enabled: pulumi.Input<boolean>;
         /**
-         * Specifies a period in the object's expire. See Expiration below for details.
+         * Specifies a period in the object's expire (documented below).
          */
         expiration?: pulumi.Input<inputs.s3.BucketLifecycleRuleExpiration>;
         /**
@@ -65637,11 +65637,13 @@ export namespace s3 {
          */
         id?: pulumi.Input<string>;
         /**
-         * Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+         * Specifies when noncurrent object versions expire (documented below).
          */
         noncurrentVersionExpiration?: pulumi.Input<inputs.s3.BucketLifecycleRuleNoncurrentVersionExpiration>;
         /**
-         * Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+         * Specifies when noncurrent object versions transitions (documented below).
+         *
+         * At least one of `abortIncompleteMultipartUploadDays`, `expiration`, `transition`, `noncurrentVersionExpiration`, `noncurrentVersionTransition` must be specified.
          */
         noncurrentVersionTransitions?: pulumi.Input<pulumi.Input<inputs.s3.BucketLifecycleRuleNoncurrentVersionTransition>[]>;
         /**
@@ -65653,7 +65655,7 @@ export namespace s3 {
          */
         tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
         /**
-         * Specifies a period in the object's transitions. See Transition below for details.
+         * Specifies a period in the object's transitions (documented below).
          */
         transitions?: pulumi.Input<pulumi.Input<inputs.s3.BucketLifecycleRuleTransition>[]>;
     }
@@ -65708,7 +65710,7 @@ export namespace s3 {
 
     export interface BucketLogging {
         /**
-         * Name of the bucket that will receive the log objects.
+         * The name of the bucket that will receive the log objects.
          */
         targetBucket: pulumi.Input<string>;
         /**
@@ -65855,33 +65857,39 @@ export namespace s3 {
 
     export interface BucketObjectLockConfiguration {
         /**
-         * Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+         * Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
          */
         objectLockEnabled: pulumi.Input<string>;
         /**
-         * Object Lock rule in place for this bucket (documented below).
+         * The Object Lock rule in place for this bucket.
          */
         rule?: pulumi.Input<inputs.s3.BucketObjectLockConfigurationRule>;
     }
 
     export interface BucketObjectLockConfigurationRule {
         /**
-         * Default retention period that you want to apply to new objects placed in this bucket (documented below).
+         * The default retention period that you want to apply to new objects placed in this bucket.
          */
         defaultRetention: pulumi.Input<inputs.s3.BucketObjectLockConfigurationRuleDefaultRetention>;
     }
 
     export interface BucketObjectLockConfigurationRuleDefaultRetention {
         /**
-         * Number of days that you want to specify for the default retention period.
+         * The number of days that you want to specify for the default retention period.
          */
         days?: pulumi.Input<number>;
         /**
-         * Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+         * The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
          */
         mode: pulumi.Input<string>;
         /**
-         * Number of years that you want to specify for the default retention period.
+         * The number of years that you want to specify for the default retention period.
+         *
+         * Either `days` or `years` must be specified, but not both.
+         *
+         * > **NOTE on `objectLockConfiguration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+         * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+         * Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
          */
         years?: pulumi.Input<number>;
     }
@@ -66132,7 +66140,7 @@ export namespace s3 {
 
     export interface BucketReplicationConfiguration {
         /**
-         * ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+         * The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
          */
         role: pulumi.Input<string>;
         /**
@@ -66163,7 +66171,7 @@ export namespace s3 {
          */
         prefix?: pulumi.Input<string>;
         /**
-         * Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+         * The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
          */
         priority?: pulumi.Input<number>;
         /**
@@ -66171,22 +66179,24 @@ export namespace s3 {
          */
         sourceSelectionCriteria?: pulumi.Input<inputs.s3.BucketReplicationConfigurationRuleSourceSelectionCriteria>;
         /**
-         * Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         * The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         *
+         * > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
          */
         status: pulumi.Input<string>;
     }
 
     export interface BucketReplicationConfigurationRuleDestination {
         /**
-         * Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `accountId` owner override configuration.
+         * Specifies the overrides to use for object owners on replication. Must be used in conjunction with `accountId` owner override configuration.
          */
         accessControlTranslation?: pulumi.Input<inputs.s3.BucketReplicationConfigurationRuleDestinationAccessControlTranslation>;
         /**
-         * Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
+         * The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
          */
         accountId?: pulumi.Input<string>;
         /**
-         * ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+         * The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
          */
         bucket: pulumi.Input<string>;
         /**
@@ -66210,7 +66220,7 @@ export namespace s3 {
 
     export interface BucketReplicationConfigurationRuleDestinationAccessControlTranslation {
         /**
-         * Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+         * The override value for the owner on replicated objects. Currently only `Destination` is supported.
          */
         owner: pulumi.Input<string>;
     }
@@ -66221,7 +66231,7 @@ export namespace s3 {
          */
         minutes?: pulumi.Input<number>;
         /**
-         * Status of replication metrics. Either `Enabled` or `Disabled`.
+         * The status of replication metrics. Either `Enabled` or `Disabled`.
          */
         status?: pulumi.Input<string>;
     }
@@ -66232,7 +66242,7 @@ export namespace s3 {
          */
         minutes?: pulumi.Input<number>;
         /**
-         * Status of RTC. Either `Enabled` or `Disabled`.
+         * The status of RTC. Either `Enabled` or `Disabled`.
          */
         status?: pulumi.Input<string>;
     }
@@ -66266,14 +66276,14 @@ export namespace s3 {
 
     export interface BucketServerSideEncryptionConfiguration {
         /**
-         * Single object for server-side encryption by default configuration. (documented below)
+         * A single object for server-side encryption by default configuration. (documented below)
          */
         rule: pulumi.Input<inputs.s3.BucketServerSideEncryptionConfigurationRule>;
     }
 
     export interface BucketServerSideEncryptionConfigurationRule {
         /**
-         * Single object for setting server-side encryption by default. (documented below)
+         * A single object for setting server-side encryption by default. (documented below)
          */
         applyServerSideEncryptionByDefault: pulumi.Input<inputs.s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault>;
         /**
@@ -66284,11 +66294,11 @@ export namespace s3 {
 
     export interface BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault {
         /**
-         * AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
+         * The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
          */
         kmsMasterKeyId?: pulumi.Input<string>;
         /**
-         * Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+         * The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
          */
         sseAlgorithm: pulumi.Input<string>;
     }
@@ -66710,7 +66720,7 @@ export namespace s3 {
 
     export interface BucketWebsite {
         /**
-         * Absolute path to the document to return in case of a 4XX error.
+         * An absolute path to the document to return in case of a 4XX error.
          */
         errorDocument?: pulumi.Input<string>;
         /**
@@ -66718,12 +66728,14 @@ export namespace s3 {
          */
         indexDocument?: pulumi.Input<string>;
         /**
-         * Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+         * A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
          */
         redirectAllRequestsTo?: pulumi.Input<string>;
         /**
-         * JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+         * A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
          * describing redirect behavior and when redirects are applied.
+         *
+         * The `CORS` object supports the following:
          */
         routingRules?: pulumi.Input<string | pulumi.Input<RoutingRule>[]>;
     }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -73717,19 +73717,19 @@ export namespace s3 {
 
     export interface BucketCorsRule {
         /**
-         * List of headers allowed.
+         * Specifies which headers are allowed.
          */
         allowedHeaders?: string[];
         /**
-         * One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+         * Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
          */
         allowedMethods: string[];
         /**
-         * One or more origins you want customers to be able to access the bucket from.
+         * Specifies which origins are allowed.
          */
         allowedOrigins: string[];
         /**
-         * One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+         * Specifies expose header in the response.
          */
         exposeHeaders?: string[];
         /**
@@ -73946,7 +73946,7 @@ export namespace s3 {
          */
         enabled: boolean;
         /**
-         * Specifies a period in the object's expire. See Expiration below for details.
+         * Specifies a period in the object's expire (documented below).
          */
         expiration?: outputs.s3.BucketLifecycleRuleExpiration;
         /**
@@ -73954,11 +73954,13 @@ export namespace s3 {
          */
         id: string;
         /**
-         * Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+         * Specifies when noncurrent object versions expire (documented below).
          */
         noncurrentVersionExpiration?: outputs.s3.BucketLifecycleRuleNoncurrentVersionExpiration;
         /**
-         * Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+         * Specifies when noncurrent object versions transitions (documented below).
+         *
+         * At least one of `abortIncompleteMultipartUploadDays`, `expiration`, `transition`, `noncurrentVersionExpiration`, `noncurrentVersionTransition` must be specified.
          */
         noncurrentVersionTransitions?: outputs.s3.BucketLifecycleRuleNoncurrentVersionTransition[];
         /**
@@ -73970,7 +73972,7 @@ export namespace s3 {
          */
         tags?: {[key: string]: string};
         /**
-         * Specifies a period in the object's transitions. See Transition below for details.
+         * Specifies a period in the object's transitions (documented below).
          */
         transitions?: outputs.s3.BucketLifecycleRuleTransition[];
     }
@@ -74025,7 +74027,7 @@ export namespace s3 {
 
     export interface BucketLogging {
         /**
-         * Name of the bucket that will receive the log objects.
+         * The name of the bucket that will receive the log objects.
          */
         targetBucket: string;
         /**
@@ -74172,33 +74174,39 @@ export namespace s3 {
 
     export interface BucketObjectLockConfiguration {
         /**
-         * Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+         * Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
          */
         objectLockEnabled: string;
         /**
-         * Object Lock rule in place for this bucket (documented below).
+         * The Object Lock rule in place for this bucket.
          */
         rule?: outputs.s3.BucketObjectLockConfigurationRule;
     }
 
     export interface BucketObjectLockConfigurationRule {
         /**
-         * Default retention period that you want to apply to new objects placed in this bucket (documented below).
+         * The default retention period that you want to apply to new objects placed in this bucket.
          */
         defaultRetention: outputs.s3.BucketObjectLockConfigurationRuleDefaultRetention;
     }
 
     export interface BucketObjectLockConfigurationRuleDefaultRetention {
         /**
-         * Number of days that you want to specify for the default retention period.
+         * The number of days that you want to specify for the default retention period.
          */
         days?: number;
         /**
-         * Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+         * The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
          */
         mode: string;
         /**
-         * Number of years that you want to specify for the default retention period.
+         * The number of years that you want to specify for the default retention period.
+         *
+         * Either `days` or `years` must be specified, but not both.
+         *
+         * > **NOTE on `objectLockConfiguration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+         * When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+         * Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
          */
         years?: number;
     }
@@ -74449,7 +74457,7 @@ export namespace s3 {
 
     export interface BucketReplicationConfiguration {
         /**
-         * ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+         * The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
          */
         role: string;
         /**
@@ -74480,7 +74488,7 @@ export namespace s3 {
          */
         prefix?: string;
         /**
-         * Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+         * The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
          */
         priority?: number;
         /**
@@ -74488,22 +74496,24 @@ export namespace s3 {
          */
         sourceSelectionCriteria?: outputs.s3.BucketReplicationConfigurationRuleSourceSelectionCriteria;
         /**
-         * Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         * The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+         *
+         * > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
          */
         status: string;
     }
 
     export interface BucketReplicationConfigurationRuleDestination {
         /**
-         * Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `accountId` owner override configuration.
+         * Specifies the overrides to use for object owners on replication. Must be used in conjunction with `accountId` owner override configuration.
          */
         accessControlTranslation?: outputs.s3.BucketReplicationConfigurationRuleDestinationAccessControlTranslation;
         /**
-         * Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
+         * The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `accessControlTranslation` override configuration.
          */
         accountId?: string;
         /**
-         * ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+         * The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
          */
         bucket: string;
         /**
@@ -74527,7 +74537,7 @@ export namespace s3 {
 
     export interface BucketReplicationConfigurationRuleDestinationAccessControlTranslation {
         /**
-         * Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+         * The override value for the owner on replicated objects. Currently only `Destination` is supported.
          */
         owner: string;
     }
@@ -74538,7 +74548,7 @@ export namespace s3 {
          */
         minutes?: number;
         /**
-         * Status of replication metrics. Either `Enabled` or `Disabled`.
+         * The status of replication metrics. Either `Enabled` or `Disabled`.
          */
         status?: string;
     }
@@ -74549,7 +74559,7 @@ export namespace s3 {
          */
         minutes?: number;
         /**
-         * Status of RTC. Either `Enabled` or `Disabled`.
+         * The status of RTC. Either `Enabled` or `Disabled`.
          */
         status?: string;
     }
@@ -74583,14 +74593,14 @@ export namespace s3 {
 
     export interface BucketServerSideEncryptionConfiguration {
         /**
-         * Single object for server-side encryption by default configuration. (documented below)
+         * A single object for server-side encryption by default configuration. (documented below)
          */
         rule: outputs.s3.BucketServerSideEncryptionConfigurationRule;
     }
 
     export interface BucketServerSideEncryptionConfigurationRule {
         /**
-         * Single object for setting server-side encryption by default. (documented below)
+         * A single object for setting server-side encryption by default. (documented below)
          */
         applyServerSideEncryptionByDefault: outputs.s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault;
         /**
@@ -74601,11 +74611,11 @@ export namespace s3 {
 
     export interface BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault {
         /**
-         * AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
+         * The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sseAlgorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sseAlgorithm` is `aws:kms`.
          */
         kmsMasterKeyId?: string;
         /**
-         * Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+         * The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
          */
         sseAlgorithm: string;
     }
@@ -75027,7 +75037,7 @@ export namespace s3 {
 
     export interface BucketWebsite {
         /**
-         * Absolute path to the document to return in case of a 4XX error.
+         * An absolute path to the document to return in case of a 4XX error.
          */
         errorDocument?: string;
         /**
@@ -75035,12 +75045,14 @@ export namespace s3 {
          */
         indexDocument?: string;
         /**
-         * Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+         * A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
          */
         redirectAllRequestsTo?: string;
         /**
-         * JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+         * A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
          * describing redirect behavior and when redirects are applied.
+         *
+         * The `CORS` object supports the following:
          */
         routingRules?: string;
     }

--- a/sdk/python/pulumi_aws/s3/_inputs.py
+++ b/sdk/python/pulumi_aws/s3/_inputs.py
@@ -1057,19 +1057,19 @@ if not MYPY:
     class BucketCorsRuleArgsDict(TypedDict):
         allowed_methods: pulumi.Input[Sequence[pulumi.Input[str]]]
         """
-        One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
         """
         allowed_origins: pulumi.Input[Sequence[pulumi.Input[str]]]
         """
-        One or more origins you want customers to be able to access the bucket from.
+        Specifies which origins are allowed.
         """
         allowed_headers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
         """
-        List of headers allowed.
+        Specifies which headers are allowed.
         """
         expose_headers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
         """
-        One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        Specifies expose header in the response.
         """
         max_age_seconds: NotRequired[pulumi.Input[int]]
         """
@@ -1087,10 +1087,10 @@ class BucketCorsRuleArgs:
                  expose_headers: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  max_age_seconds: Optional[pulumi.Input[int]] = None):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] allowed_methods: One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] allowed_origins: One or more origins you want customers to be able to access the bucket from.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] allowed_headers: List of headers allowed.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] expose_headers: One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] allowed_methods: Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] allowed_origins: Specifies which origins are allowed.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] allowed_headers: Specifies which headers are allowed.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] expose_headers: Specifies expose header in the response.
         :param pulumi.Input[int] max_age_seconds: Specifies time in seconds that browser can cache the response for a preflight request.
         """
         pulumi.set(__self__, "allowed_methods", allowed_methods)
@@ -1106,7 +1106,7 @@ class BucketCorsRuleArgs:
     @pulumi.getter(name="allowedMethods")
     def allowed_methods(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
         """
-        One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
         """
         return pulumi.get(self, "allowed_methods")
 
@@ -1118,7 +1118,7 @@ class BucketCorsRuleArgs:
     @pulumi.getter(name="allowedOrigins")
     def allowed_origins(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
         """
-        One or more origins you want customers to be able to access the bucket from.
+        Specifies which origins are allowed.
         """
         return pulumi.get(self, "allowed_origins")
 
@@ -1130,7 +1130,7 @@ class BucketCorsRuleArgs:
     @pulumi.getter(name="allowedHeaders")
     def allowed_headers(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
-        List of headers allowed.
+        Specifies which headers are allowed.
         """
         return pulumi.get(self, "allowed_headers")
 
@@ -1142,7 +1142,7 @@ class BucketCorsRuleArgs:
     @pulumi.getter(name="exposeHeaders")
     def expose_headers(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
-        One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        Specifies expose header in the response.
         """
         return pulumi.get(self, "expose_headers")
 
@@ -2113,7 +2113,7 @@ if not MYPY:
         """
         expiration: NotRequired[pulumi.Input['BucketLifecycleRuleExpirationArgsDict']]
         """
-        Specifies a period in the object's expire. See Expiration below for details.
+        Specifies a period in the object's expire (documented below).
         """
         id: NotRequired[pulumi.Input[str]]
         """
@@ -2121,11 +2121,13 @@ if not MYPY:
         """
         noncurrent_version_expiration: NotRequired[pulumi.Input['BucketLifecycleRuleNoncurrentVersionExpirationArgsDict']]
         """
-        Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+        Specifies when noncurrent object versions expire (documented below).
         """
         noncurrent_version_transitions: NotRequired[pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleNoncurrentVersionTransitionArgsDict']]]]
         """
-        Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        Specifies when noncurrent object versions transitions (documented below).
+
+        At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         """
         prefix: NotRequired[pulumi.Input[str]]
         """
@@ -2137,7 +2139,7 @@ if not MYPY:
         """
         transitions: NotRequired[pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleTransitionArgsDict']]]]
         """
-        Specifies a period in the object's transitions. See Transition below for details.
+        Specifies a period in the object's transitions (documented below).
         """
 elif False:
     BucketLifecycleRuleArgsDict: TypeAlias = Mapping[str, Any]
@@ -2157,13 +2159,15 @@ class BucketLifecycleRuleArgs:
         """
         :param pulumi.Input[bool] enabled: Specifies lifecycle rule status.
         :param pulumi.Input[int] abort_incomplete_multipart_upload_days: Specifies the number of days after initiating a multipart upload when the multipart upload must be completed.
-        :param pulumi.Input['BucketLifecycleRuleExpirationArgs'] expiration: Specifies a period in the object's expire. See Expiration below for details.
+        :param pulumi.Input['BucketLifecycleRuleExpirationArgs'] expiration: Specifies a period in the object's expire (documented below).
         :param pulumi.Input[str] id: Unique identifier for the rule. Must be less than or equal to 255 characters in length.
-        :param pulumi.Input['BucketLifecycleRuleNoncurrentVersionExpirationArgs'] noncurrent_version_expiration: Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleNoncurrentVersionTransitionArgs']]] noncurrent_version_transitions: Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        :param pulumi.Input['BucketLifecycleRuleNoncurrentVersionExpirationArgs'] noncurrent_version_expiration: Specifies when noncurrent object versions expire (documented below).
+        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleNoncurrentVersionTransitionArgs']]] noncurrent_version_transitions: Specifies when noncurrent object versions transitions (documented below).
+               
+               At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         :param pulumi.Input[str] prefix: Object key prefix identifying one or more objects to which the rule applies.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Specifies object tags key and value.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleTransitionArgs']]] transitions: Specifies a period in the object's transitions. See Transition below for details.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleTransitionArgs']]] transitions: Specifies a period in the object's transitions (documented below).
         """
         pulumi.set(__self__, "enabled", enabled)
         if abort_incomplete_multipart_upload_days is not None:
@@ -2211,7 +2215,7 @@ class BucketLifecycleRuleArgs:
     @pulumi.getter
     def expiration(self) -> Optional[pulumi.Input['BucketLifecycleRuleExpirationArgs']]:
         """
-        Specifies a period in the object's expire. See Expiration below for details.
+        Specifies a period in the object's expire (documented below).
         """
         return pulumi.get(self, "expiration")
 
@@ -2235,7 +2239,7 @@ class BucketLifecycleRuleArgs:
     @pulumi.getter(name="noncurrentVersionExpiration")
     def noncurrent_version_expiration(self) -> Optional[pulumi.Input['BucketLifecycleRuleNoncurrentVersionExpirationArgs']]:
         """
-        Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+        Specifies when noncurrent object versions expire (documented below).
         """
         return pulumi.get(self, "noncurrent_version_expiration")
 
@@ -2247,7 +2251,9 @@ class BucketLifecycleRuleArgs:
     @pulumi.getter(name="noncurrentVersionTransitions")
     def noncurrent_version_transitions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleNoncurrentVersionTransitionArgs']]]]:
         """
-        Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        Specifies when noncurrent object versions transitions (documented below).
+
+        At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         """
         return pulumi.get(self, "noncurrent_version_transitions")
 
@@ -2283,7 +2289,7 @@ class BucketLifecycleRuleArgs:
     @pulumi.getter
     def transitions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleTransitionArgs']]]]:
         """
-        Specifies a period in the object's transitions. See Transition below for details.
+        Specifies a period in the object's transitions (documented below).
         """
         return pulumi.get(self, "transitions")
 
@@ -2522,7 +2528,7 @@ if not MYPY:
     class BucketLoggingArgsDict(TypedDict):
         target_bucket: pulumi.Input[str]
         """
-        Name of the bucket that will receive the log objects.
+        The name of the bucket that will receive the log objects.
         """
         target_prefix: NotRequired[pulumi.Input[str]]
         """
@@ -2537,7 +2543,7 @@ class BucketLoggingArgs:
                  target_bucket: pulumi.Input[str],
                  target_prefix: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] target_bucket: Name of the bucket that will receive the log objects.
+        :param pulumi.Input[str] target_bucket: The name of the bucket that will receive the log objects.
         :param pulumi.Input[str] target_prefix: To specify a key prefix for log objects.
         """
         pulumi.set(__self__, "target_bucket", target_bucket)
@@ -2548,7 +2554,7 @@ class BucketLoggingArgs:
     @pulumi.getter(name="targetBucket")
     def target_bucket(self) -> pulumi.Input[str]:
         """
-        Name of the bucket that will receive the log objects.
+        The name of the bucket that will receive the log objects.
         """
         return pulumi.get(self, "target_bucket")
 
@@ -3225,11 +3231,11 @@ if not MYPY:
     class BucketObjectLockConfigurationArgsDict(TypedDict):
         object_lock_enabled: pulumi.Input[str]
         """
-        Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+        Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
         """
         rule: NotRequired[pulumi.Input['BucketObjectLockConfigurationRuleArgsDict']]
         """
-        Object Lock rule in place for this bucket (documented below).
+        The Object Lock rule in place for this bucket.
         """
 elif False:
     BucketObjectLockConfigurationArgsDict: TypeAlias = Mapping[str, Any]
@@ -3240,8 +3246,8 @@ class BucketObjectLockConfigurationArgs:
                  object_lock_enabled: pulumi.Input[str],
                  rule: Optional[pulumi.Input['BucketObjectLockConfigurationRuleArgs']] = None):
         """
-        :param pulumi.Input[str] object_lock_enabled: Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
-        :param pulumi.Input['BucketObjectLockConfigurationRuleArgs'] rule: Object Lock rule in place for this bucket (documented below).
+        :param pulumi.Input[str] object_lock_enabled: Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
+        :param pulumi.Input['BucketObjectLockConfigurationRuleArgs'] rule: The Object Lock rule in place for this bucket.
         """
         pulumi.set(__self__, "object_lock_enabled", object_lock_enabled)
         if rule is not None:
@@ -3251,7 +3257,7 @@ class BucketObjectLockConfigurationArgs:
     @pulumi.getter(name="objectLockEnabled")
     def object_lock_enabled(self) -> pulumi.Input[str]:
         """
-        Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+        Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
         """
         return pulumi.get(self, "object_lock_enabled")
 
@@ -3263,7 +3269,7 @@ class BucketObjectLockConfigurationArgs:
     @pulumi.getter
     def rule(self) -> Optional[pulumi.Input['BucketObjectLockConfigurationRuleArgs']]:
         """
-        Object Lock rule in place for this bucket (documented below).
+        The Object Lock rule in place for this bucket.
         """
         return pulumi.get(self, "rule")
 
@@ -3276,7 +3282,7 @@ if not MYPY:
     class BucketObjectLockConfigurationRuleArgsDict(TypedDict):
         default_retention: pulumi.Input['BucketObjectLockConfigurationRuleDefaultRetentionArgsDict']
         """
-        Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        The default retention period that you want to apply to new objects placed in this bucket.
         """
 elif False:
     BucketObjectLockConfigurationRuleArgsDict: TypeAlias = Mapping[str, Any]
@@ -3286,7 +3292,7 @@ class BucketObjectLockConfigurationRuleArgs:
     def __init__(__self__, *,
                  default_retention: pulumi.Input['BucketObjectLockConfigurationRuleDefaultRetentionArgs']):
         """
-        :param pulumi.Input['BucketObjectLockConfigurationRuleDefaultRetentionArgs'] default_retention: Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        :param pulumi.Input['BucketObjectLockConfigurationRuleDefaultRetentionArgs'] default_retention: The default retention period that you want to apply to new objects placed in this bucket.
         """
         pulumi.set(__self__, "default_retention", default_retention)
 
@@ -3294,7 +3300,7 @@ class BucketObjectLockConfigurationRuleArgs:
     @pulumi.getter(name="defaultRetention")
     def default_retention(self) -> pulumi.Input['BucketObjectLockConfigurationRuleDefaultRetentionArgs']:
         """
-        Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        The default retention period that you want to apply to new objects placed in this bucket.
         """
         return pulumi.get(self, "default_retention")
 
@@ -3307,15 +3313,21 @@ if not MYPY:
     class BucketObjectLockConfigurationRuleDefaultRetentionArgsDict(TypedDict):
         mode: pulumi.Input[str]
         """
-        Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
         """
         days: NotRequired[pulumi.Input[int]]
         """
-        Number of days that you want to specify for the default retention period.
+        The number of days that you want to specify for the default retention period.
         """
         years: NotRequired[pulumi.Input[int]]
         """
-        Number of years that you want to specify for the default retention period.
+        The number of years that you want to specify for the default retention period.
+
+        Either `days` or `years` must be specified, but not both.
+
+        > **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+        When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+        Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         """
 elif False:
     BucketObjectLockConfigurationRuleDefaultRetentionArgsDict: TypeAlias = Mapping[str, Any]
@@ -3327,9 +3339,15 @@ class BucketObjectLockConfigurationRuleDefaultRetentionArgs:
                  days: Optional[pulumi.Input[int]] = None,
                  years: Optional[pulumi.Input[int]] = None):
         """
-        :param pulumi.Input[str] mode: Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
-        :param pulumi.Input[int] days: Number of days that you want to specify for the default retention period.
-        :param pulumi.Input[int] years: Number of years that you want to specify for the default retention period.
+        :param pulumi.Input[str] mode: The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        :param pulumi.Input[int] days: The number of days that you want to specify for the default retention period.
+        :param pulumi.Input[int] years: The number of years that you want to specify for the default retention period.
+               
+               Either `days` or `years` must be specified, but not both.
+               
+               > **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+               When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+               Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         """
         pulumi.set(__self__, "mode", mode)
         if days is not None:
@@ -3341,7 +3359,7 @@ class BucketObjectLockConfigurationRuleDefaultRetentionArgs:
     @pulumi.getter
     def mode(self) -> pulumi.Input[str]:
         """
-        Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
         """
         return pulumi.get(self, "mode")
 
@@ -3353,7 +3371,7 @@ class BucketObjectLockConfigurationRuleDefaultRetentionArgs:
     @pulumi.getter
     def days(self) -> Optional[pulumi.Input[int]]:
         """
-        Number of days that you want to specify for the default retention period.
+        The number of days that you want to specify for the default retention period.
         """
         return pulumi.get(self, "days")
 
@@ -3365,7 +3383,13 @@ class BucketObjectLockConfigurationRuleDefaultRetentionArgs:
     @pulumi.getter
     def years(self) -> Optional[pulumi.Input[int]]:
         """
-        Number of years that you want to specify for the default retention period.
+        The number of years that you want to specify for the default retention period.
+
+        Either `days` or `years` must be specified, but not both.
+
+        > **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+        When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+        Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         """
         return pulumi.get(self, "years")
 
@@ -4505,7 +4529,7 @@ if not MYPY:
     class BucketReplicationConfigurationArgsDict(TypedDict):
         role: pulumi.Input[str]
         """
-        ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         """
         rules: pulumi.Input[Sequence[pulumi.Input['BucketReplicationConfigurationRuleArgsDict']]]
         """
@@ -4520,7 +4544,7 @@ class BucketReplicationConfigurationArgs:
                  role: pulumi.Input[str],
                  rules: pulumi.Input[Sequence[pulumi.Input['BucketReplicationConfigurationRuleArgs']]]):
         """
-        :param pulumi.Input[str] role: ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        :param pulumi.Input[str] role: The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         :param pulumi.Input[Sequence[pulumi.Input['BucketReplicationConfigurationRuleArgs']]] rules: Specifies the rules managing the replication (documented below).
         """
         pulumi.set(__self__, "role", role)
@@ -4530,7 +4554,7 @@ class BucketReplicationConfigurationArgs:
     @pulumi.getter
     def role(self) -> pulumi.Input[str]:
         """
-        ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         """
         return pulumi.get(self, "role")
 
@@ -4559,7 +4583,9 @@ if not MYPY:
         """
         status: pulumi.Input[str]
         """
-        Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+
+        > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         """
         delete_marker_replication_status: NotRequired[pulumi.Input[str]]
         """
@@ -4579,7 +4605,7 @@ if not MYPY:
         """
         priority: NotRequired[pulumi.Input[int]]
         """
-        Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         """
         source_selection_criteria: NotRequired[pulumi.Input['BucketReplicationConfigurationRuleSourceSelectionCriteriaArgsDict']]
         """
@@ -4601,12 +4627,14 @@ class BucketReplicationConfigurationRuleArgs:
                  source_selection_criteria: Optional[pulumi.Input['BucketReplicationConfigurationRuleSourceSelectionCriteriaArgs']] = None):
         """
         :param pulumi.Input['BucketReplicationConfigurationRuleDestinationArgs'] destination: Specifies the destination for the rule (documented below).
-        :param pulumi.Input[str] status: Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        :param pulumi.Input[str] status: The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+               
+               > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         :param pulumi.Input[str] delete_marker_replication_status: Whether delete markers are replicated. The only valid value is `Enabled`. To disable, omit this argument. This argument is only valid with V2 replication configurations (i.e., when `filter` is used).
         :param pulumi.Input['BucketReplicationConfigurationRuleFilterArgs'] filter: Filter that identifies subset of objects to which the replication rule applies (documented below).
         :param pulumi.Input[str] id: Unique identifier for the rule. Must be less than or equal to 255 characters in length.
         :param pulumi.Input[str] prefix: Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
-        :param pulumi.Input[int] priority: Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        :param pulumi.Input[int] priority: The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         :param pulumi.Input['BucketReplicationConfigurationRuleSourceSelectionCriteriaArgs'] source_selection_criteria: Specifies special object selection criteria (documented below).
         """
         pulumi.set(__self__, "destination", destination)
@@ -4640,7 +4668,9 @@ class BucketReplicationConfigurationRuleArgs:
     @pulumi.getter
     def status(self) -> pulumi.Input[str]:
         """
-        Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+
+        > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         """
         return pulumi.get(self, "status")
 
@@ -4700,7 +4730,7 @@ class BucketReplicationConfigurationRuleArgs:
     @pulumi.getter
     def priority(self) -> Optional[pulumi.Input[int]]:
         """
-        Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         """
         return pulumi.get(self, "priority")
 
@@ -4725,15 +4755,15 @@ if not MYPY:
     class BucketReplicationConfigurationRuleDestinationArgsDict(TypedDict):
         bucket: pulumi.Input[str]
         """
-        ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
         """
         access_control_translation: NotRequired[pulumi.Input['BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgsDict']]
         """
-        Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+        Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
         """
         account_id: NotRequired[pulumi.Input[str]]
         """
-        Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         """
         metrics: NotRequired[pulumi.Input['BucketReplicationConfigurationRuleDestinationMetricsArgsDict']]
         """
@@ -4766,9 +4796,9 @@ class BucketReplicationConfigurationRuleDestinationArgs:
                  replication_time: Optional[pulumi.Input['BucketReplicationConfigurationRuleDestinationReplicationTimeArgs']] = None,
                  storage_class: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] bucket: ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
-        :param pulumi.Input['BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs'] access_control_translation: Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
-        :param pulumi.Input[str] account_id: Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        :param pulumi.Input[str] bucket: The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        :param pulumi.Input['BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs'] access_control_translation: Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
+        :param pulumi.Input[str] account_id: The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         :param pulumi.Input['BucketReplicationConfigurationRuleDestinationMetricsArgs'] metrics: Enables replication metrics (required for S3 RTC) (documented below).
         :param pulumi.Input[str] replica_kms_key_id: Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
                `sse_kms_encrypted_objects` source selection criteria.
@@ -4793,7 +4823,7 @@ class BucketReplicationConfigurationRuleDestinationArgs:
     @pulumi.getter
     def bucket(self) -> pulumi.Input[str]:
         """
-        ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
         """
         return pulumi.get(self, "bucket")
 
@@ -4805,7 +4835,7 @@ class BucketReplicationConfigurationRuleDestinationArgs:
     @pulumi.getter(name="accessControlTranslation")
     def access_control_translation(self) -> Optional[pulumi.Input['BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs']]:
         """
-        Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+        Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
         """
         return pulumi.get(self, "access_control_translation")
 
@@ -4817,7 +4847,7 @@ class BucketReplicationConfigurationRuleDestinationArgs:
     @pulumi.getter(name="accountId")
     def account_id(self) -> Optional[pulumi.Input[str]]:
         """
-        Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         """
         return pulumi.get(self, "account_id")
 
@@ -4879,7 +4909,7 @@ if not MYPY:
     class BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgsDict(TypedDict):
         owner: pulumi.Input[str]
         """
-        Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        The override value for the owner on replicated objects. Currently only `Destination` is supported.
         """
 elif False:
     BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgsDict: TypeAlias = Mapping[str, Any]
@@ -4889,7 +4919,7 @@ class BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs:
     def __init__(__self__, *,
                  owner: pulumi.Input[str]):
         """
-        :param pulumi.Input[str] owner: Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        :param pulumi.Input[str] owner: The override value for the owner on replicated objects. Currently only `Destination` is supported.
         """
         pulumi.set(__self__, "owner", owner)
 
@@ -4897,7 +4927,7 @@ class BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs:
     @pulumi.getter
     def owner(self) -> pulumi.Input[str]:
         """
-        Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        The override value for the owner on replicated objects. Currently only `Destination` is supported.
         """
         return pulumi.get(self, "owner")
 
@@ -4914,7 +4944,7 @@ if not MYPY:
         """
         status: NotRequired[pulumi.Input[str]]
         """
-        Status of replication metrics. Either `Enabled` or `Disabled`.
+        The status of replication metrics. Either `Enabled` or `Disabled`.
         """
 elif False:
     BucketReplicationConfigurationRuleDestinationMetricsArgsDict: TypeAlias = Mapping[str, Any]
@@ -4926,7 +4956,7 @@ class BucketReplicationConfigurationRuleDestinationMetricsArgs:
                  status: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[int] minutes: Threshold within which objects are to be replicated. The only valid value is `15`.
-        :param pulumi.Input[str] status: Status of replication metrics. Either `Enabled` or `Disabled`.
+        :param pulumi.Input[str] status: The status of replication metrics. Either `Enabled` or `Disabled`.
         """
         if minutes is not None:
             pulumi.set(__self__, "minutes", minutes)
@@ -4949,7 +4979,7 @@ class BucketReplicationConfigurationRuleDestinationMetricsArgs:
     @pulumi.getter
     def status(self) -> Optional[pulumi.Input[str]]:
         """
-        Status of replication metrics. Either `Enabled` or `Disabled`.
+        The status of replication metrics. Either `Enabled` or `Disabled`.
         """
         return pulumi.get(self, "status")
 
@@ -4966,7 +4996,7 @@ if not MYPY:
         """
         status: NotRequired[pulumi.Input[str]]
         """
-        Status of RTC. Either `Enabled` or `Disabled`.
+        The status of RTC. Either `Enabled` or `Disabled`.
         """
 elif False:
     BucketReplicationConfigurationRuleDestinationReplicationTimeArgsDict: TypeAlias = Mapping[str, Any]
@@ -4978,7 +5008,7 @@ class BucketReplicationConfigurationRuleDestinationReplicationTimeArgs:
                  status: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[int] minutes: Threshold within which objects are to be replicated. The only valid value is `15`.
-        :param pulumi.Input[str] status: Status of RTC. Either `Enabled` or `Disabled`.
+        :param pulumi.Input[str] status: The status of RTC. Either `Enabled` or `Disabled`.
         """
         if minutes is not None:
             pulumi.set(__self__, "minutes", minutes)
@@ -5001,7 +5031,7 @@ class BucketReplicationConfigurationRuleDestinationReplicationTimeArgs:
     @pulumi.getter
     def status(self) -> Optional[pulumi.Input[str]]:
         """
-        Status of RTC. Either `Enabled` or `Disabled`.
+        The status of RTC. Either `Enabled` or `Disabled`.
         """
         return pulumi.get(self, "status")
 
@@ -5135,7 +5165,7 @@ if not MYPY:
     class BucketServerSideEncryptionConfigurationArgsDict(TypedDict):
         rule: pulumi.Input['BucketServerSideEncryptionConfigurationRuleArgsDict']
         """
-        Single object for server-side encryption by default configuration. (documented below)
+        A single object for server-side encryption by default configuration. (documented below)
         """
 elif False:
     BucketServerSideEncryptionConfigurationArgsDict: TypeAlias = Mapping[str, Any]
@@ -5145,7 +5175,7 @@ class BucketServerSideEncryptionConfigurationArgs:
     def __init__(__self__, *,
                  rule: pulumi.Input['BucketServerSideEncryptionConfigurationRuleArgs']):
         """
-        :param pulumi.Input['BucketServerSideEncryptionConfigurationRuleArgs'] rule: Single object for server-side encryption by default configuration. (documented below)
+        :param pulumi.Input['BucketServerSideEncryptionConfigurationRuleArgs'] rule: A single object for server-side encryption by default configuration. (documented below)
         """
         pulumi.set(__self__, "rule", rule)
 
@@ -5153,7 +5183,7 @@ class BucketServerSideEncryptionConfigurationArgs:
     @pulumi.getter
     def rule(self) -> pulumi.Input['BucketServerSideEncryptionConfigurationRuleArgs']:
         """
-        Single object for server-side encryption by default configuration. (documented below)
+        A single object for server-side encryption by default configuration. (documented below)
         """
         return pulumi.get(self, "rule")
 
@@ -5166,7 +5196,7 @@ if not MYPY:
     class BucketServerSideEncryptionConfigurationRuleArgsDict(TypedDict):
         apply_server_side_encryption_by_default: pulumi.Input['BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgsDict']
         """
-        Single object for setting server-side encryption by default. (documented below)
+        A single object for setting server-side encryption by default. (documented below)
         """
         bucket_key_enabled: NotRequired[pulumi.Input[bool]]
         """
@@ -5181,7 +5211,7 @@ class BucketServerSideEncryptionConfigurationRuleArgs:
                  apply_server_side_encryption_by_default: pulumi.Input['BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs'],
                  bucket_key_enabled: Optional[pulumi.Input[bool]] = None):
         """
-        :param pulumi.Input['BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs'] apply_server_side_encryption_by_default: Single object for setting server-side encryption by default. (documented below)
+        :param pulumi.Input['BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs'] apply_server_side_encryption_by_default: A single object for setting server-side encryption by default. (documented below)
         :param pulumi.Input[bool] bucket_key_enabled: Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
         """
         pulumi.set(__self__, "apply_server_side_encryption_by_default", apply_server_side_encryption_by_default)
@@ -5192,7 +5222,7 @@ class BucketServerSideEncryptionConfigurationRuleArgs:
     @pulumi.getter(name="applyServerSideEncryptionByDefault")
     def apply_server_side_encryption_by_default(self) -> pulumi.Input['BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs']:
         """
-        Single object for setting server-side encryption by default. (documented below)
+        A single object for setting server-side encryption by default. (documented below)
         """
         return pulumi.get(self, "apply_server_side_encryption_by_default")
 
@@ -5217,11 +5247,11 @@ if not MYPY:
     class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgsDict(TypedDict):
         sse_algorithm: pulumi.Input[str]
         """
-        Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
         """
         kms_master_key_id: NotRequired[pulumi.Input[str]]
         """
-        AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         """
 elif False:
     BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgsDict: TypeAlias = Mapping[str, Any]
@@ -5232,8 +5262,8 @@ class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefa
                  sse_algorithm: pulumi.Input[str],
                  kms_master_key_id: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] sse_algorithm: Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
-        :param pulumi.Input[str] kms_master_key_id: AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        :param pulumi.Input[str] sse_algorithm: The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        :param pulumi.Input[str] kms_master_key_id: The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         """
         pulumi.set(__self__, "sse_algorithm", sse_algorithm)
         if kms_master_key_id is not None:
@@ -5243,7 +5273,7 @@ class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefa
     @pulumi.getter(name="sseAlgorithm")
     def sse_algorithm(self) -> pulumi.Input[str]:
         """
-        Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
         """
         return pulumi.get(self, "sse_algorithm")
 
@@ -5255,7 +5285,7 @@ class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefa
     @pulumi.getter(name="kmsMasterKeyId")
     def kms_master_key_id(self) -> Optional[pulumi.Input[str]]:
         """
-        AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         """
         return pulumi.get(self, "kms_master_key_id")
 
@@ -7214,7 +7244,7 @@ if not MYPY:
     class BucketWebsiteArgsDict(TypedDict):
         error_document: NotRequired[pulumi.Input[str]]
         """
-        Absolute path to the document to return in case of a 4XX error.
+        An absolute path to the document to return in case of a 4XX error.
         """
         index_document: NotRequired[pulumi.Input[str]]
         """
@@ -7222,12 +7252,14 @@ if not MYPY:
         """
         redirect_all_requests_to: NotRequired[pulumi.Input[str]]
         """
-        Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
         """
         routing_rules: NotRequired[pulumi.Input[Union[str, Sequence[pulumi.Input[str]]]]]
         """
-        JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
         describing redirect behavior and when redirects are applied.
+
+        The `CORS` object supports the following:
         """
 elif False:
     BucketWebsiteArgsDict: TypeAlias = Mapping[str, Any]
@@ -7240,11 +7272,13 @@ class BucketWebsiteArgs:
                  redirect_all_requests_to: Optional[pulumi.Input[str]] = None,
                  routing_rules: Optional[pulumi.Input[Union[str, Sequence[pulumi.Input[str]]]]] = None):
         """
-        :param pulumi.Input[str] error_document: Absolute path to the document to return in case of a 4XX error.
+        :param pulumi.Input[str] error_document: An absolute path to the document to return in case of a 4XX error.
         :param pulumi.Input[str] index_document: Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
-        :param pulumi.Input[str] redirect_all_requests_to: Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
-        :param pulumi.Input[Union[str, Sequence[pulumi.Input[str]]]] routing_rules: JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        :param pulumi.Input[str] redirect_all_requests_to: A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        :param pulumi.Input[Union[str, Sequence[pulumi.Input[str]]]] routing_rules: A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
                describing redirect behavior and when redirects are applied.
+               
+               The `CORS` object supports the following:
         """
         if error_document is not None:
             pulumi.set(__self__, "error_document", error_document)
@@ -7259,7 +7293,7 @@ class BucketWebsiteArgs:
     @pulumi.getter(name="errorDocument")
     def error_document(self) -> Optional[pulumi.Input[str]]:
         """
-        Absolute path to the document to return in case of a 4XX error.
+        An absolute path to the document to return in case of a 4XX error.
         """
         return pulumi.get(self, "error_document")
 
@@ -7283,7 +7317,7 @@ class BucketWebsiteArgs:
     @pulumi.getter(name="redirectAllRequestsTo")
     def redirect_all_requests_to(self) -> Optional[pulumi.Input[str]]:
         """
-        Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
         """
         return pulumi.get(self, "redirect_all_requests_to")
 
@@ -7295,8 +7329,10 @@ class BucketWebsiteArgs:
     @pulumi.getter(name="routingRules")
     def routing_rules(self) -> Optional[pulumi.Input[Union[str, Sequence[pulumi.Input[str]]]]]:
         """
-        JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
         describing redirect behavior and when redirects are applied.
+
+        The `CORS` object supports the following:
         """
         return pulumi.get(self, "routing_rules")
 

--- a/sdk/python/pulumi_aws/s3/bucket.py
+++ b/sdk/python/pulumi_aws/s3/bucket.py
@@ -45,44 +45,32 @@ class BucketArgs:
                  website_endpoint: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Bucket resource.
-        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketAccelerateConfigurationV2` instead.
-        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] arn: ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
-        :param pulumi.Input[str] bucket: Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+        :param pulumi.Input[str] arn: The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        :param pulumi.Input[str] bucket: The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
         :param pulumi.Input[str] bucket_prefix: Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-        :param pulumi.Input[Sequence[pulumi.Input['BucketCorsRuleArgs']]] cors_rules: Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
-        :param pulumi.Input[bool] force_destroy: Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketGrantArgs']]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] hosted_zone_id: [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleArgs']]] lifecycle_rules: Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLifecycleConfigurationV2` instead.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketLoggingArgs']]] loggings: Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLoggingV2` instead.
-        :param pulumi.Input['BucketObjectLockConfigurationArgs'] object_lock_configuration: Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-               The provider wil only perform drift detection if a configuration value is provided.
-               Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
-        :param pulumi.Input[str] policy: Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketPolicy` instead.
-        :param pulumi.Input['BucketReplicationConfigurationArgs'] replication_configuration: Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketReplicationConfig` instead.
-        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
-               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-               See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
-        :param pulumi.Input['BucketServerSideEncryptionConfigurationArgs'] server_side_encryption_configuration: Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketCorsRuleArgs']]] cors_rules: A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+        :param pulumi.Input[bool] force_destroy: A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketGrantArgs']]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+        :param pulumi.Input[str] hosted_zone_id: The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleArgs']]] lifecycle_rules: A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+        :param pulumi.Input[Sequence[pulumi.Input['BucketLoggingArgs']]] loggings: A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+        :param pulumi.Input['BucketObjectLockConfigurationArgs'] object_lock_configuration: A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
                
-               The following arguments are deprecated, and will be removed in a future major version:
-        :param pulumi.Input['BucketVersioningArgs'] versioning: Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
-        :param pulumi.Input['BucketWebsiteArgs'] website: Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_domain: (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_endpoint: (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+               > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
+        :param pulumi.Input[str] policy: A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+        :param pulumi.Input['BucketReplicationConfigurationArgs'] replication_configuration: A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
+               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+               the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+               developer guide for more information.
+        :param pulumi.Input['BucketServerSideEncryptionConfigurationArgs'] server_side_encryption_configuration: A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input['BucketVersioningArgs'] versioning: A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+        :param pulumi.Input['BucketWebsiteArgs'] website: A website object (documented below).
+        :param pulumi.Input[str] website_domain: The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+        :param pulumi.Input[str] website_endpoint: The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         if acceleration_status is not None:
             pulumi.set(__self__, "acceleration_status", acceleration_status)
@@ -131,8 +119,7 @@ class BucketArgs:
     @pulumi.getter(name="accelerationStatus")
     def acceleration_status(self) -> Optional[pulumi.Input[str]]:
         """
-        Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+        Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
         """
         return pulumi.get(self, "acceleration_status")
 
@@ -144,7 +131,7 @@ class BucketArgs:
     @pulumi.getter
     def acl(self) -> Optional[pulumi.Input[Union[str, 'CannedAcl']]]:
         """
-        The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+        The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
         """
         return pulumi.get(self, "acl")
 
@@ -156,7 +143,7 @@ class BucketArgs:
     @pulumi.getter
     def arn(self) -> Optional[pulumi.Input[str]]:
         """
-        ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
         """
         return pulumi.get(self, "arn")
 
@@ -168,7 +155,7 @@ class BucketArgs:
     @pulumi.getter
     def bucket(self) -> Optional[pulumi.Input[str]]:
         """
-        Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+        The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
         """
         return pulumi.get(self, "bucket")
 
@@ -192,7 +179,7 @@ class BucketArgs:
     @pulumi.getter(name="corsRules")
     def cors_rules(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketCorsRuleArgs']]]]:
         """
-        Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+        A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
         """
         return pulumi.get(self, "cors_rules")
 
@@ -204,7 +191,7 @@ class BucketArgs:
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> Optional[pulumi.Input[bool]]:
         """
-        Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+        A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
         """
         return pulumi.get(self, "force_destroy")
 
@@ -216,7 +203,7 @@ class BucketArgs:
     @pulumi.getter
     def grants(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketGrantArgs']]]]:
         """
-        An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+        An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
         """
         return pulumi.get(self, "grants")
 
@@ -228,7 +215,7 @@ class BucketArgs:
     @pulumi.getter(name="hostedZoneId")
     def hosted_zone_id(self) -> Optional[pulumi.Input[str]]:
         """
-        [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
         """
         return pulumi.get(self, "hosted_zone_id")
 
@@ -240,8 +227,7 @@ class BucketArgs:
     @pulumi.getter(name="lifecycleRules")
     def lifecycle_rules(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleArgs']]]]:
         """
-        Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+        A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
         """
         return pulumi.get(self, "lifecycle_rules")
 
@@ -253,8 +239,7 @@ class BucketArgs:
     @pulumi.getter
     def loggings(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketLoggingArgs']]]]:
         """
-        Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketLoggingV2` instead.
+        A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
         """
         return pulumi.get(self, "loggings")
 
@@ -266,9 +251,9 @@ class BucketArgs:
     @pulumi.getter(name="objectLockConfiguration")
     def object_lock_configuration(self) -> Optional[pulumi.Input['BucketObjectLockConfigurationArgs']]:
         """
-        Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-        The provider wil only perform drift detection if a configuration value is provided.
-        Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+        A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+
+        > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
         """
         return pulumi.get(self, "object_lock_configuration")
 
@@ -280,9 +265,7 @@ class BucketArgs:
     @pulumi.getter
     def policy(self) -> Optional[pulumi.Input[str]]:
         """
-        Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketPolicy` instead.
+        A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
         """
         return pulumi.get(self, "policy")
 
@@ -294,8 +277,7 @@ class BucketArgs:
     @pulumi.getter(name="replicationConfiguration")
     def replication_configuration(self) -> Optional[pulumi.Input['BucketReplicationConfigurationArgs']]:
         """
-        Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketReplicationConfig` instead.
+        A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
         """
         return pulumi.get(self, "replication_configuration")
 
@@ -308,10 +290,9 @@ class BucketArgs:
     def request_payer(self) -> Optional[pulumi.Input[str]]:
         """
         Specifies who should bear the cost of Amazon S3 data transfer.
-        Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-        See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+        Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+        the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+        developer guide for more information.
         """
         return pulumi.get(self, "request_payer")
 
@@ -323,9 +304,7 @@ class BucketArgs:
     @pulumi.getter(name="serverSideEncryptionConfiguration")
     def server_side_encryption_configuration(self) -> Optional[pulumi.Input['BucketServerSideEncryptionConfigurationArgs']]:
         """
-        Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+        A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
         """
         return pulumi.get(self, "server_side_encryption_configuration")
 
@@ -337,9 +316,7 @@ class BucketArgs:
     @pulumi.getter
     def tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
-        Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-
-        The following arguments are deprecated, and will be removed in a future major version:
+        A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         return pulumi.get(self, "tags")
 
@@ -351,7 +328,7 @@ class BucketArgs:
     @pulumi.getter
     def versioning(self) -> Optional[pulumi.Input['BucketVersioningArgs']]:
         """
-        Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+        A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
         """
         return pulumi.get(self, "versioning")
 
@@ -363,8 +340,7 @@ class BucketArgs:
     @pulumi.getter
     def website(self) -> Optional[pulumi.Input['BucketWebsiteArgs']]:
         """
-        Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        A website object (documented below).
         """
         return pulumi.get(self, "website")
 
@@ -376,7 +352,7 @@ class BucketArgs:
     @pulumi.getter(name="websiteDomain")
     def website_domain(self) -> Optional[pulumi.Input[str]]:
         """
-        (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
         """
         return pulumi.get(self, "website_domain")
 
@@ -388,7 +364,7 @@ class BucketArgs:
     @pulumi.getter(name="websiteEndpoint")
     def website_endpoint(self) -> Optional[pulumi.Input[str]]:
         """
-        (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         return pulumi.get(self, "website_endpoint")
 
@@ -427,48 +403,36 @@ class _BucketState:
                  website_endpoint: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering Bucket resources.
-        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketAccelerateConfigurationV2` instead.
-        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] arn: ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
-        :param pulumi.Input[str] bucket: Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
-        :param pulumi.Input[str] bucket_domain_name: Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+        :param pulumi.Input[str] arn: The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        :param pulumi.Input[str] bucket: The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+        :param pulumi.Input[str] bucket_domain_name: The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
         :param pulumi.Input[str] bucket_prefix: Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-        :param pulumi.Input[str] bucket_regional_domain_name: The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketCorsRuleArgs']]] cors_rules: Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
-        :param pulumi.Input[bool] force_destroy: Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketGrantArgs']]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] hosted_zone_id: [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleArgs']]] lifecycle_rules: Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLifecycleConfigurationV2` instead.
-        :param pulumi.Input[Sequence[pulumi.Input['BucketLoggingArgs']]] loggings: Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLoggingV2` instead.
-        :param pulumi.Input['BucketObjectLockConfigurationArgs'] object_lock_configuration: Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-               The provider wil only perform drift detection if a configuration value is provided.
-               Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
-        :param pulumi.Input[str] policy: Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketPolicy` instead.
-        :param pulumi.Input[str] region: AWS region this bucket resides in.
-        :param pulumi.Input['BucketReplicationConfigurationArgs'] replication_configuration: Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketReplicationConfig` instead.
-        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
-               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-               See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
-        :param pulumi.Input['BucketServerSideEncryptionConfigurationArgs'] server_side_encryption_configuration: Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[str] bucket_regional_domain_name: The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketCorsRuleArgs']]] cors_rules: A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+        :param pulumi.Input[bool] force_destroy: A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketGrantArgs']]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+        :param pulumi.Input[str] hosted_zone_id: The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        :param pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleArgs']]] lifecycle_rules: A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+        :param pulumi.Input[Sequence[pulumi.Input['BucketLoggingArgs']]] loggings: A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+        :param pulumi.Input['BucketObjectLockConfigurationArgs'] object_lock_configuration: A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
                
-               The following arguments are deprecated, and will be removed in a future major version:
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags_all: Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
-        :param pulumi.Input['BucketVersioningArgs'] versioning: Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
-        :param pulumi.Input['BucketWebsiteArgs'] website: Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_domain: (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_endpoint: (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+               > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
+        :param pulumi.Input[str] policy: A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+        :param pulumi.Input[str] region: The AWS region this bucket resides in.
+        :param pulumi.Input['BucketReplicationConfigurationArgs'] replication_configuration: A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
+               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+               the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+               developer guide for more information.
+        :param pulumi.Input['BucketServerSideEncryptionConfigurationArgs'] server_side_encryption_configuration: A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags_all: A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+        :param pulumi.Input['BucketVersioningArgs'] versioning: A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+        :param pulumi.Input['BucketWebsiteArgs'] website: A website object (documented below).
+        :param pulumi.Input[str] website_domain: The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+        :param pulumi.Input[str] website_endpoint: The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         if acceleration_status is not None:
             pulumi.set(__self__, "acceleration_status", acceleration_status)
@@ -528,8 +492,7 @@ class _BucketState:
     @pulumi.getter(name="accelerationStatus")
     def acceleration_status(self) -> Optional[pulumi.Input[str]]:
         """
-        Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+        Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
         """
         return pulumi.get(self, "acceleration_status")
 
@@ -541,7 +504,7 @@ class _BucketState:
     @pulumi.getter
     def acl(self) -> Optional[pulumi.Input[Union[str, 'CannedAcl']]]:
         """
-        The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+        The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
         """
         return pulumi.get(self, "acl")
 
@@ -553,7 +516,7 @@ class _BucketState:
     @pulumi.getter
     def arn(self) -> Optional[pulumi.Input[str]]:
         """
-        ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
         """
         return pulumi.get(self, "arn")
 
@@ -565,7 +528,7 @@ class _BucketState:
     @pulumi.getter
     def bucket(self) -> Optional[pulumi.Input[str]]:
         """
-        Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+        The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
         """
         return pulumi.get(self, "bucket")
 
@@ -577,7 +540,7 @@ class _BucketState:
     @pulumi.getter(name="bucketDomainName")
     def bucket_domain_name(self) -> Optional[pulumi.Input[str]]:
         """
-        Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+        The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
         """
         return pulumi.get(self, "bucket_domain_name")
 
@@ -601,7 +564,7 @@ class _BucketState:
     @pulumi.getter(name="bucketRegionalDomainName")
     def bucket_regional_domain_name(self) -> Optional[pulumi.Input[str]]:
         """
-        The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+        The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
         """
         return pulumi.get(self, "bucket_regional_domain_name")
 
@@ -613,7 +576,7 @@ class _BucketState:
     @pulumi.getter(name="corsRules")
     def cors_rules(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketCorsRuleArgs']]]]:
         """
-        Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+        A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
         """
         return pulumi.get(self, "cors_rules")
 
@@ -625,7 +588,7 @@ class _BucketState:
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> Optional[pulumi.Input[bool]]:
         """
-        Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+        A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
         """
         return pulumi.get(self, "force_destroy")
 
@@ -637,7 +600,7 @@ class _BucketState:
     @pulumi.getter
     def grants(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketGrantArgs']]]]:
         """
-        An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+        An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
         """
         return pulumi.get(self, "grants")
 
@@ -649,7 +612,7 @@ class _BucketState:
     @pulumi.getter(name="hostedZoneId")
     def hosted_zone_id(self) -> Optional[pulumi.Input[str]]:
         """
-        [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
         """
         return pulumi.get(self, "hosted_zone_id")
 
@@ -661,8 +624,7 @@ class _BucketState:
     @pulumi.getter(name="lifecycleRules")
     def lifecycle_rules(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketLifecycleRuleArgs']]]]:
         """
-        Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+        A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
         """
         return pulumi.get(self, "lifecycle_rules")
 
@@ -674,8 +636,7 @@ class _BucketState:
     @pulumi.getter
     def loggings(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BucketLoggingArgs']]]]:
         """
-        Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketLoggingV2` instead.
+        A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
         """
         return pulumi.get(self, "loggings")
 
@@ -687,9 +648,9 @@ class _BucketState:
     @pulumi.getter(name="objectLockConfiguration")
     def object_lock_configuration(self) -> Optional[pulumi.Input['BucketObjectLockConfigurationArgs']]:
         """
-        Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-        The provider wil only perform drift detection if a configuration value is provided.
-        Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+        A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+
+        > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
         """
         return pulumi.get(self, "object_lock_configuration")
 
@@ -701,9 +662,7 @@ class _BucketState:
     @pulumi.getter
     def policy(self) -> Optional[pulumi.Input[str]]:
         """
-        Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketPolicy` instead.
+        A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
         """
         return pulumi.get(self, "policy")
 
@@ -715,7 +674,7 @@ class _BucketState:
     @pulumi.getter
     def region(self) -> Optional[pulumi.Input[str]]:
         """
-        AWS region this bucket resides in.
+        The AWS region this bucket resides in.
         """
         return pulumi.get(self, "region")
 
@@ -727,8 +686,7 @@ class _BucketState:
     @pulumi.getter(name="replicationConfiguration")
     def replication_configuration(self) -> Optional[pulumi.Input['BucketReplicationConfigurationArgs']]:
         """
-        Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketReplicationConfig` instead.
+        A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
         """
         return pulumi.get(self, "replication_configuration")
 
@@ -741,10 +699,9 @@ class _BucketState:
     def request_payer(self) -> Optional[pulumi.Input[str]]:
         """
         Specifies who should bear the cost of Amazon S3 data transfer.
-        Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-        See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+        Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+        the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+        developer guide for more information.
         """
         return pulumi.get(self, "request_payer")
 
@@ -756,9 +713,7 @@ class _BucketState:
     @pulumi.getter(name="serverSideEncryptionConfiguration")
     def server_side_encryption_configuration(self) -> Optional[pulumi.Input['BucketServerSideEncryptionConfigurationArgs']]:
         """
-        Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+        A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
         """
         return pulumi.get(self, "server_side_encryption_configuration")
 
@@ -770,9 +725,7 @@ class _BucketState:
     @pulumi.getter
     def tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
-        Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-
-        The following arguments are deprecated, and will be removed in a future major version:
+        A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         return pulumi.get(self, "tags")
 
@@ -785,7 +738,7 @@ class _BucketState:
     @_utilities.deprecated("""Please use `tags` instead.""")
     def tags_all(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
-        Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+        A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
         """
         return pulumi.get(self, "tags_all")
 
@@ -797,7 +750,7 @@ class _BucketState:
     @pulumi.getter
     def versioning(self) -> Optional[pulumi.Input['BucketVersioningArgs']]:
         """
-        Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+        A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
         """
         return pulumi.get(self, "versioning")
 
@@ -809,8 +762,7 @@ class _BucketState:
     @pulumi.getter
     def website(self) -> Optional[pulumi.Input['BucketWebsiteArgs']]:
         """
-        Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        A website object (documented below).
         """
         return pulumi.get(self, "website")
 
@@ -822,7 +774,7 @@ class _BucketState:
     @pulumi.getter(name="websiteDomain")
     def website_domain(self) -> Optional[pulumi.Input[str]]:
         """
-        (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
         """
         return pulumi.get(self, "website_domain")
 
@@ -834,7 +786,7 @@ class _BucketState:
     @pulumi.getter(name="websiteEndpoint")
     def website_endpoint(self) -> Optional[pulumi.Input[str]]:
         """
-        (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         return pulumi.get(self, "website_endpoint")
 
@@ -873,74 +825,362 @@ class Bucket(pulumi.CustomResource):
         """
         Provides a S3 bucket resource.
 
-        > This resource provides functionality for managing S3 general purpose buckets in an AWS Partition. To manage Amazon S3 Express directory buckets, use the `aws_directory_bucket` resource. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), use the `s3control.Bucket` resource.
-
-        > Object Lock can be enabled by using the `object_lock_enable` attribute or by using the `s3.BucketObjectLockConfigurationV2` resource. Please note, that by using the resource, Object Lock can be enabled/disabled without destroying and recreating the bucket.
+        > **NOTE:** Please use [aws.s3.BucketV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketv2) instead.
+        This resource is maintained for backwards compatibility only. Please see [BucketV2 Migration
+        Guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/bucketv2-migration/) for instructions on migrating
+        existing Bucket resources to BucketV2.
 
         ## Example Usage
 
-        ### Private Bucket With Tags
+        ### Private Bucket w/ Tags
 
         ```python
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.s3.BucketV2("example",
+        b = aws.s3.Bucket("b",
             bucket="my-tf-test-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
             tags={
                 "Name": "My bucket",
                 "Environment": "Dev",
             })
         ```
 
+        ### Static Website Hosting
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+        import pulumi_std as std
+
+        b = aws.s3.Bucket("b",
+            bucket="s3-website-test.mydomain.com",
+            acl=aws.s3.CannedAcl.PUBLIC_READ,
+            policy=std.file(input="policy.json").result,
+            website={
+                "index_document": "index.html",
+                "error_document": "error.html",
+                "routing_rules": \"\"\"[{
+            "Condition": {
+                "KeyPrefixEquals": "docs/"
+            },
+            "Redirect": {
+                "ReplaceKeyPrefixWith": "documents/"
+            }
+        }]
+        \"\"\",
+            })
+        ```
+
+        ### Using CORS
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        b = aws.s3.Bucket("b",
+            bucket="s3-website-test.mydomain.com",
+            acl=aws.s3.CannedAcl.PUBLIC_READ,
+            cors_rules=[{
+                "allowed_headers": ["*"],
+                "allowed_methods": [
+                    "PUT",
+                    "POST",
+                ],
+                "allowed_origins": ["https://s3-website-test.mydomain.com"],
+                "expose_headers": ["ETag"],
+                "max_age_seconds": 3000,
+            }])
+        ```
+
+        ### Using versioning
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        b = aws.s3.Bucket("b",
+            bucket="my-tf-test-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            versioning={
+                "enabled": True,
+            })
+        ```
+
+        ### Enable Logging
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        log_bucket = aws.s3.Bucket("log_bucket",
+            bucket="my-tf-log-bucket",
+            acl=aws.s3.CannedAcl.LOG_DELIVERY_WRITE)
+        b = aws.s3.Bucket("b",
+            bucket="my-tf-test-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            loggings=[{
+                "target_bucket": log_bucket.id,
+                "target_prefix": "log/",
+            }])
+        ```
+
+        ### Using object lifecycle
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        bucket = aws.s3.Bucket("bucket",
+            bucket="my-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            lifecycle_rules=[
+                {
+                    "id": "log",
+                    "enabled": True,
+                    "prefix": "log/",
+                    "tags": {
+                        "rule": "log",
+                        "autoclean": "true",
+                    },
+                    "transitions": [
+                        {
+                            "days": 30,
+                            "storage_class": "STANDARD_IA",
+                        },
+                        {
+                            "days": 60,
+                            "storage_class": "GLACIER",
+                        },
+                    ],
+                    "expiration": {
+                        "days": 90,
+                    },
+                },
+                {
+                    "id": "tmp",
+                    "prefix": "tmp/",
+                    "enabled": True,
+                    "expiration": {
+                        "date": "2016-01-12",
+                    },
+                },
+            ])
+        versioning_bucket = aws.s3.Bucket("versioning_bucket",
+            bucket="my-versioning-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            versioning={
+                "enabled": True,
+            },
+            lifecycle_rules=[{
+                "prefix": "config/",
+                "enabled": True,
+                "noncurrent_version_transitions": [
+                    {
+                        "days": 30,
+                        "storage_class": "STANDARD_IA",
+                    },
+                    {
+                        "days": 60,
+                        "storage_class": "GLACIER",
+                    },
+                ],
+                "noncurrent_version_expiration": {
+                    "days": 90,
+                },
+            }])
+        ```
+
+        ### Using replication configuration
+
+        > **NOTE:** See the `s3.BucketReplicationConfig` resource to support bi-directional replication configuration and additional features.
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        replication = aws.iam.Role("replication",
+            name="tf-iam-role-replication-12345",
+            assume_role_policy=\"\"\"{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "s3.amazonaws.com"
+              },
+              "Effect": "Allow",
+              "Sid": ""
+            }
+          ]
+        }
+        \"\"\")
+        destination = aws.s3.Bucket("destination",
+            bucket="tf-test-bucket-destination-12345",
+            versioning={
+                "enabled": True,
+            })
+        source = aws.s3.Bucket("source",
+            bucket="tf-test-bucket-source-12345",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            versioning={
+                "enabled": True,
+            },
+            replication_configuration={
+                "role": replication.arn,
+                "rules": [{
+                    "id": "foobar",
+                    "status": "Enabled",
+                    "filter": {
+                        "tags": {},
+                    },
+                    "destination": {
+                        "bucket": destination.arn,
+                        "storage_class": "STANDARD",
+                        "replication_time": {
+                            "status": "Enabled",
+                            "minutes": 15,
+                        },
+                        "metrics": {
+                            "status": "Enabled",
+                            "minutes": 15,
+                        },
+                    },
+                }],
+            })
+        replication_policy = aws.iam.Policy("replication",
+            name="tf-iam-role-policy-replication-12345",
+            policy=pulumi.Output.all(
+                sourceArn=source.arn,
+                sourceArn1=source.arn,
+                destinationArn=destination.arn
+        ).apply(lambda resolved_outputs: f\"\"\"{{
+          "Version": "2012-10-17",
+          "Statement": [
+            {{
+              "Action": [
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "{resolved_outputs['sourceArn']}"
+              ]
+            }},
+            {{
+              "Action": [
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionAcl",
+                 "s3:GetObjectVersionTagging"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "{resolved_outputs['sourceArn1']}/*"
+              ]
+            }},
+            {{
+              "Action": [
+                "s3:ReplicateObject",
+                "s3:ReplicateDelete",
+                "s3:ReplicateTags"
+              ],
+              "Effect": "Allow",
+              "Resource": "{resolved_outputs['destinationArn']}/*"
+            }}
+          ]
+        }}
+        \"\"\")
+        )
+        replication_role_policy_attachment = aws.iam.RolePolicyAttachment("replication",
+            role=replication.name,
+            policy_arn=replication_policy.arn)
+        ```
+
+        ### Enable Default Server Side Encryption
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        mykey = aws.kms.Key("mykey",
+            description="This key is used to encrypt bucket objects",
+            deletion_window_in_days=10)
+        mybucket = aws.s3.Bucket("mybucket",
+            bucket="mybucket",
+            server_side_encryption_configuration={
+                "rule": {
+                    "apply_server_side_encryption_by_default": {
+                        "kms_master_key_id": mykey.arn,
+                        "sse_algorithm": "aws:kms",
+                    },
+                },
+            })
+        ```
+
+        ### Using ACL policy grants
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        current_user = aws.s3.get_canonical_user_id()
+        bucket = aws.s3.Bucket("bucket",
+            bucket="mybucket",
+            grants=[
+                {
+                    "id": current_user.id,
+                    "type": "CanonicalUser",
+                    "permissions": ["FULL_CONTROL"],
+                },
+                {
+                    "type": "Group",
+                    "permissions": [
+                        "READ_ACP",
+                        "WRITE",
+                    ],
+                    "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                },
+            ])
+        ```
+
         ## Import
 
-        Using `pulumi import`, import S3 bucket using the `bucket`. For example:
+        S3 bucket can be imported using the `bucket`, e.g.,
 
         ```sh
         $ pulumi import aws:s3/bucket:Bucket bucket bucket-name
         ```
+        The `policy` argument is not imported and will be deprecated in a future version of the provider. Use the `aws_s3_bucket_policy` resource to manage the S3 Bucket Policy instead.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketAccelerateConfigurationV2` instead.
-        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] arn: ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
-        :param pulumi.Input[str] bucket: Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+        :param pulumi.Input[str] arn: The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        :param pulumi.Input[str] bucket: The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
         :param pulumi.Input[str] bucket_prefix: Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketCorsRuleArgs', 'BucketCorsRuleArgsDict']]]] cors_rules: Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
-        :param pulumi.Input[bool] force_destroy: Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketGrantArgs', 'BucketGrantArgsDict']]]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] hosted_zone_id: [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLifecycleRuleArgs', 'BucketLifecycleRuleArgsDict']]]] lifecycle_rules: Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLifecycleConfigurationV2` instead.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLoggingArgs', 'BucketLoggingArgsDict']]]] loggings: Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLoggingV2` instead.
-        :param pulumi.Input[Union['BucketObjectLockConfigurationArgs', 'BucketObjectLockConfigurationArgsDict']] object_lock_configuration: Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-               The provider wil only perform drift detection if a configuration value is provided.
-               Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
-        :param pulumi.Input[str] policy: Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketPolicy` instead.
-        :param pulumi.Input[Union['BucketReplicationConfigurationArgs', 'BucketReplicationConfigurationArgsDict']] replication_configuration: Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketReplicationConfig` instead.
-        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
-               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-               See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
-        :param pulumi.Input[Union['BucketServerSideEncryptionConfigurationArgs', 'BucketServerSideEncryptionConfigurationArgsDict']] server_side_encryption_configuration: Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketCorsRuleArgs', 'BucketCorsRuleArgsDict']]]] cors_rules: A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+        :param pulumi.Input[bool] force_destroy: A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketGrantArgs', 'BucketGrantArgsDict']]]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+        :param pulumi.Input[str] hosted_zone_id: The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLifecycleRuleArgs', 'BucketLifecycleRuleArgsDict']]]] lifecycle_rules: A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLoggingArgs', 'BucketLoggingArgsDict']]]] loggings: A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+        :param pulumi.Input[Union['BucketObjectLockConfigurationArgs', 'BucketObjectLockConfigurationArgsDict']] object_lock_configuration: A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
                
-               The following arguments are deprecated, and will be removed in a future major version:
-        :param pulumi.Input[Union['BucketVersioningArgs', 'BucketVersioningArgsDict']] versioning: Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
-        :param pulumi.Input[Union['BucketWebsiteArgs', 'BucketWebsiteArgsDict']] website: Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_domain: (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_endpoint: (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+               > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
+        :param pulumi.Input[str] policy: A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+        :param pulumi.Input[Union['BucketReplicationConfigurationArgs', 'BucketReplicationConfigurationArgsDict']] replication_configuration: A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
+               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+               the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+               developer guide for more information.
+        :param pulumi.Input[Union['BucketServerSideEncryptionConfigurationArgs', 'BucketServerSideEncryptionConfigurationArgsDict']] server_side_encryption_configuration: A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[Union['BucketVersioningArgs', 'BucketVersioningArgsDict']] versioning: A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+        :param pulumi.Input[Union['BucketWebsiteArgs', 'BucketWebsiteArgsDict']] website: A website object (documented below).
+        :param pulumi.Input[str] website_domain: The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+        :param pulumi.Input[str] website_endpoint: The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         ...
     @overload
@@ -951,33 +1191,333 @@ class Bucket(pulumi.CustomResource):
         """
         Provides a S3 bucket resource.
 
-        > This resource provides functionality for managing S3 general purpose buckets in an AWS Partition. To manage Amazon S3 Express directory buckets, use the `aws_directory_bucket` resource. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), use the `s3control.Bucket` resource.
-
-        > Object Lock can be enabled by using the `object_lock_enable` attribute or by using the `s3.BucketObjectLockConfigurationV2` resource. Please note, that by using the resource, Object Lock can be enabled/disabled without destroying and recreating the bucket.
+        > **NOTE:** Please use [aws.s3.BucketV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketv2) instead.
+        This resource is maintained for backwards compatibility only. Please see [BucketV2 Migration
+        Guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/bucketv2-migration/) for instructions on migrating
+        existing Bucket resources to BucketV2.
 
         ## Example Usage
 
-        ### Private Bucket With Tags
+        ### Private Bucket w/ Tags
 
         ```python
         import pulumi
         import pulumi_aws as aws
 
-        example = aws.s3.BucketV2("example",
+        b = aws.s3.Bucket("b",
             bucket="my-tf-test-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
             tags={
                 "Name": "My bucket",
                 "Environment": "Dev",
             })
         ```
 
+        ### Static Website Hosting
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+        import pulumi_std as std
+
+        b = aws.s3.Bucket("b",
+            bucket="s3-website-test.mydomain.com",
+            acl=aws.s3.CannedAcl.PUBLIC_READ,
+            policy=std.file(input="policy.json").result,
+            website={
+                "index_document": "index.html",
+                "error_document": "error.html",
+                "routing_rules": \"\"\"[{
+            "Condition": {
+                "KeyPrefixEquals": "docs/"
+            },
+            "Redirect": {
+                "ReplaceKeyPrefixWith": "documents/"
+            }
+        }]
+        \"\"\",
+            })
+        ```
+
+        ### Using CORS
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        b = aws.s3.Bucket("b",
+            bucket="s3-website-test.mydomain.com",
+            acl=aws.s3.CannedAcl.PUBLIC_READ,
+            cors_rules=[{
+                "allowed_headers": ["*"],
+                "allowed_methods": [
+                    "PUT",
+                    "POST",
+                ],
+                "allowed_origins": ["https://s3-website-test.mydomain.com"],
+                "expose_headers": ["ETag"],
+                "max_age_seconds": 3000,
+            }])
+        ```
+
+        ### Using versioning
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        b = aws.s3.Bucket("b",
+            bucket="my-tf-test-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            versioning={
+                "enabled": True,
+            })
+        ```
+
+        ### Enable Logging
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        log_bucket = aws.s3.Bucket("log_bucket",
+            bucket="my-tf-log-bucket",
+            acl=aws.s3.CannedAcl.LOG_DELIVERY_WRITE)
+        b = aws.s3.Bucket("b",
+            bucket="my-tf-test-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            loggings=[{
+                "target_bucket": log_bucket.id,
+                "target_prefix": "log/",
+            }])
+        ```
+
+        ### Using object lifecycle
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        bucket = aws.s3.Bucket("bucket",
+            bucket="my-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            lifecycle_rules=[
+                {
+                    "id": "log",
+                    "enabled": True,
+                    "prefix": "log/",
+                    "tags": {
+                        "rule": "log",
+                        "autoclean": "true",
+                    },
+                    "transitions": [
+                        {
+                            "days": 30,
+                            "storage_class": "STANDARD_IA",
+                        },
+                        {
+                            "days": 60,
+                            "storage_class": "GLACIER",
+                        },
+                    ],
+                    "expiration": {
+                        "days": 90,
+                    },
+                },
+                {
+                    "id": "tmp",
+                    "prefix": "tmp/",
+                    "enabled": True,
+                    "expiration": {
+                        "date": "2016-01-12",
+                    },
+                },
+            ])
+        versioning_bucket = aws.s3.Bucket("versioning_bucket",
+            bucket="my-versioning-bucket",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            versioning={
+                "enabled": True,
+            },
+            lifecycle_rules=[{
+                "prefix": "config/",
+                "enabled": True,
+                "noncurrent_version_transitions": [
+                    {
+                        "days": 30,
+                        "storage_class": "STANDARD_IA",
+                    },
+                    {
+                        "days": 60,
+                        "storage_class": "GLACIER",
+                    },
+                ],
+                "noncurrent_version_expiration": {
+                    "days": 90,
+                },
+            }])
+        ```
+
+        ### Using replication configuration
+
+        > **NOTE:** See the `s3.BucketReplicationConfig` resource to support bi-directional replication configuration and additional features.
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        replication = aws.iam.Role("replication",
+            name="tf-iam-role-replication-12345",
+            assume_role_policy=\"\"\"{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "s3.amazonaws.com"
+              },
+              "Effect": "Allow",
+              "Sid": ""
+            }
+          ]
+        }
+        \"\"\")
+        destination = aws.s3.Bucket("destination",
+            bucket="tf-test-bucket-destination-12345",
+            versioning={
+                "enabled": True,
+            })
+        source = aws.s3.Bucket("source",
+            bucket="tf-test-bucket-source-12345",
+            acl=aws.s3.CannedAcl.PRIVATE,
+            versioning={
+                "enabled": True,
+            },
+            replication_configuration={
+                "role": replication.arn,
+                "rules": [{
+                    "id": "foobar",
+                    "status": "Enabled",
+                    "filter": {
+                        "tags": {},
+                    },
+                    "destination": {
+                        "bucket": destination.arn,
+                        "storage_class": "STANDARD",
+                        "replication_time": {
+                            "status": "Enabled",
+                            "minutes": 15,
+                        },
+                        "metrics": {
+                            "status": "Enabled",
+                            "minutes": 15,
+                        },
+                    },
+                }],
+            })
+        replication_policy = aws.iam.Policy("replication",
+            name="tf-iam-role-policy-replication-12345",
+            policy=pulumi.Output.all(
+                sourceArn=source.arn,
+                sourceArn1=source.arn,
+                destinationArn=destination.arn
+        ).apply(lambda resolved_outputs: f\"\"\"{{
+          "Version": "2012-10-17",
+          "Statement": [
+            {{
+              "Action": [
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "{resolved_outputs['sourceArn']}"
+              ]
+            }},
+            {{
+              "Action": [
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionAcl",
+                 "s3:GetObjectVersionTagging"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "{resolved_outputs['sourceArn1']}/*"
+              ]
+            }},
+            {{
+              "Action": [
+                "s3:ReplicateObject",
+                "s3:ReplicateDelete",
+                "s3:ReplicateTags"
+              ],
+              "Effect": "Allow",
+              "Resource": "{resolved_outputs['destinationArn']}/*"
+            }}
+          ]
+        }}
+        \"\"\")
+        )
+        replication_role_policy_attachment = aws.iam.RolePolicyAttachment("replication",
+            role=replication.name,
+            policy_arn=replication_policy.arn)
+        ```
+
+        ### Enable Default Server Side Encryption
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        mykey = aws.kms.Key("mykey",
+            description="This key is used to encrypt bucket objects",
+            deletion_window_in_days=10)
+        mybucket = aws.s3.Bucket("mybucket",
+            bucket="mybucket",
+            server_side_encryption_configuration={
+                "rule": {
+                    "apply_server_side_encryption_by_default": {
+                        "kms_master_key_id": mykey.arn,
+                        "sse_algorithm": "aws:kms",
+                    },
+                },
+            })
+        ```
+
+        ### Using ACL policy grants
+
+        ```python
+        import pulumi
+        import pulumi_aws as aws
+
+        current_user = aws.s3.get_canonical_user_id()
+        bucket = aws.s3.Bucket("bucket",
+            bucket="mybucket",
+            grants=[
+                {
+                    "id": current_user.id,
+                    "type": "CanonicalUser",
+                    "permissions": ["FULL_CONTROL"],
+                },
+                {
+                    "type": "Group",
+                    "permissions": [
+                        "READ_ACP",
+                        "WRITE",
+                    ],
+                    "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                },
+            ])
+        ```
+
         ## Import
 
-        Using `pulumi import`, import S3 bucket using the `bucket`. For example:
+        S3 bucket can be imported using the `bucket`, e.g.,
 
         ```sh
         $ pulumi import aws:s3/bucket:Bucket bucket bucket-name
         ```
+        The `policy` argument is not imported and will be deprecated in a future version of the provider. Use the `aws_s3_bucket_policy` resource to manage the S3 Bucket Policy instead.
 
         :param str resource_name: The name of the resource.
         :param BucketArgs args: The arguments to use to populate this resource's properties.
@@ -1091,48 +1631,36 @@ class Bucket(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketAccelerateConfigurationV2` instead.
-        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] arn: ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
-        :param pulumi.Input[str] bucket: Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
-        :param pulumi.Input[str] bucket_domain_name: Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+        :param pulumi.Input[str] acceleration_status: Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+        :param pulumi.Input[Union[str, 'CannedAcl']] acl: The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+        :param pulumi.Input[str] arn: The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        :param pulumi.Input[str] bucket: The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+        :param pulumi.Input[str] bucket_domain_name: The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
         :param pulumi.Input[str] bucket_prefix: Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-        :param pulumi.Input[str] bucket_regional_domain_name: The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketCorsRuleArgs', 'BucketCorsRuleArgsDict']]]] cors_rules: Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
-        :param pulumi.Input[bool] force_destroy: Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketGrantArgs', 'BucketGrantArgsDict']]]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
-        :param pulumi.Input[str] hosted_zone_id: [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLifecycleRuleArgs', 'BucketLifecycleRuleArgsDict']]]] lifecycle_rules: Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLifecycleConfigurationV2` instead.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLoggingArgs', 'BucketLoggingArgsDict']]]] loggings: Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketLoggingV2` instead.
-        :param pulumi.Input[Union['BucketObjectLockConfigurationArgs', 'BucketObjectLockConfigurationArgsDict']] object_lock_configuration: Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-               The provider wil only perform drift detection if a configuration value is provided.
-               Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
-        :param pulumi.Input[str] policy: Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketPolicy` instead.
-        :param pulumi.Input[str] region: AWS region this bucket resides in.
-        :param pulumi.Input[Union['BucketReplicationConfigurationArgs', 'BucketReplicationConfigurationArgsDict']] replication_configuration: Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketReplicationConfig` instead.
-        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
-               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-               See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
-        :param pulumi.Input[Union['BucketServerSideEncryptionConfigurationArgs', 'BucketServerSideEncryptionConfigurationArgsDict']] server_side_encryption_configuration: Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-               The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[str] bucket_regional_domain_name: The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketCorsRuleArgs', 'BucketCorsRuleArgsDict']]]] cors_rules: A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+        :param pulumi.Input[bool] force_destroy: A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketGrantArgs', 'BucketGrantArgsDict']]]] grants: An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+        :param pulumi.Input[str] hosted_zone_id: The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLifecycleRuleArgs', 'BucketLifecycleRuleArgsDict']]]] lifecycle_rules: A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+        :param pulumi.Input[Sequence[pulumi.Input[Union['BucketLoggingArgs', 'BucketLoggingArgsDict']]]] loggings: A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+        :param pulumi.Input[Union['BucketObjectLockConfigurationArgs', 'BucketObjectLockConfigurationArgsDict']] object_lock_configuration: A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
                
-               The following arguments are deprecated, and will be removed in a future major version:
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags_all: Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
-        :param pulumi.Input[Union['BucketVersioningArgs', 'BucketVersioningArgsDict']] versioning: Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
-        :param pulumi.Input[Union['BucketWebsiteArgs', 'BucketWebsiteArgsDict']] website: Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-               Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_domain: (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
-        :param pulumi.Input[str] website_endpoint: (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+               > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
+        :param pulumi.Input[str] policy: A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+        :param pulumi.Input[str] region: The AWS region this bucket resides in.
+        :param pulumi.Input[Union['BucketReplicationConfigurationArgs', 'BucketReplicationConfigurationArgsDict']] replication_configuration: A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+        :param pulumi.Input[str] request_payer: Specifies who should bear the cost of Amazon S3 data transfer.
+               Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+               the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+               developer guide for more information.
+        :param pulumi.Input[Union['BucketServerSideEncryptionConfigurationArgs', 'BucketServerSideEncryptionConfigurationArgsDict']] server_side_encryption_configuration: A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags_all: A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+        :param pulumi.Input[Union['BucketVersioningArgs', 'BucketVersioningArgsDict']] versioning: A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+        :param pulumi.Input[Union['BucketWebsiteArgs', 'BucketWebsiteArgsDict']] website: A website object (documented below).
+        :param pulumi.Input[str] website_domain: The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+        :param pulumi.Input[str] website_endpoint: The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -1169,8 +1697,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="accelerationStatus")
     def acceleration_status(self) -> pulumi.Output[str]:
         """
-        Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`. Cannot be used in `cn-north-1` or `us-gov-west-1`. This provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketAccelerateConfigurationV2` instead.
+        Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
         """
         return pulumi.get(self, "acceleration_status")
 
@@ -1178,7 +1705,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def acl(self) -> pulumi.Output[Optional[str]]:
         """
-        The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+        The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
         """
         return pulumi.get(self, "acl")
 
@@ -1186,7 +1713,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def arn(self) -> pulumi.Output[str]:
         """
-        ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+        The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
         """
         return pulumi.get(self, "arn")
 
@@ -1194,7 +1721,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def bucket(self) -> pulumi.Output[str]:
         """
-        Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `s3.DirectoryBucket` resource to manage S3 Express buckets.
+        The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
         """
         return pulumi.get(self, "bucket")
 
@@ -1202,7 +1729,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="bucketDomainName")
     def bucket_domain_name(self) -> pulumi.Output[str]:
         """
-        Bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+        The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
         """
         return pulumi.get(self, "bucket_domain_name")
 
@@ -1218,7 +1745,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="bucketRegionalDomainName")
     def bucket_regional_domain_name(self) -> pulumi.Output[str]:
         """
-        The bucket region-specific domain name. The bucket domain name including the region name. Please refer to the [S3 endpoints reference](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) for format. Note: AWS CloudFront allows specifying an S3 region-specific endpoint when creating an S3 origin. This will prevent redirect issues from CloudFront to the S3 Origin URL. For more information, see the [Virtual Hosted-Style Requests for Other Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint) section in the AWS S3 User Guide.
+        The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
         """
         return pulumi.get(self, "bucket_regional_domain_name")
 
@@ -1226,7 +1753,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="corsRules")
     def cors_rules(self) -> pulumi.Output[Optional[Sequence['outputs.BucketCorsRule']]]:
         """
-        Rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html). See CORS rule below for details. This provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketCorsConfigurationV2` instead.
+        A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
         """
         return pulumi.get(self, "cors_rules")
 
@@ -1234,7 +1761,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> pulumi.Output[Optional[bool]]:
         """
-        Boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket *when the bucket is destroyed* so that the bucket can be destroyed without error. These objects are *not* recoverable. This only deletes objects when the bucket is destroyed, *not* when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `pulumi up` run before a destroy is required to update this value in the resource state. Without a successful `pulumi up` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the bucket or destroying the bucket, this flag will not work. Additionally when importing a bucket, a successful `pulumi up` is required to set this value in state before it will take effect on a destroy operation.
+        A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
         """
         return pulumi.get(self, "force_destroy")
 
@@ -1242,7 +1769,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def grants(self) -> pulumi.Output[Optional[Sequence['outputs.BucketGrant']]]:
         """
-        An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl). See Grant below for details. Conflicts with `acl`. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketAclV2` instead.
+        An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
         """
         return pulumi.get(self, "grants")
 
@@ -1250,7 +1777,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="hostedZoneId")
     def hosted_zone_id(self) -> pulumi.Output[str]:
         """
-        [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+        The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
         """
         return pulumi.get(self, "hosted_zone_id")
 
@@ -1258,8 +1785,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="lifecycleRules")
     def lifecycle_rules(self) -> pulumi.Output[Optional[Sequence['outputs.BucketLifecycleRule']]]:
         """
-        Configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html). See Lifecycle Rule below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketLifecycleConfigurationV2` instead.
+        A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
         """
         return pulumi.get(self, "lifecycle_rules")
 
@@ -1267,8 +1793,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def loggings(self) -> pulumi.Output[Optional[Sequence['outputs.BucketLogging']]]:
         """
-        Configuration of [S3 bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) parameters. See Logging below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketLoggingV2` instead.
+        A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
         """
         return pulumi.get(self, "loggings")
 
@@ -1276,9 +1801,9 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="objectLockConfiguration")
     def object_lock_configuration(self) -> pulumi.Output[Optional['outputs.BucketObjectLockConfiguration']]:
         """
-        Configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See Object Lock Configuration below for details.
-        The provider wil only perform drift detection if a configuration value is provided.
-        Use the `object_lock_enabled` parameter and the resource `s3.BucketObjectLockConfigurationV2` instead.
+        A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+
+        > **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
         """
         return pulumi.get(self, "object_lock_configuration")
 
@@ -1286,9 +1811,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def policy(self) -> pulumi.Output[Optional[str]]:
         """
-        Valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with this provider, see the AWS IAM Policy Document Guide.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketPolicy` instead.
+        A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
         """
         return pulumi.get(self, "policy")
 
@@ -1296,7 +1819,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def region(self) -> pulumi.Output[str]:
         """
-        AWS region this bucket resides in.
+        The AWS region this bucket resides in.
         """
         return pulumi.get(self, "region")
 
@@ -1304,8 +1827,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="replicationConfiguration")
     def replication_configuration(self) -> pulumi.Output[Optional['outputs.BucketReplicationConfiguration']]:
         """
-        Configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See Replication Configuration below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketReplicationConfig` instead.
+        A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
         """
         return pulumi.get(self, "replication_configuration")
 
@@ -1314,10 +1836,9 @@ class Bucket(pulumi.CustomResource):
     def request_payer(self) -> pulumi.Output[str]:
         """
         Specifies who should bear the cost of Amazon S3 data transfer.
-        Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
-        See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketRequestPaymentConfigurationV2` instead.
+        Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+        the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+        developer guide for more information.
         """
         return pulumi.get(self, "request_payer")
 
@@ -1325,9 +1846,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="serverSideEncryptionConfiguration")
     def server_side_encryption_configuration(self) -> pulumi.Output['outputs.BucketServerSideEncryptionConfiguration']:
         """
-        Configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html). See Server Side Encryption Configuration below for details.
-        The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketServerSideEncryptionConfigurationV2` instead.
+        A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
         """
         return pulumi.get(self, "server_side_encryption_configuration")
 
@@ -1335,9 +1854,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def tags(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
         """
-        Map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
-
-        The following arguments are deprecated, and will be removed in a future major version:
+        A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         return pulumi.get(self, "tags")
 
@@ -1346,7 +1863,7 @@ class Bucket(pulumi.CustomResource):
     @_utilities.deprecated("""Please use `tags` instead.""")
     def tags_all(self) -> pulumi.Output[Mapping[str, str]]:
         """
-        Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+        A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
         """
         return pulumi.get(self, "tags_all")
 
@@ -1354,7 +1871,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def versioning(self) -> pulumi.Output['outputs.BucketVersioning']:
         """
-        Configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See Versioning below for details. The provider will only perform drift detection if a configuration value is provided. Use the resource `s3.BucketVersioningV2` instead.
+        A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
         """
         return pulumi.get(self, "versioning")
 
@@ -1362,8 +1879,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter
     def website(self) -> pulumi.Output[Optional['outputs.BucketWebsite']]:
         """
-        Configuration of the [S3 bucket website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html). See Website below for details. The provider will only perform drift detection if a configuration value is provided.
-        Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        A website object (documented below).
         """
         return pulumi.get(self, "website")
 
@@ -1371,7 +1887,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="websiteDomain")
     def website_domain(self) -> pulumi.Output[str]:
         """
-        (**Deprecated**) Domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
         """
         return pulumi.get(self, "website_domain")
 
@@ -1379,7 +1895,7 @@ class Bucket(pulumi.CustomResource):
     @pulumi.getter(name="websiteEndpoint")
     def website_endpoint(self) -> pulumi.Output[str]:
         """
-        (**Deprecated**) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string. Use the resource `s3.BucketWebsiteConfigurationV2` instead.
+        The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
         """
         return pulumi.get(self, "website_endpoint")
 

--- a/sdk/python/pulumi_aws/s3/outputs.py
+++ b/sdk/python/pulumi_aws/s3/outputs.py
@@ -814,10 +814,10 @@ class BucketCorsRule(dict):
                  expose_headers: Optional[Sequence[str]] = None,
                  max_age_seconds: Optional[int] = None):
         """
-        :param Sequence[str] allowed_methods: One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
-        :param Sequence[str] allowed_origins: One or more origins you want customers to be able to access the bucket from.
-        :param Sequence[str] allowed_headers: List of headers allowed.
-        :param Sequence[str] expose_headers: One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        :param Sequence[str] allowed_methods: Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        :param Sequence[str] allowed_origins: Specifies which origins are allowed.
+        :param Sequence[str] allowed_headers: Specifies which headers are allowed.
+        :param Sequence[str] expose_headers: Specifies expose header in the response.
         :param int max_age_seconds: Specifies time in seconds that browser can cache the response for a preflight request.
         """
         pulumi.set(__self__, "allowed_methods", allowed_methods)
@@ -833,7 +833,7 @@ class BucketCorsRule(dict):
     @pulumi.getter(name="allowedMethods")
     def allowed_methods(self) -> Sequence[str]:
         """
-        One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+        Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
         """
         return pulumi.get(self, "allowed_methods")
 
@@ -841,7 +841,7 @@ class BucketCorsRule(dict):
     @pulumi.getter(name="allowedOrigins")
     def allowed_origins(self) -> Sequence[str]:
         """
-        One or more origins you want customers to be able to access the bucket from.
+        Specifies which origins are allowed.
         """
         return pulumi.get(self, "allowed_origins")
 
@@ -849,7 +849,7 @@ class BucketCorsRule(dict):
     @pulumi.getter(name="allowedHeaders")
     def allowed_headers(self) -> Optional[Sequence[str]]:
         """
-        List of headers allowed.
+        Specifies which headers are allowed.
         """
         return pulumi.get(self, "allowed_headers")
 
@@ -857,7 +857,7 @@ class BucketCorsRule(dict):
     @pulumi.getter(name="exposeHeaders")
     def expose_headers(self) -> Optional[Sequence[str]]:
         """
-        One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
+        Specifies expose header in the response.
         """
         return pulumi.get(self, "expose_headers")
 
@@ -1630,13 +1630,15 @@ class BucketLifecycleRule(dict):
         """
         :param bool enabled: Specifies lifecycle rule status.
         :param int abort_incomplete_multipart_upload_days: Specifies the number of days after initiating a multipart upload when the multipart upload must be completed.
-        :param 'BucketLifecycleRuleExpirationArgs' expiration: Specifies a period in the object's expire. See Expiration below for details.
+        :param 'BucketLifecycleRuleExpirationArgs' expiration: Specifies a period in the object's expire (documented below).
         :param str id: Unique identifier for the rule. Must be less than or equal to 255 characters in length.
-        :param 'BucketLifecycleRuleNoncurrentVersionExpirationArgs' noncurrent_version_expiration: Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
-        :param Sequence['BucketLifecycleRuleNoncurrentVersionTransitionArgs'] noncurrent_version_transitions: Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        :param 'BucketLifecycleRuleNoncurrentVersionExpirationArgs' noncurrent_version_expiration: Specifies when noncurrent object versions expire (documented below).
+        :param Sequence['BucketLifecycleRuleNoncurrentVersionTransitionArgs'] noncurrent_version_transitions: Specifies when noncurrent object versions transitions (documented below).
+               
+               At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         :param str prefix: Object key prefix identifying one or more objects to which the rule applies.
         :param Mapping[str, str] tags: Specifies object tags key and value.
-        :param Sequence['BucketLifecycleRuleTransitionArgs'] transitions: Specifies a period in the object's transitions. See Transition below for details.
+        :param Sequence['BucketLifecycleRuleTransitionArgs'] transitions: Specifies a period in the object's transitions (documented below).
         """
         pulumi.set(__self__, "enabled", enabled)
         if abort_incomplete_multipart_upload_days is not None:
@@ -1676,7 +1678,7 @@ class BucketLifecycleRule(dict):
     @pulumi.getter
     def expiration(self) -> Optional['outputs.BucketLifecycleRuleExpiration']:
         """
-        Specifies a period in the object's expire. See Expiration below for details.
+        Specifies a period in the object's expire (documented below).
         """
         return pulumi.get(self, "expiration")
 
@@ -1692,7 +1694,7 @@ class BucketLifecycleRule(dict):
     @pulumi.getter(name="noncurrentVersionExpiration")
     def noncurrent_version_expiration(self) -> Optional['outputs.BucketLifecycleRuleNoncurrentVersionExpiration']:
         """
-        Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
+        Specifies when noncurrent object versions expire (documented below).
         """
         return pulumi.get(self, "noncurrent_version_expiration")
 
@@ -1700,7 +1702,9 @@ class BucketLifecycleRule(dict):
     @pulumi.getter(name="noncurrentVersionTransitions")
     def noncurrent_version_transitions(self) -> Optional[Sequence['outputs.BucketLifecycleRuleNoncurrentVersionTransition']]:
         """
-        Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
+        Specifies when noncurrent object versions transitions (documented below).
+
+        At least one of `abort_incomplete_multipart_upload_days`, `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
         """
         return pulumi.get(self, "noncurrent_version_transitions")
 
@@ -1724,7 +1728,7 @@ class BucketLifecycleRule(dict):
     @pulumi.getter
     def transitions(self) -> Optional[Sequence['outputs.BucketLifecycleRuleTransition']]:
         """
-        Specifies a period in the object's transitions. See Transition below for details.
+        Specifies a period in the object's transitions (documented below).
         """
         return pulumi.get(self, "transitions")
 
@@ -1939,7 +1943,7 @@ class BucketLogging(dict):
                  target_bucket: str,
                  target_prefix: Optional[str] = None):
         """
-        :param str target_bucket: Name of the bucket that will receive the log objects.
+        :param str target_bucket: The name of the bucket that will receive the log objects.
         :param str target_prefix: To specify a key prefix for log objects.
         """
         pulumi.set(__self__, "target_bucket", target_bucket)
@@ -1950,7 +1954,7 @@ class BucketLogging(dict):
     @pulumi.getter(name="targetBucket")
     def target_bucket(self) -> str:
         """
-        Name of the bucket that will receive the log objects.
+        The name of the bucket that will receive the log objects.
         """
         return pulumi.get(self, "target_bucket")
 
@@ -2506,8 +2510,8 @@ class BucketObjectLockConfiguration(dict):
                  object_lock_enabled: str,
                  rule: Optional['outputs.BucketObjectLockConfigurationRule'] = None):
         """
-        :param str object_lock_enabled: Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
-        :param 'BucketObjectLockConfigurationRuleArgs' rule: Object Lock rule in place for this bucket (documented below).
+        :param str object_lock_enabled: Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
+        :param 'BucketObjectLockConfigurationRuleArgs' rule: The Object Lock rule in place for this bucket.
         """
         pulumi.set(__self__, "object_lock_enabled", object_lock_enabled)
         if rule is not None:
@@ -2517,7 +2521,7 @@ class BucketObjectLockConfiguration(dict):
     @pulumi.getter(name="objectLockEnabled")
     def object_lock_enabled(self) -> str:
         """
-        Indicates whether this bucket has an Object Lock configuration enabled. Valid values are `true` or `false`. This argument is not supported in all regions or partitions.
+        Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
         """
         return pulumi.get(self, "object_lock_enabled")
 
@@ -2525,7 +2529,7 @@ class BucketObjectLockConfiguration(dict):
     @pulumi.getter
     def rule(self) -> Optional['outputs.BucketObjectLockConfigurationRule']:
         """
-        Object Lock rule in place for this bucket (documented below).
+        The Object Lock rule in place for this bucket.
         """
         return pulumi.get(self, "rule")
 
@@ -2552,7 +2556,7 @@ class BucketObjectLockConfigurationRule(dict):
     def __init__(__self__, *,
                  default_retention: 'outputs.BucketObjectLockConfigurationRuleDefaultRetention'):
         """
-        :param 'BucketObjectLockConfigurationRuleDefaultRetentionArgs' default_retention: Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        :param 'BucketObjectLockConfigurationRuleDefaultRetentionArgs' default_retention: The default retention period that you want to apply to new objects placed in this bucket.
         """
         pulumi.set(__self__, "default_retention", default_retention)
 
@@ -2560,7 +2564,7 @@ class BucketObjectLockConfigurationRule(dict):
     @pulumi.getter(name="defaultRetention")
     def default_retention(self) -> 'outputs.BucketObjectLockConfigurationRuleDefaultRetention':
         """
-        Default retention period that you want to apply to new objects placed in this bucket (documented below).
+        The default retention period that you want to apply to new objects placed in this bucket.
         """
         return pulumi.get(self, "default_retention")
 
@@ -2572,9 +2576,15 @@ class BucketObjectLockConfigurationRuleDefaultRetention(dict):
                  days: Optional[int] = None,
                  years: Optional[int] = None):
         """
-        :param str mode: Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
-        :param int days: Number of days that you want to specify for the default retention period.
-        :param int years: Number of years that you want to specify for the default retention period.
+        :param str mode: The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        :param int days: The number of days that you want to specify for the default retention period.
+        :param int years: The number of years that you want to specify for the default retention period.
+               
+               Either `days` or `years` must be specified, but not both.
+               
+               > **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+               When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+               Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         """
         pulumi.set(__self__, "mode", mode)
         if days is not None:
@@ -2586,7 +2596,7 @@ class BucketObjectLockConfigurationRuleDefaultRetention(dict):
     @pulumi.getter
     def mode(self) -> str:
         """
-        Default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+        The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
         """
         return pulumi.get(self, "mode")
 
@@ -2594,7 +2604,7 @@ class BucketObjectLockConfigurationRuleDefaultRetention(dict):
     @pulumi.getter
     def days(self) -> Optional[int]:
         """
-        Number of days that you want to specify for the default retention period.
+        The number of days that you want to specify for the default retention period.
         """
         return pulumi.get(self, "days")
 
@@ -2602,7 +2612,13 @@ class BucketObjectLockConfigurationRuleDefaultRetention(dict):
     @pulumi.getter
     def years(self) -> Optional[int]:
         """
-        Number of years that you want to specify for the default retention period.
+        The number of years that you want to specify for the default retention period.
+
+        Either `days` or `years` must be specified, but not both.
+
+        > **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+        When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
+        Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
         """
         return pulumi.get(self, "years")
 
@@ -3442,7 +3458,7 @@ class BucketReplicationConfiguration(dict):
                  role: str,
                  rules: Sequence['outputs.BucketReplicationConfigurationRule']):
         """
-        :param str role: ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        :param str role: The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         :param Sequence['BucketReplicationConfigurationRuleArgs'] rules: Specifies the rules managing the replication (documented below).
         """
         pulumi.set(__self__, "role", role)
@@ -3452,7 +3468,7 @@ class BucketReplicationConfiguration(dict):
     @pulumi.getter
     def role(self) -> str:
         """
-        ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+        The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
         """
         return pulumi.get(self, "role")
 
@@ -3497,12 +3513,14 @@ class BucketReplicationConfigurationRule(dict):
                  source_selection_criteria: Optional['outputs.BucketReplicationConfigurationRuleSourceSelectionCriteria'] = None):
         """
         :param 'BucketReplicationConfigurationRuleDestinationArgs' destination: Specifies the destination for the rule (documented below).
-        :param str status: Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        :param str status: The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+               
+               > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         :param str delete_marker_replication_status: Whether delete markers are replicated. The only valid value is `Enabled`. To disable, omit this argument. This argument is only valid with V2 replication configurations (i.e., when `filter` is used).
         :param 'BucketReplicationConfigurationRuleFilterArgs' filter: Filter that identifies subset of objects to which the replication rule applies (documented below).
         :param str id: Unique identifier for the rule. Must be less than or equal to 255 characters in length.
         :param str prefix: Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
-        :param int priority: Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        :param int priority: The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         :param 'BucketReplicationConfigurationRuleSourceSelectionCriteriaArgs' source_selection_criteria: Specifies special object selection criteria (documented below).
         """
         pulumi.set(__self__, "destination", destination)
@@ -3532,7 +3550,9 @@ class BucketReplicationConfigurationRule(dict):
     @pulumi.getter
     def status(self) -> str:
         """
-        Status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+        The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+
+        > **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
         """
         return pulumi.get(self, "status")
 
@@ -3572,7 +3592,7 @@ class BucketReplicationConfigurationRule(dict):
     @pulumi.getter
     def priority(self) -> Optional[int]:
         """
-        Priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
+        The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
         """
         return pulumi.get(self, "priority")
 
@@ -3621,9 +3641,9 @@ class BucketReplicationConfigurationRuleDestination(dict):
                  replication_time: Optional['outputs.BucketReplicationConfigurationRuleDestinationReplicationTime'] = None,
                  storage_class: Optional[str] = None):
         """
-        :param str bucket: ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
-        :param 'BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs' access_control_translation: Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
-        :param str account_id: Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        :param str bucket: The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        :param 'BucketReplicationConfigurationRuleDestinationAccessControlTranslationArgs' access_control_translation: Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
+        :param str account_id: The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         :param 'BucketReplicationConfigurationRuleDestinationMetricsArgs' metrics: Enables replication metrics (required for S3 RTC) (documented below).
         :param str replica_kms_key_id: Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
                `sse_kms_encrypted_objects` source selection criteria.
@@ -3648,7 +3668,7 @@ class BucketReplicationConfigurationRuleDestination(dict):
     @pulumi.getter
     def bucket(self) -> str:
         """
-        ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+        The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
         """
         return pulumi.get(self, "bucket")
 
@@ -3656,7 +3676,7 @@ class BucketReplicationConfigurationRuleDestination(dict):
     @pulumi.getter(name="accessControlTranslation")
     def access_control_translation(self) -> Optional['outputs.BucketReplicationConfigurationRuleDestinationAccessControlTranslation']:
         """
-        Specifies the overrides to use for object owners on replication (documented below). Must be used in conjunction with `account_id` owner override configuration.
+        Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
         """
         return pulumi.get(self, "access_control_translation")
 
@@ -3664,7 +3684,7 @@ class BucketReplicationConfigurationRuleDestination(dict):
     @pulumi.getter(name="accountId")
     def account_id(self) -> Optional[str]:
         """
-        Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
+        The Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
         """
         return pulumi.get(self, "account_id")
 
@@ -3707,7 +3727,7 @@ class BucketReplicationConfigurationRuleDestinationAccessControlTranslation(dict
     def __init__(__self__, *,
                  owner: str):
         """
-        :param str owner: Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        :param str owner: The override value for the owner on replicated objects. Currently only `Destination` is supported.
         """
         pulumi.set(__self__, "owner", owner)
 
@@ -3715,7 +3735,7 @@ class BucketReplicationConfigurationRuleDestinationAccessControlTranslation(dict
     @pulumi.getter
     def owner(self) -> str:
         """
-        Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
+        The override value for the owner on replicated objects. Currently only `Destination` is supported.
         """
         return pulumi.get(self, "owner")
 
@@ -3727,7 +3747,7 @@ class BucketReplicationConfigurationRuleDestinationMetrics(dict):
                  status: Optional[str] = None):
         """
         :param int minutes: Threshold within which objects are to be replicated. The only valid value is `15`.
-        :param str status: Status of replication metrics. Either `Enabled` or `Disabled`.
+        :param str status: The status of replication metrics. Either `Enabled` or `Disabled`.
         """
         if minutes is not None:
             pulumi.set(__self__, "minutes", minutes)
@@ -3746,7 +3766,7 @@ class BucketReplicationConfigurationRuleDestinationMetrics(dict):
     @pulumi.getter
     def status(self) -> Optional[str]:
         """
-        Status of replication metrics. Either `Enabled` or `Disabled`.
+        The status of replication metrics. Either `Enabled` or `Disabled`.
         """
         return pulumi.get(self, "status")
 
@@ -3758,7 +3778,7 @@ class BucketReplicationConfigurationRuleDestinationReplicationTime(dict):
                  status: Optional[str] = None):
         """
         :param int minutes: Threshold within which objects are to be replicated. The only valid value is `15`.
-        :param str status: Status of RTC. Either `Enabled` or `Disabled`.
+        :param str status: The status of RTC. Either `Enabled` or `Disabled`.
         """
         if minutes is not None:
             pulumi.set(__self__, "minutes", minutes)
@@ -3777,7 +3797,7 @@ class BucketReplicationConfigurationRuleDestinationReplicationTime(dict):
     @pulumi.getter
     def status(self) -> Optional[str]:
         """
-        Status of RTC. Either `Enabled` or `Disabled`.
+        The status of RTC. Either `Enabled` or `Disabled`.
         """
         return pulumi.get(self, "status")
 
@@ -3876,7 +3896,7 @@ class BucketServerSideEncryptionConfiguration(dict):
     def __init__(__self__, *,
                  rule: 'outputs.BucketServerSideEncryptionConfigurationRule'):
         """
-        :param 'BucketServerSideEncryptionConfigurationRuleArgs' rule: Single object for server-side encryption by default configuration. (documented below)
+        :param 'BucketServerSideEncryptionConfigurationRuleArgs' rule: A single object for server-side encryption by default configuration. (documented below)
         """
         pulumi.set(__self__, "rule", rule)
 
@@ -3884,7 +3904,7 @@ class BucketServerSideEncryptionConfiguration(dict):
     @pulumi.getter
     def rule(self) -> 'outputs.BucketServerSideEncryptionConfigurationRule':
         """
-        Single object for server-side encryption by default configuration. (documented below)
+        A single object for server-side encryption by default configuration. (documented below)
         """
         return pulumi.get(self, "rule")
 
@@ -3914,7 +3934,7 @@ class BucketServerSideEncryptionConfigurationRule(dict):
                  apply_server_side_encryption_by_default: 'outputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault',
                  bucket_key_enabled: Optional[bool] = None):
         """
-        :param 'BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs' apply_server_side_encryption_by_default: Single object for setting server-side encryption by default. (documented below)
+        :param 'BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs' apply_server_side_encryption_by_default: A single object for setting server-side encryption by default. (documented below)
         :param bool bucket_key_enabled: Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
         """
         pulumi.set(__self__, "apply_server_side_encryption_by_default", apply_server_side_encryption_by_default)
@@ -3925,7 +3945,7 @@ class BucketServerSideEncryptionConfigurationRule(dict):
     @pulumi.getter(name="applyServerSideEncryptionByDefault")
     def apply_server_side_encryption_by_default(self) -> 'outputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault':
         """
-        Single object for setting server-side encryption by default. (documented below)
+        A single object for setting server-side encryption by default. (documented below)
         """
         return pulumi.get(self, "apply_server_side_encryption_by_default")
 
@@ -3963,8 +3983,8 @@ class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefa
                  sse_algorithm: str,
                  kms_master_key_id: Optional[str] = None):
         """
-        :param str sse_algorithm: Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
-        :param str kms_master_key_id: AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        :param str sse_algorithm: The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        :param str kms_master_key_id: The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         """
         pulumi.set(__self__, "sse_algorithm", sse_algorithm)
         if kms_master_key_id is not None:
@@ -3974,7 +3994,7 @@ class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefa
     @pulumi.getter(name="sseAlgorithm")
     def sse_algorithm(self) -> str:
         """
-        Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+        The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
         """
         return pulumi.get(self, "sse_algorithm")
 
@@ -3982,7 +4002,7 @@ class BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefa
     @pulumi.getter(name="kmsMasterKeyId")
     def kms_master_key_id(self) -> Optional[str]:
         """
-        AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
+        The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
         """
         return pulumi.get(self, "kms_master_key_id")
 
@@ -5530,11 +5550,13 @@ class BucketWebsite(dict):
                  redirect_all_requests_to: Optional[str] = None,
                  routing_rules: Optional[str] = None):
         """
-        :param str error_document: Absolute path to the document to return in case of a 4XX error.
+        :param str error_document: An absolute path to the document to return in case of a 4XX error.
         :param str index_document: Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
-        :param str redirect_all_requests_to: Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
-        :param Union[str, Sequence[str]] routing_rules: JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        :param str redirect_all_requests_to: A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        :param Union[str, Sequence[str]] routing_rules: A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
                describing redirect behavior and when redirects are applied.
+               
+               The `CORS` object supports the following:
         """
         if error_document is not None:
             pulumi.set(__self__, "error_document", error_document)
@@ -5549,7 +5571,7 @@ class BucketWebsite(dict):
     @pulumi.getter(name="errorDocument")
     def error_document(self) -> Optional[str]:
         """
-        Absolute path to the document to return in case of a 4XX error.
+        An absolute path to the document to return in case of a 4XX error.
         """
         return pulumi.get(self, "error_document")
 
@@ -5565,7 +5587,7 @@ class BucketWebsite(dict):
     @pulumi.getter(name="redirectAllRequestsTo")
     def redirect_all_requests_to(self) -> Optional[str]:
         """
-        Hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+        A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
         """
         return pulumi.get(self, "redirect_all_requests_to")
 
@@ -5573,8 +5595,10 @@ class BucketWebsite(dict):
     @pulumi.getter(name="routingRules")
     def routing_rules(self) -> Optional[str]:
         """
-        JSON array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+        A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
         describing redirect behavior and when redirects are applied.
+
+        The `CORS` object supports the following:
         """
         return pulumi.get(self, "routing_rules")
 


### PR DESCRIPTION
Add a note for the aws.s3.Bucket page to direct users to aws.s3.BucketV2.

Fixes https://github.com/pulumi/home/issues/3629

Fix an issue with documentation override: due to a bug `docs/resource/aws_s3_bucket_legacy.md` was not being picked up and the `aws.s3.Bucket` page was incorrectly serving docs for the `aws.s3.BucketV2` resource. This is fixed here.

This PR should not merge until https://github.com/pulumi/registry/pull/5444 gets published. 