### PR TITLE
Update gamelift patches to sdkv2

### DIFF
--- a/patches/0064-Adapt-gamelift-matchmaking-resources.patch
+++ b/patches/0064-Adapt-gamelift-matchmaking-resources.patch
@@ -3,137 +3,494 @@ From: Anton Tayanovskyy <anton@pulumi.com>
 Date: Fri, 16 Aug 2024 09:46:57 -0400
 Subject: [PATCH] Adapt gamelift matchmaking* resources
 
-Upstream continues to move away from Go SDKv2, but the matchmaking resources are maintained through patches in Pulumi
-are written against Go SDK v1. This patch is needed to preserve these resources vis upstream changes.
+Upstream has made changes that do not allow a resource to use both sdkv1
+& sdkv2 resources. This updates the gamelift resources to v2.
 
-diff --git a/internal/conns/awsclient_extra.go b/internal/conns/awsclient_extra.go
-new file mode 100644
-index 0000000000..b81d6239a7
---- /dev/null
-+++ b/internal/conns/awsclient_extra.go
-@@ -0,0 +1,14 @@
-+// Code was removed upstream but is retained for backwards-compat in the pulumi-aws provider.
-+package conns
-+
-+import (
-+	"context"
-+
-+	gamelift_sdkv1 "github.com/aws/aws-sdk-go/service/gamelift"
-+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
-+	"github.com/hashicorp/terraform-provider-aws/names"
-+)
-+
-+func (c *AWSClient) GameLiftConn(ctx context.Context) *gamelift_sdkv1.GameLift {
-+	return errs.Must(conn[*gamelift_sdkv1.GameLift](ctx, c, names.GameLift, make(map[string]any)))
-+}
 diff --git a/internal/service/gamelift/matchmaking_configuration.go b/internal/service/gamelift/matchmaking_configuration.go
-index 89ecad9db0..9138a2d741 100644
+index 89ecad9db0..4a680204d4 100644
 --- a/internal/service/gamelift/matchmaking_configuration.go
 +++ b/internal/service/gamelift/matchmaking_configuration.go
-@@ -5,8 +5,10 @@ import (
+@@ -5,17 +5,20 @@ import (
  	"log"
  	"regexp"
  
-+	types2 "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
- 	"github.com/aws/aws-sdk-go/aws"
- 	"github.com/aws/aws-sdk-go/service/gamelift"
-+	types1 "github.com/aws/aws-sdk-go/service/gamelift"
- 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/service/gamelift"
+-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/aws/aws-sdk-go-v2/aws"
++	"github.com/aws/aws-sdk-go-v2/service/gamelift"
++	awstypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
  	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
  	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-@@ -155,7 +157,7 @@ func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.Resou
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	"github.com/hashicorp/terraform-provider-aws/internal/enum"
++	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+ 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+ )
+ 
++// @SDKResource("aws_gamelift_matchmaking_configuration", name="Gamelift Matchmaking Configuration")
+ func ResourceMatchMakingConfiguration() *schema.Resource {
+ 	return &schema.Resource{
+ 		CreateWithoutTimeout: resourceMatchmakingConfigurationCreate,
+@@ -46,9 +49,9 @@ func ResourceMatchMakingConfiguration() *schema.Resource {
+ 				Computed: true,
+ 			},
+ 			"backfill_mode": {
+-				Type:         schema.TypeString,
+-				Optional:     true,
+-				ValidateFunc: validation.StringInSlice([]string{gamelift.BackfillModeAutomatic, gamelift.BackfillModeManual}, false),
++				Type:             schema.TypeString,
++				Optional:         true,
++				ValidateDiagFunc: enum.Validate[awstypes.BackfillMode](),
+ 			},
+ 			"creation_time": {
+ 				Type:     schema.TypeString,
+@@ -65,10 +68,10 @@ func ResourceMatchMakingConfiguration() *schema.Resource {
+ 				ValidateFunc: validation.StringLenBetween(1, 1024),
+ 			},
+ 			"flex_match_mode": {
+-				Type:         schema.TypeString,
+-				Optional:     true,
+-				Computed:     true,
+-				ValidateFunc: validation.StringInSlice([]string{gamelift.FlexMatchModeStandalone, gamelift.FlexMatchModeWithQueue}, false),
++				Type:             schema.TypeString,
++				Optional:         true,
++				Computed:         true,
++				ValidateDiagFunc: enum.Validate[awstypes.FlexMatchMode](),
+ 			},
+ 			"game_property": {
+ 				Type:     schema.TypeSet,
+@@ -146,26 +149,26 @@ func ResourceMatchMakingConfiguration() *schema.Resource {
+ }
+ 
+ func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+ 
+ 	input := gamelift.CreateMatchmakingConfigurationInput{
+ 		AcceptanceRequired:    aws.Bool(d.Get("acceptance_required").(bool)),
  		Name:                  aws.String(d.Get("name").(string)),
- 		RequestTimeoutSeconds: aws.Int64(int64(d.Get("request_timeout_seconds").(int))),
+-		RequestTimeoutSeconds: aws.Int64(int64(d.Get("request_timeout_seconds").(int))),
++		RequestTimeoutSeconds: aws.Int32(int32(d.Get("request_timeout_seconds").(int))),
  		RuleSetName:           aws.String(d.Get("rule_set_name").(string)),
--		Tags:                  Tags(tags.IgnoreAWS()),
-+		Tags:                  downgradeTagsToSDKv1(Tags(tags.IgnoreAWS())),
+ 		Tags:                  Tags(tags.IgnoreAWS()),
  	}
  
  	if v, ok := d.GetOk("acceptance_timeout_seconds"); ok {
-@@ -202,6 +204,7 @@ func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.Resou
+-		input.AcceptanceTimeoutSeconds = aws.Int64(int64(v.(int)))
++		input.AcceptanceTimeoutSeconds = aws.Int32(int32(v.(int)))
+ 	}
+ 	if v, ok := d.GetOk("additional_player_count"); ok {
+-		input.AdditionalPlayerCount = aws.Int64(int64(v.(int)))
++		input.AdditionalPlayerCount = aws.Int32(int32(v.(int)))
+ 	}
+ 	if v, ok := d.GetOk("backfill_mode"); ok {
+-		input.BackfillMode = aws.String(v.(string))
++		input.BackfillMode = awstypes.BackfillMode(v.(string))
+ 	}
+ 	if v, ok := d.GetOk("custom_event_data"); ok {
+ 		input.CustomEventData = aws.String(v.(string))
+@@ -174,7 +177,7 @@ func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.Resou
+ 		input.Description = aws.String(v.(string))
+ 	}
+ 	if v, ok := d.GetOk("flex_match_mode"); ok {
+-		input.FlexMatchMode = aws.String(v.(string))
++		input.FlexMatchMode = awstypes.FlexMatchMode(v.(string))
+ 	}
+ 	if v, ok := d.GetOk("game_property"); ok {
+ 		set := v.(*schema.Set)
+@@ -184,33 +187,34 @@ func resourceMatchmakingConfigurationCreate(ctx context.Context, d *schema.Resou
+ 		input.GameSessionData = aws.String(v.(string))
+ 	}
+ 	if v, ok := d.GetOk("game_session_queue_arns"); ok {
+-		input.GameSessionQueueArns = flex.ExpandStringSet(v.(*schema.Set))
++		input.GameSessionQueueArns = flex.ExpandStringValueSet(v.(*schema.Set))
+ 	}
+ 	if v, ok := d.GetOk("notification_target"); ok {
+ 		input.NotificationTarget = aws.String(v.(string))
+ 	}
+ 
+-	log.Printf("[INFO] Creating GameLift Matchmaking Configuration: %s", input)
+-	out, err := conn.CreateMatchmakingConfiguration(&input)
++	log.Printf("[INFO] Creating GameLift Matchmaking Configuration: %v", input)
++	out, err := conn.CreateMatchmakingConfiguration(ctx, &input)
+ 	if err != nil {
+ 		return diag.Errorf("error creating GameLift Matchmaking Configuration: %s", err)
+ 	}
+ 
+-	d.SetId(aws.StringValue(out.Configuration.ConfigurationArn))
++	d.SetId(aws.ToString(out.Configuration.ConfigurationArn))
+ 	return resourceMatchmakingConfigurationRead(ctx, d, meta)
+ }
  
  func resourceMatchmakingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
- 	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
-+	conn2 := meta.(*conns.AWSClient).GameLiftClient(ctx)
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
  	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
  	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
  
-@@ -249,7 +252,7 @@ func resourceMatchmakingConfigurationRead(ctx context.Context, d *schema.Resourc
- 	d.Set("rule_set_arn", configuration.RuleSetArn)
- 	d.Set("rule_set_name", configuration.RuleSetName)
- 
--	tags, err := listTags(ctx, conn, arn)
-+	tags, err := listTags(ctx, conn2, arn)
- 
+ 	log.Printf("[INFO] Describing GameLift Matchmaking Configuration: %s", d.Id())
+-	out, err := conn.DescribeMatchmakingConfigurations(&gamelift.DescribeMatchmakingConfigurationsInput{
+-		Names: aws.StringSlice([]string{d.Id()}),
++	out, err := conn.DescribeMatchmakingConfigurations(ctx, &gamelift.DescribeMatchmakingConfigurationsInput{
++		Names: []string{d.Id()},
+ 	})
  	if err != nil {
- 		return diag.Errorf("error listing tags for GameLift Matchmaking Configuration (%s): %s", arn, err)
-@@ -271,6 +274,7 @@ func resourceMatchmakingConfigurationRead(ctx context.Context, d *schema.Resourc
+-		if tfawserr.ErrStatusCodeEquals(err, 400) || tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++		if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "Configuration not found") ||
++			errs.IsA[*awstypes.NotFoundException](err) {
+ 			log.Printf("[WARN] GameLift Matchmaking Configuration (%s) not found, removing from state", d.Id())
+ 			d.SetId("")
+ 			return nil
+@@ -230,7 +234,7 @@ func resourceMatchmakingConfigurationRead(ctx context.Context, d *schema.Resourc
+ 	}
+ 	configuration := configurations[0]
+ 
+-	arn := aws.StringValue(configuration.ConfigurationArn)
++	arn := aws.ToString(configuration.ConfigurationArn)
+ 	d.Set("acceptance_required", configuration.AcceptanceRequired)
+ 	d.Set("acceptance_timeout_seconds", configuration.AcceptanceTimeoutSeconds)
+ 	d.Set("additional_player_count", configuration.AdditionalPlayerCount)
+@@ -270,25 +274,25 @@ func resourceMatchmakingConfigurationRead(ctx context.Context, d *schema.Resourc
+ }
  
  func resourceMatchmakingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
- 	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
-+	conn2 := meta.(*conns.AWSClient).GameLiftClient(ctx)
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
  
  	log.Printf("[INFO] Updating GameLift Matchmaking Configuration: %s", d.Id())
  
-@@ -325,7 +329,7 @@ func resourceMatchmakingConfigurationUpdate(ctx context.Context, d *schema.Resou
- 	if d.HasChange("tags_all") {
- 		o, n := d.GetChange("tags_all")
+ 	input := gamelift.UpdateMatchmakingConfigurationInput{
+ 		Name:                  aws.String(d.Id()),
+ 		AcceptanceRequired:    aws.Bool(d.Get("acceptance_required").(bool)),
+-		RequestTimeoutSeconds: aws.Int64(int64(d.Get("request_timeout_seconds").(int))),
++		RequestTimeoutSeconds: aws.Int32(int32(d.Get("request_timeout_seconds").(int))),
+ 		RuleSetName:           aws.String(d.Get("rule_set_name").(string)),
+ 	}
  
--		if err := updateTags(ctx, conn, arn, o, n); err != nil {
-+		if err := updateTags(ctx, conn2, arn, o, n); err != nil {
- 			return diag.Errorf("error updating GameLift Matchmaking Configuration (%s) tags: %s", arn, err)
+ 	if v, ok := d.GetOk("acceptance_timeout_seconds"); ok {
+-		input.AcceptanceTimeoutSeconds = aws.Int64(int64(v.(int)))
++		input.AcceptanceTimeoutSeconds = aws.Int32(int32(v.(int)))
+ 	}
+ 	if v, ok := d.GetOk("additional_player_count"); ok {
+-		input.AdditionalPlayerCount = aws.Int64(int64(v.(int)))
++		input.AdditionalPlayerCount = aws.Int32(int32(v.(int)))
+ 	}
+ 	if v, ok := d.GetOk("backfill_mode"); ok {
+-		input.BackfillMode = aws.String(v.(string))
++		input.BackfillMode = awstypes.BackfillMode(v.(string))
+ 	}
+ 	if v, ok := d.GetOk("custom_event_data"); ok {
+ 		input.CustomEventData = aws.String(v.(string))
+@@ -298,7 +302,7 @@ func resourceMatchmakingConfigurationUpdate(ctx context.Context, d *schema.Resou
+ 	}
+ 	if d.HasChange("flex_match_mode") {
+ 		if v, ok := d.GetOk("flex_match_mode"); ok {
+-			input.FlexMatchMode = aws.String(v.(string))
++			input.FlexMatchMode = awstypes.FlexMatchMode(v.(string))
  		}
  	}
-@@ -384,3 +388,18 @@ func expandStringList(tfList []interface{}) []*string {
+ 	if v, ok := d.GetOk("game_property"); ok {
+@@ -309,13 +313,13 @@ func resourceMatchmakingConfigurationUpdate(ctx context.Context, d *schema.Resou
+ 		input.GameSessionData = aws.String(v.(string))
+ 	}
+ 	if v, ok := d.GetOk("game_session_queue_arns"); ok {
+-		input.GameSessionQueueArns = flex.ExpandStringSet(v.(*schema.Set))
++		input.GameSessionQueueArns = flex.ExpandStringValueSet(v.(*schema.Set))
+ 	}
+ 	if v, ok := d.GetOk("notification_target"); ok {
+ 		input.NotificationTarget = aws.String(v.(string))
+ 	}
  
- 	return result
+-	_, err := conn.UpdateMatchmakingConfiguration(&input)
++	_, err := conn.UpdateMatchmakingConfiguration(ctx, &input)
+ 	if err != nil {
+ 		return diag.Errorf("error updating Gamelift Matchmaking Configuration (%s): %s", d.Id(), err)
+ 	}
+@@ -334,12 +338,13 @@ func resourceMatchmakingConfigurationUpdate(ctx context.Context, d *schema.Resou
  }
-+
-+func downgradeTagsToSDKv1(tags []types2.Tag) []*types1.Tag {
-+	res := []*types1.Tag{}
-+	for _, t := range tags {
-+		res = append(res, downgradeTagToSDKv1(t))
-+	}
-+	return res
-+}
-+
-+func downgradeTagToSDKv1(tag types2.Tag) *types1.Tag {
-+	return &types1.Tag{
-+		Key:   tag.Key,
-+		Value: tag.Value,
-+	}
-+}
+ 
+ func resourceMatchmakingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
+ 	log.Printf("[INFO] Deleting GameLift Matchmaking Configuration: %s", d.Id())
+-	_, err := conn.DeleteMatchmakingConfiguration(&gamelift.DeleteMatchmakingConfigurationInput{
++	_, err := conn.DeleteMatchmakingConfiguration(ctx, &gamelift.DeleteMatchmakingConfigurationInput{
+ 		Name: aws.String(d.Id()),
+ 	})
+-	if tfawserr.ErrStatusCodeEquals(err, 400) || tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++	if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "Configuration not found") ||
++		errs.IsA[*awstypes.NotFoundException](err) {
+ 		return nil
+ 	}
+ 	if err != nil {
+@@ -349,11 +354,11 @@ func resourceMatchmakingConfigurationDelete(ctx context.Context, d *schema.Resou
+ 	return nil
+ }
+ 
+-func expandGameliftGameProperties(cfg []interface{}) []*gamelift.GameProperty {
+-	properties := make([]*gamelift.GameProperty, len(cfg))
++func expandGameliftGameProperties(cfg []interface{}) []awstypes.GameProperty {
++	properties := make([]awstypes.GameProperty, len(cfg))
+ 	for i, property := range cfg {
+ 		prop := property.(map[string]interface{})
+-		properties[i] = &gamelift.GameProperty{
++		properties[i] = awstypes.GameProperty{
+ 			Key:   aws.String(prop["key"].(string)),
+ 			Value: aws.String(prop["value"].(string)),
+ 		}
+@@ -361,7 +366,7 @@ func expandGameliftGameProperties(cfg []interface{}) []*gamelift.GameProperty {
+ 	return properties
+ }
+ 
+-func flattenGameliftGameProperties(awsProperties []*gamelift.GameProperty) []interface{} {
++func flattenGameliftGameProperties(awsProperties []awstypes.GameProperty) []interface{} {
+ 	properties := []interface{}{}
+ 	for _, awsProperty := range awsProperties {
+ 		property := map[string]string{
+diff --git a/internal/service/gamelift/matchmaking_configuration_test.go b/internal/service/gamelift/matchmaking_configuration_test.go
+index 6453fa75a0..480b62b36b 100644
+--- a/internal/service/gamelift/matchmaking_configuration_test.go
++++ b/internal/service/gamelift/matchmaking_configuration_test.go
+@@ -6,8 +6,8 @@ import (
+ 	"regexp"
+ 	"testing"
+ 
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/service/gamelift"
++	"github.com/aws/aws-sdk-go-v2/service/gamelift"
++	awstypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+ 
+ 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+ 
+@@ -16,12 +16,13 @@ import (
+ 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+ 	tfgamelift "github.com/hashicorp/terraform-provider-aws/internal/service/gamelift"
++	"github.com/hashicorp/terraform-provider-aws/names"
+ )
+ 
+ func TestAccMatchmakingConfiguration_basic(t *testing.T) {
+ 
+ 	ctx := acctest.Context(t)
+-	var conf gamelift.MatchmakingConfiguration
++	var conf awstypes.MatchmakingConfiguration
+ 
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_gamelift_matchmaking_configuration.test"
+@@ -33,10 +34,10 @@ func TestAccMatchmakingConfiguration_basic(t *testing.T) {
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck: func() {
+ 			acctest.PreCheck(ctx, t)
+-			acctest.PreCheckPartitionHasService(t, gamelift.EndpointsID)
++			acctest.PreCheckPartitionHasService(t, names.GameLiftEndpointID)
+ 			testAccPreCheck(ctx, t)
+ 		},
+-		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ErrorCheck:               acctest.ErrorCheck(t, names.GameLiftEndpointID),
+ 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+ 		CheckDestroy:             testAccCheckGameServerGroupDestroy(ctx),
+ 		Steps: []resource.TestStep{
+@@ -51,7 +52,7 @@ func TestAccMatchmakingConfiguration_basic(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "game_session_data", "game_session_data"),
+ 					resource.TestCheckResourceAttr(resourceName, "acceptance_required", "false"),
+ 					resource.TestCheckResourceAttr(resourceName, "request_timeout_seconds", "10"),
+-					resource.TestCheckResourceAttr(resourceName, "backfill_mode", gamelift.BackfillModeManual),
++					resource.TestCheckResourceAttr(resourceName, "backfill_mode", string(awstypes.BackfillModeManual)),
+ 				),
+ 			},
+ 			{
+@@ -66,7 +67,7 @@ func TestAccMatchmakingConfiguration_basic(t *testing.T) {
+ func TestAccMatchmakingConfiguration_tags(t *testing.T) {
+ 
+ 	ctx := acctest.Context(t)
+-	var conf gamelift.MatchmakingConfiguration
++	var conf awstypes.MatchmakingConfiguration
+ 
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_gamelift_matchmaking_configuration.test"
+@@ -78,10 +79,10 @@ func TestAccMatchmakingConfiguration_tags(t *testing.T) {
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck: func() {
+ 			acctest.PreCheck(ctx, t)
+-			acctest.PreCheckPartitionHasService(t, gamelift.EndpointsID)
++			acctest.PreCheckPartitionHasService(t, names.GameLiftEndpointID)
+ 			testAccPreCheck(ctx, t)
+ 		},
+-		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ErrorCheck:               acctest.ErrorCheck(t, names.GameLiftEndpointID),
+ 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+ 		CheckDestroy:             testAccCheckGameServerGroupDestroy(ctx),
+ 		Steps: []resource.TestStep{
+@@ -97,7 +98,7 @@ func TestAccMatchmakingConfiguration_tags(t *testing.T) {
+ 					resource.TestCheckResourceAttr(resourceName, "game_session_data", "game_session_data"),
+ 					resource.TestCheckResourceAttr(resourceName, "acceptance_required", "false"),
+ 					resource.TestCheckResourceAttr(resourceName, "request_timeout_seconds", "10"),
+-					resource.TestCheckResourceAttr(resourceName, "backfill_mode", gamelift.BackfillModeManual),
++					resource.TestCheckResourceAttr(resourceName, "backfill_mode", string(awstypes.BackfillModeManual)),
+ 				),
+ 			},
+ 			{
+@@ -112,7 +113,7 @@ func TestAccMatchmakingConfiguration_tags(t *testing.T) {
+ func TestAccMatchmakingConfiguration_disappears(t *testing.T) {
+ 
+ 	ctx := acctest.Context(t)
+-	var conf gamelift.MatchmakingConfiguration
++	var conf awstypes.MatchmakingConfiguration
+ 
+ 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_gamelift_matchmaking_configuration.test"
+@@ -124,10 +125,10 @@ func TestAccMatchmakingConfiguration_disappears(t *testing.T) {
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck: func() {
+ 			acctest.PreCheck(ctx, t)
+-			acctest.PreCheckPartitionHasService(t, gamelift.EndpointsID)
++			acctest.PreCheckPartitionHasService(t, names.GameLiftEndpointID)
+ 			testAccPreCheck(ctx, t)
+ 		},
+-		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ErrorCheck:               acctest.ErrorCheck(t, names.GameLiftEndpointID),
+ 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+ 		CheckDestroy:             testAccCheckGameServerGroupDestroy(ctx),
+ 		Steps: []resource.TestStep{
+@@ -143,7 +144,7 @@ func TestAccMatchmakingConfiguration_disappears(t *testing.T) {
+ 	})
+ }
+ 
+-func testAccCheckMatchmakingConfigurationExists(ctx context.Context, n string, res *gamelift.MatchmakingConfiguration) resource.TestCheckFunc {
++func testAccCheckMatchmakingConfigurationExists(ctx context.Context, n string, res *awstypes.MatchmakingConfiguration) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+ 
+ 		rs, ok := s.RootModule().Resources[n]
+@@ -155,11 +156,11 @@ func testAccCheckMatchmakingConfigurationExists(ctx context.Context, n string, r
+ 			return fmt.Errorf("no Gamelift Matchmaking Configuration Name is set")
+ 		}
+ 
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn(ctx)
++		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftClient(ctx)
+ 
+ 		name := rs.Primary.Attributes["name"]
+-		out, err := conn.DescribeMatchmakingConfigurationsWithContext(ctx, &gamelift.DescribeMatchmakingConfigurationsInput{
+-			Names: aws.StringSlice([]string{name}),
++		out, err := conn.DescribeMatchmakingConfigurations(ctx, &gamelift.DescribeMatchmakingConfigurationsInput{
++			Names: []string{name},
+ 		})
+ 
+ 		if err != nil {
+@@ -169,7 +170,7 @@ func testAccCheckMatchmakingConfigurationExists(ctx context.Context, n string, r
+ 		if len(configurations) == 0 {
+ 			return fmt.Errorf("GameLift Matchmaking Configuration %q not found", name)
+ 		}
+-		*res = *configurations[0]
++		*res = configurations[0]
+ 
+ 		return nil
+ 	}
+@@ -189,7 +190,7 @@ func testAccAWSGameliftMatchMakingConfigurationRuleSetBody() string {
+ }
+ 
+ func testAccGameServerMatchmakingConfiguration_basic(rName string, queueName string, ruleSetName string, additionalParameters string, requestTimeoutSeconds int) string {
+-	backfillMode := gamelift.BackfillModeManual
++	backfillMode := awstypes.BackfillModeManual
+ 	return fmt.Sprintf(`
+ resource "aws_gamelift_game_session_queue" "test" {
+ 	name         = %[2]q
+@@ -230,7 +231,7 @@ resource "aws_gamelift_matchmaking_configuration" "test" {
+ }
+ 
+ func testAccGameServerMatchmakingConfiguration_tags(rName string, queueName string, ruleSetName string, additionalParameters string, requestTimeoutSeconds int) string {
+-	backfillMode := gamelift.BackfillModeManual
++	backfillMode := awstypes.BackfillModeManual
+ 	return fmt.Sprintf(`
+ resource "aws_gamelift_game_session_queue" "test" {
+ 	name         = %[2]q
 diff --git a/internal/service/gamelift/matchmaking_rule_set.go b/internal/service/gamelift/matchmaking_rule_set.go
-index d9f2424b7a..3e2b08ed08 100644
+index d9f2424b7a..edfcb269a7 100644
 --- a/internal/service/gamelift/matchmaking_rule_set.go
 +++ b/internal/service/gamelift/matchmaking_rule_set.go
-@@ -65,7 +65,7 @@ func resourceMatchmakingRuleSetCreate(ctx context.Context, d *schema.ResourceDat
- 	input := gamelift.CreateMatchmakingRuleSetInput{
- 		Name:        aws.String(d.Get("name").(string)),
+@@ -4,18 +4,20 @@ import (
+ 	"context"
+ 	"log"
+ 
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/service/gamelift"
+-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
++	"github.com/aws/aws-sdk-go-v2/aws"
++	"github.com/aws/aws-sdk-go-v2/service/gamelift"
++	awstypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+ 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+ )
+ 
++// @SDKResource("aws_gamelift_matchmaking_rule_set", name="Gamelift Matchmaking Rule Set")
+ func ResourceMatchmakingRuleSet() *schema.Resource {
+ 	return &schema.Resource{
+ 		CreateWithoutTimeout: resourceMatchmakingRuleSetCreate,
+@@ -58,7 +60,7 @@ func ResourceMatchmakingRuleSet() *schema.Resource {
+ }
+ 
+ func resourceMatchmakingRuleSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
+ 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+ 	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+ 
+@@ -67,27 +69,28 @@ func resourceMatchmakingRuleSetCreate(ctx context.Context, d *schema.ResourceDat
  		RuleSetBody: aws.String(d.Get("rule_set_body").(string)),
--		Tags:        Tags(tags.IgnoreAWS()),
-+		Tags:        downgradeTagsToSDKv1(Tags(tags.IgnoreAWS())),
+ 		Tags:        Tags(tags.IgnoreAWS()),
  	}
- 	log.Printf("[INFO] Creating GameLift Matchmaking Rule Set: %s", input)
- 	out, err := conn.CreateMatchmakingRuleSet(&input)
-@@ -80,6 +80,7 @@ func resourceMatchmakingRuleSetCreate(ctx context.Context, d *schema.ResourceDat
+-	log.Printf("[INFO] Creating GameLift Matchmaking Rule Set: %s", input)
+-	out, err := conn.CreateMatchmakingRuleSet(&input)
++	log.Printf("[INFO] Creating GameLift Matchmaking Rule Set: %v", input)
++	out, err := conn.CreateMatchmakingRuleSet(ctx, &input)
+ 	if err != nil {
+ 		return diag.Errorf("error creating GameLift Matchmaking Rule Set: %s", err)
+ 	}
+ 
+-	d.SetId(aws.StringValue(out.RuleSet.RuleSetName))
++	d.SetId(aws.ToString(out.RuleSet.RuleSetName))
+ 
+ 	return resourceMatchmakingRuleSetRead(ctx, d, meta)
+ }
  
  func resourceMatchmakingRuleSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
- 	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
-+	conn2 := meta.(*conns.AWSClient).GameLiftClient(ctx)
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
  	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
  
  	log.Printf("[INFO] Describing GameLift Matchmaking Rule Set: %s", d.Id())
-@@ -112,7 +113,7 @@ func resourceMatchmakingRuleSetRead(ctx context.Context, d *schema.ResourceData,
+-	out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{
+-		Names: aws.StringSlice([]string{d.Id()}),
++	out, err := conn.DescribeMatchmakingRuleSets(ctx, &gamelift.DescribeMatchmakingRuleSetsInput{
++		Names: []string{d.Id()},
+ 	})
+ 	if err != nil {
+-		if tfawserr.ErrStatusCodeEquals(err, 400) || tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++		if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "Failed to find rule set") ||
++			errs.IsA[*awstypes.NotFoundException](err) {
+ 			log.Printf("[WARN] GameLift Matchmaking Rule Set (%s) not found, removing from state", d.Id())
+ 			d.SetId("")
+ 			return nil
+@@ -107,7 +110,7 @@ func resourceMatchmakingRuleSetRead(ctx context.Context, d *schema.ResourceData,
+ 	}
+ 	ruleSet := ruleSets[0]
+ 
+-	arn := aws.StringValue(ruleSet.RuleSetArn)
++	arn := aws.ToString(ruleSet.RuleSetArn)
+ 	d.Set("arn", arn)
  	d.Set("name", ruleSet.RuleSetName)
  	d.Set("rule_set_body", ruleSet.RuleSetBody)
- 
--	tags, err := listTags(ctx, conn, arn)
-+	tags, err := listTags(ctx, conn2, arn)
- 
- 	if err != nil {
- 		return diag.Errorf("error listing tags for GameLift Matchmaking Rule Set (%s): %s", arn, err)
-@@ -130,7 +131,7 @@ func resourceMatchmakingRuleSetRead(ctx context.Context, d *schema.ResourceData,
+@@ -130,7 +133,7 @@ func resourceMatchmakingRuleSetRead(ctx context.Context, d *schema.ResourceData,
  }
  
  func resourceMatchmakingRuleSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -142,107 +499,120 @@ index d9f2424b7a..3e2b08ed08 100644
  
  	log.Printf("[INFO] Updating GameLift Matchmaking Rule Set: %s", d.Id())
  
-diff --git a/internal/service/gamelift/service_package_extra.go b/internal/service/gamelift/service_package_extra.go
-new file mode 100644
-index 0000000000..dc4c9b2230
---- /dev/null
-+++ b/internal/service/gamelift/service_package_extra.go
-@@ -0,0 +1,95 @@
-+package gamelift
-+
-+import (
-+	"context"
-+	"fmt"
-+	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-+	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
-+	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-+	gamelift_sdkv1 "github.com/aws/aws-sdk-go/service/gamelift"
-+	"github.com/hashicorp/terraform-plugin-log/tflog"
-+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+@@ -147,12 +150,13 @@ func resourceMatchmakingRuleSetUpdate(ctx context.Context, d *schema.ResourceDat
+ }
+ 
+ func resourceMatchmakingRuleSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+-	conn := meta.(*conns.AWSClient).GameLiftConn(ctx)
++	conn := meta.(*conns.AWSClient).GameLiftClient(ctx)
+ 	log.Printf("[INFO] Deleting GameLift Matchmaking Rule Set: %s", d.Id())
+-	_, err := conn.DeleteMatchmakingRuleSet(&gamelift.DeleteMatchmakingRuleSetInput{
++	_, err := conn.DeleteMatchmakingRuleSet(ctx, &gamelift.DeleteMatchmakingRuleSetInput{
+ 		Name: aws.String(d.Id()),
+ 	})
+-	if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
++	if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "Failed to find rule set") ||
++		errs.IsA[*awstypes.NotFoundException](err) {
+ 		return nil
+ 	}
+ 	if err != nil {
+diff --git a/internal/service/gamelift/matchmaking_rule_set_test.go b/internal/service/gamelift/matchmaking_rule_set_test.go
+index 4295987ae6..377b46816e 100644
+--- a/internal/service/gamelift/matchmaking_rule_set_test.go
++++ b/internal/service/gamelift/matchmaking_rule_set_test.go
+@@ -6,20 +6,21 @@ import (
+ 	"regexp"
+ 	"testing"
+ 
+-	"github.com/aws/aws-sdk-go/aws"
+-	"github.com/aws/aws-sdk-go/service/gamelift"
++	"github.com/aws/aws-sdk-go-v2/service/gamelift"
++	awstypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+ 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+ 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+ 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+ 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+ 	tfgamelift "github.com/hashicorp/terraform-provider-aws/internal/service/gamelift"
 +	"github.com/hashicorp/terraform-provider-aws/names"
-+	"net"
-+	"net/url"
-+)
-+
-+// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-+func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*gamelift_sdkv1.GameLift, error) {
-+	sess := config[names.AttrSession].(*session_sdkv1.Session)
-+
-+	cfg := aws_sdkv1.Config{}
-+
-+	if endpoint := config[names.AttrEndpoint].(string); endpoint != "" {
-+		tflog.Debug(ctx, "setting endpoint", map[string]any{
-+			"tf_aws.endpoint": endpoint,
-+		})
-+		cfg.Endpoint = aws_sdkv1.String(endpoint)
-+	} else {
-+		cfg.EndpointResolver = newEndpointResolverSDKv1(ctx)
-+	}
-+
-+	return gamelift_sdkv1.New(sess.Copy(&cfg)), nil
-+}
-+
-+var _ endpoints_sdkv1.Resolver = resolverSDKv1{}
-+
-+type resolverSDKv1 struct {
-+	ctx context.Context
-+}
-+
-+func newEndpointResolverSDKv1(ctx context.Context) resolverSDKv1 {
-+	return resolverSDKv1{
-+		ctx: ctx,
-+	}
-+}
-+
-+func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoints_sdkv1.Options)) (endpoint endpoints_sdkv1.ResolvedEndpoint, err error) {
-+	ctx := r.ctx
-+
-+	var opt endpoints_sdkv1.Options
-+	opt.Set(opts...)
-+
-+	useFIPS := opt.UseFIPSEndpoint == endpoints_sdkv1.FIPSEndpointStateEnabled
-+
-+	defaultResolver := endpoints_sdkv1.DefaultResolver()
-+
-+	if useFIPS {
-+		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
-+
-+		endpoint, err = defaultResolver.EndpointFor(service, region, opts...)
-+		if err != nil {
-+			return endpoint, err
-+		}
-+
-+		tflog.Debug(ctx, "endpoint resolved", map[string]any{
-+			"tf_aws.endpoint": endpoint.URL,
-+		})
-+
-+		var endpointURL *url.URL
-+		endpointURL, err = url.Parse(endpoint.URL)
-+		if err != nil {
-+			return endpoint, err
-+		}
-+
-+		hostname := endpointURL.Hostname()
-+		_, err = net.LookupHost(hostname)
-+		if err != nil {
-+			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
-+				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
-+					"tf_aws.hostname": hostname,
-+				})
-+				opts = append(opts, func(o *endpoints_sdkv1.Options) {
-+					o.UseFIPSEndpoint = endpoints_sdkv1.FIPSEndpointStateDisabled
-+				})
-+			} else {
-+				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
-+				return
-+			}
-+		} else {
-+			return endpoint, err
-+		}
-+	}
-+
-+	return defaultResolver.EndpointFor(service, region, opts...)
-+}
+ )
+ 
+ func TestAccMatchmakingRuleSet_basic(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 
+-	var conf gamelift.MatchmakingRuleSet
++	var conf awstypes.MatchmakingRuleSet
+ 
+ 	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_gamelift_matchmaking_rule_set.test"
+@@ -28,10 +29,10 @@ func TestAccMatchmakingRuleSet_basic(t *testing.T) {
+ 	resource.Test(t, resource.TestCase{
+ 		PreCheck: func() {
+ 			acctest.PreCheck(ctx, t)
+-			acctest.PreCheckPartitionHasService(t, gamelift.EndpointsID)
++			acctest.PreCheckPartitionHasService(t, names.GameLiftEndpointID)
+ 			testAccPreCheck(ctx, t)
+ 		},
+-		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ErrorCheck:               acctest.ErrorCheck(t, names.GameLiftEndpointID),
+ 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+ 		CheckDestroy:             testAccCheckGameServerGroupDestroy(ctx),
+ 		Steps: []resource.TestStep{
+@@ -57,7 +58,7 @@ func TestAccMatchmakingRuleSet_basic(t *testing.T) {
+ func TestAccMatchmakingRuleSet_disappears(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 
+-	var conf gamelift.MatchmakingRuleSet
++	var conf awstypes.MatchmakingRuleSet
+ 
+ 	ruleSetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+ 	resourceName := "aws_gamelift_matchmaking_rule_set.test"
+@@ -66,10 +67,10 @@ func TestAccMatchmakingRuleSet_disappears(t *testing.T) {
+ 	resource.ParallelTest(t, resource.TestCase{
+ 		PreCheck: func() {
+ 			acctest.PreCheck(ctx, t)
+-			acctest.PreCheckPartitionHasService(t, gamelift.EndpointsID)
++			acctest.PreCheckPartitionHasService(t, names.GameLiftEndpointID)
+ 			testAccPreCheck(ctx, t)
+ 		},
+-		ErrorCheck:               acctest.ErrorCheck(t, gamelift.EndpointsID),
++		ErrorCheck:               acctest.ErrorCheck(t, names.GameLiftEndpointID),
+ 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+ 		CheckDestroy:             testAccCheckGameServerGroupDestroy(ctx),
+ 		Steps: []resource.TestStep{
+@@ -85,7 +86,7 @@ func TestAccMatchmakingRuleSet_disappears(t *testing.T) {
+ 	})
+ }
+ 
+-func testAccCheckMatchmakingRuleSetExists(ctx context.Context, n string, res *gamelift.MatchmakingRuleSet) resource.TestCheckFunc {
++func testAccCheckMatchmakingRuleSetExists(ctx context.Context, n string, res *awstypes.MatchmakingRuleSet) resource.TestCheckFunc {
+ 	return func(s *terraform.State) error {
+ 		rs, ok := s.RootModule().Resources[n]
+ 
+@@ -97,11 +98,11 @@ func testAccCheckMatchmakingRuleSetExists(ctx context.Context, n string, res *ga
+ 			return fmt.Errorf("no Gamelift Matchmaking Rule Set Name is set")
+ 		}
+ 
+-		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn(ctx)
++		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftClient(ctx)
+ 
+ 		name := rs.Primary.Attributes["name"]
+-		out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{
+-			Names: aws.StringSlice([]string{name}),
++		out, err := conn.DescribeMatchmakingRuleSets(ctx, &gamelift.DescribeMatchmakingRuleSetsInput{
++			Names: []string{name},
+ 		})
+ 		if err != nil {
+ 			return err
+@@ -111,7 +112,7 @@ func testAccCheckMatchmakingRuleSetExists(ctx context.Context, n string, res *ga
+ 			return fmt.Errorf("GameLift Matchmaking Rule Set %q not found", name)
+ 		}
+ 
+-		*res = *ruleSets[0]
++		*res = ruleSets[0]
+ 
+ 		return nil
+ 	}
 diff --git a/names/data/names_data.hcl b/names/data/names_data.hcl
 index 5e39e18d5b..7e52012afc 100644
 --- a/names/data/names_data.hcl


### PR DESCRIPTION
Upstream [recently made a change](https://github.com/hashicorp/terraform-provider-aws/pull/39324)
so that a service cannot have resources across both sdkv1 and sdkv2.

This PR updates the `aws_gamelift_matchmaking_configuration` &
`aws_gamelift_matchmaking_rule_set` resources to sdkv2.

```console
$ make testacc TESTS=TestAccMatchmakingConfiguration PKG=gamelift
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/gamelift/... -v -count 1 -parallel 20 -run='TestAccMatchmakingConfiguration'  -timeout 360m
=== RUN   TestAccMatchmakingConfiguration_basic
=== PAUSE TestAccMatchmakingConfiguration_basic
=== RUN   TestAccMatchmakingConfiguration_tags
=== PAUSE TestAccMatchmakingConfiguration_tags
=== RUN   TestAccMatchmakingConfiguration_disappears
=== PAUSE TestAccMatchmakingConfiguration_disappears
=== CONT  TestAccMatchmakingConfiguration_basic
=== CONT  TestAccMatchmakingConfiguration_disappears
=== CONT  TestAccMatchmakingConfiguration_tags
--- PASS: TestAccMatchmakingConfiguration_disappears (12.48s)
--- PASS: TestAccMatchmakingConfiguration_tags (19.75s)
--- PASS: TestAccMatchmakingConfiguration_basic (27.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   31.040s
```

```console
$ make testacc TESTS=TestAccMatchmakingRuleSet PKG=gamelift
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/gamelift/... -v -count 1 -parallel 20 -run='TestAccMatchmakingRuleSet'  -timeout 360m
=== RUN   TestAccMatchmakingRuleSet_basic
--- PASS: TestAccMatchmakingRuleSet_basic (12.93s)
=== RUN   TestAccMatchmakingRuleSet_disappears
=== PAUSE TestAccMatchmakingRuleSet_disappears
=== CONT  TestAccMatchmakingRuleSet_disappears
--- PASS: TestAccMatchmakingRuleSet_disappears (10.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   27.193s
```

re #4479