### PR TITLE
make ci-mgmt

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -404,7 +404,7 @@ jobs:
             uses: actions/setup-go@v5
             with:
               cache: false
-              go-version: 1.22.x
+              go-version: 1.23.x
           - name: Make upstream
             run: make upstream
           - name: upstream lint

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -347,7 +347,7 @@ jobs:
             uses: actions/setup-go@v5
             with:
               cache: false
-              go-version: 1.22.x
+              go-version: 1.23.x
           - name: Make upstream
             run: make upstream
           - name: upstream lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,7 +352,7 @@ jobs:
             uses: actions/setup-go@v5
             with:
               cache: false
-              go-version: 1.22.x
+              go-version: 1.23.x
           - name: Make upstream
             run: make upstream
           - name: upstream lint


### PR DESCRIPTION
We were a little out of date wrt ci-mgmt and this helps catch up on the Go versions, simply running `make ci-mgmt`

Fixes: https://github.com/pulumi/pulumi-aws/issues/4529
