### PR TITLE
Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -2,6 +2,11 @@ module github.com/pulumi/pulumi-aws/provider/v6
 
 go 1.23.1
 
+// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
+// This was causing errors with AWS Network Firewall
+// https://github.com/pulumi/pulumi-aws/issues/4582
+godebug tlskyber=0
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.31.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.38


### PR DESCRIPTION
The AWS Provider was upgraded to Go 1.23 in v6.51.0, which introduced a change
to the crypto/tls standard library package. It enabled the post-quantum
key exchange mechanism `X25519Kyber768Draft00` by default. This experimental key
exchange mechanism is causing errors in the AWS firewall.
As a short term workaround this change disables the experimental key exchange mechanism.

Upstream maintainers and AWS are in touch to work on a long-term fix.

Fixes https://github.com/pulumi/pulumi-aws/issues/4573
Relates to https://github.com/pulumi/pulumi-aws/issues/4582
