### PR TITLE
Set explicit version for .NET core SDK requirement

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5378,7 +5378,10 @@ compatibility shim in favor of the new "name" field.`)
 		},
 		CSharp: &tfbridge.CSharpInfo{
 			RespectSchemaVersion: true,
-			Namespaces:           namespaceMap,
+			PackageReferences: map[string]string{
+				"Pulumi": "3.*",
+			},
+			Namespaces: namespaceMap,
 		},
 	}
 

--- a/sdk/dotnet/Pulumi.Aws.csproj
+++ b/sdk/dotnet/Pulumi.Aws.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Revert the change in a795267639fb926c36d459726e7ded11527fe812 for .NET as the default range emitted by sdkgen has a problem where NuGet will pick the minimum valid version that satisfies the range, rather than the latest possible version.

We can revert this after https://github.com/pulumi/pulumi/issues/17449 has been addressed.