### PR TITLE
Allow running gamelift test in parallel

### DIFF
--- a/provider/test-programs/gamelift-typescript/index.ts
+++ b/provider/test-programs/gamelift-typescript/index.ts
@@ -6,7 +6,6 @@ const config = new pulumi.Config();
 const customData = config.require("customData");
 
 const matchmakingRuleSetResource = new aws.gamelift.MatchmakingRuleSet("matchmakingRuleSetResource", {
-    name: "RuleSetName",
     ruleSetBody: `
         {
           "name": "players_vs_monster_5_vs_1",
@@ -29,7 +28,6 @@ const matchmakingRuleSetResource = new aws.gamelift.MatchmakingRuleSet("matchmak
 const mc = new aws.gamelift.MatchmakingConfiguration("mc", {
     acceptanceRequired: false,
     flexMatchMode: "STANDALONE",
-    name: "Name",
     ruleSetName: matchmakingRuleSetResource.name,
     requestTimeoutSeconds: 10,
     gameSessionData: "",


### PR DESCRIPTION
Previously the gamelift test was using hardcoded names for the resources. This means only one test run can be executed at a time in CI. Otherwise one will fail with resource exists exceptions.

This fixes that by letting pulumi generate the names of the resources.

Fixes issues like https://github.com/pulumi/pulumi-aws/issues/4593