### PR TITLE
fixed syntax error in doc comments of topicSubscription.ts

### DIFF
--- a/sdk/nodejs/sns/topicSubscription.ts
+++ b/sdk/nodejs/sns/topicSubscription.ts
@@ -69,7 +69,7 @@ import {Topic} from "./index";
  *     region: "us-east-1",
  *     "role-name": "service/service",
  * };
- * const sns-topic-policy = aws.iam.getPolicyDocument({
+ * const sns_topic_policy = aws.iam.getPolicyDocument({
  *     policyId: "__default_policy_ID",
  *     statements: [
  *         {
@@ -116,7 +116,7 @@ import {Topic} from "./index";
  *         },
  *     ],
  * });
- * const sqs-queue-policy = aws.iam.getPolicyDocument({
+ * const sqs_queue_policy = aws.iam.getPolicyDocument({
  *     policyId: `arn:aws:sqs:${sqs.region}:${sqs["account-id"]}:${sqs.name}/SQSDefaultPolicy`,
  *     statements: [{
  *         sid: "example-sns-topic",


### PR DESCRIPTION
## Changes
Fixed two typos that appear in the[ pulumi docs](https://www.pulumi.com/registry/packages/aws/api-docs/sns/topicsubscription/) for `TopicSubscription`. 

## Notes
The two variables, `sns-topic-policy` & `sns-queue-policy`, are kebab case which is not valid in typescipt. After the assignment, however, [subsequent references](https://github.com/pulumi/pulumi-aws/pull/4637/files#diff-81a590bb85aa5fad4c30c8c5c1c7f39b989b219455b53f459c444ee3dd480bdbL140) to there variables were already snake case, so I changed them to snake case.