### PR TITLE
Fix minimal schema computation

### DIFF
--- a/.github/workflows/aws-minimal-schema.yml
+++ b/.github/workflows/aws-minimal-schema.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check_minimal_schema:
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/aws-minimal-schema.yml
+++ b/.github/workflows/aws-minimal-schema.yml
@@ -7,6 +7,17 @@ on:
   pull_request:
     paths-ignore:
     - CHANGELOG.md
+  workflow_dispatch: {}
+  push:
+    branches:
+    # check integration branch
+    - master
+    paths-ignore:
+    - "**.md"
+    # check releases and pre-releases
+    tags-ignore:
+    - sdk/*
+
 
 jobs:
   check_minimal_schema:

--- a/.github/workflows/aws-minimal-schema.yml
+++ b/.github/workflows/aws-minimal-schema.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   check_minimal_schema:
+    runs-on: unbuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/provider/cmd/pulumi-resource-aws/main.go
+++ b/provider/cmd/pulumi-resource-aws/main.go
@@ -40,7 +40,7 @@ var pulumiMinimalSchema []byte
 // slower init for uses of the feature.
 func decompressMinimalSchema() []byte {
 	reader, err := gzip.NewReader(bytes.NewReader(pulumiMinimalSchema))
-	contract.AssertNoErrorf(err, "Failed to read schema-minimal-embed.json")
+	contract.AssertNoErrorf(err, "Failed to open a reader into schema-minimal-embed.json")
 	bytes, err := io.ReadAll(reader)
 	contract.AssertNoErrorf(err, "Failed to read schema-minimal-embed.json")
 	return bytes


### PR DESCRIPTION
The machinery for computing the AWS minimal schema is not working quite right. Looking at correcting the issues. 

- [x] fixed CI workflow to check that recomputing the minimal schema is a no-op
- [x] fixed gzip encoding issues with recomputing the minimal schema in go generate
- [x] recomputed the minimal schema to match the latest
