### PR TITLE
Enable zero default schema version in AWS

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5373,6 +5373,7 @@ compatibility shim in favor of the new "name" field.`)
 			},
 			Namespaces: namespaceMap,
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	rAlias := func(token string, prev, current tokens.Type, info *tfbridge.ResourceInfo) {


### PR DESCRIPTION
Roll out https://github.com/pulumi/pulumi-terraform-bridge/pull/2081 to AWS.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133