### PR TITLE
Discard log messages when initializing the provider

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -123,6 +123,23 @@ func TestChangingRegion(t *testing.T) {
 	})
 }
 
+func TestNoExtranousLogOutput(t *testing.T) {
+	skipIfShort(t)
+	dir := filepath.Join("test-programs", "bucket-obj")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	providerName := "aws"
+	options := []opttest.Option{
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+	}
+	test := pulumitest.NewPulumiTest(t, dir, options...)
+	result := test.Preview(t)
+	assert.NotContainsf(t, result.StdOut, "Diagnostics:",
+		"No diagnostics should be emitted to stdout for simple programs")
+	assert.NotContainsf(t, result.StdErr, "Diagnostics:",
+		"No diagnostics should be emitted to stderr for simple programs")
+}
+
 func TestRegressAttributeMustBeWholeNumber(t *testing.T) {
 	// pulumi/pulumi-terraform-bridge#1940
 	skipIfShort(t)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -5875,4 +5876,8 @@ func setupComputedIDs(prov *tfbridge.ProviderInfo) {
 		// the Pulumi ID as well.
 		return attrWithSeparator(state, ":", "name", "restoreTestingPlanName"), nil
 	}
+}
+
+func init() {
+	log.SetOutput(io.Discard)
 }


### PR DESCRIPTION
Messages sent early to the "log" package end up being forwarded to stderr, and Pulumi displays stderr by default to users, which is undesirable.

Later in the provider life-cycle, Pulumi Terraform Bridge will reset `log.SetOutput` again to capture and appropriately track diagnostic logs, which should still work with this change.

Fixes #4645

A test is added to ensure we do not leak diagnostics again on a simple program.