### PR TITLE
Remove slack notification from workflows

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -190,13 +190,6 @@ extraTests:
         role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
     - name: Run selected tests with configure-aws-credentials web identity/OIDC auth
       run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in running ${{ matrix.language }} tests
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
     strategy:
       fail-fast: false
       matrix:
@@ -275,13 +268,6 @@ extraTests:
       - name: Run provider tests
         run: |
           cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in running ${{ matrix.language }} provider tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -297,13 +297,6 @@ jobs:
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} provider tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:
@@ -378,13 +371,6 @@ jobs:
               unset-current-credentials: true
           - name: Run selected tests with configure-aws-credentials web identity/OIDC auth
             run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -239,13 +239,6 @@ jobs:
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} provider tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:
@@ -320,13 +313,6 @@ jobs:
               unset-current-credentials: true
           - name: Run selected tests with configure-aws-credentials web identity/OIDC auth
             run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,13 +245,6 @@ jobs:
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} provider tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:
@@ -326,13 +319,6 @@ jobs:
               unset-current-credentials: true
           - name: Run selected tests with configure-aws-credentials web identity/OIDC auth
             run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -300,13 +300,6 @@ jobs:
           - name: Run provider tests
             run: |
               cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} provider tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:
@@ -381,13 +374,6 @@ jobs:
               unset-current-credentials: true
           - name: Run selected tests with configure-aws-credentials web identity/OIDC auth
             run: cd examples && go test -v -json -count=1 -run TestAccCloudWatch -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-          - if: failure() && github.event_name == 'push'
-            name: Notify Slack
-            uses: 8398a7/action-slack@v3
-            with:
-              author_name: Failure in running ${{ matrix.language }} tests
-              fields: repo,commit,author,action
-              status: ${{ job.status }}
       strategy:
           fail-fast: false
           matrix:


### PR DESCRIPTION
Slack notifications have been removed from ci-mgmt, but we still had
some specified in `.ci-mgmt.yaml`.

It looks like the Slack Secret was recently removed causing these jobs
to fail

closes #4691