### PR TITLE
Handle writer errors when creating archives for Lambda test

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi-aws/provider/v6/pkg/elb"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -207,6 +208,7 @@ func TestParallelLambdaCreation(t *testing.T) {
 		return
 	}
 
+	t.TempDir()
 	tempFile, err := createLambdaArchive(25 * 1024 * 1024)
 	require.NoError(t, err)
 	defer os.Remove(tempFile)
@@ -398,7 +400,12 @@ func createLambdaArchive(size int64) (string, error) {
 
 	// Create a new zip archive
 	zipWriter := zip.NewWriter(tempFile)
-	defer zipWriter.Close()
+	defer func() {
+		err := zipWriter.Close()
+		contract.AssertNoErrorf(err, "Failed closing zip archive")
+		err = tempFile.Close()
+		contract.AssertNoErrorf(err, "Failed closing temporary file")
+	}()
 
 	randomDataReader := io.LimitReader(rand.Reader, size)
 

--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -208,7 +208,6 @@ func TestParallelLambdaCreation(t *testing.T) {
 		return
 	}
 
-	t.TempDir()
 	tempFile, err := createLambdaArchive(25 * 1024 * 1024)
 	require.NoError(t, err)
 	defer os.Remove(tempFile)


### PR DESCRIPTION
The flaky Lambda test might be caused by errors when flushing & closing the writers for the Lambda archives (e.g. out of space).

This change adds handling for those errors, to help understand why the files appear to not be found when executing the pulumi programs.

Relates to https://github.com/pulumi/pulumi-aws/issues/4731