### PR TITLE
Fix `TestIMDSAuth` test by increasing root volume size

### DIFF
--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -118,6 +118,8 @@ resources:
         httpPutResponseHopLimit: 1
       vpcSecurityGroupIds:
         - ${segroup}
+      rootBlockDevice:
+        volumeSize: 20
       userData: |
         #!/bin/bash
         # Reconfigure SSHD - workaround for pulumi Command issues


### PR DESCRIPTION
The `TestIMDSAuth` was broken because the default 8GB root volume was not enough anymore to fit pulumi and the aws provider.
This change fixes that.

Fixes https://github.com/pulumi/pulumi-aws/issues/4780