### PR TITLE
Update ci-mgmt to strip debug symbols from provider binaries

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -10,7 +10,7 @@ toolVersions:
   go: "1.23.x"
   java: "11"
   gradle: "7.6"
-  node: "20.x"
+  nodejs: "20.x"
   pulumi: "dev"
   python: "3.11.8"
 env:

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -20,7 +20,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -13,7 +13,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -19,7 +19,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -13,7 +13,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,7 +14,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -30,7 +30,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -15,7 +15,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -24,7 +24,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -46,7 +46,7 @@ env:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  PULUMI_MISSING_DOCS_ERROR: true
+  PULUMI_MISSING_DOCS_ERROR: "true"
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   PYPI_USERNAME: __token__
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ PROVIDER_VERSION ?= 6.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC) -X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=-X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=v$(VERSION_GENERIC)
 LDFLAGS_EXTRAS=
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 


### PR DESCRIPTION
This change pulls the latest ci-mgmt changes in order to reduce the size of provider binaries. In detail, we're now setting the `-s -w` linker flags to strip debug symbols. This cuts the provider binary size by roughly 300MB, resulting in a 32% smaller provider binary.

Note: I also had to change `toolVersions.node` to `toolVersions.nodejs` because the configuration is now type checked. The `toolVersions.node` configuration option was renamed to `nodejs` in this PR: https://github.com/pulumi/ci-mgmt/pull/1063
