### PR TITLE
Fix TestIMDS flaky test

### DIFF
--- a/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
+++ b/provider/test-programs/imds-auth/imds-v2/Pulumi.yaml
@@ -20,7 +20,7 @@ variables:
       arguments:
         filters:
           - name: name
-            values: ["al2023*x86_64*"]
+            values: ["al2023-ami-2023*x86_64*"]
         owners:
           - amazon
         mostRecent: true


### PR DESCRIPTION
The ami filter we were using picked up a new AMI which had a minimum
volume size of 30. This PR modifies the filter to be a little more
specific to filter out these special case AMIs.

e.g.
- `amazon/al2023-ami-2023.6.20241111.0-kernel-6.1-x86_64` (good)
- `amazon/al2023-ami-ecs-neuron-hvm-2023.0.20241115-kernel-6.1-x86_64` (bad)