### PR TITLE
Skip flaky TestParallelLambdaCreation test

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -203,6 +203,8 @@ func TestRegress4079(t *testing.T) {
 }
 
 func TestParallelLambdaCreation(t *testing.T) {
+	// This test is flaky and needs to be fixed. It occasionally fails to find the lambda zip archive
+	t.Skipf("TODO[pulumi/pulumi-aws#4731]")
 	if testing.Short() {
 		t.Skipf("Skipping test in -short mode because it needs cloud credentials")
 		return


### PR DESCRIPTION
Skipping `TestParallelLambdaCreation` because it started to be flaky.

Skipping the test for now to bring stability back into the release process while we investigate the issue.

Relates to #4731 