### PR TITLE
Remove embed wildcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yarn.lock
 ci-scripts
 provider/shim/coverage.txt
 provider/**/*-embed.json
+provider/**/schema-minimal.json
 **/version.txt
 **/nuget
 **/dist

--- a/.mk/minimal_schema.mk
+++ b/.mk/minimal_schema.mk
@@ -2,16 +2,16 @@ minimal_schema:		provider/cmd/pulumi-resource-aws/schema-minimal-embed.json
 
 .PHONY: minimal_schema
 
-provider/cmd/pulumi-resource-aws/schema-minimal-embed.json:	.make/schema
+provider/cmd/pulumi-resource-aws/schema-minimal-embed.json:	provider/cmd/pulumi-resource-aws/schema.json
 	echo "Computing minimal schema"
 	cd provider/cmd/pulumi-resource-aws && PULUMI_AWS_MINIMAL_SCHEMA=true VERSION=$(VERSION_GENERIC) go generate
 
 # In build_provider.yml workflow, minimal schema needs to be rebuilt right before the provider binary.
-bin/linux-amd64/$(PROVIDER): minimal_schema_no_deps
-bin/linux-arm64/$(PROVIDER): minimal_schema_no_deps
-bin/darwin-amd64/$(PROVIDER): minimal_schema_no_deps
-bin/darwin-arm64/$(PROVIDER): minimal_schema_no_deps
-bin/windows-amd64/$(PROVIDER).exe: minimal_schema_no_deps
+bin/linux-amd64/$(PROVIDER): minimal_schema
+bin/linux-arm64/$(PROVIDER): minimal_schema
+bin/darwin-amd64/$(PROVIDER): minimal_schema
+bin/darwin-arm64/$(PROVIDER): minimal_schema
+bin/windows-amd64/$(PROVIDER).exe: minimal_schema
 
 # In prerequisites.yml workflow, minimal schema needs to be rebuilt right before the provider binary.
-bin/pulumi-resource-aws: minimal_schema_no_deps
+bin/pulumi-resource-aws: minimal_schema

--- a/.mk/minimal_schema.mk
+++ b/.mk/minimal_schema.mk
@@ -1,16 +1,17 @@
-minimal_schema:		tfgen minimal_schema_no_deps
+minimal_schema:		provider/cmd/pulumi-resource-aws/schema-minimal-embed.json
 
-minimal_schema_no_deps:
+.PHONY: minimal_schema
+
+provider/cmd/pulumi-resource-aws/schema-minimal-embed.json:	.make/schema
 	echo "Computing minimal schema"
 	cd provider/cmd/pulumi-resource-aws && PULUMI_AWS_MINIMAL_SCHEMA=true VERSION=$(VERSION_GENERIC) go generate
-.PHONY: minimal_schema minimal_schema_no_deps
 
-# To work around CI limitations, ensure that minimal schema is rebuilt for embedding right before the provider binary is
-# built for a given platform.
+# In build_provider.yml workflow, minimal schema needs to be rebuilt right before the provider binary.
 bin/linux-amd64/$(PROVIDER): minimal_schema_no_deps
 bin/linux-arm64/$(PROVIDER): minimal_schema_no_deps
 bin/darwin-amd64/$(PROVIDER): minimal_schema_no_deps
 bin/darwin-arm64/$(PROVIDER): minimal_schema_no_deps
 bin/windows-amd64/$(PROVIDER).exe: minimal_schema_no_deps
-provider_no_deps: minimal_schema_no_deps
-provider: minimal_schema_no_deps
+
+# In prerequisites.yml workflow, minimal schema needs to be rebuilt right before the provider binary.
+bin/pulumi-resource-aws: minimal_schema_no_deps


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-aws/commit/ea37daecbb549cbf52749147da1e1cb59c2d3cbe an error was introduced invalidating the production provider build - a subtle error by moving a `go:embed` directory to wildcards and FS type.

Per https://pkg.go.dev/embed#hdr-Strings_and_Bytes the path to a go:embed directory is a pattern. Apparently in the case of pulumi-aws CI the binary is built twice, once for testing and once for production release. In the for-testing build environment, schema-embed.json is a file which works as expected. In the for-production build environment, schema-embed.json is a folder created by the download-artifacts action that contains a single file. Before the change, this code worked correctly in both cases:

```
//go:embed schema-embed.json
var pulumiSchema []byte
```

After the change, unfortunately the replacement code worked only for the for-test build scenario where schema-embed.json is a straight file, while failing in production.

This change goes back to using the `[]byte` version of go:embed and makes sure the builds recompute the minimal schema as necessary for both builds to succeed.

This fixes https://github.com/pulumi/pulumi-aws/issues/4863

We still should address the root cause and refactor the builds to reduce double-building the provider, so that the exact release build is qualified by integration tests; which is tracked in https://github.com/pulumi/ci-mgmt/issues/967