### PR TITLE
Test shim as a normal unit test

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -65,40 +65,6 @@ actions:
       run: make upstream
 
 extraTests:
-  go_test_shim:
-    name: Run test of provider shim
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        swap-storage: false
-        tool-cache: false
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.PR_COMMIT_SHA }}
-        submodules: true
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
-      with:
-        tools: pulumictl, pulumi, go
-    - name: Prepare local workspace
-      run: make prepare_local_workspace
-    - name: go test
-      run: |
-        cd upstream
-        go get github.com/hashicorp/aws-sdk-go-base@v1.1.0
-        cd shim
-        go test -v -coverprofile="coverage.txt" .
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
-      env:
-       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   upstream_lint:
     name: Run upstream provider-lint

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -99,7 +99,6 @@ jobs:
       - build_provider
       - test
       - license_check
-      - go_test_shim
       - upstream_lint
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -202,40 +201,6 @@ jobs:
         - dotnet
         - go
         - java
-  go_test_shim:
-      name: Run test of provider shim
-      runs-on: ubuntu-latest
-      steps:
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ env.PR_COMMIT_SHA }}
-              submodules: true
-          - uses: pulumi/provider-version-action@v1
-            with:
-              set-env: PROVIDER_VERSION
-          - name: Setup tools
-            uses: ./.github/actions/setup-tools
-            with:
-              tools: pulumictl, pulumi, go
-          - name: Prepare local workspace
-            run: make prepare_local_workspace
-          - name: go test
-            run: |
-              cd upstream
-              go get github.com/hashicorp/aws-sdk-go-base@v1.1.0
-              cd shim
-              go test -v -coverprofile="coverage.txt" .
-          - env:
-              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-            name: Upload coverage reports to Codecov
-            uses: codecov/codecov-action@v4
-      timeout-minutes: 60
   upstream_lint:
       name: Run upstream provider-lint
       runs-on: ubuntu-latest

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,7 +59,6 @@ jobs:
       - build_provider
       - test
       - license_check
-      - go_test_shim
       - upstream_lint
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -142,40 +141,6 @@ jobs:
         - dotnet
         - go
         - java
-  go_test_shim:
-      name: Run test of provider shim
-      runs-on: ubuntu-latest
-      steps:
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ env.PR_COMMIT_SHA }}
-              submodules: true
-          - uses: pulumi/provider-version-action@v1
-            with:
-              set-env: PROVIDER_VERSION
-          - name: Setup tools
-            uses: ./.github/actions/setup-tools
-            with:
-              tools: pulumictl, pulumi, go
-          - name: Prepare local workspace
-            run: make prepare_local_workspace
-          - name: go test
-            run: |
-              cd upstream
-              go get github.com/hashicorp/aws-sdk-go-base@v1.1.0
-              cd shim
-              go test -v -coverprofile="coverage.txt" .
-          - env:
-              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-            name: Upload coverage reports to Codecov
-            uses: codecov/codecov-action@v4
-      timeout-minutes: 60
   upstream_lint:
       name: Run upstream provider-lint
       runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
       - build_provider
       - test
       - license_check
-      - go_test_shim
       - upstream_lint
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -148,40 +147,6 @@ jobs:
         - dotnet
         - go
         - java
-  go_test_shim:
-      name: Run test of provider shim
-      runs-on: ubuntu-latest
-      steps:
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ env.PR_COMMIT_SHA }}
-              submodules: true
-          - uses: pulumi/provider-version-action@v1
-            with:
-              set-env: PROVIDER_VERSION
-          - name: Setup tools
-            uses: ./.github/actions/setup-tools
-            with:
-              tools: pulumictl, pulumi, go
-          - name: Prepare local workspace
-            run: make prepare_local_workspace
-          - name: go test
-            run: |
-              cd upstream
-              go get github.com/hashicorp/aws-sdk-go-base@v1.1.0
-              cd shim
-              go test -v -coverprofile="coverage.txt" .
-          - env:
-              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-            name: Upload coverage reports to Codecov
-            uses: codecov/codecov-action@v4
-      timeout-minutes: 60
   upstream_lint:
       name: Run upstream provider-lint
       runs-on: ubuntu-latest

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -94,7 +94,6 @@ jobs:
     - test
     - build_provider
     - license_check
-    - go_test_shim
     - upstream_lint
     runs-on: ubuntu-latest
     steps:
@@ -203,40 +202,6 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  go_test_shim:
-      name: Run test of provider shim
-      runs-on: ubuntu-latest
-      steps:
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              swap-storage: false
-              tool-cache: false
-          - name: Checkout Repo
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ env.PR_COMMIT_SHA }}
-              submodules: true
-          - uses: pulumi/provider-version-action@v1
-            with:
-              set-env: PROVIDER_VERSION
-          - name: Setup tools
-            uses: ./.github/actions/setup-tools
-            with:
-              tools: pulumictl, pulumi, go
-          - name: Prepare local workspace
-            run: make prepare_local_workspace
-          - name: go test
-            run: |
-              cd upstream
-              go get github.com/hashicorp/aws-sdk-go-base@v1.1.0
-              cd shim
-              go test -v -coverprofile="coverage.txt" .
-          - env:
-              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-            name: Upload coverage reports to Codecov
-            uses: codecov/codecov-action@v4
-      timeout-minutes: 60
   upstream_lint:
       name: Run upstream provider-lint
       runs-on: ubuntu-latest

--- a/patches/0025-move-shim-logic-to-upstream-as-a-patch.patch
+++ b/patches/0025-move-shim-logic-to-upstream-as-a-patch.patch
@@ -46,38 +46,3 @@ index 0000000000..2af7c06925
 +func NewTagConfig(ctx context.Context, i interface{}) TagConfig {
 +	return TagConfig{Tags: tags.New(ctx, i)}
 +}
-diff --git a/shim/shim_test.go b/shim/shim_test.go
-new file mode 100644
-index 0000000000..f8ee8a0c54
---- /dev/null
-+++ b/shim/shim_test.go
-@@ -0,0 +1,29 @@
-+// Copyright 2023, Pulumi Corporation.
-+//
-+// Licensed under the Apache License, Version 2.0 (the "License");
-+// you may not use this file except in compliance with the License.
-+// You may obtain a copy of the License at
-+//
-+//     http://www.apache.org/licenses/LICENSE-2.0
-+//
-+// Unless required by applicable law or agreed to in writing, software
-+// distributed under the License is distributed on an "AS IS" BASIS,
-+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+// See the License for the specific language governing permissions and
-+// limitations under the License.
-+
-+package shim
-+
-+import (
-+	"context"
-+	"testing"
-+)
-+
-+// This checks that any runtime checks in the underlying provider (with patches) are passed.
-+func TestProviderShim(t *testing.T) {
-+	ctx := context.Background()
-+	_, err := NewUpstreamProvider(ctx)
-+	if err != nil {
-+		t.Fatal(err)
-+	}
-+}

--- a/provider/shim_test.go
+++ b/provider/shim_test.go
@@ -1,0 +1,31 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	shim "github.com/hashicorp/terraform-provider-aws/shim"
+)
+
+// This checks that any runtime checks in the underlying provider (with patches) are passed.
+func TestProviderShim(t *testing.T) {
+	ctx := context.Background()
+	_, err := shim.NewUpstreamProvider(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This removes the `go_test_shim` job defined in `extraTests` by making it a normal provider unit test instead of something that needs to be run as part of upstream.

We currently attempt to upload coverage as part of this test, but it [doesn't work](https://app.codecov.io/gh/pulumi/pulumi-aws). https://github.com/pulumi/ci-mgmt/pull/1224 will start uploading unit test coverage by default.