### PR TITLE
Remove unused npm dependencies

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5275,9 +5275,7 @@ compatibility shim in favor of the new "name" field.`)
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"mime":            "^2.0.0",
-				"builtin-modules": "3.0.0",
-				"resolve":         "^1.7.1",
+				"mime": "^2.0.0",
 			},
 			DevDependencies: map[string]string{
 				"@types/node": "^10.0.0", // so we can access strongly typed node definitions.

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -14,9 +14,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.142.0",
-        "builtin-modules": "3.0.0",
-        "mime": "^2.0.0",
-        "resolve": "^1.7.1"
+        "mime": "^2.0.0"
     },
     "devDependencies": {
         "@types/mime": "^2.0.0",


### PR DESCRIPTION
It looks like the `resolve` and `builtin-modules` dependencies aren't actually used anywhere, so stop depending on them.

The motivation for this change is that the dependency on `resolve` causes errors to be logged in logs during plugin discovery, because the package includes tests that have malformed `package.json` files. If we don't actually need the dependency it'd be nice to remove it so those errors are no longer logged (so users don't [ask us about them](https://github.com/pulumi/pulumi/issues/17578)).

Also remove the `builtin-modules` dependency while cleaning this up, since it doesn't appear to be used either AFAICT.

Similar to https://github.com/pulumi/pulumi-aws/pull/3238
Reference: https://github.com/pulumi/pulumi/issues/17578