### PR TITLE
chore: disable running `waf` upstream tests

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -45,7 +45,6 @@ jobs:
       matrix:
         service:
           - sqs
-          - waf
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
These tests are hitting quota limitations such as:

        === NAME  TestAccWAFRuleGroup_changeNameForceNew
            rule_group_test.go:75: Step 1/3 error: Error running apply: exit status 1

                Error: creating WAF Rule Group (tfaccyzotq): operation error WAF: CreateRuleGroup, https response error StatusCode: 400, RequestID: fcb7db05-54ed-4ab1-8a3b-cecdb02574fb, WAFLimitsExceededException: Operation would result in exceeding resource limits.

                  with aws_waf_rule_group.test,
                  on terraform_plugin_test.tf line 17, in resource "aws_waf_rule_group" "test":
                  17: resource "aws_waf_rule_group" "test" {

The intent of these tests was to smoke-test the upstream provider post-patching. However it appears that instead of smoke-testing the `wafv2` module that was patched the older `waf` module is being smoke-tested which might have stricter quotas. Removing for now.