### PR TITLE
fix: Restore minimal schema

### DIFF
--- a/.mk/minimal_schema.mk
+++ b/.mk/minimal_schema.mk
@@ -1,10 +1,6 @@
-minimal_schema:		provider/cmd/pulumi-resource-aws/schema-minimal-embed.json
-
 .PHONY: minimal_schema
-
-provider/cmd/pulumi-resource-aws/schema-minimal-embed.json:	provider/cmd/pulumi-resource-aws/schema.json
-	echo "Computing minimal schema"
-	cd provider/cmd/pulumi-resource-aws && PULUMI_AWS_MINIMAL_SCHEMA=true VERSION=$(VERSION_GENERIC) go generate
+minimal_schema:
+	@(cd provider/cmd/pulumi-resource-aws && PULUMI_AWS_MINIMAL_SCHEMA=true VERSION=$(VERSION_GENERIC) go generate)
 
 # In build_provider.yml workflow, minimal schema needs to be rebuilt right before the provider binary.
 bin/linux-amd64/$(PROVIDER): minimal_schema

--- a/examples/minimal_schema_test.go
+++ b/examples/minimal_schema_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+//go:build nodejs || all
+// +build nodejs all
+
+package examples
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinimalSchema(t *testing.T) {
+	var buf bytes.Buffer
+	schemaSource := filepath.Join("..", "bin", "pulumi-resource-aws")
+	t.Logf("pulumi package get-schema %s", schemaSource)
+	cmd := exec.Command("pulumi", "package", "get-schema", schemaSource)
+	cmd.Env = append(os.Environ(), "PULUMI_AWS_MINIMAL_SCHEMA=true")
+	cmd.Stdout = &buf
+	err := cmd.Run()
+	cmd.Stderr = os.Stderr
+	if err != nil {
+		t.Logf("%s", buf.String())
+		require.NoError(t, err)
+	}
+	var packageSpec schema.PackageSpec
+	err = json.Unmarshal(buf.Bytes(), &packageSpec)
+	require.NoError(t, err)
+	t.Logf("Parsed minimal schema")
+	loader := schema.NewPluginLoader(utils.NewHostWithProviders(t.TempDir()))
+	_, diags, err := schema.BindSpec(packageSpec, loader)
+	require.NoError(t, err)
+	for _, d := range diags {
+		t.Logf("sev=%v summary: %s\n    detail: %s", d.Severity, d.Summary, d.Detail)
+	}
+	require.False(t, diags.HasErrors())
+	t.Logf("Validated minimal schema")
+}


### PR DESCRIPTION
Since v6.62.1 minimal schema was not working. This is now fixed.

A change in standard CI scripts aimed at speeding up makefiles broke the assumptions of pulumi-aws specific Makefile extensions in .mk/minimal_schema.mk - that is CI would now run `make --touch provider schema` which would create an empty provider/cmd/pulumi-resource-aws/schema-minimal-embed.json file instead of recalculating it.

The change in question is: https://github.com/pulumi/ci-mgmt/pull/1157

The fix makes `minimal_schema` a PHONY target that may be a bit less efficient for rebuilding but is no longer affected by `make --touch`.

A regression test is added to catch this problem should it reoccur.

Fixes https://github.com/pulumi/pulumi-aws/issues/5016