### PR TITLE
chore: enable release verification take 2

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -61,3 +61,8 @@ actions:
         role-duration-seconds: 7200
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+releaseVerification:
+  nodejs: examples/release-verification
+  python: examples/webserver-py
+  dotnet: examples/webserver-cs
+  go: examples/webserver-go

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -94,7 +94,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false
+    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Upload Provider Binaries
       run: aws s3 cp dist s3://get.pulumi.com/releases/plugins/ --recursive
     - name: Create GH Release
-      uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
       if: inputs.isPrerelease == false
       with:
         tag_name: v${{ inputs.version }}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -65,18 +65,13 @@ env:
 jobs:
   verify-release:
     name: verify-release
-    # We don't have any release verification configurations, so we never run this workflow.
-    # Configure your .ci-mgmt.yaml files to include the release verification configurations e.g.
-    # releaseVerification:
-    #   nodejs: path/to/nodejs/project
-    #   python: path/to/python/project
-    #   dotnet: path/to/dotnet/project
-    #   go: path/to/go/project
-    if: false
     strategy:
       matrix:
-        # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
-        runner: ["ubuntu-latest"]
+        # We always run on Linux and Windows, and optionally on MacOS. This is because MacOS runners have limited availability.
+        # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
+        # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
+        # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner == 'true' && ',"macos-latest"' || '')) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo
@@ -87,3 +82,42 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 7200
+          role-session-name: aws@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Verify nodejs release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: nodejs
+          directory: examples/release-verification
+          provider: aws
+          providerVersion: ${{ inputs.providerVersion }}
+      - name: Verify python release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: python
+          directory: examples/webserver-py
+          provider: aws
+          providerVersion: ${{ inputs.providerVersion }}
+          packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
+      - name: Verify dotnet release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: dotnet
+          directory: examples/webserver-cs
+          provider: aws
+          providerVersion: ${{ inputs.providerVersion }}
+      - name: Verify go release
+        uses: pulumi/verify-provider-release@v1
+        if: inputs.skipGoSdk == false
+        with:
+          runtime: go
+          directory: examples/webserver-go
+          provider: aws
+          providerVersion: ${{ inputs.providerVersion }}

--- a/examples/release-verification/Pulumi.yaml
+++ b/examples/release-verification/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: bucket
+runtime: nodejs
+description: A simple example of using the `Bucket` APIs.

--- a/examples/release-verification/README.md
+++ b/examples/release-verification/README.md
@@ -1,0 +1,3 @@
+# examples/release-verification
+
+An example that can be used in the release verification workflow

--- a/examples/release-verification/index.ts
+++ b/examples/release-verification/index.ts
@@ -1,0 +1,71 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+// Import the nested module directly to regression test:
+// https://github.com/pulumi/pulumi-aws/issues/772
+import { Bucket } from "@pulumi/aws/s3";
+import * as aws from "@pulumi/aws";
+import * as s3 from "@aws-sdk/client-s3";
+
+const bucket = new Bucket("testbucket", {
+    serverSideEncryptionConfiguration: {
+        rule: {
+            applyServerSideEncryptionByDefault: {
+                sseAlgorithm: "AES256",
+            },
+        },
+    },
+    forceDestroy: true,
+});
+
+bucket.onObjectCreated("bucket-callback", async (event) => {
+    const s3Client = new s3.S3Client({});
+    const recordFile = "lastPutFile.json";
+    const records = event.Records || [];
+    for (const record of records) {
+        const key = record.s3.object.key;
+
+        if (key !== recordFile) {
+            // Construct an event arguments object.
+            const args = {
+                key: record.s3.object.key,
+                size: record.s3.object.size,
+                eventTime: record.eventTime,
+            };
+            const res = await s3Client.send(new s3.PutObjectCommand({
+                Bucket: bucket.id.get(),
+                Key: recordFile,
+                Body: JSON.stringify(args),
+            }));
+        }
+    }
+});
+
+// Another bucket with some strongly-typed routingRules.
+const websiteBucket = new aws.s3.Bucket("websiteBucket", {
+    website: {
+        indexDocument: "index.html",
+        routingRules: [{
+            Condition: {
+                KeyPrefixEquals: "docs/",
+            },
+            Redirect: {
+                ReplaceKeyPrefixWith: "documents/",
+            }
+        }]
+    }
+});
+
+export const bucketName = bucket.id;

--- a/examples/release-verification/package.json
+++ b/examples/release-verification/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "bucket",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@aws-sdk/client-s3": "^3.362.0",
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/release-verification/tsconfig.json
+++ b/examples/release-verification/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/webserver-py/Pulumi.yaml
+++ b/examples/webserver-py/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: webserver-py
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of an AWS web server accessible over HTTP (in Python!)


### PR DESCRIPTION
This enables release verification for AWS.

Tested by manually executing the `Verify-Release` workflow using this branch. Run can be seen here https://github.com/pulumi/pulumi-aws/actions/runs/12691069824

closes https://github.com/pulumi/ci-mgmt/issues/1265