### PR TITLE
Added thailand region

### DIFF
--- a/provider/types.go
+++ b/provider/types.go
@@ -42,6 +42,7 @@ var extraTypes = map[string]schema.ComplexTypeSpec{
 			{Value: "ap-southeast-3", Name: "APSoutheast3"}, // Asia Pacific (Jakarta)
 			{Value: "ap-southeast-4", Name: "APSoutheast4"}, // Asia Pacific (Melbourne)
 			{Value: "ap-southeast-5", Name: "APSoutheast5"}, // Asia Pacific (Malaysia)
+			{Value: "ap-southeast-7", Name: "APSoutheast7"}, // Asia Pacific (Thailand)
 			{Value: "ca-central-1", Name: "CACentral"},      // Canada (Central)
 			{Value: "ca-west-1", Name: "CAWest1"},           // Canada (Calgary)
 			{Value: "eu-central-1", Name: "EUCentral1"},     // Europe (Frankfurt)

--- a/sdk/dotnet/Enums.cs
+++ b/sdk/dotnet/Enums.cs
@@ -32,6 +32,7 @@ namespace Pulumi.Aws
         public static Region APSoutheast3 { get; } = new Region("ap-southeast-3");
         public static Region APSoutheast4 { get; } = new Region("ap-southeast-4");
         public static Region APSoutheast5 { get; } = new Region("ap-southeast-5");
+        public static Region APSoutheast7 { get; } = new Region("ap-southeast-7");
         public static Region CACentral { get; } = new Region("ca-central-1");
         public static Region CAWest1 { get; } = new Region("ca-west-1");
         public static Region EUCentral1 { get; } = new Region("eu-central-1");

--- a/sdk/go/aws/pulumiEnums.go
+++ b/sdk/go/aws/pulumiEnums.go
@@ -26,6 +26,7 @@ const (
 	RegionAPSoutheast3 = Region("ap-southeast-3")
 	RegionAPSoutheast4 = Region("ap-southeast-4")
 	RegionAPSoutheast5 = Region("ap-southeast-5")
+	RegionAPSoutheast7 = Region("ap-southeast-7")
 	RegionCACentral    = Region("ca-central-1")
 	RegionCAWest1      = Region("ca-west-1")
 	RegionEUCentral1   = Region("eu-central-1")
@@ -188,6 +189,7 @@ func (o RegionPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulum
 //	RegionAPSoutheast3
 //	RegionAPSoutheast4
 //	RegionAPSoutheast5
+//	RegionAPSoutheast7
 //	RegionCACentral
 //	RegionCAWest1
 //	RegionEUCentral1

--- a/sdk/java/src/main/java/com/pulumi/aws/enums/Region.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/enums/Region.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
         APSoutheast3("ap-southeast-3"),
         APSoutheast4("ap-southeast-4"),
         APSoutheast5("ap-southeast-5"),
+        APSoutheast7("ap-southeast-7"),
         CACentral("ca-central-1"),
         CAWest1("ca-west-1"),
         EUCentral1("eu-central-1"),

--- a/sdk/nodejs/types/enums/index.ts
+++ b/sdk/nodejs/types/enums/index.ts
@@ -23,7 +23,7 @@ export {
     rds,
     route53,
     s3,
-    ssm,
+    ssm
 };
 
 export const Region = {
@@ -39,6 +39,7 @@ export const Region = {
     APSoutheast3: "ap-southeast-3",
     APSoutheast4: "ap-southeast-4",
     APSoutheast5: "ap-southeast-5",
+    APSoutheast7: "ap-southeast-7",
     CACentral: "ca-central-1",
     CAWest1: "ca-west-1",
     EUCentral1: "eu-central-1",

--- a/sdk/python/pulumi_aws/_enums.py
+++ b/sdk/python/pulumi_aws/_enums.py
@@ -25,6 +25,7 @@ class Region(str, Enum):
     AP_SOUTHEAST3 = "ap-southeast-3"
     AP_SOUTHEAST4 = "ap-southeast-4"
     AP_SOUTHEAST5 = "ap-southeast-5"
+    AP_SOUTHEAST7 = "ap-southeast-7"
     CA_CENTRAL = "ca-central-1"
     CA_WEST1 = "ca-west-1"
     EU_CENTRAL1 = "eu-central-1"


### PR DESCRIPTION
Added the new AWS Thailand (Bangkok) region `ap-southeast-7` to the Region enum/interfaces.

This region was recently announced by AWS and is now generally available.

Reference: https://aws.amazon.com/local/thailand/