### PR TITLE
chore: enable refresh for regress-2868

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -593,9 +593,6 @@ func TestRegress2868(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "regress-2868"),
-
-			// TODO[pulumi/pulumi-aws#3303] does not refresh cleanly
-			SkipRefresh: true,
 		})
 	// Disable envRegion mangling
 	test.Config = nil

--- a/examples/regress-2868/package.json
+++ b/examples/regress-2868/package.json
@@ -10,7 +10,6 @@
         "@pulumi/aws": "^6.0.0"
     },
     "devDependencies": {
-        "@types/aws-sdk": "^2.7.0",
         "@types/node": "^8.0.0"
     }
 }


### PR DESCRIPTION
Issue #3303 looks to be fixed so removing the `SkipRefresh` on the test.