### PR TITLE
chore: fix TestRdsGetEngineVersion

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -744,7 +744,7 @@ func TestRdsGetEngineVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	engineVersion := res.Outputs["vs"]
-	require.Equal(t, engineVersion.Value, "15.2")
+	require.Equal(t, engineVersion.Value, "15.8")
 }
 
 // Checks static get function for ssm.parameter that was broken for versioned IDs.

--- a/examples/rds-getengineversion/index.ts
+++ b/examples/rds-getengineversion/index.ts
@@ -2,7 +2,9 @@ import * as aws from "@pulumi/aws";
 
 const output = aws.rds.getEngineVersionOutput({
   engine: "aurora-postgresql",
-  version: "15.2",
+  // we need to specify the version because we want to test
+  // the upstream behavior when version is set
+  version: "15.8",
   filters: [{
     name: "engine-mode",
     values: ["provisioned"],


### PR DESCRIPTION
Looks like AWS got rid of `15.2` and it now starts at `15.3`. Updating
to the highest version number to give us more time.

fixes #5128