### PR TITLE
Don't auto-merge upstream upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -69,3 +69,4 @@ releaseVerification:
   python: examples/webserver-py
   dotnet: examples/webserver-cs
   go: examples/webserver-go
+autoMergeProviderUpgrades: false


### PR DESCRIPTION
Sets the `AutoMergeProviderUpgrades` ci-mgmt config to false to avoid auto-merging upstream upgrades. This maintains the current behaviour.

Part of https://github.com/pulumi/ci-mgmt/issues/1344