### PR TITLE
Disallow missing resource docs on upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -52,6 +52,7 @@ plugins:
     kind: converter
 # Use `pulumi convert` for translating examples from TF to Pulumi.
 pulumiConvert: 1
+allowMissingDocs: false
 goBuildParallelism: 2
 actions:
   preTest:


### PR DESCRIPTION
Sets the `allowMissingDocs` ci-mgmt config to false to error on missing resource docs. This maintains the current behaviour.

Part of https://github.com/pulumi/upgrade-provider/issues/303