### PR TITLE
Fix signing profile docs

### DIFF
--- a/sdk/nodejs/signer/signingJob.ts
+++ b/sdk/nodejs/signer/signingJob.ts
@@ -16,7 +16,10 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const testSp = new aws.signer.SigningProfile("test_sp", {platformId: "AWSLambda-SHA384-ECDSA"});
+ * const testSp = new aws.signer.SigningProfile("test_sp", {
+ *     platformId: "AWSLambda-SHA384-ECDSA",
+ *     namePrefix: "test_sp_",
+ * });
  * const buildSigningJob = new aws.signer.SigningJob("build_signing_job", {
  *     profileName: testSp.name,
  *     source: {

--- a/sdk/nodejs/signer/signingProfile.ts
+++ b/sdk/nodejs/signer/signingProfile.ts
@@ -16,7 +16,6 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
- * const testSp = new aws.signer.SigningProfile("test_sp", {platformId: "AWSLambda-SHA384-ECDSA"});
  * const prodSp = new aws.signer.SigningProfile("prod_sp", {
  *     platformId: "AWSLambda-SHA384-ECDSA",
  *     namePrefix: "prod_sp_",


### PR DESCRIPTION
Without setting `name` or `namePrefix`, I get the following error:
```
Diagnostics:
  aws:signer:SigningProfile (test_sp):
    error: aws:signer/signingProfile:SigningProfile resource 'test_sp' has a problem: invalid value for name (must be alphanumeric with max length of 64 characters). Examine values at 'test_sp.name'.
```