### PR TITLE
chore: unpin .NET 6

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -9,7 +9,6 @@ providerVersion: github.com/hashicorp/terraform-provider-aws/version.ProviderVer
 buildProviderPre: "VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh"
 
 toolVersions:
-  dotnet: "6.0.x"
   go: "1.23.x"
   java: "11"
   gradle: "7.6"

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/devbox.json
+++ b/devbox.json
@@ -5,7 +5,7 @@
     "go@1.23.",
     "nodejs@20.",
     "python3@3.11.8",
-    "dotnet-sdk@6.0.",
+    "dotnet-sdk@8.0.",
     "gradle_7@7.6",
     "curl@8"
   ],

--- a/examples/sqs-fifo-queue/csharp/testing-aws-fifo-dotnet.csproj
+++ b/examples/sqs-fifo-queue/csharp/testing-aws-fifo-dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/webserver-cs/AWS.Webserver.csproj
+++ b/examples/webserver-cs/AWS.Webserver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
This repository does not need to pin .NET 6 version with respect to ci-mgmt defaults.