### PR TITLE
Add PolicyDocument types to KMS inputs

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2869,12 +2869,30 @@ compatibility shim in favor of the new "name" field.`)
 					}),
 				},
 			},
-			"aws_kms_ciphertext":           {Tok: awsResource(kmsMod, "Ciphertext")},
-			"aws_kms_custom_key_store":     {Tok: awsResource(kmsMod, "CustomKeyStore")},
-			"aws_kms_external_key":         {Tok: awsResource(kmsMod, "ExternalKey")},
-			"aws_kms_grant":                {Tok: awsResource(kmsMod, "Grant")},
-			"aws_kms_key":                  {Tok: awsResource(kmsMod, "Key")},
-			"aws_kms_key_policy":           {Tok: awsResource(kmsMod, "KeyPolicy")},
+			"aws_kms_ciphertext":       {Tok: awsResource(kmsMod, "Ciphertext")},
+			"aws_kms_custom_key_store": {Tok: awsResource(kmsMod, "CustomKeyStore")},
+			"aws_kms_external_key":     {Tok: awsResource(kmsMod, "ExternalKey")},
+			"aws_kms_grant":            {Tok: awsResource(kmsMod, "Grant")},
+			"aws_kms_key": {
+				Tok: awsResource(kmsMod, "Key"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
+			"aws_kms_key_policy": {
+				Tok: awsResource(kmsMod, "KeyPolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
 			"aws_kms_replica_external_key": {Tok: awsResource(kmsMod, "ReplicaExternalKey")},
 			"aws_kms_replica_key":          {Tok: awsResource(kmsMod, "ReplicaKey")},
 			// Lambda

--- a/sdk/go/aws/kms/key.go
+++ b/sdk/go/aws/kms/key.go
@@ -573,7 +573,7 @@ type keyState struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy *string `pulumi:"policy"`
+	Policy interface{} `pulumi:"policy"`
 	// Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
 	RotationPeriodInDays *int `pulumi:"rotationPeriodInDays"`
 	// A map of tags to assign to the object. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -619,7 +619,7 @@ type KeyState struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy pulumi.StringPtrInput
+	Policy pulumi.Input
 	// Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
 	RotationPeriodInDays pulumi.IntPtrInput
 	// A map of tags to assign to the object. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -665,7 +665,7 @@ type keyArgs struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy *string `pulumi:"policy"`
+	Policy interface{} `pulumi:"policy"`
 	// Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
 	RotationPeriodInDays *int `pulumi:"rotationPeriodInDays"`
 	// A map of tags to assign to the object. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -704,7 +704,7 @@ type KeyArgs struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy pulumi.StringPtrInput
+	Policy pulumi.Input
 	// Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
 	RotationPeriodInDays pulumi.IntPtrInput
 	// A map of tags to assign to the object. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.

--- a/sdk/go/aws/kms/keyPolicy.go
+++ b/sdk/go/aws/kms/keyPolicy.go
@@ -135,7 +135,7 @@ type keyPolicyState struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used. For more information about building policy documents, see the AWS IAM Policy Document Guide.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, or this resource is destroyed, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy *string `pulumi:"policy"`
+	Policy interface{} `pulumi:"policy"`
 }
 
 type KeyPolicyState struct {
@@ -148,7 +148,7 @@ type KeyPolicyState struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used. For more information about building policy documents, see the AWS IAM Policy Document Guide.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, or this resource is destroyed, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy pulumi.StringPtrInput
+	Policy pulumi.Input
 }
 
 func (KeyPolicyState) ElementType() reflect.Type {
@@ -165,7 +165,7 @@ type keyPolicyArgs struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used. For more information about building policy documents, see the AWS IAM Policy Document Guide.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, or this resource is destroyed, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy string `pulumi:"policy"`
+	Policy interface{} `pulumi:"policy"`
 }
 
 // The set of arguments for constructing a KeyPolicy resource.
@@ -179,7 +179,7 @@ type KeyPolicyArgs struct {
 	// A valid policy JSON document. Although this is a key policy, not an IAM policy, an `iam.getPolicyDocument`, in the form that designates a principal, can be used. For more information about building policy documents, see the AWS IAM Policy Document Guide.
 	//
 	// > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, or this resource is destroyed, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
-	Policy pulumi.StringInput
+	Policy pulumi.Input
 }
 
 func (KeyPolicyArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/kms/key.ts
+++ b/sdk/nodejs/kms/key.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PolicyDocument} from "../iam";
+
 /**
  * Manages a single-Region or multi-Region primary KMS key.
  *
@@ -535,7 +537,7 @@ export interface KeyState {
      *
      * > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
      */
-    policy?: pulumi.Input<string>;
+    policy?: pulumi.Input<string | PolicyDocument>;
     /**
      * Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
      */
@@ -608,7 +610,7 @@ export interface KeyArgs {
      *
      * > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
      */
-    policy?: pulumi.Input<string>;
+    policy?: pulumi.Input<string | PolicyDocument>;
     /**
      * Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
      */

--- a/sdk/nodejs/kms/keyPolicy.ts
+++ b/sdk/nodejs/kms/keyPolicy.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+import {PolicyDocument} from "../iam";
+
 /**
  * Attaches a policy to a KMS Key.
  *
@@ -137,7 +139,7 @@ export interface KeyPolicyState {
      *
      * > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, or this resource is destroyed, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
      */
-    policy?: pulumi.Input<string>;
+    policy?: pulumi.Input<string | PolicyDocument>;
 }
 
 /**
@@ -159,5 +161,5 @@ export interface KeyPolicyArgs {
      *
      * > **NOTE:** Note: All KMS keys must have a key policy. If a key policy is not specified, or this resource is destroyed, AWS gives the KMS key a [default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) that gives all principals in the owning account unlimited access to all KMS operations for the key. This default key policy effectively delegates all access control to IAM policies and KMS grants.
      */
-    policy: pulumi.Input<string>;
+    policy: pulumi.Input<string | PolicyDocument>;
 }


### PR DESCRIPTION
KMS key policies have slightly stricter requirements around the `Principal` field then normal policy documents, but are otherwise shaped the same.

This mirrors our other input types for resources that support policy documents. While the Typescript gets nicer. Looking at the generated golang, it seems like it makes things slightly worse though. Since our golang sdk doesn't seem to support an `aws.iam.PolicyDocument` type and recommends `GetPolicyDocument` as universal practice, should SDK gen just ignore that alt type and stick to strings?