### PR TITLE
Create stale_issues.yaml

### DIFF
--- a/.github/workflows/stale_issues.yaml
+++ b/.github/workflows/stale_issues.yaml
@@ -1,0 +1,45 @@
+name: "Comment on stale issues"
+
+# Controls when the action will run.
+on:
+  pull_request: {} # for testing only
+  #schedule:
+  # - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v3
+      with:
+        issueTypes: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?" 
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic, kind/engineering # only run on kind/bug for now
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true


### PR DESCRIPTION
Dry run for adding an action that would comment on very old issues and apply the awaiting-feedback label.  (see [Automate comments on stale issues](https://docs.google.com/document/d/1UCGvPZ9m7vHpl5E6jIt8PUV7J6SVGOf-wMHrB4OfBt0/edit?tab=t.0#heading=h.vmiybe9heukw), [Stale Issues Proposal](https://docs.google.com/document/d/1dw7ehY3kchsyEO_M5z9vcpleHNEzwpTdl2G-8UnmpKQ/edit?tab=t.0))