### PR TITLE
Use standard aws setup from ci-mgmt

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -53,20 +53,7 @@ plugins:
 pulumiConvert: 1
 allowMissingDocs: false
 goBuildParallelism: 2
-actions:
-  preTest:
-    - name: Generate Pulumi Access Token
-      id: generate_pulumi_token
-      uses: pulumi/auth-actions@v1
-      with:
-        organization: pulumi
-        requested-token-type: urn:pulumi:token-type:access_token:organization
-        export-environment-variables: false
-    - uses: pulumi/esc-action@v1
-      env:
-        PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
-      with:
-        environment: logins/pulumi-ci
+aws: true
 
 releaseVerification:
   nodejs: examples/release-verification

--- a/.github/actions/download-prerequisites/action.yml
+++ b/.github/actions/download-prerequisites/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the prerequisites bin
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: prerequisites-bin
         path: bin
@@ -19,7 +19,7 @@ runs:
       run: rm bin/executables.txt
 
     - name: Download schema-embed.json
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         # Use a pattern to avoid failing if the artifact doesn't exist
         pattern: schema-embed.*

--- a/.github/actions/download-provider/action.yml
+++ b/.github/actions/download-provider/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
 
     - name: Download pulumi-resource-aws
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         pattern: pulumi-resource-aws-*-linux-amd64.tar.gz
         path: ${{ github.workspace }}/bin

--- a/.github/actions/download-sdk/action.yml
+++ b/.github/actions/download-sdk/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Download ${{ inputs.language }} SDK
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: ${{ inputs.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,14 +75,14 @@ jobs:
     - name: Create dist directory
       run: mkdir -p dist
     - name: Download provider assets
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         pattern: pulumi-resource-aws-v${{ inputs.version }}-*
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
     - name: Download schema
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         # Use a pattern to avoid failing if the artifact doesn't exist
         pattern: schema-embed.*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,20 +81,21 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
-    - id: generate_pulumi_token
-      name: Generate Pulumi Access Token
-      uses: pulumi/auth-actions@v1
+    - name: Generate Pulumi Access Token
+      id: generate_pulumi_token
+      uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        export-environment-variables: false
         organization: pulumi
         requested-token-type: urn:pulumi:token-type:access_token:organization
-    - env:
+        export-environment-variables: false
+    - name: Export AWS Credentials
+      uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+      env:
         PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
-      uses: pulumi/esc-action@v1
       with:
         environment: logins/pulumi-ci
+    - name: Install dependencies
+      run: make install_${{ matrix.language}}_sdk
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -78,16 +78,25 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
-      - id: generate_pulumi_token
-        name: Generate Pulumi Access Token
-        uses: pulumi/auth-actions@v1
+      - name: Generate Pulumi Access Token
+        id: generate_pulumi_token
+        uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
         with:
-          export-environment-variables: false
           organization: pulumi
           requested-token-type: urn:pulumi:token-type:access_token:organization
-      - env:
+          export-environment-variables: false
+      # workaround for https://github.com/pulumi/esc-action/issues/10
+      - name: Install esc on Windows
+        if: ${{ matrix.runner == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/esc/install.ps1'))
+          Copy-Item "$env:USERPROFILE\.pulumi\bin\esc.exe" "C:\Windows\System32\esc.exe"
+      - name: Export AWS Credentials
+        uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+        env:
           PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
-        uses: pulumi/esc-action@v1
         with:
           environment: logins/pulumi-ci
       - name: Verify nodejs release


### PR DESCRIPTION
This removes our custom actions in `.ci-mgmt.yaml` and sets `aws: true`
to use the default `aws` configuration from ci-mgmt