### PR TITLE
Fix route53.ResolverEndpoint hangs with 6-10 IPs

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -54,6 +54,8 @@ jobs:
             tests: TestAccDocDBCluster_basic
           - service: redshiftserverless
             tests: TestAccRedshiftServerlessNamespace_basic
+          - service: route53resolver
+            tests: TestAccRoute53Resolver
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1080,6 +1080,33 @@ func TestRegress4568(t *testing.T) {
 	})
 }
 
+func TestRegress5219(t *testing.T) {
+	skipIfShort(t)
+	dir := filepath.Join("test-programs", "regress-5219")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	providerName := "aws"
+	options := []opttest.Option{
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+		opttest.YarnLink("@pulumi/aws"),
+	}
+	test := pulumitest.NewPulumiTest(t, dir, options...)
+	ef := &expectFailure{T: t}
+	upResult := test.Up(ef)
+	t.Logf("%#v", upResult.Summary.ResourceChanges)
+	assert.Truef(t, ef.failed, "Expected pulumi up to fail")
+}
+
+type expectFailure struct {
+	*testing.T
+	failed bool
+}
+
+func (ef *expectFailure) FailNow() {
+	ef.T.Log("Ignoring FailNow()")
+	ef.failed = true
+}
+
 // Tests that there are no diagnostics by default on simple programs.
 func TestNoExtranousLogOutput(t *testing.T) {
 	skipIfShort(t)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1091,10 +1091,13 @@ func TestRegress5219(t *testing.T) {
 		opttest.YarnLink("@pulumi/aws"),
 	}
 	test := pulumitest.NewPulumiTest(t, dir, options...)
+	t1 := time.Now()
 	ef := &expectFailure{T: t}
 	upResult := test.Up(ef)
 	t.Logf("%#v", upResult.Summary.ResourceChanges)
+	t2 := time.Now()
 	assert.Truef(t, ef.failed, "Expected pulumi up to fail")
+	assert.Truef(t, t2.Sub(t1) < 10*time.Minute, "Expected pulumi up to fail within 10 minutes")
 }
 
 type expectFailure struct {

--- a/examples/test-programs/regress-5219/Pulumi.yaml
+++ b/examples/test-programs/regress-5219/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: regress-5219
+runtime: nodejs
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/examples/test-programs/regress-5219/index.ts
+++ b/examples/test-programs/regress-5219/index.ts
@@ -1,0 +1,63 @@
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import { SubnetAllocationStrategy } from "@pulumi/awsx/ec2";
+
+// This will have 9 subnets (numberOfAvailabilityZones * subnetSpecs.length = 3 * 3 = 9).
+//
+// Over 10 subnets will trigger:
+//    error: aws:route53/resolverEndpoint:ResolverEndpoint resource 're' has a problem: Too many list items.
+//    Attribute ip_address supports 10 item maximum, but config has 12 declared.. Examine values at 're.ipAddresses'.
+//
+// Under 6 subnets is fine.
+//
+// With 6-10 subnets we currently have a hang.
+const vpc = new awsx.ec2.Vpc("vpc", {
+    numberOfAvailabilityZones: 3,
+    subnetStrategy: SubnetAllocationStrategy.Auto,
+    subnetSpecs: [
+        {
+            name: "private-1",
+            type: "Private",
+            cidrMask: 25,
+        },
+        {
+            name: "private-2",
+            type: "Private",
+            cidrMask: 25,
+        },
+        {
+            name: "public-1",
+            type: "Public",
+            cidrMask: 27,
+        },
+    ],
+});
+
+const securityGroup = new aws.ec2.SecurityGroup("s3ResolverSecurityGroup", {
+    vpcId: vpc.vpcId,
+    egress: [
+        {
+            protocol: "tcp",
+            fromPort: 443,
+            toPort: 443,
+            cidrBlocks: ["0.0.0.0/0"],
+            description: "Allow outbound HTTPS traffic to S3",
+        },
+    ],
+});
+
+const re = new aws.route53.ResolverEndpoint("re", {
+    direction: "OUTBOUND",
+    resolverEndpointType: "IPV4",
+    protocols: ["Do53", "DoH"],
+
+    // Every entry in ipAddresses must have a unique subnetid apparently.
+    ipAddresses: vpc.subnets.apply(xs => xs.map(subnet => ({
+        subnetId: subnet.id,
+    }))),
+    securityGroupIds: [securityGroup.id],
+});
+
+export const reIPS = re.ipAddresses;
+export const reIPSLen = re.ipAddresses.apply(x => x.length);
+export const subnetCount = vpc.subnets.apply(x => x.length);

--- a/examples/test-programs/regress-5219/package.json
+++ b/examples/test-programs/regress-5219/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "regress-5219",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/awsx": "^2.0.0"
+    }
+}

--- a/examples/test-programs/regress-5219/tsconfig.json
+++ b/examples/test-programs/regress-5219/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/patches/0091-Do-not-retry-route53resolver-LimitExceededException.patch
+++ b/patches/0091-Do-not-retry-route53resolver-LimitExceededException.patch
@@ -1,15 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Tayanovskyy <anton@pulumi.com>
-Date: Thu, 27 Mar 2025 15:34:04 -0400
+Date: Fri, 28 Mar 2025 10:11:28 -0400
 Subject: [PATCH] Do not retry route53resolver LimitExceededException
 
 
 diff --git a/internal/service/route53resolver/service_package_extra_options.go b/internal/service/route53resolver/service_package_extra_options.go
 new file mode 100644
-index 0000000000..658e591e18
+index 0000000000..e35a2237a4
 --- /dev/null
 +++ b/internal/service/route53resolver/service_package_extra_options.go
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,49 @@
 +package route53resolver
 +
 +import (
@@ -29,26 +29,23 @@ index 0000000000..658e591e18
 +	ctx context.Context,
 +	config map[string]any,
 +) []func(*route53resolver.Options) {
-+	retryer := mustFindRetryer(config)
++	retryer := findRetryer(config)
 +	return []func(*route53resolver.Options){func(o *route53resolver.Options) {
 +		o.Retryer = conns.AddIsErrorRetryables(retryer, doNotRetryLimitExceededException())
 +	}}
 +
 +}
 +
-+func mustFindRetryer(config map[string]any) aws_sdkv2.RetryerV2 {
-+	var retryer *aws_sdkv2.RetryerV2
++func findRetryer(config map[string]any) aws_sdkv2.RetryerV2 {
++	var retryer aws_sdkv2.RetryerV2
 +	if cfg, ok := config["aws_sdkv2_config"]; ok {
 +		if cfgp, ok := cfg.(*aws_sdkv2.Config); ok {
 +			if r, ok := cfgp.Retryer().(aws_sdkv2.RetryerV2); ok {
-+				retryer = &r
++				retryer = r
 +			}
 +		}
 +	}
-+	if retryer == nil {
-+		panic("Expected config['aws_sdk2_config'] to carry a Config with a RetryerV2")
-+	}
-+	return *retryer
++	return retryer
 +}
 +
 +func doNotRetryLimitExceededException() retry_sdkv2.IsErrorRetryable {

--- a/patches/0091-Do-not-retry-route53resolver-LimitExceededException.patch
+++ b/patches/0091-Do-not-retry-route53resolver-LimitExceededException.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Tayanovskyy <anton@pulumi.com>
+Date: Thu, 27 Mar 2025 15:34:04 -0400
+Subject: [PATCH] Do not retry route53resolver LimitExceededException
+
+
+diff --git a/internal/service/route53resolver/service_package_extra_options.go b/internal/service/route53resolver/service_package_extra_options.go
+new file mode 100644
+index 0000000000..658e591e18
+--- /dev/null
++++ b/internal/service/route53resolver/service_package_extra_options.go
+@@ -0,0 +1,52 @@
++package route53resolver
++
++import (
++	"context"
++	"errors"
++
++	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
++	retry_sdkv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
++	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
++	smithy "github.com/aws/smithy-go"
++	"github.com/hashicorp/terraform-provider-aws/internal/conns"
++)
++
++// service_package_gen.go is a generated file but the behavior can be extended in another file by defining this
++// function which NewClient will call. Use this to customize error retries.
++func (p *servicePackage) withExtraOptions(
++	ctx context.Context,
++	config map[string]any,
++) []func(*route53resolver.Options) {
++	retryer := mustFindRetryer(config)
++	return []func(*route53resolver.Options){func(o *route53resolver.Options) {
++		o.Retryer = conns.AddIsErrorRetryables(retryer, doNotRetryLimitExceededException())
++	}}
++
++}
++
++func mustFindRetryer(config map[string]any) aws_sdkv2.RetryerV2 {
++	var retryer *aws_sdkv2.RetryerV2
++	if cfg, ok := config["aws_sdkv2_config"]; ok {
++		if cfgp, ok := cfg.(*aws_sdkv2.Config); ok {
++			if r, ok := cfgp.Retryer().(aws_sdkv2.RetryerV2); ok {
++				retryer = &r
++			}
++		}
++	}
++	if retryer == nil {
++		panic("Expected config['aws_sdk2_config'] to carry a Config with a RetryerV2")
++	}
++	return *retryer
++}
++
++func doNotRetryLimitExceededException() retry_sdkv2.IsErrorRetryable {
++	return retry_sdkv2.IsErrorRetryableFunc(func(err error) aws_sdkv2.Ternary {
++		var smithyErr smithy.APIError
++		if ok := errors.As(err, &smithyErr); ok {
++			if smithyErr.ErrorCode() == "LimitExceededException" {
++				return aws_sdkv2.FalseTernary
++			}
++		}
++		return aws_sdkv2.UnknownTernary // Delegate to the configured Retryer.
++	})
++}


### PR DESCRIPTION
Fixes #5219 

LimitExceededException is no longer retried but fails fast.

Added a patch tracking issue:

https://github.com/pulumi/pulumi-aws/issues/5385

Sent an upstream PR.