### PR TITLE
fix(lambda): architecture doc

### DIFF
--- a/sdk/nodejs/lambda/function.ts
+++ b/sdk/nodejs/lambda/function.ts
@@ -256,7 +256,7 @@ export class Function extends pulumi.CustomResource {
     }
 
     /**
-     * Instruction set architecture for your Lambda function. Valid values are `["x8664"]` and `["arm64"]`. Default is `["x8664"]`. Removing this attribute, function's architecture stay the same.
+     * Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]`. Removing this attribute, function's architecture stay the same.
      */
     public readonly architectures!: pulumi.Output<string[]>;
     /**
@@ -557,7 +557,7 @@ export class Function extends pulumi.CustomResource {
  */
 export interface FunctionState {
     /**
-     * Instruction set architecture for your Lambda function. Valid values are `["x8664"]` and `["arm64"]`. Default is `["x8664"]`. Removing this attribute, function's architecture stay the same.
+     * Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]`. Removing this attribute, function's architecture stay the same.
      */
     architectures?: pulumi.Input<pulumi.Input<string>[]>;
     /**
@@ -747,7 +747,7 @@ export interface FunctionState {
  */
 export interface FunctionArgs {
     /**
-     * Instruction set architecture for your Lambda function. Valid values are `["x8664"]` and `["arm64"]`. Default is `["x8664"]`. Removing this attribute, function's architecture stay the same.
+     * Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]`. Removing this attribute, function's architecture stay the same.
      */
     architectures?: pulumi.Input<pulumi.Input<string>[]>;
     /**


### PR DESCRIPTION
```
      aws:lambda:Function transformity-auditor  error: aws:lambda/function:Function resource 'transformity-auditor' has a problem: expected architectures to be one of ["x86_64" "arm64"], got x8664. Examine values at 'transformity-auditor.architectures[0]'.
      pulumi:pulumi:Stack transformity-auditor-gamma  
      aws:lambda:Function transformity-auditor **failed** 1 error
  Diagnostics:
    aws:lambda:Function (transformity-auditor):
      error: aws:lambda/function:Function resource 'transformity-auditor' has a problem: expected architectures to be one of ["x86_64" "arm64"], got x8664. Examine values at 'transformity-auditor.architectures[0]'.
  Resources:
      4 unchanged
  Duration: 10s
  /home/runner/work/_actions/pulumi/actions/v6/webpack:/pulumi-github-action/node_modules/@pulumi/pulumi/automation/errors.js:81
                      : new CommandError(result);
  ^
  CommandError: code: -2
   stdout: 
   stderr: Command failed with exit code 255: pulumi up --yes --skip-preview --exec-agent pulumi/actions@v5 --color auto --exec-kind auto.local --stack gamma --non-interactive
```