### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5435,6 +5435,7 @@ compatibility shim in favor of the new "name" field.`)
 			},
 			Namespaces: namespaceMap,
 		},
+		EnableAccurateBridgePreview: true,
 	}
 
 	rAlias := func(token string, prev, current tokens.Type, info *tfbridge.ResourceInfo) {


### PR DESCRIPTION
Enables accurate bridge previews for the AWS provider. This should improve the accuracy of our diffs and previews.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598