### PR TITLE
Compare schema from v7 branch

### DIFF
--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -92,7 +92,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p aws -o 7.0.0-alpha -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -92,7 +92,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p aws -o 7.0.0-alpha -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.base.ref }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 


### PR DESCRIPTION
This should run schema check against the `7.0.0-alpha` branch for pull requests made against it. 

I don't think that we need to worry about central CI management clobbering this either.