### PR TITLE
Remove more resource refs

### DIFF
--- a/docs/v7-upgrade.md
+++ b/docs/v7-upgrade.md
@@ -522,3 +522,5 @@ You should not see any diffs on your stack.
 - `apigateway.Stage`
   - `restApi: <your-api>` --> `restApi: <your-api>.id`
   - `deployment: <your-deployment>` --> `deployment: <your-deployment>.id`
+- `iot.PolicyAttachment`
+  - `policy: <your-iot-policy>` --> `policy: <your-iot-policy>.name`

--- a/docs/v7-upgrade.md
+++ b/docs/v7-upgrade.md
@@ -479,4 +479,46 @@ You should not see any diffs on your stack.
   `bucket: <your-bucket>` --> `bucket: <your-bucket>.id`
 - `s3.BucketObject`
   - `bucket: <your-bucket>` --> `bucket: <your-bucket>.id`
-
+- `iam.InstanceProfile`
+  - `role: <your-role>` --> `role: <your-role>.name`
+- `iam.PolicyAttachment`
+  - `roles: [<your-role>]` --> `roles: [<your-role>.name]`
+  - `users: [<your-user>]` --> `roles: [<your-user>.name]`
+  - `groups: [<your-group>]` --> `roles: [<your-group>.name]`
+- `iam.RolePolicy`
+  - `role: <your-role>` --> `role: <your-role>.name`
+- `iam.RolePolicyAttachment`
+  - `role: <your-role>` --> `role: <your-role>.name`
+- `iam.UserPolicyAttachment`
+  - `user: <your-user>` --> `role: <your-user>.name`
+- `iam.GroupPolicyAttachment`
+  - `group: <your-group>` --> `role: <your-group>.name`
+- `ec2.LaunchConfiguration`
+  - `iamInstanceProfile: <your-instance-profile>` --> `iamInstanceProfile: <your-instance-profile>.name`
+- `ec2.Instance`
+  - `iamInstanceProfile: <your-instance-profile>` --> `iamInstanceProfile: <your-instance-profile>.name`
+- `apigateway.Authorizer`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.BasePathMapping`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.Deployment`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.Integration`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.IntegrationResponse`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.Method`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.MethodResponse`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.MethodSettings`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.Model`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.RequestValidator`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.Resource`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+- `apigateway.Stage`
+  - `restApi: <your-api>` --> `restApi: <your-api>.id`
+  - `deployment: <your-deployment>` --> `deployment: <your-deployment>.id`

--- a/docs/v7-upgrade.md
+++ b/docs/v7-upgrade.md
@@ -524,3 +524,5 @@ You should not see any diffs on your stack.
   - `deployment: <your-deployment>` --> `deployment: <your-deployment>.id`
 - `iot.PolicyAttachment`
   - `policy: <your-iot-policy>` --> `policy: <your-iot-policy>.name`
+- `lambda.Permission`
+  - `function: <your-lambda-function>` --> `function: <your-lambda-function>.name`

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1189,6 +1189,8 @@ func TestResourceRefsMigrateCleanlyToStringRefs(t *testing.T) {
 		filepath.Join(resourceRefMigrateDir, "elasticbeanstalk"),
 		filepath.Join(resourceRefMigrateDir, "cloudwatch-with-topic"),
 		filepath.Join(resourceRefMigrateDir, "bucketobject"),
+		filepath.Join(resourceRefMigrateDir, "iamresources"),
+		filepath.Join(resourceRefMigrateDir, "apigatewaystage"),
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1185,12 +1185,12 @@ func TestResourceRefsMigrateCleanlyToStringRefs(t *testing.T) {
 	skipIfShort(t)
 	resourceRefMigrateDir := "migrate-resource-refs"
 	dirs := []string{
-		//filepath.Join(resourceRefMigrateDir, "autoscalinggroup"),
-		//filepath.Join(resourceRefMigrateDir, "elasticbeanstalk"),
-		//filepath.Join(resourceRefMigrateDir, "cloudwatch-with-topic"),
-		//filepath.Join(resourceRefMigrateDir, "bucketobject"),
-		//filepath.Join(resourceRefMigrateDir, "iamresources"),
-		//filepath.Join(resourceRefMigrateDir, "apigatewaystage"),
+		filepath.Join(resourceRefMigrateDir, "autoscalinggroup"),
+		filepath.Join(resourceRefMigrateDir, "elasticbeanstalk"),
+		filepath.Join(resourceRefMigrateDir, "cloudwatch-with-topic"),
+		filepath.Join(resourceRefMigrateDir, "bucketobject"),
+		filepath.Join(resourceRefMigrateDir, "iamresources"),
+		filepath.Join(resourceRefMigrateDir, "apigatewaystage"),
 		filepath.Join(resourceRefMigrateDir, "iotpolicy"),
 	}
 	cwd, err := os.Getwd()

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1185,12 +1185,13 @@ func TestResourceRefsMigrateCleanlyToStringRefs(t *testing.T) {
 	skipIfShort(t)
 	resourceRefMigrateDir := "migrate-resource-refs"
 	dirs := []string{
-		filepath.Join(resourceRefMigrateDir, "autoscalinggroup"),
-		filepath.Join(resourceRefMigrateDir, "elasticbeanstalk"),
-		filepath.Join(resourceRefMigrateDir, "cloudwatch-with-topic"),
-		filepath.Join(resourceRefMigrateDir, "bucketobject"),
-		filepath.Join(resourceRefMigrateDir, "iamresources"),
-		filepath.Join(resourceRefMigrateDir, "apigatewaystage"),
+		//filepath.Join(resourceRefMigrateDir, "autoscalinggroup"),
+		//filepath.Join(resourceRefMigrateDir, "elasticbeanstalk"),
+		//filepath.Join(resourceRefMigrateDir, "cloudwatch-with-topic"),
+		//filepath.Join(resourceRefMigrateDir, "bucketobject"),
+		//filepath.Join(resourceRefMigrateDir, "iamresources"),
+		//filepath.Join(resourceRefMigrateDir, "apigatewaystage"),
+		filepath.Join(resourceRefMigrateDir, "iotpolicy"),
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/examples/migrate-resource-refs/apigatewaystage/Pulumi.yaml
+++ b/examples/migrate-resource-refs/apigatewaystage/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: apigatewaystage
+runtime: nodejs
+description: A stack that shows moving from resource inputs to string inputs on some fields has no changes.

--- a/examples/migrate-resource-refs/apigatewaystage/index.ts
+++ b/examples/migrate-resource-refs/apigatewaystage/index.ts
@@ -1,0 +1,67 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create the API Gateway REST API
+const api = new aws.apigateway.RestApi("test-api", {
+    description: "Test API Gateway",
+});
+
+const resource = new aws.apigateway.Resource("test-resource", {
+    restApi: api,
+    parentId: api.rootResourceId,
+    pathPart: "test",
+});
+
+const method = new aws.apigateway.Method("test-method", {
+    restApi: api,
+    resourceId: resource.id,
+    httpMethod: "GET",
+    authorization: "NONE",
+});
+
+const integration = new aws.apigateway.Integration("test-integration", {
+    restApi: api,
+    resourceId: resource.id,
+    httpMethod: method.httpMethod,
+    type: "MOCK",
+    requestTemplates: {
+        "application/json": '{"statusCode": 200}',
+    },
+});
+
+const methodResponse = new aws.apigateway.MethodResponse("test-method-response", {
+    restApi: api,
+    resourceId: resource.id,
+    httpMethod: method.httpMethod,
+    statusCode: "200",
+    responseModels: {
+        "application/json": "Empty",
+    },
+});
+
+const integrationResponse = new aws.apigateway.IntegrationResponse("test-integration-response", {
+    restApi: api,
+    resourceId: resource.id,
+    httpMethod: method.httpMethod,
+    statusCode: methodResponse.statusCode,
+    responseTemplates: {
+        "application/json": '{"message": "Hello from API Gateway!"}',
+    },
+});
+
+const deployment = new aws.apigateway.Deployment("test-deployment", {
+    restApi: api,
+    triggers: {
+        redeployment: pulumi.all([resource.id, method.id, integration.id])
+            .apply(([resourceId, methodId, integrationId]) =>
+                JSON.stringify([resourceId, methodId, integrationId])),
+    },
+});
+
+const stage = new aws.apigateway.Stage("test-stage", {
+    deployment: deployment,
+    restApi: api,
+    stageName: "test",
+});
+
+export const apiUrl = pulumi.interpolate`${api.executionArn}${stage.stageName}/test`;

--- a/examples/migrate-resource-refs/apigatewaystage/package.json
+++ b/examples/migrate-resource-refs/apigatewaystage/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "apigatewaystage",
+  "devDependencies": {
+    "@types/node": "^18"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.80.0",
+    "@pulumi/pulumi": "^3.113.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/migrate-resource-refs/apigatewaystage/tsconfig.json
+++ b/examples/migrate-resource-refs/apigatewaystage/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/examples/migrate-resource-refs/apigatewaystage/v7/index.ts
+++ b/examples/migrate-resource-refs/apigatewaystage/v7/index.ts
@@ -1,0 +1,67 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create the API Gateway REST API
+const api = new aws.apigateway.RestApi("test-api", {
+    description: "Test API Gateway",
+});
+
+const resource = new aws.apigateway.Resource("test-resource", {
+    restApi: api.id,
+    parentId: api.rootResourceId,
+    pathPart: "test",
+});
+
+const method = new aws.apigateway.Method("test-method", {
+    restApi: api.id,
+    resourceId: resource.id,
+    httpMethod: "GET",
+    authorization: "NONE",
+});
+
+const integration = new aws.apigateway.Integration("test-integration", {
+    restApi: api.id,
+    resourceId: resource.id,
+    httpMethod: method.httpMethod,
+    type: "MOCK",
+    requestTemplates: {
+        "application/json": '{"statusCode": 200}',
+    },
+});
+
+const methodResponse = new aws.apigateway.MethodResponse("test-method-response", {
+    restApi: api.id,
+    resourceId: resource.id,
+    httpMethod: method.httpMethod,
+    statusCode: "200",
+    responseModels: {
+        "application/json": "Empty",
+    },
+});
+
+const integrationResponse = new aws.apigateway.IntegrationResponse("test-integration-response", {
+    restApi: api.id,
+    resourceId: resource.id,
+    httpMethod: method.httpMethod,
+    statusCode: methodResponse.statusCode,
+    responseTemplates: {
+        "application/json": '{"message": "Hello from API Gateway!"}',
+    },
+});
+
+const deployment = new aws.apigateway.Deployment("test-deployment", {
+    restApi: api.id,
+    triggers: {
+        redeployment: pulumi.all([resource.id, method.id, integration.id])
+            .apply(([resourceId, methodId, integrationId]) =>
+                JSON.stringify([resourceId, methodId, integrationId])),
+    },
+});
+
+const stage = new aws.apigateway.Stage("test-stage", {
+    deployment: deployment.id,
+    restApi: api.id,
+    stageName: "test",
+});
+
+export const apiUrl = pulumi.interpolate`${api.executionArn}${stage.stageName}/test`;

--- a/examples/migrate-resource-refs/iamresources/Pulumi.yaml
+++ b/examples/migrate-resource-refs/iamresources/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: iamresources
+runtime: nodejs
+description: A stack that shows moving from resource inputs to string inputs on some fields has no changes.

--- a/examples/migrate-resource-refs/iamresources/index.ts
+++ b/examples/migrate-resource-refs/iamresources/index.ts
@@ -1,0 +1,84 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const user = new aws.iam.User("test-user");
+
+const group = new aws.iam.Group("test-group");
+
+const role = new aws.iam.Role("test-role", {
+    assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Principal: {
+                Service: "ec2.amazonaws.com",
+            },
+        }],
+    }),
+});
+
+// Create an instance profile
+const instanceProfile = new aws.iam.InstanceProfile("test-profile", {
+    role: role,
+});
+
+const policy = new aws.iam.Policy("test-policy", {
+    description: "Test policy",
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: ["s3:ListBucket"],
+            Effect: "Allow",
+            Resource: "*",
+        }],
+    }),
+});
+
+const rolePolicy = new aws.iam.RolePolicy("test-role-policy", {
+    role: role,
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: ["ec2:DescribeInstances"],
+            Effect: "Allow",
+            Resource: "*",
+        }],
+    }),
+});
+
+const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("test-role-policy-attachment", {
+    role: role,
+    policyArn: policy.arn,
+});
+
+const groupPolicyAttachment = new aws.iam.GroupPolicyAttachment("test-group-policy-attachment", {
+    group: group,
+    policyArn: policy.arn,
+});
+
+const userPolicyAttachment = new aws.iam.UserPolicyAttachment("test-user-policy-attachment", {
+    user: user,
+    policyArn: policy.arn,
+});
+
+const policyAttachment = new aws.iam.PolicyAttachment("test-policy-attachment", {
+    users: [user],
+    roles: [role],
+    groups: [group],
+    policyArn: policy.arn,
+});
+
+const launchConfig = new aws.ec2.LaunchConfiguration("test-lc", {
+    imageId: "ami-0735c191cf914754d",
+    instanceType: "t2.micro",
+    iamInstanceProfile: instanceProfile,
+});
+
+const instance = new aws.ec2.Instance("test-instance", {
+    ami: "ami-0735c191cf914754d",
+    instanceType: "t2.micro",
+    iamInstanceProfile: instanceProfile,
+});
+
+export const instanceId = instance.id;

--- a/examples/migrate-resource-refs/iamresources/package.json
+++ b/examples/migrate-resource-refs/iamresources/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "iamresources",
+  "devDependencies": {
+    "@types/node": "^18"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.80.0",
+    "@pulumi/pulumi": "^3.113.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/migrate-resource-refs/iamresources/tsconfig.json
+++ b/examples/migrate-resource-refs/iamresources/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/examples/migrate-resource-refs/iamresources/v7/index.ts
+++ b/examples/migrate-resource-refs/iamresources/v7/index.ts
@@ -1,0 +1,84 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const user = new aws.iam.User("test-user");
+
+const group = new aws.iam.Group("test-group");
+
+const role = new aws.iam.Role("test-role", {
+    assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Principal: {
+                Service: "ec2.amazonaws.com",
+            },
+        }],
+    }),
+});
+
+// Create an instance profile
+const instanceProfile = new aws.iam.InstanceProfile("test-profile", {
+    role: role.name,
+});
+
+const policy = new aws.iam.Policy("test-policy", {
+    description: "Test policy",
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: ["s3:ListBucket"],
+            Effect: "Allow",
+            Resource: "*",
+        }],
+    }),
+});
+
+const rolePolicy = new aws.iam.RolePolicy("test-role-policy", {
+    role: role.name,
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: ["ec2:DescribeInstances"],
+            Effect: "Allow",
+            Resource: "*",
+        }],
+    }),
+});
+
+const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("test-role-policy-attachment", {
+    role: role.name,
+    policyArn: policy.arn,
+});
+
+const groupPolicyAttachment = new aws.iam.GroupPolicyAttachment("test-group-policy-attachment", {
+    group: group.name,
+    policyArn: policy.arn,
+});
+
+const userPolicyAttachment = new aws.iam.UserPolicyAttachment("test-user-policy-attachment", {
+    user: user.name,
+    policyArn: policy.arn,
+});
+
+const policyAttachment = new aws.iam.PolicyAttachment("test-policy-attachment", {
+    users: [user.name],
+    roles: [role.name],
+    groups: [group.name],
+    policyArn: policy.arn,
+});
+
+const launchConfig = new aws.ec2.LaunchConfiguration("test-lc", {
+    imageId: "ami-0735c191cf914754d",
+    instanceType: "t2.micro",
+    iamInstanceProfile: instanceProfile.name,
+});
+
+const instance = new aws.ec2.Instance("test-instance", {
+    ami: "ami-0735c191cf914754d",
+    instanceType: "t2.micro",
+    iamInstanceProfile: instanceProfile.name,
+});
+
+export const instanceId = instance.id;

--- a/examples/migrate-resource-refs/iotpolicy/Pulumi.yaml
+++ b/examples/migrate-resource-refs/iotpolicy/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: iotpolicy
+runtime: nodejs
+description: A stack that shows moving from resource inputs to string inputs on some fields has no changes.

--- a/examples/migrate-resource-refs/iotpolicy/index.ts
+++ b/examples/migrate-resource-refs/iotpolicy/index.ts
@@ -1,0 +1,23 @@
+import * as aws from "@pulumi/aws";
+
+const cert = new aws.iot.Certificate("test-cert", {
+    active: true,
+});
+
+const iotPolicy = new aws.iot.Policy("test-policy", {
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Effect: "Allow",
+            Action: "iot:Connect",
+            Resource: "*"
+        }]
+    })
+});
+
+const policyAttachment = new aws.iot.PolicyAttachment("test-policy-attachment", {
+    policy: iotPolicy,
+    target: cert.arn
+});
+
+export const policyName = iotPolicy.name;

--- a/examples/migrate-resource-refs/iotpolicy/package.json
+++ b/examples/migrate-resource-refs/iotpolicy/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "iotpolicy",
+  "devDependencies": {
+    "@types/node": "^18"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.80.0",
+    "@pulumi/pulumi": "^3.113.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/migrate-resource-refs/iotpolicy/tsconfig.json
+++ b/examples/migrate-resource-refs/iotpolicy/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/examples/migrate-resource-refs/iotpolicy/v7/index.ts
+++ b/examples/migrate-resource-refs/iotpolicy/v7/index.ts
@@ -1,0 +1,23 @@
+import * as aws from "@pulumi/aws";
+
+const cert = new aws.iot.Certificate("test-cert", {
+    active: true,
+});
+
+const iotPolicy = new aws.iot.Policy("test-policy", {
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Effect: "Allow",
+            Action: "iot:Connect",
+            Resource: "*"
+        }]
+    })
+});
+
+const policyAttachment = new aws.iot.PolicyAttachment("test-policy-attachment", {
+    policy: iotPolicy.name,
+    target: cert.arn
+});
+
+export const policyName = iotPolicy.name;

--- a/examples/migrate-resource-refs/lambdapermission/Pulumi.yaml
+++ b/examples/migrate-resource-refs/lambdapermission/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: lambdapermission
+runtime: nodejs
+description: A stack that shows moving from resource inputs to string inputs on some fields has no changes.

--- a/examples/migrate-resource-refs/lambdapermission/index.ts
+++ b/examples/migrate-resource-refs/lambdapermission/index.ts
@@ -1,0 +1,42 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const lambdaRole = new aws.iam.Role("lambda-role", {
+    assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Principal: {
+                Service: "lambda.amazonaws.com",
+            },
+        }],
+    }),
+});
+
+const lambdaPolicy = new aws.iam.RolePolicyAttachment("lambda-policy", {
+    role: lambdaRole.name,
+    policyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+});
+
+const lambda = new aws.lambda.Function("test-lambda", {
+    runtime: "nodejs18.x",
+    handler: "index.handler",
+    role: lambdaRole.arn,
+    code: new pulumi.asset.AssetArchive({
+        "index.js": new pulumi.asset.StringAsset(`
+            exports.handler = async (event) => {
+                return { message: "Hello from Lambda!" };
+            };
+        `),
+    }),
+});
+
+const permission = new aws.lambda.Permission("test-permission", {
+    action: "lambda:InvokeFunction",
+    function: lambda,
+    principal: "s3.amazonaws.com",
+    sourceArn: "arn:aws:s3:::test-bucket"
+});
+
+export const functionName = lambda.name;

--- a/examples/migrate-resource-refs/lambdapermission/package.json
+++ b/examples/migrate-resource-refs/lambdapermission/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "lambdapermission",
+  "devDependencies": {
+    "@types/node": "^18"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.80.0",
+    "@pulumi/pulumi": "^3.113.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/migrate-resource-refs/lambdapermission/tsconfig.json
+++ b/examples/migrate-resource-refs/lambdapermission/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/examples/migrate-resource-refs/lambdapermission/v7/index.ts
+++ b/examples/migrate-resource-refs/lambdapermission/v7/index.ts
@@ -1,0 +1,42 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const lambdaRole = new aws.iam.Role("lambda-role", {
+    assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Principal: {
+                Service: "lambda.amazonaws.com",
+            },
+        }],
+    }),
+});
+
+const lambdaPolicy = new aws.iam.RolePolicyAttachment("lambda-policy", {
+    role: lambdaRole.name,
+    policyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+});
+
+const lambda = new aws.lambda.Function("test-lambda", {
+    runtime: "nodejs18.x",
+    handler: "index.handler",
+    role: lambdaRole.arn,
+    code: new pulumi.asset.AssetArchive({
+        "index.js": new pulumi.asset.StringAsset(`
+            exports.handler = async (event) => {
+                return { message: "Hello from Lambda!" };
+            };
+        `),
+    }),
+});
+
+const permission = new aws.lambda.Permission("test-permission", {
+    action: "lambda:InvokeFunction",
+    function: lambda.name,
+    principal: "s3.amazonaws.com",
+    sourceArn: "arn:aws:s3:::test-bucket"
+});
+
+export const functionName = lambda.name;

--- a/examples/serverless-raw/index.ts
+++ b/examples/serverless-raw/index.ts
@@ -30,7 +30,7 @@ let role = new aws.iam.Role("mylambda-role", {
     assumeRolePolicy: JSON.stringify(policy),
 }, providerOpts);
 let fullAccess = new aws.iam.RolePolicyAttachment("mylambda-access", {
-    role: role,
+    role: role.name,
     policyArn: aws.iam.ManagedPolicy.LambdaFullAccess,
 }, providerOpts);
 let lambda = new aws.lambda.Function("mylambda", {
@@ -115,20 +115,20 @@ let music = new aws.dynamodb.Table("music", {
 let restApi = new aws.apigateway.RestApi("myrestapi", {}, providerOpts);
 
 let resource = new aws.apigateway.Resource("myrestapi-resource", {
-    restApi: restApi,
+    restApi: restApi.id,
     pathPart: "bambam",
     parentId: restApi.rootResourceId!,
 }, providerOpts);
 
 let method = new aws.apigateway.Method("myrestapi-method", {
-    restApi: restApi,
+    restApi: restApi.id,
     resourceId: resource.id,
     httpMethod: "ANY",
     authorization: "NONE",
 }, providerOpts);
 
 let integration = new aws.apigateway.Integration("myrestapi-integration", {
-    restApi: restApi,
+    restApi: restApi.id,
     resourceId: resource.id,
     httpMethod: "ANY",
     type: "AWS_PROXY",
@@ -138,12 +138,12 @@ let integration = new aws.apigateway.Integration("myrestapi-integration", {
 }, { dependsOn: [method], provider: providerOpts.provider });
 
 let deployment = new aws.apigateway.Deployment("myrestapi-deployment-prod", {
-    restApi: restApi,
+    restApi: restApi.id,
     description: "my deployment",
 }, { dependsOn: [integration], provider: providerOpts.provider });
 
 let stage = new aws.apigateway.Stage("myrestapi-stage", {
-    restApi: restApi,
-    deployment: deployment,
+    restApi: restApi.id,
+    deployment: deployment.id,
     stageName: "prod",
 }, { provider: providerOpts.provider });

--- a/examples/serverless-raw/index.ts
+++ b/examples/serverless-raw/index.ts
@@ -66,7 +66,7 @@ let permission = new aws.lambda.Permission("logcollector-permission", {
     action: "lambda:InvokeFunction",
     principal: "logs." + region + ".amazonaws.com",
     sourceArn: pulumi.interpolate`${logGroup.arn}:*`,
-    function: logcollector,
+    function: logcollector.name,
 }, providerOpts);
 
 let logSubscription = new aws.cloudwatch.LogSubscriptionFilter("logsubscription", {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2876,9 +2876,9 @@ compatibility shim in favor of the new "name" field.`)
 				IDFields: []string{"statement_id"},
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"function_name": {
-						Name:     "function",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(lambdaMod, "Function")},
+						Name: "function",
+						Type: "string",
+						//AltTypes: []tokens.Type{awsTypeDefaultFile(lambdaMod, "Function")},
 					},
 					"statement_id": tfbridge.AutoName("statementId", 100, "-"),
 				},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1866,8 +1866,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(ec2Mod, "Instance"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"iam_instance_profile": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "InstanceProfile")},
+						Type: "string",
 					},
 					"instance_type": {
 						Type:     "string",
@@ -1904,8 +1903,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(ec2Mod, "LaunchConfiguration"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"iam_instance_profile": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "InstanceProfile")},
+						Type: "string",
 					},
 				},
 			},
@@ -2500,8 +2498,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(iamMod, "GroupPolicyAttachment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"group": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Group")},
+						Type: "string",
 					},
 					"policy_arn": {
 						Name: "policyArn",
@@ -2516,8 +2513,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(iamMod, "InstanceProfile"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"role": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+						Type: "string",
 					},
 				},
 			},
@@ -2538,20 +2534,17 @@ compatibility shim in favor of the new "name" field.`)
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"users": {
 						Elem: &tfbridge.SchemaInfo{
-							Type:     "string",
-							AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "User")},
+							Type: "string",
 						},
 					},
 					"roles": {
 						Elem: &tfbridge.SchemaInfo{
-							Type:     "string",
-							AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+							Type: "string",
 						},
 					},
 					"groups": {
 						Elem: &tfbridge.SchemaInfo{
-							Type:     "string",
-							AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Group")},
+							Type: "string",
 						},
 					},
 					"policy_arn": {
@@ -2567,8 +2560,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(iamMod, "RolePolicyAttachment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"role": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+						Type: "string",
 					},
 					"policy_arn": {
 						Name: "policyArn",
@@ -2583,8 +2575,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(iamMod, "RolePolicy"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"role": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+						Type: "string",
 					},
 					"policy": {
 						Type:      "string",
@@ -2650,8 +2641,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(iamMod, "UserPolicyAttachment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"user": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "User")},
+						Type: "string",
 					},
 					"policy_arn": {
 						Name: "policyArn",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2878,7 +2878,6 @@ compatibility shim in favor of the new "name" field.`)
 					"function_name": {
 						Name: "function",
 						Type: "string",
-						//AltTypes: []tokens.Type{awsTypeDefaultFile(lambdaMod, "Function")},
 					},
 					"statement_id": tfbridge.AutoName("statementId", 100, "-"),
 				},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2694,8 +2694,7 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(iotMod, "PolicyAttachment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"policy": {
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(iotMod, "Policy")},
+						Type: "string",
 					},
 					"target": {
 						Type: awsTypeDefaultFile(awsMod, "ARN"),

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1048,9 +1048,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "Authorizer"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1058,9 +1057,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "BasePathMapping"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1069,9 +1067,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "Deployment"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1089,9 +1086,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "Integration"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 				DeleteBeforeReplace: true,
@@ -1100,9 +1096,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "IntegrationResponse"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1110,9 +1105,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "Method"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1120,9 +1114,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "MethodResponse"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1130,9 +1123,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "MethodSettings"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1140,9 +1132,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "Model"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1150,9 +1141,8 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "RequestValidator"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1165,9 +1155,8 @@ compatibility shim in favor of the new "name" field.`)
 					// 	Type: awsTypeDefaultFile(apigatewayMod, "Resource"),
 					// },
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},
@@ -1177,14 +1166,12 @@ compatibility shim in favor of the new "name" field.`)
 				Tok: awsResource(apigatewayMod, "Stage"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"deployment_id": {
-						Name:     "deployment",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "Deployment")},
+						Name: "deployment",
+						Type: "string",
 					},
 					"rest_api_id": {
-						Name:     "restApi",
-						Type:     "string",
-						AltTypes: []tokens.Type{awsTypeDefaultFile(apigatewayMod, "RestApi")},
+						Name: "restApi",
+						Type: "string",
 					},
 				},
 			},

--- a/sdk/go/aws/apigateway/authorizer.go
+++ b/sdk/go/aws/apigateway/authorizer.go
@@ -236,7 +236,7 @@ type authorizerState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
 	Type *string `pulumi:"type"`
 }
@@ -262,7 +262,7 @@ type AuthorizerState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
 	Type pulumi.StringPtrInput
 }
@@ -290,7 +290,7 @@ type authorizerArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
 	Type *string `pulumi:"type"`
 }
@@ -315,7 +315,7 @@ type AuthorizerArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
 	Type pulumi.StringPtrInput
 }

--- a/sdk/go/aws/apigateway/basePathMapping.go
+++ b/sdk/go/aws/apigateway/basePathMapping.go
@@ -101,7 +101,7 @@ type basePathMappingState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the API to connect.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 	StageName *string `pulumi:"stageName"`
 }
@@ -116,7 +116,7 @@ type BasePathMappingState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the API to connect.
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 	StageName pulumi.StringPtrInput
 }
@@ -135,7 +135,7 @@ type basePathMappingArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the API to connect.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 	StageName *string `pulumi:"stageName"`
 }
@@ -151,7 +151,7 @@ type BasePathMappingArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the API to connect.
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 	StageName pulumi.StringPtrInput
 }

--- a/sdk/go/aws/apigateway/deployment.go
+++ b/sdk/go/aws/apigateway/deployment.go
@@ -88,7 +88,7 @@ type deploymentState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// REST API identifier.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Map of arbitrary keys and values that, when changed, will trigger a redeployment.
 	Triggers map[string]string `pulumi:"triggers"`
 	// Map to set on the related stage.
@@ -103,7 +103,7 @@ type DeploymentState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// REST API identifier.
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Map of arbitrary keys and values that, when changed, will trigger a redeployment.
 	Triggers pulumi.StringMapInput
 	// Map to set on the related stage.
@@ -120,7 +120,7 @@ type deploymentArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// REST API identifier.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Map of arbitrary keys and values that, when changed, will trigger a redeployment.
 	Triggers map[string]string `pulumi:"triggers"`
 	// Map to set on the related stage.
@@ -134,7 +134,7 @@ type DeploymentArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// REST API identifier.
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Map of arbitrary keys and values that, when changed, will trigger a redeployment.
 	Triggers pulumi.StringMapInput
 	// Map to set on the related stage.

--- a/sdk/go/aws/apigateway/integration.go
+++ b/sdk/go/aws/apigateway/integration.go
@@ -427,7 +427,7 @@ type integrationState struct {
 	// API resource ID.
 	ResourceId *string `pulumi:"resourceId"`
 	// ID of the associated REST API.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
 	TimeoutMilliseconds *int `pulumi:"timeoutMilliseconds"`
 	// TLS configuration. See below.
@@ -474,7 +474,7 @@ type IntegrationState struct {
 	// API resource ID.
 	ResourceId pulumi.StringPtrInput
 	// ID of the associated REST API.
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
 	TimeoutMilliseconds pulumi.IntPtrInput
 	// TLS configuration. See below.
@@ -525,7 +525,7 @@ type integrationArgs struct {
 	// API resource ID.
 	ResourceId string `pulumi:"resourceId"`
 	// ID of the associated REST API.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
 	TimeoutMilliseconds *int `pulumi:"timeoutMilliseconds"`
 	// TLS configuration. See below.
@@ -573,7 +573,7 @@ type IntegrationArgs struct {
 	// API resource ID.
 	ResourceId pulumi.StringInput
 	// ID of the associated REST API.
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
 	TimeoutMilliseconds pulumi.IntPtrInput
 	// TLS configuration. See below.

--- a/sdk/go/aws/apigateway/integrationResponse.go
+++ b/sdk/go/aws/apigateway/integrationResponse.go
@@ -187,7 +187,7 @@ type integrationResponseState struct {
 	// Map of templates used to transform the integration response body.
 	ResponseTemplates map[string]string `pulumi:"responseTemplates"`
 	// ID of the associated REST API.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Regular expression pattern used to choose an integration response based on the response from the backend. Omit configuring this to make the integration the default one. If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched. For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 	SelectionPattern *string `pulumi:"selectionPattern"`
 	// HTTP status code.
@@ -210,7 +210,7 @@ type IntegrationResponseState struct {
 	// Map of templates used to transform the integration response body.
 	ResponseTemplates pulumi.StringMapInput
 	// ID of the associated REST API.
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Regular expression pattern used to choose an integration response based on the response from the backend. Omit configuring this to make the integration the default one. If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched. For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 	SelectionPattern pulumi.StringPtrInput
 	// HTTP status code.
@@ -237,7 +237,7 @@ type integrationResponseArgs struct {
 	// Map of templates used to transform the integration response body.
 	ResponseTemplates map[string]string `pulumi:"responseTemplates"`
 	// ID of the associated REST API.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Regular expression pattern used to choose an integration response based on the response from the backend. Omit configuring this to make the integration the default one. If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched. For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 	SelectionPattern *string `pulumi:"selectionPattern"`
 	// HTTP status code.
@@ -261,7 +261,7 @@ type IntegrationResponseArgs struct {
 	// Map of templates used to transform the integration response body.
 	ResponseTemplates pulumi.StringMapInput
 	// ID of the associated REST API.
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Regular expression pattern used to choose an integration response based on the response from the backend. Omit configuring this to make the integration the default one. If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched. For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 	SelectionPattern pulumi.StringPtrInput
 	// HTTP status code.

--- a/sdk/go/aws/apigateway/method.go
+++ b/sdk/go/aws/apigateway/method.go
@@ -231,7 +231,7 @@ type methodState struct {
 	// API resource ID
 	ResourceId *string `pulumi:"resourceId"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 }
 
 type MethodState struct {
@@ -261,7 +261,7 @@ type MethodState struct {
 	// API resource ID
 	ResourceId pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 }
 
 func (MethodState) ElementType() reflect.Type {
@@ -295,7 +295,7 @@ type methodArgs struct {
 	// API resource ID
 	ResourceId string `pulumi:"resourceId"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 }
 
 // The set of arguments for constructing a Method resource.
@@ -326,7 +326,7 @@ type MethodArgs struct {
 	// API resource ID
 	ResourceId pulumi.StringInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 }
 
 func (MethodArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/apigateway/methodResponse.go
+++ b/sdk/go/aws/apigateway/methodResponse.go
@@ -256,7 +256,7 @@ type methodResponseState struct {
 	// The response parameter names defined here are available in the integration response to be mapped from an integration response header expressed in `integration.response.header.{name}`, a static value enclosed within a pair of single quotes (e.g., '`application/json'`), or a JSON expression from the back-end response payload in the form of `integration.response.body.{JSON-expression}`, where `JSON-expression` is a valid JSON expression without the `$` prefix.)
 	ResponseParameters map[string]bool `pulumi:"responseParameters"`
 	// The string identifier of the associated REST API.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// The method response's status code.
 	StatusCode *string `pulumi:"statusCode"`
 }
@@ -275,7 +275,7 @@ type MethodResponseState struct {
 	// The response parameter names defined here are available in the integration response to be mapped from an integration response header expressed in `integration.response.header.{name}`, a static value enclosed within a pair of single quotes (e.g., '`application/json'`), or a JSON expression from the back-end response payload in the form of `integration.response.body.{JSON-expression}`, where `JSON-expression` is a valid JSON expression without the `$` prefix.)
 	ResponseParameters pulumi.BoolMapInput
 	// The string identifier of the associated REST API.
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// The method response's status code.
 	StatusCode pulumi.StringPtrInput
 }
@@ -298,7 +298,7 @@ type methodResponseArgs struct {
 	// The response parameter names defined here are available in the integration response to be mapped from an integration response header expressed in `integration.response.header.{name}`, a static value enclosed within a pair of single quotes (e.g., '`application/json'`), or a JSON expression from the back-end response payload in the form of `integration.response.body.{JSON-expression}`, where `JSON-expression` is a valid JSON expression without the `$` prefix.)
 	ResponseParameters map[string]bool `pulumi:"responseParameters"`
 	// The string identifier of the associated REST API.
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// The method response's status code.
 	StatusCode string `pulumi:"statusCode"`
 }
@@ -318,7 +318,7 @@ type MethodResponseArgs struct {
 	// The response parameter names defined here are available in the integration response to be mapped from an integration response header expressed in `integration.response.header.{name}`, a static value enclosed within a pair of single quotes (e.g., '`application/json'`), or a JSON expression from the back-end response payload in the form of `integration.response.body.{JSON-expression}`, where `JSON-expression` is a valid JSON expression without the `$` prefix.)
 	ResponseParameters pulumi.BoolMapInput
 	// The string identifier of the associated REST API.
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// The method response's status code.
 	StatusCode pulumi.StringInput
 }

--- a/sdk/go/aws/apigateway/methodSettings.go
+++ b/sdk/go/aws/apigateway/methodSettings.go
@@ -219,7 +219,7 @@ type methodSettingsState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Settings block, see below.
 	Settings *MethodSettingsSettings `pulumi:"settings"`
 	// Name of the stage
@@ -232,7 +232,7 @@ type MethodSettingsState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Settings block, see below.
 	Settings MethodSettingsSettingsPtrInput
 	// Name of the stage
@@ -249,7 +249,7 @@ type methodSettingsArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Settings block, see below.
 	Settings MethodSettingsSettings `pulumi:"settings"`
 	// Name of the stage
@@ -263,7 +263,7 @@ type MethodSettingsArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Settings block, see below.
 	Settings MethodSettingsSettingsInput
 	// Name of the stage

--- a/sdk/go/aws/apigateway/model.go
+++ b/sdk/go/aws/apigateway/model.go
@@ -129,7 +129,7 @@ type modelState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Schema of the model in a JSON form
 	Schema *string `pulumi:"schema"`
 }
@@ -144,7 +144,7 @@ type ModelState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Schema of the model in a JSON form
 	Schema pulumi.StringPtrInput
 }
@@ -163,7 +163,7 @@ type modelArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Schema of the model in a JSON form
 	Schema *string `pulumi:"schema"`
 }
@@ -179,7 +179,7 @@ type ModelArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Schema of the model in a JSON form
 	Schema pulumi.StringPtrInput
 }

--- a/sdk/go/aws/apigateway/requestValidator.go
+++ b/sdk/go/aws/apigateway/requestValidator.go
@@ -103,7 +103,7 @@ type requestValidatorState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated Rest API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Boolean whether to validate request body. Defaults to `false`.
 	ValidateRequestBody *bool `pulumi:"validateRequestBody"`
 	// Boolean whether to validate request parameters. Defaults to `false`.
@@ -116,7 +116,7 @@ type RequestValidatorState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated Rest API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Boolean whether to validate request body. Defaults to `false`.
 	ValidateRequestBody pulumi.BoolPtrInput
 	// Boolean whether to validate request parameters. Defaults to `false`.
@@ -133,7 +133,7 @@ type requestValidatorArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated Rest API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Boolean whether to validate request body. Defaults to `false`.
 	ValidateRequestBody *bool `pulumi:"validateRequestBody"`
 	// Boolean whether to validate request parameters. Defaults to `false`.
@@ -147,7 +147,7 @@ type RequestValidatorArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated Rest API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Boolean whether to validate request body. Defaults to `false`.
 	ValidateRequestBody pulumi.BoolPtrInput
 	// Boolean whether to validate request parameters. Defaults to `false`.

--- a/sdk/go/aws/apigateway/resource.go
+++ b/sdk/go/aws/apigateway/resource.go
@@ -119,7 +119,7 @@ type resourceState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 }
 
 type ResourceState struct {
@@ -132,7 +132,7 @@ type ResourceState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 }
 
 func (ResourceState) ElementType() reflect.Type {
@@ -147,7 +147,7 @@ type resourceArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 }
 
 // The set of arguments for constructing a Resource resource.
@@ -159,7 +159,7 @@ type ResourceArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/apigateway/stage.go
+++ b/sdk/go/aws/apigateway/stage.go
@@ -171,7 +171,7 @@ type stageState struct {
 	// Identifier of a client certificate for the stage.
 	ClientCertificateId *string `pulumi:"clientCertificateId"`
 	// ID of the deployment that the stage points to
-	Deployment interface{} `pulumi:"deployment"`
+	Deployment *string `pulumi:"deployment"`
 	// Description of the stage.
 	Description *string `pulumi:"description"`
 	// Version of the associated API documentation.
@@ -186,7 +186,7 @@ type stageState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi *string `pulumi:"restApi"`
 	// Name of the stage
 	StageName *string `pulumi:"stageName"`
 	// Map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -215,7 +215,7 @@ type StageState struct {
 	// Identifier of a client certificate for the stage.
 	ClientCertificateId pulumi.StringPtrInput
 	// ID of the deployment that the stage points to
-	Deployment pulumi.Input
+	Deployment pulumi.StringPtrInput
 	// Description of the stage.
 	Description pulumi.StringPtrInput
 	// Version of the associated API documentation.
@@ -230,7 +230,7 @@ type StageState struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringPtrInput
 	// Name of the stage
 	StageName pulumi.StringPtrInput
 	// Map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -261,7 +261,7 @@ type stageArgs struct {
 	// Identifier of a client certificate for the stage.
 	ClientCertificateId *string `pulumi:"clientCertificateId"`
 	// ID of the deployment that the stage points to
-	Deployment interface{} `pulumi:"deployment"`
+	Deployment string `pulumi:"deployment"`
 	// Description of the stage.
 	Description *string `pulumi:"description"`
 	// Version of the associated API documentation.
@@ -269,7 +269,7 @@ type stageArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// ID of the associated REST API
-	RestApi interface{} `pulumi:"restApi"`
+	RestApi string `pulumi:"restApi"`
 	// Name of the stage
 	StageName string `pulumi:"stageName"`
 	// Map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -293,7 +293,7 @@ type StageArgs struct {
 	// Identifier of a client certificate for the stage.
 	ClientCertificateId pulumi.StringPtrInput
 	// ID of the deployment that the stage points to
-	Deployment pulumi.Input
+	Deployment pulumi.StringInput
 	// Description of the stage.
 	Description pulumi.StringPtrInput
 	// Version of the associated API documentation.
@@ -301,7 +301,7 @@ type StageArgs struct {
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// ID of the associated REST API
-	RestApi pulumi.Input
+	RestApi pulumi.StringInput
 	// Name of the stage
 	StageName pulumi.StringInput
 	// Map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.

--- a/sdk/go/aws/ec2/instance.go
+++ b/sdk/go/aws/ec2/instance.go
@@ -543,7 +543,7 @@ type instanceState struct {
 	// ARN of the host resource group in which to launch the instances. If you specify an ARN, omit the `tenancy` parameter or set it to `host`.
 	HostResourceGroupArn *string `pulumi:"hostResourceGroupArn"`
 	// IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
-	IamInstanceProfile interface{} `pulumi:"iamInstanceProfile"`
+	IamInstanceProfile *string `pulumi:"iamInstanceProfile"`
 	// Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
 	InstanceInitiatedShutdownBehavior *string `pulumi:"instanceInitiatedShutdownBehavior"`
 	// Indicates whether this is a Spot Instance or a Scheduled Instance.
@@ -666,7 +666,7 @@ type InstanceState struct {
 	// ARN of the host resource group in which to launch the instances. If you specify an ARN, omit the `tenancy` parameter or set it to `host`.
 	HostResourceGroupArn pulumi.StringPtrInput
 	// IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
-	IamInstanceProfile pulumi.Input
+	IamInstanceProfile pulumi.StringPtrInput
 	// Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
 	InstanceInitiatedShutdownBehavior pulumi.StringPtrInput
 	// Indicates whether this is a Spot Instance or a Scheduled Instance.
@@ -791,7 +791,7 @@ type instanceArgs struct {
 	// ARN of the host resource group in which to launch the instances. If you specify an ARN, omit the `tenancy` parameter or set it to `host`.
 	HostResourceGroupArn *string `pulumi:"hostResourceGroupArn"`
 	// IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
-	IamInstanceProfile interface{} `pulumi:"iamInstanceProfile"`
+	IamInstanceProfile *string `pulumi:"iamInstanceProfile"`
 	// Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
 	InstanceInitiatedShutdownBehavior *string `pulumi:"instanceInitiatedShutdownBehavior"`
 	// Describes the market (purchasing) option for the instances. See Market Options below for details on attributes.
@@ -893,7 +893,7 @@ type InstanceArgs struct {
 	// ARN of the host resource group in which to launch the instances. If you specify an ARN, omit the `tenancy` parameter or set it to `host`.
 	HostResourceGroupArn pulumi.StringPtrInput
 	// IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
-	IamInstanceProfile pulumi.Input
+	IamInstanceProfile pulumi.StringPtrInput
 	// Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
 	InstanceInitiatedShutdownBehavior pulumi.StringPtrInput
 	// Describes the market (purchasing) option for the instances. See Market Options below for details on attributes.

--- a/sdk/go/aws/ec2/launchConfiguration.go
+++ b/sdk/go/aws/ec2/launchConfiguration.go
@@ -172,7 +172,7 @@ type launchConfigurationState struct {
 	// Customize Ephemeral (also known as "Instance Store") volumes on the instance. See Block Devices below for details.
 	EphemeralBlockDevices []LaunchConfigurationEphemeralBlockDevice `pulumi:"ephemeralBlockDevices"`
 	// The name attribute of the IAM instance profile to associate with launched instances.
-	IamInstanceProfile interface{} `pulumi:"iamInstanceProfile"`
+	IamInstanceProfile *string `pulumi:"iamInstanceProfile"`
 	// The EC2 image ID to launch.
 	ImageId *string `pulumi:"imageId"`
 	// The size of instance to launch.
@@ -217,7 +217,7 @@ type LaunchConfigurationState struct {
 	// Customize Ephemeral (also known as "Instance Store") volumes on the instance. See Block Devices below for details.
 	EphemeralBlockDevices LaunchConfigurationEphemeralBlockDeviceArrayInput
 	// The name attribute of the IAM instance profile to associate with launched instances.
-	IamInstanceProfile pulumi.Input
+	IamInstanceProfile pulumi.StringPtrInput
 	// The EC2 image ID to launch.
 	ImageId pulumi.StringPtrInput
 	// The size of instance to launch.
@@ -264,7 +264,7 @@ type launchConfigurationArgs struct {
 	// Customize Ephemeral (also known as "Instance Store") volumes on the instance. See Block Devices below for details.
 	EphemeralBlockDevices []LaunchConfigurationEphemeralBlockDevice `pulumi:"ephemeralBlockDevices"`
 	// The name attribute of the IAM instance profile to associate with launched instances.
-	IamInstanceProfile interface{} `pulumi:"iamInstanceProfile"`
+	IamInstanceProfile *string `pulumi:"iamInstanceProfile"`
 	// The EC2 image ID to launch.
 	ImageId string `pulumi:"imageId"`
 	// The size of instance to launch.
@@ -308,7 +308,7 @@ type LaunchConfigurationArgs struct {
 	// Customize Ephemeral (also known as "Instance Store") volumes on the instance. See Block Devices below for details.
 	EphemeralBlockDevices LaunchConfigurationEphemeralBlockDeviceArrayInput
 	// The name attribute of the IAM instance profile to associate with launched instances.
-	IamInstanceProfile pulumi.Input
+	IamInstanceProfile pulumi.StringPtrInput
 	// The EC2 image ID to launch.
 	ImageId pulumi.StringInput
 	// The size of instance to launch.

--- a/sdk/go/aws/iam/groupPolicyAttachment.go
+++ b/sdk/go/aws/iam/groupPolicyAttachment.go
@@ -110,14 +110,14 @@ func GetGroupPolicyAttachment(ctx *pulumi.Context,
 // Input properties used for looking up and filtering GroupPolicyAttachment resources.
 type groupPolicyAttachmentState struct {
 	// The group the policy should be applied to
-	Group interface{} `pulumi:"group"`
+	Group *string `pulumi:"group"`
 	// The ARN of the policy you want to apply
 	PolicyArn *string `pulumi:"policyArn"`
 }
 
 type GroupPolicyAttachmentState struct {
 	// The group the policy should be applied to
-	Group pulumi.Input
+	Group pulumi.StringPtrInput
 	// The ARN of the policy you want to apply
 	PolicyArn pulumi.StringPtrInput
 }
@@ -128,7 +128,7 @@ func (GroupPolicyAttachmentState) ElementType() reflect.Type {
 
 type groupPolicyAttachmentArgs struct {
 	// The group the policy should be applied to
-	Group interface{} `pulumi:"group"`
+	Group string `pulumi:"group"`
 	// The ARN of the policy you want to apply
 	PolicyArn string `pulumi:"policyArn"`
 }
@@ -136,7 +136,7 @@ type groupPolicyAttachmentArgs struct {
 // The set of arguments for constructing a GroupPolicyAttachment resource.
 type GroupPolicyAttachmentArgs struct {
 	// The group the policy should be applied to
-	Group pulumi.Input
+	Group pulumi.StringInput
 	// The ARN of the policy you want to apply
 	PolicyArn pulumi.StringInput
 }

--- a/sdk/go/aws/iam/instanceProfile.go
+++ b/sdk/go/aws/iam/instanceProfile.go
@@ -142,7 +142,7 @@ type instanceProfileState struct {
 	// Path to the instance profile. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide. Can be a string of characters consisting of either a forward slash (`/`) by itself or a string that must begin and end with forward slashes. Can include any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercase letters.
 	Path *string `pulumi:"path"`
 	// Name of the role to add to the profile.
-	Role interface{} `pulumi:"role"`
+	Role *string `pulumi:"role"`
 	// Map of resource tags for the IAM Instance Profile. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 	// A map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
@@ -163,7 +163,7 @@ type InstanceProfileState struct {
 	// Path to the instance profile. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide. Can be a string of characters consisting of either a forward slash (`/`) by itself or a string that must begin and end with forward slashes. Can include any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercase letters.
 	Path pulumi.StringPtrInput
 	// Name of the role to add to the profile.
-	Role pulumi.Input
+	Role pulumi.StringPtrInput
 	// Map of resource tags for the IAM Instance Profile. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 	// A map of tags assigned to the resource, including those inherited from the provider `defaultTags` configuration block.
@@ -184,7 +184,7 @@ type instanceProfileArgs struct {
 	// Path to the instance profile. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide. Can be a string of characters consisting of either a forward slash (`/`) by itself or a string that must begin and end with forward slashes. Can include any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercase letters.
 	Path *string `pulumi:"path"`
 	// Name of the role to add to the profile.
-	Role interface{} `pulumi:"role"`
+	Role *string `pulumi:"role"`
 	// Map of resource tags for the IAM Instance Profile. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -198,7 +198,7 @@ type InstanceProfileArgs struct {
 	// Path to the instance profile. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide. Can be a string of characters consisting of either a forward slash (`/`) by itself or a string that must begin and end with forward slashes. Can include any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercase letters.
 	Path pulumi.StringPtrInput
 	// Name of the role to add to the profile.
-	Role pulumi.Input
+	Role pulumi.StringPtrInput
 	// Map of resource tags for the IAM Instance Profile. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }

--- a/sdk/go/aws/iam/policyAttachment.go
+++ b/sdk/go/aws/iam/policyAttachment.go
@@ -102,13 +102,13 @@ import (
 //			}
 //			_, err = iam.NewPolicyAttachment(ctx, "test-attach", &iam.PolicyAttachmentArgs{
 //				Name: pulumi.String("test-attachment"),
-//				Users: pulumi.Array{
+//				Users: pulumi.StringArray{
 //					user.Name,
 //				},
-//				Roles: pulumi.Array{
+//				Roles: pulumi.StringArray{
 //					role.Name,
 //				},
-//				Groups: pulumi.Array{
+//				Groups: pulumi.StringArray{
 //					group.Name,
 //				},
 //				PolicyArn: policyPolicy.Arn,
@@ -170,28 +170,28 @@ func GetPolicyAttachment(ctx *pulumi.Context,
 // Input properties used for looking up and filtering PolicyAttachment resources.
 type policyAttachmentState struct {
 	// Group(s) the policy should be applied to.
-	Groups []interface{} `pulumi:"groups"`
+	Groups []string `pulumi:"groups"`
 	// Name of the attachment. This cannot be an empty string.
 	Name *string `pulumi:"name"`
 	// ARN of the policy you want to apply. Typically this should be a reference to the ARN of another resource to ensure dependency ordering, such as `aws_iam_policy.example.arn`.
 	PolicyArn *string `pulumi:"policyArn"`
 	// Role(s) the policy should be applied to.
-	Roles []interface{} `pulumi:"roles"`
+	Roles []string `pulumi:"roles"`
 	// User(s) the policy should be applied to.
-	Users []interface{} `pulumi:"users"`
+	Users []string `pulumi:"users"`
 }
 
 type PolicyAttachmentState struct {
 	// Group(s) the policy should be applied to.
-	Groups pulumi.ArrayInput
+	Groups pulumi.StringArrayInput
 	// Name of the attachment. This cannot be an empty string.
 	Name pulumi.StringPtrInput
 	// ARN of the policy you want to apply. Typically this should be a reference to the ARN of another resource to ensure dependency ordering, such as `aws_iam_policy.example.arn`.
 	PolicyArn pulumi.StringPtrInput
 	// Role(s) the policy should be applied to.
-	Roles pulumi.ArrayInput
+	Roles pulumi.StringArrayInput
 	// User(s) the policy should be applied to.
-	Users pulumi.ArrayInput
+	Users pulumi.StringArrayInput
 }
 
 func (PolicyAttachmentState) ElementType() reflect.Type {
@@ -200,29 +200,29 @@ func (PolicyAttachmentState) ElementType() reflect.Type {
 
 type policyAttachmentArgs struct {
 	// Group(s) the policy should be applied to.
-	Groups []interface{} `pulumi:"groups"`
+	Groups []string `pulumi:"groups"`
 	// Name of the attachment. This cannot be an empty string.
 	Name *string `pulumi:"name"`
 	// ARN of the policy you want to apply. Typically this should be a reference to the ARN of another resource to ensure dependency ordering, such as `aws_iam_policy.example.arn`.
 	PolicyArn string `pulumi:"policyArn"`
 	// Role(s) the policy should be applied to.
-	Roles []interface{} `pulumi:"roles"`
+	Roles []string `pulumi:"roles"`
 	// User(s) the policy should be applied to.
-	Users []interface{} `pulumi:"users"`
+	Users []string `pulumi:"users"`
 }
 
 // The set of arguments for constructing a PolicyAttachment resource.
 type PolicyAttachmentArgs struct {
 	// Group(s) the policy should be applied to.
-	Groups pulumi.ArrayInput
+	Groups pulumi.StringArrayInput
 	// Name of the attachment. This cannot be an empty string.
 	Name pulumi.StringPtrInput
 	// ARN of the policy you want to apply. Typically this should be a reference to the ARN of another resource to ensure dependency ordering, such as `aws_iam_policy.example.arn`.
 	PolicyArn pulumi.StringInput
 	// Role(s) the policy should be applied to.
-	Roles pulumi.ArrayInput
+	Roles pulumi.StringArrayInput
 	// User(s) the policy should be applied to.
-	Users pulumi.ArrayInput
+	Users pulumi.StringArrayInput
 }
 
 func (PolicyAttachmentArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/iam/rolePolicy.go
+++ b/sdk/go/aws/iam/rolePolicy.go
@@ -155,7 +155,7 @@ type rolePolicyState struct {
 	// The inline policy document. This is a JSON formatted string. For more information about building IAM policy documents with the provider, see the AWS IAM Policy Document Guide
 	Policy interface{} `pulumi:"policy"`
 	// The name of the IAM role to attach to the policy.
-	Role interface{} `pulumi:"role"`
+	Role *string `pulumi:"role"`
 }
 
 type RolePolicyState struct {
@@ -168,7 +168,7 @@ type RolePolicyState struct {
 	// The inline policy document. This is a JSON formatted string. For more information about building IAM policy documents with the provider, see the AWS IAM Policy Document Guide
 	Policy pulumi.Input
 	// The name of the IAM role to attach to the policy.
-	Role pulumi.Input
+	Role pulumi.StringPtrInput
 }
 
 func (RolePolicyState) ElementType() reflect.Type {
@@ -185,7 +185,7 @@ type rolePolicyArgs struct {
 	// The inline policy document. This is a JSON formatted string. For more information about building IAM policy documents with the provider, see the AWS IAM Policy Document Guide
 	Policy interface{} `pulumi:"policy"`
 	// The name of the IAM role to attach to the policy.
-	Role interface{} `pulumi:"role"`
+	Role string `pulumi:"role"`
 }
 
 // The set of arguments for constructing a RolePolicy resource.
@@ -199,7 +199,7 @@ type RolePolicyArgs struct {
 	// The inline policy document. This is a JSON formatted string. For more information about building IAM policy documents with the provider, see the AWS IAM Policy Document Guide
 	Policy pulumi.Input
 	// The name of the IAM role to attach to the policy.
-	Role pulumi.Input
+	Role pulumi.StringInput
 }
 
 func (RolePolicyArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/iam/rolePolicyAttachment.go
+++ b/sdk/go/aws/iam/rolePolicyAttachment.go
@@ -152,14 +152,14 @@ type rolePolicyAttachmentState struct {
 	// The ARN of the policy you want to apply
 	PolicyArn *string `pulumi:"policyArn"`
 	// The name of the IAM role to which the policy should be applied
-	Role interface{} `pulumi:"role"`
+	Role *string `pulumi:"role"`
 }
 
 type RolePolicyAttachmentState struct {
 	// The ARN of the policy you want to apply
 	PolicyArn pulumi.StringPtrInput
 	// The name of the IAM role to which the policy should be applied
-	Role pulumi.Input
+	Role pulumi.StringPtrInput
 }
 
 func (RolePolicyAttachmentState) ElementType() reflect.Type {
@@ -170,7 +170,7 @@ type rolePolicyAttachmentArgs struct {
 	// The ARN of the policy you want to apply
 	PolicyArn string `pulumi:"policyArn"`
 	// The name of the IAM role to which the policy should be applied
-	Role interface{} `pulumi:"role"`
+	Role string `pulumi:"role"`
 }
 
 // The set of arguments for constructing a RolePolicyAttachment resource.
@@ -178,7 +178,7 @@ type RolePolicyAttachmentArgs struct {
 	// The ARN of the policy you want to apply
 	PolicyArn pulumi.StringInput
 	// The name of the IAM role to which the policy should be applied
-	Role pulumi.Input
+	Role pulumi.StringInput
 }
 
 func (RolePolicyAttachmentArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/iam/userPolicyAttachment.go
+++ b/sdk/go/aws/iam/userPolicyAttachment.go
@@ -112,14 +112,14 @@ type userPolicyAttachmentState struct {
 	// The ARN of the policy you want to apply
 	PolicyArn *string `pulumi:"policyArn"`
 	// The user the policy should be applied to
-	User interface{} `pulumi:"user"`
+	User *string `pulumi:"user"`
 }
 
 type UserPolicyAttachmentState struct {
 	// The ARN of the policy you want to apply
 	PolicyArn pulumi.StringPtrInput
 	// The user the policy should be applied to
-	User pulumi.Input
+	User pulumi.StringPtrInput
 }
 
 func (UserPolicyAttachmentState) ElementType() reflect.Type {
@@ -130,7 +130,7 @@ type userPolicyAttachmentArgs struct {
 	// The ARN of the policy you want to apply
 	PolicyArn string `pulumi:"policyArn"`
 	// The user the policy should be applied to
-	User interface{} `pulumi:"user"`
+	User string `pulumi:"user"`
 }
 
 // The set of arguments for constructing a UserPolicyAttachment resource.
@@ -138,7 +138,7 @@ type UserPolicyAttachmentArgs struct {
 	// The ARN of the policy you want to apply
 	PolicyArn pulumi.StringInput
 	// The user the policy should be applied to
-	User pulumi.Input
+	User pulumi.StringInput
 }
 
 func (UserPolicyAttachmentArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/iot/policyAttachment.go
+++ b/sdk/go/aws/iot/policyAttachment.go
@@ -126,7 +126,7 @@ func GetPolicyAttachment(ctx *pulumi.Context,
 // Input properties used for looking up and filtering PolicyAttachment resources.
 type policyAttachmentState struct {
 	// The name of the policy to attach.
-	Policy interface{} `pulumi:"policy"`
+	Policy *string `pulumi:"policy"`
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// The identity to which the policy is attached.
@@ -135,7 +135,7 @@ type policyAttachmentState struct {
 
 type PolicyAttachmentState struct {
 	// The name of the policy to attach.
-	Policy pulumi.Input
+	Policy pulumi.StringPtrInput
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// The identity to which the policy is attached.
@@ -148,7 +148,7 @@ func (PolicyAttachmentState) ElementType() reflect.Type {
 
 type policyAttachmentArgs struct {
 	// The name of the policy to attach.
-	Policy interface{} `pulumi:"policy"`
+	Policy string `pulumi:"policy"`
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region *string `pulumi:"region"`
 	// The identity to which the policy is attached.
@@ -158,7 +158,7 @@ type policyAttachmentArgs struct {
 // The set of arguments for constructing a PolicyAttachment resource.
 type PolicyAttachmentArgs struct {
 	// The name of the policy to attach.
-	Policy pulumi.Input
+	Policy pulumi.StringInput
 	// The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
 	Region pulumi.StringPtrInput
 	// The identity to which the policy is attached.

--- a/sdk/go/aws/lambda/permission.go
+++ b/sdk/go/aws/lambda/permission.go
@@ -202,7 +202,7 @@ import (
 //			_, err = lambda.NewPermission(ctx, "lambda_permission", &lambda.PermissionArgs{
 //				StatementId: pulumi.String("AllowMyDemoAPIInvoke"),
 //				Action:      pulumi.String("lambda:InvokeFunction"),
-//				Function:    pulumi.Any("MyDemoFunction"),
+//				Function:    pulumi.String("MyDemoFunction"),
 //				Principal:   pulumi.String("apigateway.amazonaws.com"),
 //				SourceArn: myDemoAPI.ExecutionArn.ApplyT(func(executionArn string) (string, error) {
 //					return fmt.Sprintf("%v/*", executionArn), nil
@@ -435,7 +435,7 @@ type permissionState struct {
 	// The Event Source Token to validate.  Used with [Alexa Skills](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli).
 	EventSourceToken *string `pulumi:"eventSourceToken"`
 	// Name of the Lambda function whose resource policy you are updating
-	Function interface{} `pulumi:"function"`
+	Function *string `pulumi:"function"`
 	// Lambda Function URLs [authentication type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html). Valid values are: `AWS_IAM` or `NONE`. Only supported for `lambda:InvokeFunctionUrl` action.
 	FunctionUrlAuthType *string `pulumi:"functionUrlAuthType"`
 	// The principal who is getting this permission e.g., `s3.amazonaws.com`, an AWS account ID, or AWS IAM principal, or AWS service principal such as `events.amazonaws.com` or `sns.amazonaws.com`.
@@ -470,7 +470,7 @@ type PermissionState struct {
 	// The Event Source Token to validate.  Used with [Alexa Skills](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli).
 	EventSourceToken pulumi.StringPtrInput
 	// Name of the Lambda function whose resource policy you are updating
-	Function pulumi.Input
+	Function pulumi.StringPtrInput
 	// Lambda Function URLs [authentication type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html). Valid values are: `AWS_IAM` or `NONE`. Only supported for `lambda:InvokeFunctionUrl` action.
 	FunctionUrlAuthType pulumi.StringPtrInput
 	// The principal who is getting this permission e.g., `s3.amazonaws.com`, an AWS account ID, or AWS IAM principal, or AWS service principal such as `events.amazonaws.com` or `sns.amazonaws.com`.
@@ -509,7 +509,7 @@ type permissionArgs struct {
 	// The Event Source Token to validate.  Used with [Alexa Skills](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli).
 	EventSourceToken *string `pulumi:"eventSourceToken"`
 	// Name of the Lambda function whose resource policy you are updating
-	Function interface{} `pulumi:"function"`
+	Function string `pulumi:"function"`
 	// Lambda Function URLs [authentication type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html). Valid values are: `AWS_IAM` or `NONE`. Only supported for `lambda:InvokeFunctionUrl` action.
 	FunctionUrlAuthType *string `pulumi:"functionUrlAuthType"`
 	// The principal who is getting this permission e.g., `s3.amazonaws.com`, an AWS account ID, or AWS IAM principal, or AWS service principal such as `events.amazonaws.com` or `sns.amazonaws.com`.
@@ -545,7 +545,7 @@ type PermissionArgs struct {
 	// The Event Source Token to validate.  Used with [Alexa Skills](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli).
 	EventSourceToken pulumi.StringPtrInput
 	// Name of the Lambda function whose resource policy you are updating
-	Function pulumi.Input
+	Function pulumi.StringInput
 	// Lambda Function URLs [authentication type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html). Valid values are: `AWS_IAM` or `NONE`. Only supported for `lambda:InvokeFunctionUrl` action.
 	FunctionUrlAuthType pulumi.StringPtrInput
 	// The principal who is getting this permission e.g., `s3.amazonaws.com`, an AWS account ID, or AWS IAM principal, or AWS service principal such as `events.amazonaws.com` or `sns.amazonaws.com`.

--- a/sdk/nodejs/apigateway/authorizer.ts
+++ b/sdk/nodejs/apigateway/authorizer.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides an API Gateway Authorizer.
  *
@@ -247,7 +245,7 @@ export interface AuthorizerState {
     /**
      * ID of the associated REST API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
      */
@@ -294,7 +292,7 @@ export interface AuthorizerArgs {
     /**
      * ID of the associated REST API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
      */

--- a/sdk/nodejs/apigateway/basePathMapping.ts
+++ b/sdk/nodejs/apigateway/basePathMapping.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Connects a custom domain name registered via `aws.apigateway.DomainName`
  * with a deployed API so that its methods can be called via the
@@ -150,7 +148,7 @@ export interface BasePathMappingState {
     /**
      * ID of the API to connect.
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
      */
@@ -180,7 +178,7 @@ export interface BasePathMappingArgs {
     /**
      * ID of the API to connect.
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
      */

--- a/sdk/nodejs/apigateway/deployment.ts
+++ b/sdk/nodejs/apigateway/deployment.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Manages an API Gateway REST Deployment. A deployment is a snapshot of the REST API configuration. The deployment can then be published to callable endpoints via the `aws.apigateway.Stage` resource and optionally managed further with the `aws.apigateway.BasePathMapping` resource, `aws.apigateway.DomainName` resource, and `awsApiMethodSettings` resource. For more information, see the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html).
  *
@@ -135,7 +133,7 @@ export interface DeploymentState {
     /**
      * REST API identifier.
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Map of arbitrary keys and values that, when changed, will trigger a redeployment.
      */
@@ -161,7 +159,7 @@ export interface DeploymentArgs {
     /**
      * REST API identifier.
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Map of arbitrary keys and values that, when changed, will trigger a redeployment.
      */

--- a/sdk/nodejs/apigateway/integration.ts
+++ b/sdk/nodejs/apigateway/integration.ts
@@ -7,8 +7,6 @@ import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides an HTTP Method Integration for an API Gateway Integration.
  *
@@ -427,7 +425,7 @@ export interface IntegrationState {
     /**
      * ID of the associated REST API.
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
      */
@@ -513,7 +511,7 @@ export interface IntegrationArgs {
     /**
      * ID of the associated REST API.
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
      */

--- a/sdk/nodejs/apigateway/integrationResponse.ts
+++ b/sdk/nodejs/apigateway/integrationResponse.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides an HTTP Method Integration Response for an API Gateway Resource.
  *
@@ -218,7 +216,7 @@ export interface IntegrationResponseState {
     /**
      * ID of the associated REST API.
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Regular expression pattern used to choose an integration response based on the response from the backend. Omit configuring this to make the integration the default one. If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched. For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
      */
@@ -262,7 +260,7 @@ export interface IntegrationResponseArgs {
     /**
      * ID of the associated REST API.
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Regular expression pattern used to choose an integration response based on the response from the backend. Omit configuring this to make the integration the default one. If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched. For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
      */

--- a/sdk/nodejs/apigateway/method.ts
+++ b/sdk/nodejs/apigateway/method.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides a HTTP Method for an API Gateway Resource.
  *
@@ -266,7 +264,7 @@ export interface MethodState {
     /**
      * ID of the associated REST API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
 }
 
 /**
@@ -323,5 +321,5 @@ export interface MethodArgs {
     /**
      * ID of the associated REST API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
 }

--- a/sdk/nodejs/apigateway/methodResponse.ts
+++ b/sdk/nodejs/apigateway/methodResponse.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides an HTTP Method Response for an API Gateway Resource. More information about API Gateway method responses can be found in the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-response.html).
  *
@@ -247,7 +245,7 @@ export interface MethodResponseState {
     /**
      * The string identifier of the associated REST API.
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * The method response's status code.
      */
@@ -283,7 +281,7 @@ export interface MethodResponseArgs {
     /**
      * The string identifier of the associated REST API.
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * The method response's status code.
      */

--- a/sdk/nodejs/apigateway/methodSettings.ts
+++ b/sdk/nodejs/apigateway/methodSettings.ts
@@ -7,8 +7,6 @@ import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Manages API Gateway Stage Method Settings. For example, CloudWatch logging and metrics.
  *
@@ -203,7 +201,7 @@ export interface MethodSettingsState {
     /**
      * ID of the REST API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Settings block, see below.
      */
@@ -229,7 +227,7 @@ export interface MethodSettingsArgs {
     /**
      * ID of the REST API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Settings block, see below.
      */

--- a/sdk/nodejs/apigateway/model.ts
+++ b/sdk/nodejs/apigateway/model.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides a Model for a REST API Gateway.
  *
@@ -153,7 +151,7 @@ export interface ModelState {
     /**
      * ID of the associated REST API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Schema of the model in a JSON form
      */
@@ -183,7 +181,7 @@ export interface ModelArgs {
     /**
      * ID of the associated REST API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Schema of the model in a JSON form
      */

--- a/sdk/nodejs/apigateway/requestValidator.ts
+++ b/sdk/nodejs/apigateway/requestValidator.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Manages an API Gateway Request Validator.
  *
@@ -129,7 +127,7 @@ export interface RequestValidatorState {
     /**
      * ID of the associated Rest API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Boolean whether to validate request body. Defaults to `false`.
      */
@@ -155,7 +153,7 @@ export interface RequestValidatorArgs {
     /**
      * ID of the associated Rest API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Boolean whether to validate request body. Defaults to `false`.
      */

--- a/sdk/nodejs/apigateway/resource.ts
+++ b/sdk/nodejs/apigateway/resource.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {RestApi} from "./index";
-
 /**
  * Provides an API Gateway Resource.
  *
@@ -146,7 +144,7 @@ export interface ResourceState {
     /**
      * ID of the associated REST API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
 }
 
 /**
@@ -168,5 +166,5 @@ export interface ResourceArgs {
     /**
      * ID of the associated REST API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
 }

--- a/sdk/nodejs/apigateway/stage.ts
+++ b/sdk/nodejs/apigateway/stage.ts
@@ -7,8 +7,6 @@ import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
-import {Deployment, RestApi} from "./index";
-
 /**
  * Manages an API Gateway Stage. A stage is a named reference to a deployment, which can be done via the `aws.apigateway.Deployment` resource. Stages can be optionally managed further with the `aws.apigateway.BasePathMapping` resource, `aws.apigateway.DomainName` resource, and `awsApiMethodSettings` resource. For more information, see the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-stages.html).
  *
@@ -247,7 +245,7 @@ export interface StageState {
     /**
      * ID of the deployment that the stage points to
      */
-    deployment?: pulumi.Input<string | Deployment>;
+    deployment?: pulumi.Input<string>;
     /**
      * Description of the stage.
      */
@@ -274,7 +272,7 @@ export interface StageState {
     /**
      * ID of the associated REST API
      */
-    restApi?: pulumi.Input<string | RestApi>;
+    restApi?: pulumi.Input<string>;
     /**
      * Name of the stage
      */
@@ -328,7 +326,7 @@ export interface StageArgs {
     /**
      * ID of the deployment that the stage points to
      */
-    deployment: pulumi.Input<string | Deployment>;
+    deployment: pulumi.Input<string>;
     /**
      * Description of the stage.
      */
@@ -344,7 +342,7 @@ export interface StageArgs {
     /**
      * ID of the associated REST API
      */
-    restApi: pulumi.Input<string | RestApi>;
+    restApi: pulumi.Input<string>;
     /**
      * Name of the stage
      */

--- a/sdk/nodejs/cloudwatch/eventRuleMixins.ts
+++ b/sdk/nodejs/cloudwatch/eventRuleMixins.ts
@@ -98,7 +98,7 @@ export class EventRuleEventSubscription extends lambda.EventSubscription {
 
         this.permission = new lambda.Permission(name, {
             action: "lambda:invokeFunction",
-            function: this.func,
+            function: this.func.name,
             principal: "events.amazonaws.com",
             sourceArn: this.eventRule.arn,
         }, parentOpts);

--- a/sdk/nodejs/cloudwatch/logGroupMixins.ts
+++ b/sdk/nodejs/cloudwatch/logGroupMixins.ts
@@ -94,7 +94,7 @@ export class LogGroupEventSubscription extends lambda.EventSubscription {
 
         this.permission = new lambda.Permission(name, {
             action: "lambda:invokeFunction",
-            function: this.func,
+            function: this.func.name,
             principal: pulumi.interpolate`logs.${region}.amazonaws.com`,
             sourceArn: pulumi.interpolate`${logGroup.arn}:*`,
         }, parentOpts);

--- a/sdk/nodejs/dynamodb/dynamodbMixins.ts
+++ b/sdk/nodejs/dynamodb/dynamodbMixins.ts
@@ -133,7 +133,7 @@ export class TableEventSubscription extends lambda.EventSubscription {
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);
 
         this.permission = new lambda.Permission(name, {
-            function: this.func,
+            function: this.func.name,
             action: "lambda:InvokeFunction",
             principal: "dynamodb.amazonaws.com",
             sourceArn: streamArn,

--- a/sdk/nodejs/ec2/instance.ts
+++ b/sdk/nodejs/ec2/instance.ts
@@ -7,8 +7,6 @@ import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
-import {InstanceProfile} from "../iam";
-
 /**
  * Provides an EC2 instance resource. This allows instances to be created, updated, and deleted.
  *
@@ -692,7 +690,7 @@ export interface InstanceState {
     /**
      * IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
      */
-    iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
+    iamInstanceProfile?: pulumi.Input<string>;
     /**
      * Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
      */
@@ -928,7 +926,7 @@ export interface InstanceArgs {
     /**
      * IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
      */
-    iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
+    iamInstanceProfile?: pulumi.Input<string>;
     /**
      * Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
      */

--- a/sdk/nodejs/ec2/launchConfiguration.ts
+++ b/sdk/nodejs/ec2/launchConfiguration.ts
@@ -7,8 +7,6 @@ import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
-import {InstanceProfile} from "../iam";
-
 /**
  * Provides a resource to create a new launch configuration, used for autoscaling groups.
  *
@@ -260,7 +258,7 @@ export interface LaunchConfigurationState {
     /**
      * The name attribute of the IAM instance profile to associate with launched instances.
      */
-    iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
+    iamInstanceProfile?: pulumi.Input<string>;
     /**
      * The EC2 image ID to launch.
      */
@@ -344,7 +342,7 @@ export interface LaunchConfigurationArgs {
     /**
      * The name attribute of the IAM instance profile to associate with launched instances.
      */
-    iamInstanceProfile?: pulumi.Input<string | InstanceProfile>;
+    iamInstanceProfile?: pulumi.Input<string>;
     /**
      * The EC2 image ID to launch.
      */

--- a/sdk/nodejs/iam/groupPolicyAttachment.ts
+++ b/sdk/nodejs/iam/groupPolicyAttachment.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {ARN} from "..";
-import {Group} from "./index";
 
 /**
  * Attaches a Managed IAM Policy to an IAM group
@@ -113,7 +112,7 @@ export interface GroupPolicyAttachmentState {
     /**
      * The group the policy should be applied to
      */
-    group?: pulumi.Input<string | Group>;
+    group?: pulumi.Input<string>;
     /**
      * The ARN of the policy you want to apply
      */
@@ -127,7 +126,7 @@ export interface GroupPolicyAttachmentArgs {
     /**
      * The group the policy should be applied to
      */
-    group: pulumi.Input<string | Group>;
+    group: pulumi.Input<string>;
     /**
      * The ARN of the policy you want to apply
      */

--- a/sdk/nodejs/iam/instanceProfile.ts
+++ b/sdk/nodejs/iam/instanceProfile.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Role} from "./index";
-
 /**
  * Provides an IAM instance profile.
  *
@@ -177,7 +175,7 @@ export interface InstanceProfileState {
     /**
      * Name of the role to add to the profile.
      */
-    role?: pulumi.Input<string | Role>;
+    role?: pulumi.Input<string>;
     /**
      * Map of resource tags for the IAM Instance Profile. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */
@@ -211,7 +209,7 @@ export interface InstanceProfileArgs {
     /**
      * Name of the role to add to the profile.
      */
-    role?: pulumi.Input<string | Role>;
+    role?: pulumi.Input<string>;
     /**
      * Map of resource tags for the IAM Instance Profile. If configured with a provider `defaultTags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
      */

--- a/sdk/nodejs/iam/policyAttachment.ts
+++ b/sdk/nodejs/iam/policyAttachment.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {ARN} from "..";
-import {Group, Role, User} from "./index";
 
 /**
  * Attaches a Managed IAM Policy to user(s), role(s), and/or group(s)
@@ -151,7 +150,7 @@ export interface PolicyAttachmentState {
     /**
      * Group(s) the policy should be applied to.
      */
-    groups?: pulumi.Input<pulumi.Input<string | Group>[]>;
+    groups?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * Name of the attachment. This cannot be an empty string.
      */
@@ -163,11 +162,11 @@ export interface PolicyAttachmentState {
     /**
      * Role(s) the policy should be applied to.
      */
-    roles?: pulumi.Input<pulumi.Input<string | Role>[]>;
+    roles?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * User(s) the policy should be applied to.
      */
-    users?: pulumi.Input<pulumi.Input<string | User>[]>;
+    users?: pulumi.Input<pulumi.Input<string>[]>;
 }
 
 /**
@@ -177,7 +176,7 @@ export interface PolicyAttachmentArgs {
     /**
      * Group(s) the policy should be applied to.
      */
-    groups?: pulumi.Input<pulumi.Input<string | Group>[]>;
+    groups?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * Name of the attachment. This cannot be an empty string.
      */
@@ -189,9 +188,9 @@ export interface PolicyAttachmentArgs {
     /**
      * Role(s) the policy should be applied to.
      */
-    roles?: pulumi.Input<pulumi.Input<string | Role>[]>;
+    roles?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * User(s) the policy should be applied to.
      */
-    users?: pulumi.Input<pulumi.Input<string | User>[]>;
+    users?: pulumi.Input<pulumi.Input<string>[]>;
 }

--- a/sdk/nodejs/iam/rolePolicy.ts
+++ b/sdk/nodejs/iam/rolePolicy.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {PolicyDocument, Role} from "./index";
+import {PolicyDocument} from "./index";
 
 /**
  * Provides an IAM role inline policy.
@@ -158,7 +158,7 @@ export interface RolePolicyState {
     /**
      * The name of the IAM role to attach to the policy.
      */
-    role?: pulumi.Input<string | Role>;
+    role?: pulumi.Input<string>;
 }
 
 /**
@@ -182,5 +182,5 @@ export interface RolePolicyArgs {
     /**
      * The name of the IAM role to attach to the policy.
      */
-    role: pulumi.Input<string | Role>;
+    role: pulumi.Input<string>;
 }

--- a/sdk/nodejs/iam/rolePolicyAttachment.ts
+++ b/sdk/nodejs/iam/rolePolicyAttachment.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {ARN} from "..";
-import {Role} from "./index";
 
 /**
  * Attaches a Managed IAM Policy to an IAM role
@@ -139,7 +138,7 @@ export interface RolePolicyAttachmentState {
     /**
      * The name of the IAM role to which the policy should be applied
      */
-    role?: pulumi.Input<string | Role>;
+    role?: pulumi.Input<string>;
 }
 
 /**
@@ -153,5 +152,5 @@ export interface RolePolicyAttachmentArgs {
     /**
      * The name of the IAM role to which the policy should be applied
      */
-    role: pulumi.Input<string | Role>;
+    role: pulumi.Input<string>;
 }

--- a/sdk/nodejs/iam/userPolicyAttachment.ts
+++ b/sdk/nodejs/iam/userPolicyAttachment.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {ARN} from "..";
-import {User} from "./index";
 
 /**
  * Attaches a Managed IAM Policy to an IAM user
@@ -117,7 +116,7 @@ export interface UserPolicyAttachmentState {
     /**
      * The user the policy should be applied to
      */
-    user?: pulumi.Input<string | User>;
+    user?: pulumi.Input<string>;
 }
 
 /**
@@ -131,5 +130,5 @@ export interface UserPolicyAttachmentArgs {
     /**
      * The user the policy should be applied to
      */
-    user: pulumi.Input<string | User>;
+    user: pulumi.Input<string>;
 }

--- a/sdk/nodejs/iot/policyAttachment.ts
+++ b/sdk/nodejs/iot/policyAttachment.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 import {ARN} from "..";
-import {Policy} from "./index";
 
 /**
  * Provides an IoT policy attachment.
@@ -121,7 +120,7 @@ export interface PolicyAttachmentState {
     /**
      * The name of the policy to attach.
      */
-    policy?: pulumi.Input<string | Policy>;
+    policy?: pulumi.Input<string>;
     /**
      * The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
      */
@@ -139,7 +138,7 @@ export interface PolicyAttachmentArgs {
     /**
      * The name of the policy to attach.
      */
-    policy: pulumi.Input<string | Policy>;
+    policy: pulumi.Input<string>;
     /**
      * The AWS Region to use for API operations. Overrides the Region set in the provider configuration.
      */

--- a/sdk/nodejs/kinesis/kinesisMixins.ts
+++ b/sdk/nodejs/kinesis/kinesisMixins.ts
@@ -123,7 +123,7 @@ export class StreamEventSubscription extends lambda.EventSubscription {
         this.func = createFunctionFromEventHandler(name, handler, parentOpts);
 
         this.permission = new lambda.Permission(name, {
-            function: this.func,
+            function: this.func.name,
             action: "lambda:InvokeFunction",
             principal: "kinesis.amazonaws.com",
             sourceArn: stream.arn,

--- a/sdk/nodejs/lambda/lambdaMixins.ts
+++ b/sdk/nodejs/lambda/lambdaMixins.ts
@@ -351,7 +351,7 @@ export class CallbackFunction<E, R> extends LambdaFunction {
 
                 for (const policy of policies) {
                     const attachment = new iam.RolePolicyAttachment(`${name}-${utils.sha1hash(policy)}`, {
-                        role: role,
+                        role: role.name,
                         policyArn: policy,
                     }, opts);
                 }
@@ -367,7 +367,7 @@ export class CallbackFunction<E, R> extends LambdaFunction {
                     // structurally based on the `role` and `policyArn`.  So we need to make sure our Pulumi name matches the
                     // structural identity by using a name that includes the role name and policyArn.
                     const attachment = new iam.RolePolicyAttachment(`${name}-${key}`, {
-                        role: role,
+                        role: role.name,
                         policyArn,
                     }, opts);
                 }

--- a/sdk/nodejs/lambda/permission.ts
+++ b/sdk/nodejs/lambda/permission.ts
@@ -4,8 +4,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
-import {Function} from "./index";
-
 /**
  * Gives an external source (like an EventBridge Rule, SNS, or S3) permission to access the Lambda function.
  *
@@ -343,7 +341,7 @@ export interface PermissionState {
     /**
      * Name of the Lambda function whose resource policy you are updating
      */
-    function?: pulumi.Input<string | Function>;
+    function?: pulumi.Input<string>;
     /**
      * Lambda Function URLs [authentication type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html). Valid values are: `AWS_IAM` or `NONE`. Only supported for `lambda:InvokeFunctionUrl` action.
      */
@@ -405,7 +403,7 @@ export interface PermissionArgs {
     /**
      * Name of the Lambda function whose resource policy you are updating
      */
-    function: pulumi.Input<string | Function>;
+    function: pulumi.Input<string>;
     /**
      * Lambda Function URLs [authentication type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html). Valid values are: `AWS_IAM` or `NONE`. Only supported for `lambda:InvokeFunctionUrl` action.
      */

--- a/sdk/nodejs/s3/s3Mixins.ts
+++ b/sdk/nodejs/s3/s3Mixins.ts
@@ -143,7 +143,7 @@ export class BucketEventSubscription extends lambda.EventSubscription {
         this.func = lambda.createFunctionFromEventHandler(name, handler, parentOpts);
 
         this.permission = new lambda.Permission(name, {
-            function: this.func,
+            function: this.func.name,
             action: "lambda:InvokeFunction",
             principal: "s3.amazonaws.com",
             sourceArn: bucket.arn,

--- a/sdk/nodejs/sns/snsMixins.ts
+++ b/sdk/nodejs/sns/snsMixins.ts
@@ -111,7 +111,7 @@ export class TopicEventSubscription extends lambda.EventSubscription {
 
         this.permission = new lambda.Permission(name, {
             action: "lambda:invokeFunction",
-            function: this.func,
+            function: this.func.name,
             principal: "sns.amazonaws.com",
             sourceArn: topic.id,
         }, parentOpts);

--- a/sdk/nodejs/sqs/sqsMixins.ts
+++ b/sdk/nodejs/sqs/sqsMixins.ts
@@ -86,7 +86,7 @@ export class QueueEventSubscription extends lambda.EventSubscription {
 
         this.permission = new lambda.Permission(name, {
             action: "lambda:*",
-            function: this.func,
+            function: this.func.name,
             principal: "sqs.amazonaws.com",
             sourceArn: queue.arn,
         }, parentOpts);


### PR DESCRIPTION
This pull request removes dangling resource refs (implemented as AltTypes) from the provider schema:

"$ref": "#/types/aws:apigateway/restApi:RestApi"
"$ref": "#/types/aws:apigateway/deployment:Deployment"
"$ref": "#/types/aws:iam/instanceProfile:InstanceProfile"
"$ref": "#/types/aws:iam/group:Group"
"$ref": "#/types/aws:iam/role:Role"
"$ref": "#/types/aws:iam/user:User"
"$ref": "#/types/aws:iot/policy:Policy"
"$ref": "#/types/aws:lambda/function:Function"

Tests are added and migration guide is updated.

Not resolved:
"$ref": "#/types/aws:elasticbeanstalk/applicationVersion:ApplicationVersion" - this ref is implemented without AltTypes and additionally part of an involved integration test so it will be handled separately.

Followup to #5549.
Part of #5540.