### PR TITLE
Migrate applicationversion to applicationversion.name in v7

### DIFF
--- a/docs/v7-upgrade.md
+++ b/docs/v7-upgrade.md
@@ -475,6 +475,7 @@ You should not see any diffs on your stack.
   - `bucket: <your-app-bucket>` --> `bucket: <your-app-bucket>.id`
 - `elasticbeanstalk.Environment`
   - `application: <your-app>` --> `application: <your-app>.name`
+  - `version: <your-app-version>` --> `version: <your-app-version>.name`
 - `s3.BucketObjectv2`
   `bucket: <your-bucket>` --> `bucket: <your-bucket>.id`
 - `s3.BucketObject`

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1192,6 +1192,7 @@ func TestResourceRefsMigrateCleanlyToStringRefs(t *testing.T) {
 		filepath.Join(resourceRefMigrateDir, "iamresources"),
 		filepath.Join(resourceRefMigrateDir, "apigatewaystage"),
 		filepath.Join(resourceRefMigrateDir, "iotpolicy"),
+		filepath.Join(resourceRefMigrateDir, "lambdapermission"),
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/examples/migrate-resource-refs/elasticbeanstalk/v7/index.ts
+++ b/examples/migrate-resource-refs/elasticbeanstalk/v7/index.ts
@@ -81,7 +81,7 @@ const appVersion = new aws.elasticbeanstalk.ApplicationVersion("myAppVersion", {
 
 const env = new aws.elasticbeanstalk.Environment("myEnv", {
     application: app.name,
-    version: appVersion,
+    version: appVersion.name,
     solutionStackName: solutionStack.then(stack => stack.name),
     description: "Test environment for debugging",
     settings: [

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1773,7 +1773,6 @@ compatibility shim in favor of the new "name" field.`)
 					"name": tfbridge.AutoName("name", 40, "-"),
 					"version_label": {
 						Name: "version",
-						Type: awsResource(elasticbeanstalkMod, "ApplicationVersion"),
 					},
 				},
 			},

--- a/sdk/nodejs/elasticbeanstalk/environment.ts
+++ b/sdk/nodejs/elasticbeanstalk/environment.ts
@@ -7,8 +7,6 @@ import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
-import {ApplicationVersion} from "./index";
-
 /**
  * Provides an Elastic Beanstalk Environment Resource. Elastic Beanstalk allows
  * you to deploy and manage applications in the AWS cloud without worrying about
@@ -218,7 +216,7 @@ export class Environment extends pulumi.CustomResource {
      * The name of the Elastic Beanstalk Application Version
      * to use in deployment.
      */
-    public readonly version!: pulumi.Output<ApplicationVersion>;
+    public readonly version!: pulumi.Output<string>;
     /**
      * The maximum
      * [duration](https://golang.org/pkg/time/#ParseDuration) that this provider should
@@ -412,7 +410,7 @@ export interface EnvironmentState {
      * The name of the Elastic Beanstalk Application Version
      * to use in deployment.
      */
-    version?: pulumi.Input<ApplicationVersion>;
+    version?: pulumi.Input<string>;
     /**
      * The maximum
      * [duration](https://golang.org/pkg/time/#ParseDuration) that this provider should
@@ -490,7 +488,7 @@ export interface EnvironmentArgs {
      * The name of the Elastic Beanstalk Application Version
      * to use in deployment.
      */
-    version?: pulumi.Input<ApplicationVersion>;
+    version?: pulumi.Input<string>;
     /**
      * The maximum
      * [duration](https://golang.org/pkg/time/#ParseDuration) that this provider should


### PR DESCRIPTION
This pull request resolves the final dangling reference to what is a resource type.

Instead of `version: appVersion`, users will now need to use `version: appVersion.name`. This is documented, and the case is added to the test.

edit: also a test for lambdaFunction is enabled that was missed previously.

Closes https://github.com/pulumi/pulumi-aws/issues/5540.