### PR TITLE
Configure autonaming for aws.backup.RestoreTestingPlan

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1369,6 +1369,12 @@ compatibility shim in favor of the new "name" field.`)
 					},
 				},
 			},
+			"aws_backup_restore_testing_plan": {
+				Tok: awsResource(backupMod, "RestoreTestingPlan"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": tfbridge.AutoName("name", 255, "_"),
+				},
+			},
 			// Batch
 			"aws_batch_compute_environment": batch.ComputeEnvironment(awsResource(batchMod, "ComputeEnvironment"), tfbridge.GetLogger),
 			"aws_batch_job_definition":      {Tok: awsResource(batchMod, "JobDefinition")},


### PR DESCRIPTION
The default auto naming resulted in errors such as:

    Attribute name must contain only alphanumeric characters, and underscores, got: test-31e72eb.

With the configuraiton fix, autonatmic names use `_` instead of '-' and pass this resource check.

Fixes #5570
