### PR TITLE
[v7]: Support `string` or `IpAddressType` for LoadBalancer

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5273,7 +5273,10 @@ compatibility shim in favor of the new "name" field.`)
 		awsResource(albMod, "LoadBalancer"), &tfbridge.ResourceInfo{
 			Fields: map[string]*tfbridge.SchemaInfo{
 				"load_balancer_type": {Type: awsType(albMod, "LoadBalancerType", "LoadBalancerType")},
-				"ip_address_type":    {Type: awsType(albMod, "IpAddressType", "IpAddressType")},
+				"ip_address_type": {
+					Type:     "string",
+					AltTypes: []tokens.Type{awsType(albMod, "IpAddressType", "IpAddressType")},
+				},
 			},
 			Docs: &tfbridge.DocInfo{Source: "lb.html.markdown"},
 		})

--- a/provider/types.go
+++ b/provider/types.go
@@ -131,8 +131,13 @@ var extraTypes = map[string]schema.ComplexTypeSpec{
 			Type: "string",
 		},
 		Enum: []schema.EnumValueSpec{
-			{Name: "Ipv4", Value: "ipv4"},
-			{Name: "Dualstack", Value: "dualstack"},
+			{Name: "Ipv4", Value: "ipv4", Description: "IPv4 addresses"},
+			{Name: "Dualstack", Value: "dualstack", Description: "IPv4 and IPv6 addresses"},
+			{
+				Name:        "DualstackWithoutPublicIpv4",
+				Value:       "dualstack-without-public-ipv4",
+				Description: "Public IPv6 addresses and private IPv4 and IPv6 addresses",
+			},
 		},
 	},
 	"aws:alb/LoadBalancerType:LoadBalancerType": {

--- a/sdk/dotnet/Alb/Enums.cs
+++ b/sdk/dotnet/Alb/Enums.cs
@@ -17,8 +17,18 @@ namespace Pulumi.Aws.Alb
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// IPv4 addresses
+        /// </summary>
         public static IpAddressType Ipv4 { get; } = new IpAddressType("ipv4");
+        /// <summary>
+        /// IPv4 and IPv6 addresses
+        /// </summary>
         public static IpAddressType Dualstack { get; } = new IpAddressType("dualstack");
+        /// <summary>
+        /// Public IPv6 addresses and private IPv4 and IPv6 addresses
+        /// </summary>
+        public static IpAddressType DualstackWithoutPublicIpv4 { get; } = new IpAddressType("dualstack-without-public-ipv4");
 
         public static bool operator ==(IpAddressType left, IpAddressType right) => left.Equals(right);
         public static bool operator !=(IpAddressType left, IpAddressType right) => !left.Equals(right);

--- a/sdk/dotnet/Alb/LoadBalancer.cs
+++ b/sdk/dotnet/Alb/LoadBalancer.cs
@@ -283,7 +283,7 @@ namespace Pulumi.Aws.Alb
         /// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         /// </summary>
         [Output("ipAddressType")]
-        public Output<Pulumi.Aws.Alb.IpAddressType> IpAddressType { get; private set; } = null!;
+        public Output<string> IpAddressType { get; private set; } = null!;
 
         /// <summary>
         /// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.
@@ -526,7 +526,7 @@ namespace Pulumi.Aws.Alb
         /// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         /// </summary>
         [Input("ipAddressType")]
-        public Input<Pulumi.Aws.Alb.IpAddressType>? IpAddressType { get; set; }
+        public InputUnion<string, Pulumi.Aws.Alb.IpAddressType>? IpAddressType { get; set; }
 
         /// <summary>
         /// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.
@@ -754,7 +754,7 @@ namespace Pulumi.Aws.Alb
         /// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         /// </summary>
         [Input("ipAddressType")]
-        public Input<Pulumi.Aws.Alb.IpAddressType>? IpAddressType { get; set; }
+        public InputUnion<string, Pulumi.Aws.Alb.IpAddressType>? IpAddressType { get; set; }
 
         /// <summary>
         /// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.

--- a/sdk/go/aws/alb/loadBalancer.go
+++ b/sdk/go/aws/alb/loadBalancer.go
@@ -142,7 +142,7 @@ type LoadBalancer struct {
 	// If true, the LB will be internal. Defaults to `false`.
 	Internal pulumi.BoolOutput `pulumi:"internal"`
 	// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
-	IpAddressType IpAddressTypeOutput `pulumi:"ipAddressType"`
+	IpAddressType pulumi.StringOutput `pulumi:"ipAddressType"`
 	// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
 	IpamPools LoadBalancerIpamPoolsPtrOutput `pulumi:"ipamPools"`
 	// Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
@@ -253,7 +253,7 @@ type loadBalancerState struct {
 	// If true, the LB will be internal. Defaults to `false`.
 	Internal *bool `pulumi:"internal"`
 	// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
-	IpAddressType *IpAddressType `pulumi:"ipAddressType"`
+	IpAddressType *string `pulumi:"ipAddressType"`
 	// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
 	IpamPools *LoadBalancerIpamPools `pulumi:"ipamPools"`
 	// Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
@@ -329,7 +329,7 @@ type LoadBalancerState struct {
 	// If true, the LB will be internal. Defaults to `false`.
 	Internal pulumi.BoolPtrInput
 	// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
-	IpAddressType IpAddressTypePtrInput
+	IpAddressType pulumi.StringPtrInput
 	// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
 	IpamPools LoadBalancerIpamPoolsPtrInput
 	// Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
@@ -403,7 +403,7 @@ type loadBalancerArgs struct {
 	// If true, the LB will be internal. Defaults to `false`.
 	Internal *bool `pulumi:"internal"`
 	// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
-	IpAddressType *IpAddressType `pulumi:"ipAddressType"`
+	IpAddressType *string `pulumi:"ipAddressType"`
 	// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
 	IpamPools *LoadBalancerIpamPools `pulumi:"ipamPools"`
 	// Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
@@ -469,7 +469,7 @@ type LoadBalancerArgs struct {
 	// If true, the LB will be internal. Defaults to `false`.
 	Internal pulumi.BoolPtrInput
 	// Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
-	IpAddressType IpAddressTypePtrInput
+	IpAddressType pulumi.StringPtrInput
 	// . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
 	IpamPools LoadBalancerIpamPoolsPtrInput
 	// Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
@@ -688,8 +688,8 @@ func (o LoadBalancerOutput) Internal() pulumi.BoolOutput {
 }
 
 // Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
-func (o LoadBalancerOutput) IpAddressType() IpAddressTypeOutput {
-	return o.ApplyT(func(v *LoadBalancer) IpAddressTypeOutput { return v.IpAddressType }).(IpAddressTypeOutput)
+func (o LoadBalancerOutput) IpAddressType() pulumi.StringOutput {
+	return o.ApplyT(func(v *LoadBalancer) pulumi.StringOutput { return v.IpAddressType }).(pulumi.StringOutput)
 }
 
 // . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.

--- a/sdk/go/aws/alb/pulumiEnums.go
+++ b/sdk/go/aws/alb/pulumiEnums.go
@@ -13,8 +13,12 @@ import (
 type IpAddressType string
 
 const (
-	IpAddressTypeIpv4      = IpAddressType("ipv4")
+	// IPv4 addresses
+	IpAddressTypeIpv4 = IpAddressType("ipv4")
+	// IPv4 and IPv6 addresses
 	IpAddressTypeDualstack = IpAddressType("dualstack")
+	// Public IPv6 addresses and private IPv4 and IPv6 addresses
+	IpAddressTypeDualstackWithoutPublicIpv4 = IpAddressType("dualstack-without-public-ipv4")
 )
 
 func (IpAddressType) ElementType() reflect.Type {
@@ -141,6 +145,7 @@ func (o IpAddressTypePtrOutput) ToStringPtrOutputWithContext(ctx context.Context
 //
 //	IpAddressTypeIpv4
 //	IpAddressTypeDualstack
+//	IpAddressTypeDualstackWithoutPublicIpv4
 type IpAddressTypeInput interface {
 	pulumi.Input
 

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/LoadBalancer.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/LoadBalancer.java
@@ -5,7 +5,6 @@ package com.pulumi.aws.alb;
 
 import com.pulumi.aws.Utilities;
 import com.pulumi.aws.alb.LoadBalancerArgs;
-import com.pulumi.aws.alb.enums.IpAddressType;
 import com.pulumi.aws.alb.enums.LoadBalancerType;
 import com.pulumi.aws.alb.inputs.LoadBalancerState;
 import com.pulumi.aws.alb.outputs.LoadBalancerAccessLogs;
@@ -429,14 +428,14 @@ public class LoadBalancer extends com.pulumi.resources.CustomResource {
      * Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      * 
      */
-    @Export(name="ipAddressType", refs={IpAddressType.class}, tree="[0]")
-    private Output<IpAddressType> ipAddressType;
+    @Export(name="ipAddressType", refs={String.class}, tree="[0]")
+    private Output<String> ipAddressType;
 
     /**
      * @return Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      * 
      */
-    public Output<IpAddressType> ipAddressType() {
+    public Output<String> ipAddressType() {
         return this.ipAddressType;
     }
     /**

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/LoadBalancerArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/LoadBalancerArgs.java
@@ -9,6 +9,7 @@ import com.pulumi.aws.alb.inputs.LoadBalancerAccessLogsArgs;
 import com.pulumi.aws.alb.inputs.LoadBalancerConnectionLogsArgs;
 import com.pulumi.aws.alb.inputs.LoadBalancerIpamPoolsArgs;
 import com.pulumi.aws.alb.inputs.LoadBalancerSubnetMappingArgs;
+import com.pulumi.core.Either;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.Boolean;
@@ -285,13 +286,13 @@ public final class LoadBalancerArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="ipAddressType")
-    private @Nullable Output<IpAddressType> ipAddressType;
+    private @Nullable Output<Either<String,IpAddressType>> ipAddressType;
 
     /**
      * @return Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      * 
      */
-    public Optional<Output<IpAddressType>> ipAddressType() {
+    public Optional<Output<Either<String,IpAddressType>>> ipAddressType() {
         return Optional.ofNullable(this.ipAddressType);
     }
 
@@ -883,7 +884,7 @@ public final class LoadBalancerArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder ipAddressType(@Nullable Output<IpAddressType> ipAddressType) {
+        public Builder ipAddressType(@Nullable Output<Either<String,IpAddressType>> ipAddressType) {
             $.ipAddressType = ipAddressType;
             return this;
         }
@@ -894,8 +895,28 @@ public final class LoadBalancerArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder ipAddressType(IpAddressType ipAddressType) {
+        public Builder ipAddressType(Either<String,IpAddressType> ipAddressType) {
             return ipAddressType(Output.of(ipAddressType));
+        }
+
+        /**
+         * @param ipAddressType Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ipAddressType(String ipAddressType) {
+            return ipAddressType(Either.ofLeft(ipAddressType));
+        }
+
+        /**
+         * @param ipAddressType Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ipAddressType(IpAddressType ipAddressType) {
+            return ipAddressType(Either.ofRight(ipAddressType));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/enums/IpAddressType.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/enums/IpAddressType.java
@@ -10,8 +10,21 @@ import java.util.StringJoiner;
 
     @EnumType
     public enum IpAddressType {
+        /**
+         * IPv4 addresses
+         * 
+         */
         Ipv4("ipv4"),
-        Dualstack("dualstack");
+        /**
+         * IPv4 and IPv6 addresses
+         * 
+         */
+        Dualstack("dualstack"),
+        /**
+         * Public IPv6 addresses and private IPv4 and IPv6 addresses
+         * 
+         */
+        DualstackWithoutPublicIpv4("dualstack-without-public-ipv4");
 
         private final String value;
 

--- a/sdk/java/src/main/java/com/pulumi/aws/alb/inputs/LoadBalancerState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/alb/inputs/LoadBalancerState.java
@@ -9,6 +9,7 @@ import com.pulumi.aws.alb.inputs.LoadBalancerAccessLogsArgs;
 import com.pulumi.aws.alb.inputs.LoadBalancerConnectionLogsArgs;
 import com.pulumi.aws.alb.inputs.LoadBalancerIpamPoolsArgs;
 import com.pulumi.aws.alb.inputs.LoadBalancerSubnetMappingArgs;
+import com.pulumi.core.Either;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.Boolean;
@@ -330,13 +331,13 @@ public final class LoadBalancerState extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="ipAddressType")
-    private @Nullable Output<IpAddressType> ipAddressType;
+    private @Nullable Output<Either<String,IpAddressType>> ipAddressType;
 
     /**
      * @return Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      * 
      */
-    public Optional<Output<IpAddressType>> ipAddressType() {
+    public Optional<Output<Either<String,IpAddressType>>> ipAddressType() {
         return Optional.ofNullable(this.ipAddressType);
     }
 
@@ -1034,7 +1035,7 @@ public final class LoadBalancerState extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder ipAddressType(@Nullable Output<IpAddressType> ipAddressType) {
+        public Builder ipAddressType(@Nullable Output<Either<String,IpAddressType>> ipAddressType) {
             $.ipAddressType = ipAddressType;
             return this;
         }
@@ -1045,8 +1046,28 @@ public final class LoadBalancerState extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder ipAddressType(IpAddressType ipAddressType) {
+        public Builder ipAddressType(Either<String,IpAddressType> ipAddressType) {
             return ipAddressType(Output.of(ipAddressType));
+        }
+
+        /**
+         * @param ipAddressType Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ipAddressType(String ipAddressType) {
+            return ipAddressType(Either.ofLeft(ipAddressType));
+        }
+
+        /**
+         * @param ipAddressType Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ipAddressType(IpAddressType ipAddressType) {
+            return ipAddressType(Either.ofRight(ipAddressType));
         }
 
         /**

--- a/sdk/nodejs/alb/loadBalancer.ts
+++ b/sdk/nodejs/alb/loadBalancer.ts
@@ -219,7 +219,7 @@ export class LoadBalancer extends pulumi.CustomResource {
     /**
      * Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      */
-    public readonly ipAddressType!: pulumi.Output<enums.alb.IpAddressType>;
+    public readonly ipAddressType!: pulumi.Output<string>;
     /**
      * . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
      */
@@ -458,7 +458,7 @@ export interface LoadBalancerState {
     /**
      * Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      */
-    ipAddressType?: pulumi.Input<enums.alb.IpAddressType>;
+    ipAddressType?: pulumi.Input<string | enums.alb.IpAddressType>;
     /**
      * . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
      */
@@ -593,7 +593,7 @@ export interface LoadBalancerArgs {
     /**
      * Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
      */
-    ipAddressType?: pulumi.Input<enums.alb.IpAddressType>;
+    ipAddressType?: pulumi.Input<string | enums.alb.IpAddressType>;
     /**
      * . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipamPools for more information.
      */

--- a/sdk/nodejs/types/enums/alb/index.ts
+++ b/sdk/nodejs/types/enums/alb/index.ts
@@ -3,8 +3,18 @@
 
 
 export const IpAddressType = {
+    /**
+     * IPv4 addresses
+     */
     Ipv4: "ipv4",
+    /**
+     * IPv4 and IPv6 addresses
+     */
     Dualstack: "dualstack",
+    /**
+     * Public IPv6 addresses and private IPv4 and IPv6 addresses
+     */
+    DualstackWithoutPublicIpv4: "dualstack-without-public-ipv4",
 } as const;
 
 export type IpAddressType = (typeof IpAddressType)[keyof typeof IpAddressType];

--- a/sdk/python/pulumi_aws/alb/_enums.py
+++ b/sdk/python/pulumi_aws/alb/_enums.py
@@ -15,7 +15,17 @@ __all__ = [
 @pulumi.type_token("aws:alb/IpAddressType:IpAddressType")
 class IpAddressType(builtins.str, Enum):
     IPV4 = "ipv4"
+    """
+    IPv4 addresses
+    """
     DUALSTACK = "dualstack"
+    """
+    IPv4 and IPv6 addresses
+    """
+    DUALSTACK_WITHOUT_PUBLIC_IPV4 = "dualstack-without-public-ipv4"
+    """
+    Public IPv6 addresses and private IPv4 and IPv6 addresses
+    """
 
 
 @pulumi.type_token("aws:alb/LoadBalancerType:LoadBalancerType")

--- a/sdk/python/pulumi_aws/alb/load_balancer.py
+++ b/sdk/python/pulumi_aws/alb/load_balancer.py
@@ -40,7 +40,7 @@ class LoadBalancerArgs:
                  enforce_security_group_inbound_rules_on_private_link_traffic: Optional[pulumi.Input[builtins.str]] = None,
                  idle_timeout: Optional[pulumi.Input[builtins.int]] = None,
                  internal: Optional[pulumi.Input[builtins.bool]] = None,
-                 ip_address_type: Optional[pulumi.Input['IpAddressType']] = None,
+                 ip_address_type: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]] = None,
                  ipam_pools: Optional[pulumi.Input['LoadBalancerIpamPoolsArgs']] = None,
                  load_balancer_type: Optional[pulumi.Input['LoadBalancerType']] = None,
                  name: Optional[pulumi.Input[builtins.str]] = None,
@@ -71,7 +71,7 @@ class LoadBalancerArgs:
         :param pulumi.Input[builtins.str] enforce_security_group_inbound_rules_on_private_link_traffic: Whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
         :param pulumi.Input[builtins.int] idle_timeout: Time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
         :param pulumi.Input[builtins.bool] internal: If true, the LB will be internal. Defaults to `false`.
-        :param pulumi.Input['IpAddressType'] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+        :param pulumi.Input[Union[builtins.str, 'IpAddressType']] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         :param pulumi.Input['LoadBalancerIpamPoolsArgs'] ipam_pools: . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.
         :param pulumi.Input['LoadBalancerType'] load_balancer_type: Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
         :param pulumi.Input[builtins.str] name: Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, this provider will autogenerate a name beginning with `tf-lb`.
@@ -353,14 +353,14 @@ class LoadBalancerArgs:
 
     @property
     @pulumi.getter(name="ipAddressType")
-    def ip_address_type(self) -> Optional[pulumi.Input['IpAddressType']]:
+    def ip_address_type(self) -> Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]]:
         """
         Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         """
         return pulumi.get(self, "ip_address_type")
 
     @ip_address_type.setter
-    def ip_address_type(self, value: Optional[pulumi.Input['IpAddressType']]):
+    def ip_address_type(self, value: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]]):
         pulumi.set(self, "ip_address_type", value)
 
     @property
@@ -523,7 +523,7 @@ class _LoadBalancerState:
                  enforce_security_group_inbound_rules_on_private_link_traffic: Optional[pulumi.Input[builtins.str]] = None,
                  idle_timeout: Optional[pulumi.Input[builtins.int]] = None,
                  internal: Optional[pulumi.Input[builtins.bool]] = None,
-                 ip_address_type: Optional[pulumi.Input['IpAddressType']] = None,
+                 ip_address_type: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]] = None,
                  ipam_pools: Optional[pulumi.Input['LoadBalancerIpamPoolsArgs']] = None,
                  load_balancer_type: Optional[pulumi.Input['LoadBalancerType']] = None,
                  name: Optional[pulumi.Input[builtins.str]] = None,
@@ -560,7 +560,7 @@ class _LoadBalancerState:
         :param pulumi.Input[builtins.str] enforce_security_group_inbound_rules_on_private_link_traffic: Whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
         :param pulumi.Input[builtins.int] idle_timeout: Time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
         :param pulumi.Input[builtins.bool] internal: If true, the LB will be internal. Defaults to `false`.
-        :param pulumi.Input['IpAddressType'] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+        :param pulumi.Input[Union[builtins.str, 'IpAddressType']] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         :param pulumi.Input['LoadBalancerIpamPoolsArgs'] ipam_pools: . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.
         :param pulumi.Input['LoadBalancerType'] load_balancer_type: Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
         :param pulumi.Input[builtins.str] name: Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, this provider will autogenerate a name beginning with `tf-lb`.
@@ -892,14 +892,14 @@ class _LoadBalancerState:
 
     @property
     @pulumi.getter(name="ipAddressType")
-    def ip_address_type(self) -> Optional[pulumi.Input['IpAddressType']]:
+    def ip_address_type(self) -> Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]]:
         """
         Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         """
         return pulumi.get(self, "ip_address_type")
 
     @ip_address_type.setter
-    def ip_address_type(self, value: Optional[pulumi.Input['IpAddressType']]):
+    def ip_address_type(self, value: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]]):
         pulumi.set(self, "ip_address_type", value)
 
     @property
@@ -1095,7 +1095,7 @@ class LoadBalancer(pulumi.CustomResource):
                  enforce_security_group_inbound_rules_on_private_link_traffic: Optional[pulumi.Input[builtins.str]] = None,
                  idle_timeout: Optional[pulumi.Input[builtins.int]] = None,
                  internal: Optional[pulumi.Input[builtins.bool]] = None,
-                 ip_address_type: Optional[pulumi.Input['IpAddressType']] = None,
+                 ip_address_type: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]] = None,
                  ipam_pools: Optional[pulumi.Input[Union['LoadBalancerIpamPoolsArgs', 'LoadBalancerIpamPoolsArgsDict']]] = None,
                  load_balancer_type: Optional[pulumi.Input['LoadBalancerType']] = None,
                  name: Optional[pulumi.Input[builtins.str]] = None,
@@ -1224,7 +1224,7 @@ class LoadBalancer(pulumi.CustomResource):
         :param pulumi.Input[builtins.str] enforce_security_group_inbound_rules_on_private_link_traffic: Whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
         :param pulumi.Input[builtins.int] idle_timeout: Time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
         :param pulumi.Input[builtins.bool] internal: If true, the LB will be internal. Defaults to `false`.
-        :param pulumi.Input['IpAddressType'] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+        :param pulumi.Input[Union[builtins.str, 'IpAddressType']] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         :param pulumi.Input[Union['LoadBalancerIpamPoolsArgs', 'LoadBalancerIpamPoolsArgsDict']] ipam_pools: . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.
         :param pulumi.Input['LoadBalancerType'] load_balancer_type: Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
         :param pulumi.Input[builtins.str] name: Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, this provider will autogenerate a name beginning with `tf-lb`.
@@ -1376,7 +1376,7 @@ class LoadBalancer(pulumi.CustomResource):
                  enforce_security_group_inbound_rules_on_private_link_traffic: Optional[pulumi.Input[builtins.str]] = None,
                  idle_timeout: Optional[pulumi.Input[builtins.int]] = None,
                  internal: Optional[pulumi.Input[builtins.bool]] = None,
-                 ip_address_type: Optional[pulumi.Input['IpAddressType']] = None,
+                 ip_address_type: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]] = None,
                  ipam_pools: Optional[pulumi.Input[Union['LoadBalancerIpamPoolsArgs', 'LoadBalancerIpamPoolsArgsDict']]] = None,
                  load_balancer_type: Optional[pulumi.Input['LoadBalancerType']] = None,
                  name: Optional[pulumi.Input[builtins.str]] = None,
@@ -1464,7 +1464,7 @@ class LoadBalancer(pulumi.CustomResource):
             enforce_security_group_inbound_rules_on_private_link_traffic: Optional[pulumi.Input[builtins.str]] = None,
             idle_timeout: Optional[pulumi.Input[builtins.int]] = None,
             internal: Optional[pulumi.Input[builtins.bool]] = None,
-            ip_address_type: Optional[pulumi.Input['IpAddressType']] = None,
+            ip_address_type: Optional[pulumi.Input[Union[builtins.str, 'IpAddressType']]] = None,
             ipam_pools: Optional[pulumi.Input[Union['LoadBalancerIpamPoolsArgs', 'LoadBalancerIpamPoolsArgsDict']]] = None,
             load_balancer_type: Optional[pulumi.Input['LoadBalancerType']] = None,
             name: Optional[pulumi.Input[builtins.str]] = None,
@@ -1506,7 +1506,7 @@ class LoadBalancer(pulumi.CustomResource):
         :param pulumi.Input[builtins.str] enforce_security_group_inbound_rules_on_private_link_traffic: Whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
         :param pulumi.Input[builtins.int] idle_timeout: Time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
         :param pulumi.Input[builtins.bool] internal: If true, the LB will be internal. Defaults to `false`.
-        :param pulumi.Input['IpAddressType'] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
+        :param pulumi.Input[Union[builtins.str, 'IpAddressType']] ip_address_type: Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         :param pulumi.Input[Union['LoadBalancerIpamPoolsArgs', 'LoadBalancerIpamPoolsArgsDict']] ipam_pools: . The IPAM pools to use with the load balancer.  Only valid for Load Balancers of type `application`. See ipam_pools for more information.
         :param pulumi.Input['LoadBalancerType'] load_balancer_type: Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
         :param pulumi.Input[builtins.str] name: Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, this provider will autogenerate a name beginning with `tf-lb`.
@@ -1728,7 +1728,7 @@ class LoadBalancer(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="ipAddressType")
-    def ip_address_type(self) -> pulumi.Output['IpAddressType']:
+    def ip_address_type(self) -> pulumi.Output[builtins.str]:
         """
         Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
         """


### PR DESCRIPTION
This switches the type from an enum to a union `string | IpAddressType`.
It also adds a missing enum value. By making it a union we will avoid
issues like #4684 in the future if AWS adds additional values.

fixes #4684