### PR TITLE
Enable bucket upgrade tests

### DIFF
--- a/examples/bucket-sidecar-renames/Pulumi.yaml
+++ b/examples/bucket-sidecar-renames/Pulumi.yaml
@@ -1,6 +1,11 @@
 name: test-aws-bucket-migration
 runtime: yaml
 resources:
+  aws:
+    type: pulumi:providers:aws
+    defaultProvider: true
+    options:
+      version: 6.78.0
   loggingBucket:
     type: aws:s3:BucketV2
     properties:

--- a/examples/bucket-sidecar-renames/step1/Pulumi.yaml
+++ b/examples/bucket-sidecar-renames/step1/Pulumi.yaml
@@ -1,6 +1,11 @@
 name: test-aws-bucket-migration
 runtime: yaml
 resources:
+  aws:
+    type: pulumi:providers:aws
+    defaultProvider: true
+    options:
+      version: 7.0.0
   loggingBucket:
     type: aws:s3:Bucket
     properties:

--- a/examples/bucket-to-bucket/Pulumi.yaml
+++ b/examples/bucket-to-bucket/Pulumi.yaml
@@ -1,10 +1,14 @@
 name: test-aws-bucket-migration
 runtime: yaml
 resources:
+  aws:
+    type: pulumi:providers:aws
+    defaultProvider: true
+    options:
+      version: 6.78.0
   replication:
     type: aws:iam:Role
     properties:
-      name: tf-iam-role-replication-12345
       assumeRolePolicy: |
         {
           "Version": "2012-10-17",
@@ -23,7 +27,6 @@ resources:
     type: aws:iam:Policy
     name: replication
     properties:
-      name: tf-iam-role-policy-replication-12345
       policy: |
         {
           "Version": "2012-10-17",

--- a/examples/bucket-to-bucket/step1/Pulumi.yaml
+++ b/examples/bucket-to-bucket/step1/Pulumi.yaml
@@ -1,10 +1,14 @@
 name: test-aws-bucket-migration
 runtime: yaml
 resources:
+  aws:
+    type: pulumi:providers:aws
+    defaultProvider: true
+    options:
+      version: 7.0.0
   replication:
     type: aws:iam:Role
     properties:
-      name: tf-iam-role-replication-12345
       assumeRolePolicy: |
         {
           "Version": "2012-10-17",
@@ -23,7 +27,6 @@ resources:
     type: aws:iam:Policy
     name: replication
     properties:
-      name: tf-iam-role-policy-replication-12345
       policy: |
         {
           "Version": "2012-10-17",

--- a/examples/bucketv2-to-bucket/Pulumi.yaml
+++ b/examples/bucketv2-to-bucket/Pulumi.yaml
@@ -1,10 +1,14 @@
 name: test-aws-bucket-migration
 runtime: yaml
 resources:
+  aws:
+    type: pulumi:providers:aws
+    defaultProvider: true
+    options:
+      version: 6.78.0
   replication:
     type: aws:iam:Role
     properties:
-      name: tf-iam-role-replication-12345
       assumeRolePolicy: |
         {
           "Version": "2012-10-17",
@@ -23,7 +27,6 @@ resources:
     type: aws:iam:Policy
     name: replication
     properties:
-      name: tf-iam-role-policy-replication-12345
       policy: |
         {
           "Version": "2012-10-17",

--- a/examples/bucketv2-to-bucket/step1/Pulumi.yaml
+++ b/examples/bucketv2-to-bucket/step1/Pulumi.yaml
@@ -1,10 +1,14 @@
 name: test-aws-bucket-migration
 runtime: yaml
 resources:
+  aws:
+    type: pulumi:providers:aws
+    defaultProvider: true
+    options:
+      version: 7.0.0
   replication:
     type: aws:iam:Role
     properties:
-      name: tf-iam-role-replication-12345
       assumeRolePolicy: |
         {
           "Version": "2012-10-17",
@@ -23,7 +27,6 @@ resources:
     type: aws:iam:Policy
     name: replication
     properties:
-      name: tf-iam-role-policy-replication-12345
       policy: |
         {
           "Version": "2012-10-17",

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -184,29 +184,49 @@ func TestElasticacheReplicationGroupUpgrade(t *testing.T) {
 }
 
 func TestS3BucketToBucketUpgrade(t *testing.T) {
-	/*previewRes := */ testProviderUpgrade(t, "bucket-to-bucket", nil,
+	test, _ := testProviderUpgrade(t, "bucket-to-bucket", &testProviderUpgradeOptions{
+		skipDefaultPreviewTest: true,
+		runProgram:             true,
+		skipCache:              true,
+	},
 		optproviderupgrade.NewSourcePath(filepath.Join("bucket-to-bucket", "step1")),
 	)
-	// TODO: [pulumi-aws#5514] fix bucket v7 upgrade
-	// assertpreview.HasNoChanges(t, previewRes)
+	res := test.Preview(t, optpreview.Refresh(), optpreview.Diff())
+	assert.Equal(t, map[apitype.OpType]int{
+		apitype.OpUpdate: 1, // the provider gets updated because of the version update
+		apitype.OpSame:   9,
+	}, res.ChangeSummary)
+
 }
 
 func TestS3BucketV2ToBucketUpgrade(t *testing.T) {
-	/*previewRes := */ testProviderUpgrade(t, "bucketv2-to-bucket", nil,
+	test, _ := testProviderUpgrade(t, "bucketv2-to-bucket", &testProviderUpgradeOptions{
+		skipDefaultPreviewTest: true,
+		skipCache:              true,
+		runProgram:             true,
+	},
 		optproviderupgrade.NewSourcePath(filepath.Join("bucketv2-to-bucket", "step1")),
 	)
-	// TODO: [pulumi-aws#1111] fix bucket v7 upgrade
-	// assertpreview.HasNoChanges(t, previewRes)
+	res := test.Preview(t, optpreview.Refresh(), optpreview.Diff())
+	assert.Equal(t, map[apitype.OpType]int{
+		apitype.OpUpdate: 1, // the provider gets updated because of the version update
+		apitype.OpSame:   9,
+	}, res.ChangeSummary)
 }
 
 func TestS3BucketV2ToBucketSidecarUpgrade(t *testing.T) {
 	test, _ := testProviderUpgrade(t, "bucket-sidecar-renames", &testProviderUpgradeOptions{
 		skipDefaultPreviewTest: true,
+		skipCache:              true,
+		runProgram:             true,
 	},
 		optproviderupgrade.NewSourcePath(filepath.Join("bucket-sidecar-renames", "step1")),
 	)
-	diff := runPreviewWithPlanDiff(t, test)
-	assert.Equal(t, map[string]interface{}{}, diff)
+	res := test.Preview(t, optpreview.Refresh(), optpreview.Diff())
+	assert.Equal(t, map[apitype.OpType]int{
+		apitype.OpUpdate: 1, // the provider gets updated because of the version update
+		apitype.OpSame:   11,
+	}, res.ChangeSummary)
 }
 
 func TestRdsParameterGroupUnclearDiff(t *testing.T) {

--- a/examples/iam-policy-document/csharp/AWS.Webserver.csproj
+++ b/examples/iam-policy-document/csharp/AWS.Webserver.csproj
@@ -5,10 +5,4 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.82.1" />
-    <PackageReference Include="Pulumi.Aws" Version="7.0.0-alpha.0" />
-  </ItemGroup>
-
 </Project>

--- a/examples/provider_test.go
+++ b/examples/provider_test.go
@@ -124,6 +124,7 @@ type testProviderUpgradeOptions struct {
 	region                 string
 	skipDefaultPreviewTest bool
 	skipCache              bool
+	runProgram             bool
 }
 
 func testProviderUpgrade(t *testing.T, dir string, opts *testProviderUpgradeOptions, upgradeOpts ...optproviderupgrade.PreviewProviderUpgradeOpt) (*pulumitest.PulumiTest, auto.PreviewResult) {
@@ -140,8 +141,14 @@ func testProviderUpgrade(t *testing.T, dir string, opts *testProviderUpgradeOpti
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	options := []opttest.Option{
+		// disable auto destroy on this initial stack. AutoDestroy is set
+		// later on the baseline stack
+		opttest.NewStackOptions(optnewstack.DisableAutoDestroy()),
 		opttest.DownloadProviderVersion(providerName, baselineVersion),
 		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+	}
+	if opts != nil && opts.runProgram {
+		options = append(options, opttest.Env("PULUMI_RUN_PROGRAM", "true"))
 	}
 	if opts == nil || !opts.installDeps {
 		options = append(options, opttest.SkipInstall())


### PR DESCRIPTION
This enables a couple of tests to test the upgrade of the
Bucket/BucketV2 related resources. When the upgrade is performed with
`--refresh --run-program` it produces no diff.

closes #5514