### PR TITLE
[v7]: Re-export iam PolicyDocument types

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5153,6 +5153,11 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 							"dynamodbMixins.ts",
 						},
 					},
+					"ecr": {
+						DestFiles: []string{
+							"lifecyclePolicyDocument.ts",
+						},
+					},
 					"ecs": {
 						DestFiles: []string{
 							"container.ts", // Container definition JSON schema

--- a/sdk/nodejs/ecr/index.ts
+++ b/sdk/nodejs/ecr/index.ts
@@ -50,6 +50,7 @@ export type LifecyclePolicy = import("./lifecyclePolicy").LifecyclePolicy;
 export const LifecyclePolicy: typeof import("./lifecyclePolicy").LifecyclePolicy = null as any;
 utilities.lazyLoad(exports, ["LifecyclePolicy"], () => require("./lifecyclePolicy"));
 
+export * from "./lifecyclePolicyDocument";
 export { PullThroughCacheRuleArgs, PullThroughCacheRuleState } from "./pullThroughCacheRule";
 export type PullThroughCacheRule = import("./pullThroughCacheRule").PullThroughCacheRule;
 export const PullThroughCacheRule: typeof import("./pullThroughCacheRule").PullThroughCacheRule = null as any;

--- a/sdk/nodejs/ecr/lifecyclePolicyDocument.ts
+++ b/sdk/nodejs/ecr/lifecyclePolicyDocument.ts
@@ -1,0 +1,7 @@
+import * as inputs from '../types/input';
+
+// re-exporting these for backwards compatibility
+export type LifecyclePolicyDocument = inputs.ecr.LifecyclePolicyDocument;
+export type PolicyRule = inputs.ecr.LifecyclePolicyRule;
+export type Action = inputs.ecr.LifecyclePolicyAction;
+export type Selection = inputs.ecr.LifecyclePolicySelection;

--- a/sdk/nodejs/iam/documents.ts
+++ b/sdk/nodejs/iam/documents.ts
@@ -63,3 +63,10 @@ export function assumeRolePolicyForPrincipal(principal: Principal): inputs.iam.P
         ]
     };
 }
+
+// re-exporting these for backwards compatibility
+export type PolicyDocument = inputs.iam.PolicyDocument;
+export type PolicyStatement = inputs.iam.PolicyStatement;
+export type ServicePrincipal = inputs.iam.ServicePrincipal;
+export type AWSPrincipal = inputs.iam.AWSPrincipal;
+export type FederatedPrincipal = inputs.iam.FederatedPrincipal;

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -927,6 +927,7 @@
         "ecr/getRepositoryCreationTemplate.ts",
         "ecr/index.ts",
         "ecr/lifecyclePolicy.ts",
+        "ecr/lifecyclePolicyDocument.ts",
         "ecr/pullThroughCacheRule.ts",
         "ecr/registryPolicy.ts",
         "ecr/registryScanningConfiguration.ts",


### PR DESCRIPTION
Re-exporting the `PolicyDocument` and `PolicyStatement` types. This
avoids an unnecessary breaking change for users.