### PR TITLE
[v7]: Skip resource reference migration tests

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1331,6 +1331,8 @@ func createLambdaArchive(size int64) (string, error) {
 }
 
 func TestResourceRefsMigrateCleanlyToStringRefs(t *testing.T) {
+	// See pulumi/pulumi-aws#5540
+	t.Skip("Skipping for now since we are not removing resource references")
 	skipIfShort(t)
 	resourceRefMigrateDir := "migrate-resource-refs"
 	dirs := []string{


### PR DESCRIPTION
Skipping these for now since we have backtracked on the decision to
remove these resource references.

re #5540