### PR TITLE
Do not replace Go examples with local SDK

### DIFF
--- a/examples/iam-policy-document/doc-go/go.mod
+++ b/examples/iam-policy-document/doc-go/go.mod
@@ -5,11 +5,9 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )
-
-replace github.com/pulumi/pulumi-aws/sdk/v7 => ../../../sdk
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/examples/tags-combinations-go/go.mod
+++ b/examples/tags-combinations-go/go.mod
@@ -5,11 +5,9 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )
-
-replace github.com/pulumi/pulumi-aws/sdk/v7 => ../../sdk
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/examples/webserver-go/go.mod
+++ b/examples/webserver-go/go.mod
@@ -5,11 +5,9 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )
-
-replace github.com/pulumi/pulumi-aws/sdk/v7 => ../../sdk
 
 require (
 	dario.cat/mergo v1.0.0 // indirect


### PR DESCRIPTION
Using go mod replace causes the verify-release job to fail. This pull request removes the replace, and pins the test version to SDK v7.


