### PR TITLE
Fix removal of eks.Cluster `certificateAuthority`

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2283,8 +2283,6 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 					if _, ok := pm["bootstrapSelfManagedAddons"]; !ok {
 						pm["bootstrapSelfManagedAddons"] = resource.NewBoolProperty(true)
 					}
-					// Remove deprecated certificateAuthority key from state
-					delete(pm, "certificateAuthority")
 					return pm, nil
 				},
 			},


### PR DESCRIPTION
The removal was added in #5655, but forgot to remove it in #5661