### PR TITLE
Remove extraneous test

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -164,13 +164,6 @@ func TestTagsCombinationsGo(t *testing.T) {
 	}
 }
 
-// TestTagsCombinationsGoSingle runs just one test case to verify basic functionality
-func TestTagsCombinationsGoSingle(t *testing.T) {
-	s1 := tagsState{ResourceTags: map[string]string{"x": "s"}}
-	s2 := tagsState{ResourceTags: map[string]string{"x": "s"}}
-	s1.validateTransitionTo(t, 0, s2)
-}
-
 func TestRandomTagsCombinationsGo(t *testing.T) {
 	t.Skipf("Skipping for now until related issues are resolved")
 	tagValues := []string{"", "s"} // empty values are conflated with unknowns in TF internals, must test


### PR DESCRIPTION
This pull request removes a single test that was added for verification and should have remained local. It's part of the Tags test suite already.
