### PR TITLE
Fix region injection for global resources

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -672,7 +672,7 @@ func TestRegress3421Update(t *testing.T) {
 	test.Up(t)
 }
 
-func TestGlobalRegionResource(t *testing.T) {
+func TestGlobalResourcesUseSeparateRegionArgument(t *testing.T) {
 	skipIfShort(t)
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "test-programs/global-region-res",

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -672,6 +672,18 @@ func TestRegress3421Update(t *testing.T) {
 	test.Up(t)
 }
 
+func TestGlobalRegionResource(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+	test := pulumitest.NewPulumiTest(t, "test-programs/global-region-res",
+		opttest.LocalProviderPath("aws", filepath.Join(getCwd(t), "..", "bin")),
+		opttest.YarnLink("@pulumi/aws"),
+	)
+
+	// only preview is needed to verify this
+	test.Preview(t)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	envRegion := getEnvRegion(t)
 	baseJS := integration.ProgramTestOptions{

--- a/examples/test-programs/global-region-res/Pulumi.yaml
+++ b/examples/test-programs/global-region-res/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: global-region-res
+runtime: nodejs
+description: Testing global region resources

--- a/examples/test-programs/global-region-res/README.md
+++ b/examples/test-programs/global-region-res/README.md
@@ -1,0 +1,2 @@
+# examples
+

--- a/examples/test-programs/global-region-res/index.ts
+++ b/examples/test-programs/global-region-res/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from '@pulumi/aws';
+
+const stackset = new aws.cloudformation.StackSet('stackset', {
+  autoDeployment: { enabled: true, retainStacksOnAccountRemoval: false },
+  capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+  description: 'my stack set',
+  permissionModel: 'SERVICE_MANAGED',
+  templateBody: `
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+  `,
+});
+
+new aws.cloudformation.StackSetInstance('instance', {
+  stackSetName: stackset.name,
+  stackSetInstanceRegion: 'us-east-2',
+});

--- a/examples/test-programs/global-region-res/package.json
+++ b/examples/test-programs/global-region-res/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "global-region-res",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^7.0.0",
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/test-programs/global-region-res/tsconfig.json
+++ b/examples/test-programs/global-region-res/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/region.go
+++ b/provider/region.go
@@ -19,7 +19,9 @@ func applyRegionPreCheckCallback(
 	key string,
 	res shim.Resource,
 ) {
-	if _, ok := res.Schema().GetOk("region"); !ok {
+	// global resources have a separate region argument (e.g. `stack_set_instance_region`)
+	// and have deprecated the `region` argument if they had one
+	if r, ok := res.Schema().GetOk("region"); !ok || r.Deprecated() != "" {
 		return
 	}
 	if callback := prov.Resources[key].PreCheckCallback; callback != nil {

--- a/provider/region.go
+++ b/provider/region.go
@@ -21,7 +21,7 @@ func applyRegionPreCheckCallback(
 ) {
 	// global resources have a separate region argument (e.g. `stack_set_instance_region`)
 	// and have deprecated the `region` argument if they had one
-	if r, ok := res.Schema().GetOk("region"); !ok || r.Deprecated() != "" {
+	if region, ok := res.Schema().GetOk("region"); !ok || region.Deprecated() != "" {
 		return
 	}
 	if callback := prov.Resources[key].PreCheckCallback; callback != nil {


### PR DESCRIPTION
Global resources that had a `region` argument in v6 have deprecated the
`region` argument and added a new resource specific region argument
(e.g. `StackSetInstance` has a `stackSetInstanceRegion` argument).

This PR adds an additional check to exclude any `region` argument that
has been deprecated.

fixes #5707