### PR TITLE
Fix `defaultAddonsToRemove` should be `defaultAddonsToRemoves`

### DIFF
--- a/examples/eks-remove-addons/index.ts
+++ b/examples/eks-remove-addons/index.ts
@@ -101,5 +101,5 @@ const cluster2 = new aws.eks.Cluster('test-cluster2', {
     vpcConfig: {
         subnetIds: [subnet1.id, subnet2.id],
     },
-    defaultAddonsToRemove: ['vpc-cni', 'kube-proxy'],
+    defaultAddonsToRemoves: ['vpc-cni', 'kube-proxy'],
 });

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2270,9 +2270,6 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 			},
 			"aws_eks_cluster": {
 				Fields: map[string]*info.Schema{
-					"default_addons_to_remove": {
-						Name: "defaultAddonsToRemove",
-					},
 					"certificate_authority": {
 						Name: "certificateAuthority",
 						// The upstream API only returns a single item

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -483,8 +483,8 @@ namespace Pulumi.Aws.Eks
         [Output("createdAt")]
         public Output<string> CreatedAt { get; private set; } = null!;
 
-        [Output("defaultAddonsToRemove")]
-        public Output<ImmutableArray<string>> DefaultAddonsToRemove { get; private set; } = null!;
+        [Output("defaultAddonsToRemoves")]
+        public Output<ImmutableArray<string>> DefaultAddonsToRemoves { get; private set; } = null!;
 
         /// <summary>
         /// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
@@ -672,13 +672,13 @@ namespace Pulumi.Aws.Eks
         [Input("computeConfig")]
         public Input<Inputs.ClusterComputeConfigArgs>? ComputeConfig { get; set; }
 
-        [Input("defaultAddonsToRemove")]
-        private InputList<string>? _defaultAddonsToRemove;
+        [Input("defaultAddonsToRemoves")]
+        private InputList<string>? _defaultAddonsToRemoves;
         [Obsolete(@"Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider")]
-        public InputList<string> DefaultAddonsToRemove
+        public InputList<string> DefaultAddonsToRemoves
         {
-            get => _defaultAddonsToRemove ?? (_defaultAddonsToRemove = new InputList<string>());
-            set => _defaultAddonsToRemove = value;
+            get => _defaultAddonsToRemoves ?? (_defaultAddonsToRemoves = new InputList<string>());
+            set => _defaultAddonsToRemoves = value;
         }
 
         [Input("enabledClusterLogTypes")]
@@ -835,13 +835,13 @@ namespace Pulumi.Aws.Eks
         [Input("createdAt")]
         public Input<string>? CreatedAt { get; set; }
 
-        [Input("defaultAddonsToRemove")]
-        private InputList<string>? _defaultAddonsToRemove;
+        [Input("defaultAddonsToRemoves")]
+        private InputList<string>? _defaultAddonsToRemoves;
         [Obsolete(@"Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider")]
-        public InputList<string> DefaultAddonsToRemove
+        public InputList<string> DefaultAddonsToRemoves
         {
-            get => _defaultAddonsToRemove ?? (_defaultAddonsToRemove = new InputList<string>());
-            set => _defaultAddonsToRemove = value;
+            get => _defaultAddonsToRemoves ?? (_defaultAddonsToRemoves = new InputList<string>());
+            set => _defaultAddonsToRemoves = value;
         }
 
         [Input("enabledClusterLogTypes")]

--- a/sdk/go/aws/eks/cluster.go
+++ b/sdk/go/aws/eks/cluster.go
@@ -472,7 +472,7 @@ type Cluster struct {
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt pulumi.StringOutput `pulumi:"createdAt"`
 	// Deprecated: Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
-	DefaultAddonsToRemove pulumi.StringArrayOutput `pulumi:"defaultAddonsToRemove"`
+	DefaultAddonsToRemoves pulumi.StringArrayOutput `pulumi:"defaultAddonsToRemoves"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
 	EnabledClusterLogTypes pulumi.StringArrayOutput `pulumi:"enabledClusterLogTypes"`
 	// Configuration block with encryption configuration for the cluster. Detailed below.
@@ -568,7 +568,7 @@ type clusterState struct {
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt *string `pulumi:"createdAt"`
 	// Deprecated: Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
-	DefaultAddonsToRemove []string `pulumi:"defaultAddonsToRemove"`
+	DefaultAddonsToRemoves []string `pulumi:"defaultAddonsToRemoves"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
 	EnabledClusterLogTypes []string `pulumi:"enabledClusterLogTypes"`
 	// Configuration block with encryption configuration for the cluster. Detailed below.
@@ -629,7 +629,7 @@ type ClusterState struct {
 	// Unix epoch timestamp in seconds for when the cluster was created.
 	CreatedAt pulumi.StringPtrInput
 	// Deprecated: Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
-	DefaultAddonsToRemove pulumi.StringArrayInput
+	DefaultAddonsToRemoves pulumi.StringArrayInput
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
 	EnabledClusterLogTypes pulumi.StringArrayInput
 	// Configuration block with encryption configuration for the cluster. Detailed below.
@@ -686,7 +686,7 @@ type clusterArgs struct {
 	// Configuration block with compute configuration for EKS Auto Mode. Detailed below.
 	ComputeConfig *ClusterComputeConfig `pulumi:"computeConfig"`
 	// Deprecated: Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
-	DefaultAddonsToRemove []string `pulumi:"defaultAddonsToRemove"`
+	DefaultAddonsToRemoves []string `pulumi:"defaultAddonsToRemoves"`
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
 	EnabledClusterLogTypes []string `pulumi:"enabledClusterLogTypes"`
 	// Configuration block with encryption configuration for the cluster. Detailed below.
@@ -730,7 +730,7 @@ type ClusterArgs struct {
 	// Configuration block with compute configuration for EKS Auto Mode. Detailed below.
 	ComputeConfig ClusterComputeConfigPtrInput
 	// Deprecated: Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
-	DefaultAddonsToRemove pulumi.StringArrayInput
+	DefaultAddonsToRemoves pulumi.StringArrayInput
 	// List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
 	EnabledClusterLogTypes pulumi.StringArrayInput
 	// Configuration block with encryption configuration for the cluster. Detailed below.
@@ -888,8 +888,8 @@ func (o ClusterOutput) CreatedAt() pulumi.StringOutput {
 }
 
 // Deprecated: Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
-func (o ClusterOutput) DefaultAddonsToRemove() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *Cluster) pulumi.StringArrayOutput { return v.DefaultAddonsToRemove }).(pulumi.StringArrayOutput)
+func (o ClusterOutput) DefaultAddonsToRemoves() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringArrayOutput { return v.DefaultAddonsToRemoves }).(pulumi.StringArrayOutput)
 }
 
 // List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).

--- a/sdk/java/src/main/java/com/pulumi/aws/eks/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/eks/Cluster.java
@@ -571,11 +571,11 @@ public class Cluster extends com.pulumi.resources.CustomResource {
      * 
      */
     @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-    @Export(name="defaultAddonsToRemove", refs={List.class,String.class}, tree="[0,1]")
-    private Output</* @Nullable */ List<String>> defaultAddonsToRemove;
+    @Export(name="defaultAddonsToRemoves", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> defaultAddonsToRemoves;
 
-    public Output<Optional<List<String>>> defaultAddonsToRemove() {
-        return Codegen.optional(this.defaultAddonsToRemove);
+    public Output<Optional<List<String>>> defaultAddonsToRemoves() {
+        return Codegen.optional(this.defaultAddonsToRemoves);
     }
     /**
      * List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).

--- a/sdk/java/src/main/java/com/pulumi/aws/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/eks/ClusterArgs.java
@@ -80,8 +80,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-    @Import(name="defaultAddonsToRemove")
-    private @Nullable Output<List<String>> defaultAddonsToRemove;
+    @Import(name="defaultAddonsToRemoves")
+    private @Nullable Output<List<String>> defaultAddonsToRemoves;
 
     /**
      * @deprecated
@@ -89,8 +89,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-    public Optional<Output<List<String>>> defaultAddonsToRemove() {
-        return Optional.ofNullable(this.defaultAddonsToRemove);
+    public Optional<Output<List<String>>> defaultAddonsToRemoves() {
+        return Optional.ofNullable(this.defaultAddonsToRemoves);
     }
 
     /**
@@ -328,7 +328,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         this.accessConfig = $.accessConfig;
         this.bootstrapSelfManagedAddons = $.bootstrapSelfManagedAddons;
         this.computeConfig = $.computeConfig;
-        this.defaultAddonsToRemove = $.defaultAddonsToRemove;
+        this.defaultAddonsToRemoves = $.defaultAddonsToRemoves;
         this.enabledClusterLogTypes = $.enabledClusterLogTypes;
         this.encryptionConfig = $.encryptionConfig;
         this.forceUpdateVersion = $.forceUpdateVersion;
@@ -435,8 +435,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * 
          */
         @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-        public Builder defaultAddonsToRemove(@Nullable Output<List<String>> defaultAddonsToRemove) {
-            $.defaultAddonsToRemove = defaultAddonsToRemove;
+        public Builder defaultAddonsToRemoves(@Nullable Output<List<String>> defaultAddonsToRemoves) {
+            $.defaultAddonsToRemoves = defaultAddonsToRemoves;
             return this;
         }
 
@@ -448,8 +448,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * 
          */
         @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-        public Builder defaultAddonsToRemove(List<String> defaultAddonsToRemove) {
-            return defaultAddonsToRemove(Output.of(defaultAddonsToRemove));
+        public Builder defaultAddonsToRemoves(List<String> defaultAddonsToRemoves) {
+            return defaultAddonsToRemoves(Output.of(defaultAddonsToRemoves));
         }
 
         /**
@@ -460,8 +460,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * 
          */
         @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-        public Builder defaultAddonsToRemove(String... defaultAddonsToRemove) {
-            return defaultAddonsToRemove(List.of(defaultAddonsToRemove));
+        public Builder defaultAddonsToRemoves(String... defaultAddonsToRemoves) {
+            return defaultAddonsToRemoves(List.of(defaultAddonsToRemoves));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/aws/eks/inputs/ClusterState.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/eks/inputs/ClusterState.java
@@ -141,8 +141,8 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-    @Import(name="defaultAddonsToRemove")
-    private @Nullable Output<List<String>> defaultAddonsToRemove;
+    @Import(name="defaultAddonsToRemoves")
+    private @Nullable Output<List<String>> defaultAddonsToRemoves;
 
     /**
      * @deprecated
@@ -150,8 +150,8 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-    public Optional<Output<List<String>>> defaultAddonsToRemove() {
-        return Optional.ofNullable(this.defaultAddonsToRemove);
+    public Optional<Output<List<String>>> defaultAddonsToRemoves() {
+        return Optional.ofNullable(this.defaultAddonsToRemoves);
     }
 
     /**
@@ -468,7 +468,7 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
         this.clusterId = $.clusterId;
         this.computeConfig = $.computeConfig;
         this.createdAt = $.createdAt;
-        this.defaultAddonsToRemove = $.defaultAddonsToRemove;
+        this.defaultAddonsToRemoves = $.defaultAddonsToRemoves;
         this.enabledClusterLogTypes = $.enabledClusterLogTypes;
         this.encryptionConfig = $.encryptionConfig;
         this.endpoint = $.endpoint;
@@ -664,8 +664,8 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
          * 
          */
         @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-        public Builder defaultAddonsToRemove(@Nullable Output<List<String>> defaultAddonsToRemove) {
-            $.defaultAddonsToRemove = defaultAddonsToRemove;
+        public Builder defaultAddonsToRemoves(@Nullable Output<List<String>> defaultAddonsToRemoves) {
+            $.defaultAddonsToRemoves = defaultAddonsToRemoves;
             return this;
         }
 
@@ -677,8 +677,8 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
          * 
          */
         @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-        public Builder defaultAddonsToRemove(List<String> defaultAddonsToRemove) {
-            return defaultAddonsToRemove(Output.of(defaultAddonsToRemove));
+        public Builder defaultAddonsToRemoves(List<String> defaultAddonsToRemoves) {
+            return defaultAddonsToRemoves(Output.of(defaultAddonsToRemoves));
         }
 
         /**
@@ -689,8 +689,8 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
          * 
          */
         @Deprecated /* Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider */
-        public Builder defaultAddonsToRemove(String... defaultAddonsToRemove) {
-            return defaultAddonsToRemove(List.of(defaultAddonsToRemove));
+        public Builder defaultAddonsToRemoves(String... defaultAddonsToRemoves) {
+            return defaultAddonsToRemoves(List.of(defaultAddonsToRemoves));
         }
 
         /**

--- a/sdk/nodejs/eks/cluster.ts
+++ b/sdk/nodejs/eks/cluster.ts
@@ -346,7 +346,7 @@ export class Cluster extends pulumi.CustomResource {
     /**
      * @deprecated Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
      */
-    public readonly defaultAddonsToRemove!: pulumi.Output<string[] | undefined>;
+    public readonly defaultAddonsToRemoves!: pulumi.Output<string[] | undefined>;
     /**
      * List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
      */
@@ -450,7 +450,7 @@ export class Cluster extends pulumi.CustomResource {
             resourceInputs["clusterId"] = state ? state.clusterId : undefined;
             resourceInputs["computeConfig"] = state ? state.computeConfig : undefined;
             resourceInputs["createdAt"] = state ? state.createdAt : undefined;
-            resourceInputs["defaultAddonsToRemove"] = state ? state.defaultAddonsToRemove : undefined;
+            resourceInputs["defaultAddonsToRemoves"] = state ? state.defaultAddonsToRemoves : undefined;
             resourceInputs["enabledClusterLogTypes"] = state ? state.enabledClusterLogTypes : undefined;
             resourceInputs["encryptionConfig"] = state ? state.encryptionConfig : undefined;
             resourceInputs["endpoint"] = state ? state.endpoint : undefined;
@@ -482,7 +482,7 @@ export class Cluster extends pulumi.CustomResource {
             resourceInputs["accessConfig"] = args ? args.accessConfig : undefined;
             resourceInputs["bootstrapSelfManagedAddons"] = args ? args.bootstrapSelfManagedAddons : undefined;
             resourceInputs["computeConfig"] = args ? args.computeConfig : undefined;
-            resourceInputs["defaultAddonsToRemove"] = args ? args.defaultAddonsToRemove : undefined;
+            resourceInputs["defaultAddonsToRemoves"] = args ? args.defaultAddonsToRemoves : undefined;
             resourceInputs["enabledClusterLogTypes"] = args ? args.enabledClusterLogTypes : undefined;
             resourceInputs["encryptionConfig"] = args ? args.encryptionConfig : undefined;
             resourceInputs["forceUpdateVersion"] = args ? args.forceUpdateVersion : undefined;
@@ -548,7 +548,7 @@ export interface ClusterState {
     /**
      * @deprecated Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
      */
-    defaultAddonsToRemove?: pulumi.Input<pulumi.Input<string>[]>;
+    defaultAddonsToRemoves?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
      */
@@ -652,7 +652,7 @@ export interface ClusterArgs {
     /**
      * @deprecated Configure bootstrapSelfManagedAddons instead. This attribute will be removed in the next major version of the provider
      */
-    defaultAddonsToRemove?: pulumi.Input<pulumi.Input<string>[]>;
+    defaultAddonsToRemoves?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
      */

--- a/sdk/python/pulumi_aws/eks/cluster.py
+++ b/sdk/python/pulumi_aws/eks/cluster.py
@@ -26,7 +26,7 @@ class ClusterArgs:
                  access_config: Optional[pulumi.Input['ClusterAccessConfigArgs']] = None,
                  bootstrap_self_managed_addons: Optional[pulumi.Input[_builtins.bool]] = None,
                  compute_config: Optional[pulumi.Input['ClusterComputeConfigArgs']] = None,
-                 default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 default_addons_to_removes: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  encryption_config: Optional[pulumi.Input['ClusterEncryptionConfigArgs']] = None,
                  force_update_version: Optional[pulumi.Input[_builtins.bool]] = None,
@@ -71,11 +71,11 @@ class ClusterArgs:
             pulumi.set(__self__, "bootstrap_self_managed_addons", bootstrap_self_managed_addons)
         if compute_config is not None:
             pulumi.set(__self__, "compute_config", compute_config)
-        if default_addons_to_remove is not None:
+        if default_addons_to_removes is not None:
             warnings.warn("""Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""", DeprecationWarning)
-            pulumi.log.warn("""default_addons_to_remove is deprecated: Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
-        if default_addons_to_remove is not None:
-            pulumi.set(__self__, "default_addons_to_remove", default_addons_to_remove)
+            pulumi.log.warn("""default_addons_to_removes is deprecated: Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
+        if default_addons_to_removes is not None:
+            pulumi.set(__self__, "default_addons_to_removes", default_addons_to_removes)
         if enabled_cluster_log_types is not None:
             pulumi.set(__self__, "enabled_cluster_log_types", enabled_cluster_log_types)
         if encryption_config is not None:
@@ -166,14 +166,14 @@ class ClusterArgs:
         pulumi.set(self, "compute_config", value)
 
     @_builtins.property
-    @pulumi.getter(name="defaultAddonsToRemove")
+    @pulumi.getter(name="defaultAddonsToRemoves")
     @_utilities.deprecated("""Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
-    def default_addons_to_remove(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
-        return pulumi.get(self, "default_addons_to_remove")
+    def default_addons_to_removes(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+        return pulumi.get(self, "default_addons_to_removes")
 
-    @default_addons_to_remove.setter
-    def default_addons_to_remove(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
-        pulumi.set(self, "default_addons_to_remove", value)
+    @default_addons_to_removes.setter
+    def default_addons_to_removes(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+        pulumi.set(self, "default_addons_to_removes", value)
 
     @_builtins.property
     @pulumi.getter(name="enabledClusterLogTypes")
@@ -342,7 +342,7 @@ class _ClusterState:
                  cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
                  compute_config: Optional[pulumi.Input['ClusterComputeConfigArgs']] = None,
                  created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 default_addons_to_removes: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  encryption_config: Optional[pulumi.Input['ClusterEncryptionConfigArgs']] = None,
                  endpoint: Optional[pulumi.Input[_builtins.str]] = None,
@@ -409,11 +409,11 @@ class _ClusterState:
             pulumi.set(__self__, "compute_config", compute_config)
         if created_at is not None:
             pulumi.set(__self__, "created_at", created_at)
-        if default_addons_to_remove is not None:
+        if default_addons_to_removes is not None:
             warnings.warn("""Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""", DeprecationWarning)
-            pulumi.log.warn("""default_addons_to_remove is deprecated: Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
-        if default_addons_to_remove is not None:
-            pulumi.set(__self__, "default_addons_to_remove", default_addons_to_remove)
+            pulumi.log.warn("""default_addons_to_removes is deprecated: Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
+        if default_addons_to_removes is not None:
+            pulumi.set(__self__, "default_addons_to_removes", default_addons_to_removes)
         if enabled_cluster_log_types is not None:
             pulumi.set(__self__, "enabled_cluster_log_types", enabled_cluster_log_types)
         if encryption_config is not None:
@@ -540,14 +540,14 @@ class _ClusterState:
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
-    @pulumi.getter(name="defaultAddonsToRemove")
+    @pulumi.getter(name="defaultAddonsToRemoves")
     @_utilities.deprecated("""Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
-    def default_addons_to_remove(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
-        return pulumi.get(self, "default_addons_to_remove")
+    def default_addons_to_removes(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+        return pulumi.get(self, "default_addons_to_removes")
 
-    @default_addons_to_remove.setter
-    def default_addons_to_remove(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
-        pulumi.set(self, "default_addons_to_remove", value)
+    @default_addons_to_removes.setter
+    def default_addons_to_removes(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+        pulumi.set(self, "default_addons_to_removes", value)
 
     @_builtins.property
     @pulumi.getter(name="enabledClusterLogTypes")
@@ -801,7 +801,7 @@ class Cluster(pulumi.CustomResource):
                  access_config: Optional[pulumi.Input[Union['ClusterAccessConfigArgs', 'ClusterAccessConfigArgsDict']]] = None,
                  bootstrap_self_managed_addons: Optional[pulumi.Input[_builtins.bool]] = None,
                  compute_config: Optional[pulumi.Input[Union['ClusterComputeConfigArgs', 'ClusterComputeConfigArgsDict']]] = None,
-                 default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 default_addons_to_removes: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  encryption_config: Optional[pulumi.Input[Union['ClusterEncryptionConfigArgs', 'ClusterEncryptionConfigArgsDict']]] = None,
                  force_update_version: Optional[pulumi.Input[_builtins.bool]] = None,
@@ -1383,7 +1383,7 @@ class Cluster(pulumi.CustomResource):
                  access_config: Optional[pulumi.Input[Union['ClusterAccessConfigArgs', 'ClusterAccessConfigArgsDict']]] = None,
                  bootstrap_self_managed_addons: Optional[pulumi.Input[_builtins.bool]] = None,
                  compute_config: Optional[pulumi.Input[Union['ClusterComputeConfigArgs', 'ClusterComputeConfigArgsDict']]] = None,
-                 default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 default_addons_to_removes: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  encryption_config: Optional[pulumi.Input[Union['ClusterEncryptionConfigArgs', 'ClusterEncryptionConfigArgsDict']]] = None,
                  force_update_version: Optional[pulumi.Input[_builtins.bool]] = None,
@@ -1411,7 +1411,7 @@ class Cluster(pulumi.CustomResource):
             __props__.__dict__["access_config"] = access_config
             __props__.__dict__["bootstrap_self_managed_addons"] = bootstrap_self_managed_addons
             __props__.__dict__["compute_config"] = compute_config
-            __props__.__dict__["default_addons_to_remove"] = default_addons_to_remove
+            __props__.__dict__["default_addons_to_removes"] = default_addons_to_removes
             __props__.__dict__["enabled_cluster_log_types"] = enabled_cluster_log_types
             __props__.__dict__["encryption_config"] = encryption_config
             __props__.__dict__["force_update_version"] = force_update_version
@@ -1457,7 +1457,7 @@ class Cluster(pulumi.CustomResource):
             cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
             compute_config: Optional[pulumi.Input[Union['ClusterComputeConfigArgs', 'ClusterComputeConfigArgsDict']]] = None,
             created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            default_addons_to_removes: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
             enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
             encryption_config: Optional[pulumi.Input[Union['ClusterEncryptionConfigArgs', 'ClusterEncryptionConfigArgsDict']]] = None,
             endpoint: Optional[pulumi.Input[_builtins.str]] = None,
@@ -1526,7 +1526,7 @@ class Cluster(pulumi.CustomResource):
         __props__.__dict__["cluster_id"] = cluster_id
         __props__.__dict__["compute_config"] = compute_config
         __props__.__dict__["created_at"] = created_at
-        __props__.__dict__["default_addons_to_remove"] = default_addons_to_remove
+        __props__.__dict__["default_addons_to_removes"] = default_addons_to_removes
         __props__.__dict__["enabled_cluster_log_types"] = enabled_cluster_log_types
         __props__.__dict__["encryption_config"] = encryption_config
         __props__.__dict__["endpoint"] = endpoint
@@ -1606,10 +1606,10 @@ class Cluster(pulumi.CustomResource):
         return pulumi.get(self, "created_at")
 
     @_builtins.property
-    @pulumi.getter(name="defaultAddonsToRemove")
+    @pulumi.getter(name="defaultAddonsToRemoves")
     @_utilities.deprecated("""Configure bootstrap_self_managed_addons instead. This attribute will be removed in the next major version of the provider""")
-    def default_addons_to_remove(self) -> pulumi.Output[Optional[Sequence[_builtins.str]]]:
-        return pulumi.get(self, "default_addons_to_remove")
+    def default_addons_to_removes(self) -> pulumi.Output[Optional[Sequence[_builtins.str]]]:
+        return pulumi.get(self, "default_addons_to_removes")
 
     @_builtins.property
     @pulumi.getter(name="enabledClusterLogTypes")


### PR DESCRIPTION
In v6 the property had an `s` at the end. The previous PR incorrectly removed the `s`.

https://github.com/pulumi/pulumi-aws/blob/v6.83.0/sdk/nodejs/eks/cluster.ts#L644