### PR TITLE
Fix assumeRole validation in validateCredentials

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -270,8 +270,8 @@ values:
     AWS_REGION: <YOUR_AWS_REGION>
   pulumiConfig: # exposes Pulumi config values to the Pulumi CLI
     project:environment: 'dev'
-    aws:assumeRole:
-      roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
+    aws:assumeRoles:
+      - roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
     aws:dynamodbEndpoint: 'dynamodb.us-east-2.amazonaws.com'
 ```
 
@@ -292,8 +292,8 @@ values:
     aws:secretKey: ${aws.login.secretAccessKey}
     aws:token: ${aws.login.sessionToken}
     project:environment: 'dev'
-    aws:assumeRole:
-      roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
+    aws:assumeRoles:
+      - roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
     aws:dynamodbEndpoint: 'dynamodb.us-east-2.amazonaws.com'
 ```
 
@@ -332,7 +332,7 @@ Use `pulumi config set aws:<option>` or pass options to the [constructor of `new
 | `region` | Required | The region where AWS operations will take place. Examples are `us-east-1`, `us-west-2`, etc. |
 | `allowedAccountIds` | Optional | List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one (and potentially end up destroying a live environment). Conflicts with `forbiddenAccountIds`. |
 | `accessKey` | Optional | The access key for API operations. You can retrieve this from the ‘Security & Credentials’ section of the AWS console. |
-| `assumeRole` | Optional | A JSON object representing an IAM role to assume.  To set these nested properties, see docs on [structured configuration](/docs/concepts/config#structured-configuration), for example `pulumi config set --path aws:assumeRole.roleArn arn:aws:iam::058111598222:role/OrganizationAccountAccessRole`. The object contains the properties marked with a ↳ below: |
+| `assumeRoles` | Optional | A List of JSON objects representing an IAM role to assume.  To set these nested properties, see docs on [structured configuration](/docs/concepts/config#structured-configuration), for example `pulumi config set --path aws:assumeRoles[0].roleArn arn:aws:iam::058111598222:role/OrganizationAccountAccessRole`. The object contains the properties marked with a ↳ below: |
 | ↳ `durationSeconds` | Optional |  Number of seconds to restrict the assume role session duration. |
 | ↳ `externalId` | Optional | External identifier to use when assuming the role. |
 | ↳ `policy` | Optional | IAM Policy JSON describing further restricting permissions for the IAM Role being assumed. |

--- a/docs/version-7-upgrade.md
+++ b/docs/version-7-upgrade.md
@@ -182,6 +182,23 @@ const provider = new aws.Provider("provider", {
 });
 ```
 
+Similarly, if you are using the `aws:assumeRole` config you will need to update it to match the new type.
+
+**This (v6)**
+
+```yaml
+config:
+  aws:assumeRole:
+    roleArn: arn:aws:iam::12345678912/someRole
+```
+
+**Becomes this (v7)**
+```yaml
+config:
+  aws:assumeRoles:
+    - roleArn: arn:aws:iam::12345678912/someRole
+```
+
 
 ## S3 Bucket/BucketV2 Changes
 

--- a/examples/assume-role-config/Pulumi.yaml
+++ b/examples/assume-role-config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: assume-role-config
+runtime: nodejs
+description: Shows how to configure aws:assumeRoles

--- a/examples/assume-role-config/index.ts
+++ b/examples/assume-role-config/index.ts
@@ -1,0 +1,24 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+
+const account = aws.getCallerIdentityOutput({}).accountId;
+const accountArn = pulumi.interpolate`arn:aws:iam::${account}:root`
+const assumableRole = new aws.iam.Role('assumable', {
+    assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({ AWS: accountArn }),
+    managedPolicyArns: [aws.iam.ManagedPolicy.AdministratorAccess],
+});
+
+export const roleArn = assumableRole.arn;

--- a/examples/assume-role-config/package.json
+++ b/examples/assume-role-config/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "assume-role-config",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^7.0.0",
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/assume-role-config/step2/index.ts
+++ b/examples/assume-role-config/step2/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as aws from '@pulumi/aws'
+
+new aws.s3.Bucket('bucket', {});

--- a/examples/assume-role-config/tsconfig.json
+++ b/examples/assume-role-config/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -9,6 +9,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_parseAssumeRoles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses correctly", func(t *testing.T) {
+		vars := resource.PropertyMap{
+			"assumeRoles": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"roleArn": resource.NewStringProperty("arn:aws:iam::12345678912:root"),
+				}),
+			}),
+		}
+
+		res, err := parseAssumeRoles(vars)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(res))
+		assert.Equal(t, "arn:aws:iam::12345678912:root", res[0].RoleARN)
+	})
+
+	t.Run("handles incorrect type", func(t *testing.T) {
+		vars := resource.PropertyMap{
+			"assumeRoles": resource.NewObjectProperty(resource.PropertyMap{
+				"roleArn": resource.NewStringProperty("arn:aws:iam::12345678912:root"),
+			}),
+		}
+
+		_, err := parseAssumeRoles(vars)
+		assert.ErrorContains(t, err, "expected aws:assumeRoles to be an array, got object")
+	})
+}
+
 func TestParseDuration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This fixes the validation around the `aws:assumeRoles` config. We were
validating the old `assumeRole` config instead of the new `assumeRoles`.

This also adds some additional validation so that we throw some nice
errors rather than panics.