### PR TITLE
Add support for Ruby 3.4 lambda runtime

### DIFF
--- a/provider/types.go
+++ b/provider/types.go
@@ -249,6 +249,7 @@ var extraTypes = map[string]schema.ComplexTypeSpec{
 			{Value: "python3.9", Name: "Python3d9"},
 			{Value: "ruby3.2", Name: "Ruby3d2"},
 			{Value: "ruby3.3", Name: "Ruby3d3"},
+			{Value: "ruby3.4", Name: "Ruby3d4"},
 
 			deprecateRuntime("dotnet5.0", "Dotnet5d0"),
 			deprecateRuntime("dotnet7", "Dotnet7"),

--- a/sdk/dotnet/Lambda/Enums.cs
+++ b/sdk/dotnet/Lambda/Enums.cs
@@ -38,6 +38,7 @@ namespace Pulumi.Aws.Lambda
         public static Runtime Python3d9 { get; } = new Runtime("python3.9");
         public static Runtime Ruby3d2 { get; } = new Runtime("ruby3.2");
         public static Runtime Ruby3d3 { get; } = new Runtime("ruby3.3");
+        public static Runtime Ruby3d4 { get; } = new Runtime("ruby3.4");
         [Obsolete(@"This runtime is now deprecated")]
         public static Runtime Dotnet5d0 { get; } = new Runtime("dotnet5.0");
         [Obsolete(@"This runtime is now deprecated")]

--- a/sdk/go/aws/lambda/pulumiEnums.go
+++ b/sdk/go/aws/lambda/pulumiEnums.go
@@ -32,6 +32,7 @@ const (
 	RuntimePython3d9    = Runtime("python3.9")
 	RuntimeRuby3d2      = Runtime("ruby3.2")
 	RuntimeRuby3d3      = Runtime("ruby3.3")
+	RuntimeRuby3d4      = Runtime("ruby3.4")
 	// Deprecated: This runtime is now deprecated
 	RuntimeDotnet5d0 = Runtime("dotnet5.0")
 	// Deprecated: This runtime is now deprecated
@@ -208,6 +209,7 @@ func (o RuntimePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulu
 //	RuntimePython3d9
 //	RuntimeRuby3d2
 //	RuntimeRuby3d3
+//	RuntimeRuby3d4
 type RuntimeInput interface {
 	pulumi.Input
 

--- a/sdk/java/src/main/java/com/pulumi/aws/lambda/enums/Runtime.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/lambda/enums/Runtime.java
@@ -32,6 +32,7 @@ import java.util.StringJoiner;
         Python3d9("python3.9"),
         Ruby3d2("ruby3.2"),
         Ruby3d3("ruby3.3"),
+        Ruby3d4("ruby3.4"),
         /**
          * @deprecated
          * This runtime is now deprecated

--- a/sdk/nodejs/types/enums/lambda/index.ts
+++ b/sdk/nodejs/types/enums/lambda/index.ts
@@ -21,6 +21,7 @@ export const Runtime = {
     Python3d9: "python3.9",
     Ruby3d2: "ruby3.2",
     Ruby3d3: "ruby3.3",
+    Ruby3d4: "ruby3.4",
     /**
      * @deprecated This runtime is now deprecated
      */

--- a/sdk/python/pulumi_aws/lambda_/_enums.py
+++ b/sdk/python/pulumi_aws/lambda_/_enums.py
@@ -34,6 +34,7 @@ class Runtime(_builtins.str, Enum):
     PYTHON3D9 = "python3.9"
     RUBY3D2 = "ruby3.2"
     RUBY3D3 = "ruby3.3"
+    RUBY3D4 = "ruby3.4"
     DOTNET5D0 = "dotnet5.0"
     DOTNET7 = "dotnet7"
     DOTNET_CORE2D1 = "dotnetcore2.1"


### PR DESCRIPTION
AWS Introduced Lambda support for Ruby 3.4 in March 2025.

https://aws.amazon.com/about-aws/whats-new/2025/03/aws-lambda-support-ruby-3-4/

* Add Ruby 3.4 to Lambda runtime enum

* Update SDKs