### PR TITLE
Enable RawStateDelta

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -5248,6 +5248,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo {
 			Namespaces: namespaceMap,
 		},
 		EnableAccurateBridgePreview: true,
+		EnableRawStateDelta:         true,
 	}
 
 	rAlias := func(token string, prev, current tokens.Type, info *tfbridge.ResourceInfo) {


### PR DESCRIPTION
A bridge feature for preserving Terraform raw state is being rolled out to this provider. See also:

- https://github.com/pulumi/pulumi-terraform-bridge/issues/1667
- https://github.com/pulumi/pulumi-terraform-bridge/issues/3003