### PR TITLE
fix: ordered list should start at 1

### DIFF
--- a/docs/version-7-upgrade.md
+++ b/docs/version-7-upgrade.md
@@ -226,9 +226,9 @@ We have also introduced new Bucket configuration resources that are alternatives
 
 In order to perform this migration first update your code to use the new resource or property names and then run pulumi with the `--refresh` and `--run-program` arguments. Make sure you have [installed](https://www.pulumi.com/docs/iac/download-install/) the latest version of the Pulumi CLI.
 
-3. Fix any differences in property types (e.g. `Bucket.loggings` (array) to `Bucket.logging` (object))
-4. Run `pulumi up --refresh --run-program`
-5. Ensure there is no diff in the update. If there is, go back to step 1
+1. Fix any differences in property types (e.g. `Bucket.loggings` (array) to `Bucket.logging` (object))
+2. Run `pulumi up --refresh --run-program`
+3. Ensure there is no diff in the update. If there is, go back to step 1
 
 [!NOTE] You may see a refresh diff as Pulumi migrates the state to the new structure, but you should not see an update diff.
 


### PR DESCRIPTION
Quick fix to sort an ordered list. It looks like there are missing steps, but the steps were removed in https://github.com/pulumi/pulumi-aws/commit/6bc468cca67e8d4c7424d6d994410c65ed141507 because they're covered by the previous section (the list of resources to rename).