### PR TITLE
upstream tests: free disk space prior to tests

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -61,6 +61,13 @@ jobs:
           # - service: route53resolver
           #   tests: TestAccRoute53Resolver
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
@@ -92,13 +99,6 @@ jobs:
           role-duration-seconds: 7200
           role-session-name: aws@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      # Free space before running tests.
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          swap-storage: false
-          dotnet: false
       - if: ${{ matrix.tests }}
         name: Test ${{ matrix.service }}
         run: |


### PR DESCRIPTION
Lack of disk space is causing these tests to fail to build. Attempt to
rectify this by cleaning up space prior to the tests themselves.

Fixes #6065.
