### PR TITLE
feat: add NodeJS24dX

### DIFF
--- a/sdk/nodejs/types/enums/lambda/index.ts
+++ b/sdk/nodejs/types/enums/lambda/index.ts
@@ -12,6 +12,7 @@ export const Runtime = {
     NodeJS18dX: "nodejs18.x",
     NodeJS20dX: "nodejs20.x",
     NodeJS22dX: "nodejs22.x",
+    NodeJS24dX: "nodejs24.x",
     CustomAL2: "provided.al2",
     CustomAL2023: "provided.al2023",
     Python3d10: "python3.10",


### PR DESCRIPTION
Adding `NodeJS24dX` to `Runtime` enum.