### PR TITLE
[chore] disable TestAccSQSQueue_List_basic

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -97,4 +97,4 @@ jobs:
         # TODO[pulumi/pulumi-aws#6115]: reenable TestAccSQSQueue_List_basic
         run: |
           cd upstream
-          TF_ACC=1 make testacc GO_VER=go PKG=${{ matrix.service }} ACCTEST_PARALLELISM=6 TESTS="${{ matrix.tests }}" TESTARGS="-skip 'tags|.*/.*/Tags|TestAccSQSQueue_List_basic'"
+          TF_ACC=1 make testacc GO_VER=go PKG=${{ matrix.service }} ACCTEST_PARALLELISM=6 TESTS="${{ matrix.tests }}" TESTARGS="-skip 'tags|TestAccSQSQueue_List_basic|.*/.*/Tags'"


### PR DESCRIPTION
This test is broken as of upstream@v6.28.0.
https://github.com/pulumi/pulumi-aws/issues/6115 tracks re-enabling the test.
