### PR TITLE
Replace legacy TypeScript module declaration with namespace

### DIFF
--- a/sdk/nodejs/iam/principals.ts
+++ b/sdk/nodejs/iam/principals.ts
@@ -14,7 +14,7 @@
 
 import { Principal } from "./documents";
 
-export module Principals {
+export namespace Principals {
     /**
      * Service Principal for Amazon Certificate Manager
      */


### PR DESCRIPTION
## Summary
- Problem: `iam/principals.ts` contains a legacy TypeScript module declaration which is deprecated in TypeScript 6.
- Change: replace `module` with `namespace`, which has been available since TypeScript 1.5
- Related issue/PR: #6259 

## Change Type
- [ ] Provider logic only (`provider/`)
- [x] Schema or mapping change (may require SDK regeneration)
- [ ] Upstream or patch pipeline change (`upstream/`, `patches/`, `scripts/upstream.sh`)
- [ ] CI workflow source change (`.ci-mgmt.yaml`)

## Validation Evidence
Paste exact commands and outcomes.

- [x] `make lint`
- [x] `make test_provider`
- [x] If schema-affecting: `make schema`
- [x] If schema-affecting: `make build_sdks`
- [ ] If CI source changed: `make ci-mgmt`

### Command output snippets
`make lint`:  [make-lint.txt](https://github.com/user-attachments/files/26443887/make-lint.txt)
`make test_provider`:  [make-test_provider.txt](https://github.com/user-attachments/files/26444177/make-test_provider.txt)
`make schema`:  [make-schema.txt](https://github.com/user-attachments/files/26444875/make-schema.txt)
`make build_sdks`:  [make-build_sdks.txt](https://github.com/user-attachments/files/26444880/make-build_sdks.txt)

## Risk
- Blast radius: low; changed TypeScript keyword with equivalent value.
- Edge cases: users on TypeScript < 1.5

## Rollback
- Revert plan: change `namespace` back to `module`
- Follow-up cleanup: N/A?
