### PR TITLE
Don't nest the Region type

### DIFF
--- a/provider/types.go
+++ b/provider/types.go
@@ -22,7 +22,7 @@ import (
 
 // extraTypes augment the types defined by the upstream AWS provider
 var extraTypes = map[string]schema.ComplexTypeSpec{
-	"aws:index/Region:Region": {
+	"aws:index:Region": {
 		ObjectTypeSpec: schema.ObjectTypeSpec{
 			Type:        "string",
 			Description: "A Region represents any valid Amazon region that may be targeted with deployments.",


### PR DESCRIPTION
Core doesn't want to support modules nested under the "index" module. It makes little sense, and this appears to be the only instance of a type trying to do it. 

This needs updating so we can tighten the token validation in the CLI to dis-allow patterns like this without breaking aws-native builds.