### PR TITLE
Fix release-verification example compilation

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1438,7 +1438,6 @@ func TestAccConfigureClusterAddons(t *testing.T) {
 
 // also test the release verification test so it will also fail in CI
 func TestReleaseVerification(t *testing.T) {
-	t.Skip("temporarily disabled, see https://github.com/pulumi/pulumi-aws/issues/6272")
 	region := getEnvRegion(t)
 	test := integration.ProgramTestOptions{
 		Dir: filepath.Join(getCwd(t), "release-verification"),

--- a/examples/release-verification/package.json
+++ b/examples/release-verification/package.json
@@ -11,6 +11,7 @@
         "@pulumi/pulumi": "^3.0.0"
     },
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^18.0.0",
+        "typescript": "^5.0.0"
     }
 }


### PR DESCRIPTION
This was causing master to go red on release verification. I've added `needs-release/minor` to ensure that [the recent upstream upgrade](https://github.com/pulumi/pulumi-aws/pull/6270) gets released also.

## Summary

- Bump `@types/node` from `^8.0.0` to `^18.0.0` in `examples/release-verification/package.json` — the old version is too ancient for `@aws-sdk/client-s3` v3 types
- Add `typescript: ^5.0.0` as a devDependency — without it, `@pulumi/pulumi`'s bundled TypeScript 3.8.3 is used, which can't resolve modern AWS SDK generics (`S3Client.send`)
- Re-enable `TestReleaseVerification` (remove `t.Skip`)

Fixes #6272
Fixes #6275

## Test plan

- [x] Verified `pulumi preview` succeeds locally with the updated deps
- [ ] CI verify-release workflow should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)