### PR TITLE
Remove redundant broad smoke examples

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -9,37 +9,14 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestAccWebserverCs(t *testing.T) {
+// Keep the .NET release-verification example covered in normal CI.
+func TestReleaseVerificationCs(t *testing.T) {
 	test := getCSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: false, //this is newly moved to a new namespace
-			Dir:           filepath.Join(getCwd(t), "webserver-cs"),
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccPolicyDocumentCs(t *testing.T) {
-	test := getCSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			RunUpdateTest: false, //this is newly moved to a new namespace
-			Dir:           filepath.Join(getCwd(t), "iam-policy-document", "csharp"),
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccFifoSqsQueueCs(t *testing.T) {
-	test := getCSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "sqs-fifo-queue", "csharp"),
 			RunUpdateTest: false,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assert.Contains(t, stack.Outputs["QueueName"].(string), ".fifo")
-			},
+			Dir:           filepath.Join(getCwd(t), "webserver-cs"),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -42,19 +42,11 @@ func getGoBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	}
 }
 
-func TestAccWebserverGo(t *testing.T) {
+// Keep the Go release-verification example covered in normal CI.
+func TestReleaseVerificationGo(t *testing.T) {
 	test := getGoBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "webserver-go"),
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccPolicyDocumentGo(t *testing.T) {
-	test := getGoBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "iam-policy-document", "doc-go"),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -50,15 +50,6 @@ func TestAccDedicatedHosts(t *testing.T) {
 }
 */
 
-func TestAccMinimal(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "minimal"),
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
 func TestAccExpress(t *testing.T) {
 	// This example is reused to further validate that provisioned CallbackFunctions in Node are working at runtime
 	// as expected, in particular their default runtime is not deprecated and they can utilize new APIs like the
@@ -152,17 +143,6 @@ func TestAccBucket(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-func TestAccCloudWatch(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "cloudwatch"),
-			RunUpdateTest: true,
-			// Inherit ambient credentials.
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
 func TestAccCloudWatchWithOIDC(t *testing.T) {
 	ctx := context.Background()
 
@@ -195,21 +175,6 @@ func TestAccCloudWatchWithOIDC(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-func TestAccCloudWatchOIDCAmbient(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "cloudwatchOidcManual"),
-
-			// TODO[pulumi/pulumi-aws#3193] multiple issues with refreshing and updating cleanly.
-			SkipRefresh:              true,
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
-			// Inherit ambient credentials.
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
 func TestAccCloudWatchOIDCManual(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
@@ -228,65 +193,6 @@ func TestAccCloudWatchOIDCManual(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccLogGroup(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "logGroup"),
-			RunUpdateTest: false,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccQueue(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "queue"),
-			RunUpdateTest: true,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccEventBus(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "eventbus"),
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccStream(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "stream"),
-			RunUpdateTest: true,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccTable(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "table"),
-			RunUpdateTest: true,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccTopic(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "topic"),
-			RunUpdateTest: true,
-		})
-	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -341,56 +247,6 @@ func TestAccCallbackFunction(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-func TestAccSsmParameter(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "ssmparameter"),
-			RunUpdateTest: true,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				tier, ok := stack.Outputs["tier"]
-				require.Equalf(t, true, ok, "tier not found in outputs")
-				assert.Equal(t, "Standard", tier)
-
-				tier2, ok := stack.Outputs["tier2"]
-				require.Equalf(t, true, ok, "tier2 not found in outputs")
-				assert.Equal(t, "Standard", tier2)
-			},
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccSsmParameterWithS3State(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "ssmparameter"),
-			RunUpdateTest: true,
-			CloudURL:      "s3://ci-remote-state-bucket",
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccRoute53(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "route53"),
-			RunUpdateTest: true,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccLambdaLayer(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "lambda-layer-old"),
-			RunUpdateTest: true,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
 func TestAccLambdaContainerImages(t *testing.T) {
 	// TODO[pulumi/pulumi-awsx#1612]
 	t.Skipf("Skipping test until awsx is update to use getAuthorizationToken %s", t.Name())
@@ -399,26 +255,6 @@ func TestAccLambdaContainerImages(t *testing.T) {
 			Dir: filepath.Join(getCwd(t), "lambda-container-image"),
 		})
 	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccLambdaLayerNewEnums(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "lambda-layer-new"),
-			RunUpdateTest: false,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccEcr(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "ecr"),
-			RunUpdateTest: true,
-		})
-
 	integration.ProgramTest(t, &test)
 }
 
@@ -460,116 +296,6 @@ func TestAccIgnoreChanges(t *testing.T) {
 				},
 			},
 		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccWebserver(t *testing.T) {
-	skipIfShort(t)
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "webserver"),
-			//
-			// TODO[pulumi/pulumi#12859] temporarily disable EditDirs to workaround ProgramTest bug
-			//
-			// EditDirs: []integration.EditDir{
-			// 	// First, look up the server just created using get.  No new resources.
-			// 	createEditDir(filepath.Join(getCwd(t), "webserver", "variants", "get")),
-			// 	// Next, patch the ingress rules by adding port 20: should be a quick update.
-			// 	createEditDir(filepath.Join(getCwd(t), "webserver", "variants", "ssh")),
-			// 	// Now do the reverse; this basically ensures that an update that deletes a property works.
-			// 	createEditDir(filepath.Join(getCwd(t), "webserver")),
-			// 	// Next patch the security group description, necessitating a full replacement of resources.
-			// 	createEditDir(filepath.Join(getCwd(t), "webserver", "variants", "ssh_description")),
-			// },
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccWebserverVariants(t *testing.T) {
-	skipIfShort(t)
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "webserver", "variants", "zones"),
-			RunUpdateTest: true,
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccWebserverComp(t *testing.T) {
-	skipIfShort(t)
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "webserver-comp"),
-			Secrets: map[string]string{
-				"aws:accessKey": os.Getenv("AWS_ACCESS_KEY_ID"),
-				"aws:secretKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
-			},
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccServerlessRaw(t *testing.T) {
-	skipIfShort(t)
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "serverless-raw"),
-			RunUpdateTest: false,
-			// Two changes are known to occur during refresh of the resources in this example:
-			// * `~  aws:apigateway:Method myrestapi-method updated changes: + authorizationScopes,...`
-			// * `~  aws:lambda:Function mylambda-logcollector updated changes: ~ lastModified`
-			ExpectRefreshChanges: true,
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccMultipleRegions(t *testing.T) {
-	skipIfShort(t)
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "multiple-regions"),
-			// RunUpdateTest: true,
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccFifoSqsQueueTs(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "sqs-fifo-queue", "ts"),
-			RunUpdateTest: false,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assert.Contains(t, stack.Outputs["name"].(string), ".fifo")
-			},
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccKmsAliasTs(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "kms-alias"),
-			RunUpdateTest: false,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assert.Contains(t, stack.Outputs["autonamedAlias"].(string), "alias/")
-			},
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccWafV2(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "wafv2"),
-		})
-	skipRefresh(&test)
 
 	integration.ProgramTest(t, &test)
 }
@@ -805,31 +531,6 @@ func TestRoleInlinePolicyAutoName(t *testing.T) {
 
 	require.Regexp(t, regexp.MustCompile("testrole-*"), inlinePolicy.Name)
 	require.JSONEq(t, `{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*" }]}`, inlinePolicy.Policy)
-}
-
-func TestRdsGetEngineVersion(t *testing.T) {
-	skipIfShort(t)
-	t.Parallel()
-	test := pulumitest.NewPulumiTest(t, "rds-getengineversion",
-		opttest.LocalProviderPath("aws", filepath.Join(getCwd(t), "..", "bin")),
-	)
-	res, err := test.CurrentStack().Up(test.Context())
-	require.NoError(t, err)
-
-	engineVersion := res.Outputs["vs"]
-	require.Equal(t, engineVersion.Value, "15.8")
-}
-
-func TestServerlessAppRepositoryApplication(t *testing.T) {
-	test := getJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "serverless-app-repository-application"),
-			Config: map[string]string{
-				"functionName": "athena-cloudwatch-connector-" + randomString(10),
-			},
-		})
-
-	integration.ProgramTest(t, &test)
 }
 
 func TestAccEcrImage(t *testing.T) {

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -25,16 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccBucketPy(t *testing.T) {
-	test := getPythonBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "bucket-py"),
-			RunUpdateTest: true,
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
 func TestAccPolicyDocument(t *testing.T) {
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
@@ -55,38 +45,6 @@ func TestAccWebserverPy(t *testing.T) {
 			integration.ProgramTest(t, &test)
 		})
 	}
-}
-
-func TestAccCodeBuildProjectPy(t *testing.T) {
-	test := getPythonBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "codebuild-project-py"),
-			RunUpdateTest: false,
-		})
-	skipRefresh(&test)
-	integration.ProgramTest(t, &test)
-}
-
-func TestAccFifoSqsQueuePy(t *testing.T) {
-	test := getPythonBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "sqs-fifo-queue", "python"),
-			RunUpdateTest: false,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assert.Contains(t, stack.Outputs["name"].(string), ".fifo")
-			},
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestSecretManagerPy(t *testing.T) {
-	test := getPythonBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "secretmanager"),
-		})
-
-	integration.ProgramTest(t, &test)
 }
 
 func TestRegress4031(t *testing.T) {

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1182,15 +1182,6 @@ func TestRegressLandingZoneDiff(t *testing.T) {
 	replay(t, event)
 }
 
-func TestElasticacheReplicationGroup(t *testing.T) {
-	t.Parallel()
-
-	ptest := pulumiTest(t, filepath.Join("test-programs", "elasticache-replication-group"), opttest.SkipInstall())
-	upResult := ptest.Up(t)
-	replicationGroupArn := upResult.Outputs["replicationGroupArn"].Value.(string)
-	assert.NotEmpty(t, replicationGroupArn)
-}
-
 func TestSecurityGroupPreviewWarning(t *testing.T) {
 	t.Parallel()
 	pt := pulumiTest(t, filepath.Join("test-programs", "security-group", "security-group-1"))

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/stretchr/testify/assert"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -103,6 +105,70 @@ func TestHasOptionalOrRequiredNamePropertyOptimized(t *testing.T) {
 		}
 	}
 }
+
+func TestCustomAutoNameTransforms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		resource   string
+		properties resource.PropertyMap
+		urnName    string
+		prefix     string
+		suffix     string
+	}{
+		{
+			name:     "SQS FIFO queue name ends with fifo suffix",
+			resource: "aws_sqs_queue",
+			properties: resource.PropertyMap{
+				"fifoQueue": resource.NewBoolProperty(true),
+			},
+			urnName: "queue",
+			prefix:  "queue-",
+			suffix:  ".fifo",
+		},
+		{
+			name:     "SQS standard queue name omits fifo suffix",
+			resource: "aws_sqs_queue",
+			properties: resource.PropertyMap{
+				"fifoQueue": resource.NewBoolProperty(false),
+			},
+			urnName: "queue",
+			prefix:  "queue-",
+		},
+		{
+			name:     "KMS alias name has required alias prefix",
+			resource: "aws_kms_alias",
+			urnName:  "key",
+			prefix:   "alias/key-",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field := Provider().Resources[tt.resource].Fields["name"]
+			actual, err := field.Default.ComputeDefault(context.Background(), tfbridge.ComputeDefaultOptions{
+				URN:        resource.NewURN("stack", "project", "", "aws:index/resource:Resource", tt.urnName),
+				Properties: tt.properties,
+				Seed:       []byte("test-seed"),
+			})
+			assert.NoError(t, err)
+
+			name, ok := actual.(string)
+			assert.True(t, ok)
+			assert.Truef(t, strings.HasPrefix(name, tt.prefix), "expected %q to have prefix %q", name, tt.prefix)
+			if tt.suffix != "" {
+				assert.Truef(t, strings.HasSuffix(name, tt.suffix), "expected %q to have suffix %q", name, tt.suffix)
+			} else {
+				assert.Falsef(t, strings.HasSuffix(name, ".fifo"), "expected %q to omit .fifo suffix", name)
+			}
+		})
+	}
+}
+
 func TestExtractTags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Remove redundant broad-smoke example tests identified by the examples audit for #6292.
- Preserve the intentionally kept broad-smoke matrix and keep live coverage for manual OIDC auth plus release-verification examples.
- Add provider-level coverage for SQS FIFO and KMS alias custom autonaming before deleting the live example smoke tests that previously exercised those paths.

## Notes
- `TestAccCloudWatchOIDCManual` is intentionally kept even though it was in the original broad-smoke delete queue: tracing #3074/#3084 showed it is the live e2e guard for provider `assumeRoleWithWebIdentity`, originally added for #2252.
- `webserver-cs` and `webserver-go` remain covered by new `TestReleaseVerificationCs` and `TestReleaseVerificationGo` tests because `.ci-mgmt.yaml` uses those directories for release verification.
- This PR removes 35 broad-smoke tests after those corrections.

## Tests
- `mise exec -- make test_provider`
- `mise exec -- make test TESTTAGS=all GO_TEST_EXEC='go test -exec true' GOTESTARGS='-run ^$'`
- `git diff --check`

Fixes #6292
Part of #6284