### PR TITLE
Update CallbackFunction default runtime to Node 22

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -52,11 +52,12 @@ func TestAccDedicatedHosts(t *testing.T) {
 
 func TestAccExpress(t *testing.T) {
 	// This example is reused to further validate that provisioned CallbackFunctions in Node are working at runtime
-	// as expected, in particular their default runtime is not deprecated and they can utilize new APIs like the
-	// fetch() API that is new in the Node 18 runtime.
+	// as expected, in particular their default runtime is not deprecated and they can utilize modern APIs like
+	// fetch().
 	validate := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		lambdaRuntime := stack.Outputs["lambdaRuntime"].(string)
 		t.Logf("Picked the following runtime by default: %v", lambdaRuntime)
+		assert.Equal(t, "nodejs22.x", lambdaRuntime)
 
 		lambdaARN := stack.Outputs["lambdaARN"].(string)
 

--- a/provider/overlays.go
+++ b/provider/overlays.go
@@ -99,7 +99,7 @@ var callbackFunction = schema.ResourceSpec{
 			TypeSpec: schema.TypeSpec{
 				Ref: "#/types/aws:lambda/Runtime:Runtime",
 			},
-			Description: "The Lambda runtime to use. If not provided, will default to `NodeJS20dX`.",
+			Description: "The Lambda runtime to use. If not provided, will default to `NodeJS22dX`.",
 		},
 		"codePathOptions": {
 			TypeSpec: schema.TypeSpec{

--- a/sdk/nodejs/lambda/lambdaMixins.ts
+++ b/sdk/nodejs/lambda/lambdaMixins.ts
@@ -223,7 +223,7 @@ export type BaseCallbackFunctionArgs = utils.Overwrite<FunctionArgs, {
     policies?: Record<string, pulumi.Input<string>> | string[];
 
     /**
-     * The Lambda runtime to use.  If not provided, will default to [aws.lambda.Runtime.NodeJS20dX].
+     * The Lambda runtime to use.  If not provided, will default to [aws.lambda.Runtime.NodeJS22dX].
      */
     runtime?: Runtime | string;
 
@@ -409,7 +409,7 @@ export class CallbackFunction<E, R> extends LambdaFunction {
             ...args,
             code: code,
             handler: serializedFileNameNoExtension + "." + handlerName,
-            runtime: args.runtime || Runtime.NodeJS20dX,
+            runtime: args.runtime || Runtime.NodeJS22dX,
             role: iam.Role.isInstance(role) ? role.arn : role,
             timeout: args.timeout === undefined ? 180 : args.timeout,
         };


### PR DESCRIPTION
## Summary

- Update `aws.lambda.CallbackFunction` to default to `NodeJS22dX` instead of `NodeJS20dX`.
- Refresh the CallbackFunction schema description for the new default.
- Assert the expected `nodejs22.x` default in the existing Node callback Lambda integration validation.

## Notes

AWS lists `nodejs20.x` as deprecated on April 30, 2026. This intentionally moves the magic-function default to Node.js 22 rather than Node.js 24 because the Node.js 24 Lambda runtime removes callback-based handler support, while `CallbackFunction` still exposes callback-style completion in its public TypeScript API.

Tracked the Node.js 24 compatibility work separately in #6336.

Fixes #6334.

## Testing

- `mise exec -- make schema`
- `mise exec -- make test_provider`