### PR TITLE
Fix EC2 key pair public key import drift

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -48,11 +48,14 @@ jobs:
       matrix:
         service:
           - sqs
+          - ec2
           - docdb
           - redshiftserverless
         include:
           - service: sqs
             tests: TestAccSQSQueue
+          - service: ec2
+            tests: TestAccEC2KeyPair_publicKey
           - service: docdb
             tests: TestAccDocDBCluster_basic
           - service: redshiftserverless

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/providertest/optproviderupgrade"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
+	"github.com/pulumi/providertest/pulumitest/optnewstack"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
@@ -370,6 +371,80 @@ func randSeq(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+func TestImportEC2KeyPairPublicKeyChecksCleanly(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+
+	cwd := getCwd(t)
+	options := []opttest.Option{
+		opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
+		opttest.SkipInstall(),
+	}
+
+	keyName := fmt.Sprintf("pulumi-key-pair-import-%s", randSeq(8))
+	publicKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+
+	createDir := t.TempDir()
+	createProgram := `name: ec2-keypair-import-create
+runtime: yaml
+description: EC2 key pair import regression setup
+config:
+  keyName:
+    type: string
+  publicKey:
+    type: string
+resources:
+  keyPair:
+    type: aws:ec2:KeyPair
+    properties:
+      keyName: ${keyName}
+      publicKey: ${publicKey}
+outputs:
+  keyName: ${keyPair.keyName}
+  publicKey: ${keyPair.publicKey}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(createDir, "Pulumi.yaml"), []byte(createProgram), 0o600))
+	createTest := pulumitest.NewPulumiTest(t, createDir, options...)
+	createTest.SetConfig(t, "aws:region", "us-west-2")
+	createTest.SetConfig(t, "keyName", keyName)
+	createTest.SetConfig(t, "publicKey", publicKey)
+
+	createTest.Up(t)
+
+	importOptions := append([]opttest.Option{}, options...)
+	importOptions = append(importOptions, opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
+	importDir := t.TempDir()
+	importProgram := fmt.Sprintf(`name: ec2-keypair-import-import
+runtime: yaml
+description: EC2 key pair import regression
+config:
+  keyName:
+    type: string
+  publicKey:
+    type: string
+resources:
+  keyPair:
+    type: aws:ec2:KeyPair
+    properties:
+      keyName: ${keyName}
+      publicKey: ${publicKey}
+    options:
+      import: %s
+outputs:
+  keyName: ${keyPair.keyName}
+  publicKey: ${keyPair.publicKey}
+`, keyName)
+	require.NoError(t, os.WriteFile(filepath.Join(importDir, "Pulumi.yaml"), []byte(importProgram), 0o600))
+	importTest := pulumitest.NewPulumiTest(t, importDir, importOptions...)
+	importTest.SetConfig(t, "aws:region", "us-west-2")
+	importTest.SetConfig(t, "keyName", keyName)
+	importTest.SetConfig(t, "publicKey", publicKey)
+
+	importResult := importTest.Up(t)
+	assert.Equal(t, 1, (*importResult.Summary.ResourceChanges)["import"])
+	assertpreview.HasNoChanges(t, importTest.Preview(t))
 }
 
 func TestNonIdempotentSnsTopic(t *testing.T) {

--- a/patches/0026-resource-aws_key_pair-fix-public-key-import-drift.patch
+++ b/patches/0026-resource-aws_key_pair-fix-public-key-import-drift.patch
@@ -1,0 +1,201 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: corymhall <43035978+corymhall@users.noreply.github.com>
+Date: Thu, 30 Apr 2026 08:20:40 -0400
+Subject: [PATCH] resource/aws_key_pair: fix public key import drift
+
+Backport the upstream fix for EC2 key pair imports so reads request and persist
+public_key, then normalize OpenSSH public keys to avoid drift when AWS rewrites
+comments or trailing formatting.
+
+Fixes: https://github.com/pulumi/pulumi-aws/issues/5898
+Upstream: https://github.com/hashicorp/terraform-provider-aws/pull/46870
+Test: TestAccEC2KeyPair_publicKey
+
+diff --git a/.changelog/46870.txt b/.changelog/46870.txt
+new file mode 100644
+index 00000000000..c166a5e1f64
+--- /dev/null
++++ b/.changelog/46870.txt
+@@ -0,0 +1,3 @@
++```release-note:bug
++resource/aws_key_pair: Fix import drift by persisting and normalizing `public_key`
++```
+diff --git a/internal/service/ec2/ec2_key_pair.go b/internal/service/ec2/ec2_key_pair.go
+index 5eac7d28062..40fa13dfb6e 100644
+--- a/internal/service/ec2/ec2_key_pair.go
++++ b/internal/service/ec2/ec2_key_pair.go
+@@ -85,7 +85,7 @@ func resourceKeyPair() *schema.Resource {
+ 				StateFunc: func(v any) string {
+ 					switch v := v.(type) {
+ 					case string:
+-						return strings.TrimSpace(v)
++						return normalizeOpenSSHPublicKey(v)
+ 					default:
+ 						return ""
+ 					}
+@@ -142,6 +142,7 @@ func resourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta any)
+ 	d.Set("key_name_prefix", create.NamePrefixFromName(aws.ToString(keyPair.KeyName)))
+ 	d.Set("key_pair_id", keyPair.KeyPairId)
+ 	d.Set("key_type", keyPair.KeyType)
++	d.Set(names.AttrPublicKey, normalizeOpenSSHPublicKey(aws.ToString(keyPair.PublicKey)))
+ 
+ 	setTagsOut(ctx, keyPair.Tags)
+ 
+@@ -190,6 +191,23 @@ func openSSHPublicKeysEqual(v1, v2 string) bool {
+ 
+ 	return key1.Type() == key2.Type() && bytes.Equal(key1.Marshal(), key2.Marshal())
+ }
++
++// normalizeOpenSSHPublicKey canonicalizes an OpenSSH public key so provider state
++// does not drift when AWS rewrites the trailing comment or formatting.
++// For example, AWS may return:
++// "ssh-rsa AAAA... tf-acc-test-123\n"
++// for config that was originally:
++// "ssh-rsa AAAA... no-reply@hashicorp.com".
++func normalizeOpenSSHPublicKey(v string) string {
++	key, _, _, _, err := ssh.ParseAuthorizedKey([]byte(v))
++
++	if err != nil {
++		return strings.TrimSpace(v)
++	}
++
++	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key)))
++}
++
+ func keyPairARN(ctx context.Context, c *conns.AWSClient, keyName string) string {
+ 	return c.RegionalARN(ctx, names.EC2, "key-pair/"+keyName)
+ }
+diff --git a/internal/service/ec2/ec2_key_pair_test.go b/internal/service/ec2/ec2_key_pair_test.go
+index 9553a75bb1d..459c6fedba0 100644
+--- a/internal/service/ec2/ec2_key_pair_test.go
++++ b/internal/service/ec2/ec2_key_pair_test.go
+@@ -44,14 +44,19 @@ func TestAccEC2KeyPair_basic(t *testing.T) {
+ 					resource.TestMatchResourceAttr(resourceName, "fingerprint", regexache.MustCompile(`[0-9a-f]{2}(:[0-9a-f]{2}){15}`)),
+ 					resource.TestCheckResourceAttr(resourceName, "key_name", rName),
+ 					resource.TestCheckResourceAttr(resourceName, "key_name_prefix", ""),
+-					resource.TestCheckResourceAttr(resourceName, names.AttrPublicKey, publicKey),
++					resource.TestCheckResourceAttrWith(resourceName, names.AttrPublicKey, func(v string) error {
++						if !tfec2.OpenSSHPublicKeysEqual(v, publicKey) {
++							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
++						}
++
++						return nil
++					}),
+ 				),
+ 			},
+ 			{
+-				ResourceName:            resourceName,
+-				ImportState:             true,
+-				ImportStateVerify:       true,
+-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
+ 			},
+ 		},
+ 	})
+@@ -83,10 +88,9 @@ func TestAccEC2KeyPair_tags(t *testing.T) {
+ 				),
+ 			},
+ 			{
+-				ResourceName:            resourceName,
+-				ImportState:             true,
+-				ImportStateVerify:       true,
+-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
+ 			},
+ 			{
+ 				Config: testAccKeyPairConfig_tags2(rName, publicKey, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+@@ -134,10 +138,9 @@ func TestAccEC2KeyPair_nameGenerated(t *testing.T) {
+ 				),
+ 			},
+ 			{
+-				ResourceName:            resourceName,
+-				ImportState:             true,
+-				ImportStateVerify:       true,
+-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
+ 			},
+ 		},
+ 	})
+@@ -168,10 +171,48 @@ func TestAccEC2KeyPair_namePrefix(t *testing.T) {
+ 				),
+ 			},
+ 			{
+-				ResourceName:            resourceName,
+-				ImportState:             true,
+-				ImportStateVerify:       true,
+-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
++			},
++		},
++	})
++}
++
++func TestAccEC2KeyPair_publicKey(t *testing.T) {
++	ctx := acctest.Context(t)
++	var keyPair awstypes.KeyPairInfo
++	resourceName := "aws_key_pair.test"
++	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
++
++	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
++	if err != nil {
++		t.Fatalf("error generating random SSH key: %s", err)
++	}
++
++	acctest.ParallelTest(ctx, t, resource.TestCase{
++		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
++		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckKeyPairDestroy(ctx, t),
++		Steps: []resource.TestStep{
++			{
++				Config: testAccKeyPairConfig_basic(rName, publicKey),
++				Check: resource.ComposeAggregateTestCheckFunc(
++					testAccCheckKeyPairExists(ctx, t, resourceName, &keyPair),
++					resource.TestCheckResourceAttrWith(resourceName, names.AttrPublicKey, func(v string) error {
++						if !tfec2.OpenSSHPublicKeysEqual(v, publicKey) {
++							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
++						}
++
++						return nil
++					}),
++				),
++			},
++			{
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateVerify: true,
+ 			},
+ 		},
+ 	})
+diff --git a/internal/service/ec2/find.go b/internal/service/ec2/find.go
+index 348a589baab..6a71042c433 100644
+--- a/internal/service/ec2/find.go
++++ b/internal/service/ec2/find.go
+@@ -5972,7 +5972,8 @@ func findKeyPairs(ctx context.Context, conn *ec2.Client, input *ec2.DescribeKeyP
+ 
+ func findKeyPairByName(ctx context.Context, conn *ec2.Client, name string) (*awstypes.KeyPairInfo, error) {
+ 	input := ec2.DescribeKeyPairsInput{
+-		KeyNames: []string{name},
++		KeyNames:         []string{name},
++		IncludePublicKey: aws.Bool(true),
+ 	}
+ 
+ 	output, err := findKeyPair(ctx, conn, &input)
+diff --git a/website/docs/r/key_pair.html.markdown b/website/docs/r/key_pair.html.markdown
+index bd40e0af88f..c5ea4c2071d 100644
+--- a/website/docs/r/key_pair.html.markdown
++++ b/website/docs/r/key_pair.html.markdown
+@@ -65,5 +65,3 @@ Using `terraform import`, import Key Pairs using the `key_name`. For example:
+ ```console
+ % terraform import aws_key_pair.deployer deployer-key
+ ```
+-
+-~> **NOTE:** The AWS API does not include the public key in the response, so `terraform apply` will attempt to replace the key pair. There is currently no supported workaround for this limitation.

--- a/sdk/dotnet/Ec2/KeyPair.cs
+++ b/sdk/dotnet/Ec2/KeyPair.cs
@@ -46,8 +46,6 @@ namespace Pulumi.Aws.Ec2
     /// ```sh
     /// $ pulumi import aws:ec2/keyPair:KeyPair deployer deployer-key
     /// ```
-    /// 
-    /// &gt; **NOTE:** The AWS API does not include the public key in the response, so `pulumi up` will attempt to replace the key pair. There is currently no supported workaround for this limitation.
     /// </summary>
     [AwsResourceType("aws:ec2/keyPair:KeyPair")]
     public partial class KeyPair : global::Pulumi.CustomResource

--- a/sdk/go/aws/ec2/keyPair.go
+++ b/sdk/go/aws/ec2/keyPair.go
@@ -56,8 +56,6 @@ import (
 // ```sh
 // $ pulumi import aws:ec2/keyPair:KeyPair deployer deployer-key
 // ```
-//
-// > **NOTE:** The AWS API does not include the public key in the response, so `pulumi up` will attempt to replace the key pair. There is currently no supported workaround for this limitation.
 type KeyPair struct {
 	pulumi.CustomResourceState
 

--- a/sdk/java/src/main/java/com/pulumi/aws/ec2/KeyPair.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/ec2/KeyPair.java
@@ -68,8 +68,6 @@ import javax.annotation.Nullable;
  * $ pulumi import aws:ec2/keyPair:KeyPair deployer deployer-key
  * ```
  * 
- * &gt; **NOTE:** The AWS API does not include the public key in the response, so `pulumi up` will attempt to replace the key pair. There is currently no supported workaround for this limitation.
- * 
  */
 @ResourceType(type="aws:ec2/keyPair:KeyPair")
 public class KeyPair extends com.pulumi.resources.CustomResource {

--- a/sdk/nodejs/ec2/keyPair.ts
+++ b/sdk/nodejs/ec2/keyPair.ts
@@ -34,8 +34,6 @@ import * as utilities from "../utilities";
  * ```sh
  * $ pulumi import aws:ec2/keyPair:KeyPair deployer deployer-key
  * ```
- *
- * > **NOTE:** The AWS API does not include the public key in the response, so `pulumi up` will attempt to replace the key pair. There is currently no supported workaround for this limitation.
  */
 export class KeyPair extends pulumi.CustomResource {
     /**

--- a/sdk/python/pulumi_aws/ec2/key_pair.py
+++ b/sdk/python/pulumi_aws/ec2/key_pair.py
@@ -315,8 +315,6 @@ class KeyPair(pulumi.CustomResource):
         $ pulumi import aws:ec2/keyPair:KeyPair deployer deployer-key
         ```
 
-        > **NOTE:** The AWS API does not include the public key in the response, so `pulumi up` will attempt to replace the key pair. There is currently no supported workaround for this limitation.
-
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -361,8 +359,6 @@ class KeyPair(pulumi.CustomResource):
         ```sh
         $ pulumi import aws:ec2/keyPair:KeyPair deployer deployer-key
         ```
-
-        > **NOTE:** The AWS API does not include the public key in the response, so `pulumi up` will attempt to replace the key pair. There is currently no supported workaround for this limitation.
 
 
         :param str resource_name: The name of the resource.


### PR DESCRIPTION
## Summary
- Backport upstream terraform-provider-aws PR 46870 as a Pulumi upstream patch for EC2 key pair public key import drift
- Add upstream EC2 key pair acceptance coverage to the upstream-tests workflow
- Add a YAML Pulumi integration test that imports an EC2 key pair and verifies the following preview is clean
- Remove the stale generated SDK/docs note that said key pair imports always drift

Fixes #5898

## Verification
- `mise exec -- make test TESTTAGS=java GOTESTARGS='-run TestImportEC2KeyPairPublicKeyChecksCleanly -count=0'`
- `mise exec -- make provider`
- `mise exec -- make test_provider`
- `mise exec -- make build`
- `git diff --cached --check -- . ':(exclude)patches/*.patch'`

Note: `git diff --cached --check` reports whitespace inside the committed `.patch` file itself because patch files contain diff context and tab-indented Go code.