### PR TITLE
Add patch enabling IamCredentialProvider on Bedrock AgentCore gateway targets

### DIFF
--- a/patches/0027-r-aws_bedrockagentcore_gateway_target-Support-IAM-Si.patch
+++ b/patches/0027-r-aws_bedrockagentcore_gateway_target-Support-IAM-Si.patch
@@ -1,0 +1,102 @@
+From 1ebb9463fc0e98eb0fa2526ed8f30bfa5b9a55e0 Mon Sep 17 00:00:00 2001
+From: Engin Diri <engin.diri@gmail.com>
+Date: Wed, 6 May 2026 15:50:03 +0200
+Subject: [PATCH] r/aws_bedrockagentcore_gateway_target: Support IAM SigV4
+ (IamCredentialProvider) on gateway_iam_role
+
+Adds optional 'service' and 'region' attributes to the
+credential_provider_configuration.gateway_iam_role block so the gateway
+can SigV4-sign upstream requests when the mcp_server endpoint is an
+AWS-hosted SigV4-protected service (e.g. another Bedrock AgentCore
+Runtime).
+
+Backward-compatible: existing 'gateway_iam_role {}' configs continue to
+mean 'send no IamCredentialProvider body'.
+
+Backport of upstream PR hashicorp/terraform-provider-aws#47626.
+---
+ .../bedrockagentcore/gateway_target.go        | 46 +++++++++++++++++--
+ 1 file changed, 42 insertions(+), 4 deletions(-)
+
+diff --git a/internal/service/bedrockagentcore/gateway_target.go b/internal/service/bedrockagentcore/gateway_target.go
+index 1e0c61ed01..06de92b37b 100644
+--- a/internal/service/bedrockagentcore/gateway_target.go
++++ b/internal/service/bedrockagentcore/gateway_target.go
+@@ -448,7 +448,22 @@ func (r *gatewayTargetResource) Schema(ctx context.Context, request resource.Sch
+ 								),
+ 							},
+ 							NestedObject: schema.NestedBlockObject{
+-								// Empty block - no attributes needed for Gateway IAM Role
++								Attributes: map[string]schema.Attribute{
++									"service": schema.StringAttribute{
++										Optional: true,
++										Description: "The target AWS service name used for SigV4 signing of upstream requests. " +
++											"Required when calling SigV4-protected endpoints such as another Bedrock AgentCore " +
++											"Runtime (use `bedrock-agentcore`). Omit for non-SigV4 IAM-role-based authentication.",
++									},
++									names.AttrRegion: schema.StringAttribute{
++										Optional: true,
++										Description: "AWS Region used for SigV4 signing of upstream requests. " +
++											"Defaults to the gateway's Region when omitted. Only meaningful when `service` is set.",
++										Validators: []validator.String{
++											stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("service")),
++										},
++									},
++								},
+ 							},
+ 						},
+ 					},
+@@ -1095,7 +1110,14 @@ func (m *credentialProviderConfigurationModel) Flatten(ctx context.Context, v an
+ 			}
+ 
+ 		case awstypes.CredentialProviderTypeGatewayIamRole:
+-			m.GatewayIAMRole = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{})
++			var model gatewayIAMRoleProviderModel
++			if iamProvider, ok := t.CredentialProvider.(*awstypes.CredentialProviderMemberIamCredentialProvider); ok {
++				smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, iamProvider.Value, &model))
++				if diags.HasError() {
++					return diags
++				}
++			}
++			m.GatewayIAMRole = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &model)
+ 
+ 		default:
+ 			diags.AddError(
+@@ -1150,8 +1172,23 @@ func (m credentialProviderConfigurationModel) Expand(ctx context.Context) (any,
+ 		return &c, diags
+ 
+ 	case !m.GatewayIAMRole.IsNull():
++		gatewayIAMRoleData, d := m.GatewayIAMRole.ToPtr(ctx)
++		smerr.AddEnrich(ctx, &diags, d)
++		if diags.HasError() {
++			return nil, diags
++		}
++
+ 		c.CredentialProviderType = awstypes.CredentialProviderTypeGatewayIamRole
+-		c.CredentialProvider = nil
++		if gatewayIAMRoleData != nil && !gatewayIAMRoleData.Service.IsNull() {
++			var r awstypes.CredentialProviderMemberIamCredentialProvider
++			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, gatewayIAMRoleData, &r.Value))
++			if diags.HasError() {
++				return nil, diags
++			}
++			c.CredentialProvider = &r
++		} else {
++			c.CredentialProvider = nil
++		}
+ 		return &c, diags
+ 
+ 	default:
+@@ -1385,7 +1422,8 @@ type oauthCredentialProviderModel struct {
+ }
+ 
+ type gatewayIAMRoleProviderModel struct {
+-	// Empty struct - Gateway IAM Role provider requires no configuration
++	Service types.String `tfsdk:"service"`
++	Region  types.String `tfsdk:"region"`
+ }
+ 
+ type mcpApiGatewayConfigurationModel struct {
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## What this is

A backport of an open upstream fix, [hashicorp/terraform-provider-aws#47626](https://github.com/hashicorp/terraform-provider-aws/pull/47626), as a new patch under `patches/`. The patch adds two optional attributes (`service` and `region`) to the `gateway_iam_role` block on `aws_bedrockagentcore_gateway_target`.

## Why I want this

Without these attributes you cannot use `aws.bedrock.AgentcoreGatewayTarget` to point a Bedrock AgentCore Gateway at an `mcp_server` endpoint that needs SigV4 signing, like another Bedrock AgentCore Runtime. The schema currently exposes `gateway_iam_role {}` as an empty block, and the Expand path hard-codes `CredentialProvider = nil`. AWS happily accepts the create call and returns a 200, but the gateway's tool-discovery probe then fails with `Missing Authentication Token` because there is no SigV4 service for the gateway to sign with.

I hit this while wiring up the AgentCore Gateway -> AgentCore Runtime MCP server pattern for a workshop. The only workaround today is to drop out of Pulumi for that one resource and call `boto3.create_gateway_target(...)` inside `pulumi env run`, which is fine but ugly.

## What the patch changes

Forty-two lines added, four removed, all in `internal/service/bedrockagentcore/gateway_target.go`:

- adds `service` and `region` attributes to the `gateway_iam_role` schema block
- updates `Flatten` to read the existing `IamCredentialProvider` body when one is present
- updates `Expand` to construct `awstypes.CredentialProviderMemberIamCredentialProvider` when `service` is set
- adds `Service` and `Region` fields to `gatewayIAMRoleProviderModel`

It is byte-identical to the upstream PR and applies cleanly on top of the other 26 patches. Backward compatible too, since existing `gateway_iam_role {}` configs still send no `IamCredentialProvider` body.

After the patch, this works:

```typescript
new aws.bedrock.AgentcoreGatewayTarget("mcp", {
  // ...
  credentialProviderConfigurations: [{
    credentialProviderType: "GATEWAY_IAM_ROLE",
    credentialProvider: {
      gatewayIamRole: { service: "bedrock-agentcore" },
    },
  }],
});
```

## What I did not do

I did not regenerate the SDKs. The schema regen does pick up the new `service`/`region` properties on the bedrock types, and from there the SDK regen ripples through TypeScript, Python, Go, .NET, and Java. I would rather a maintainer run that on a clean CI machine than push partial SDK diffs from my laptop.

Happy to add the SDK regen on top of this PR once a maintainer confirms the direction is fine. Equally happy if you would rather close this and wait for upstream #47626 to merge, then bump the submodule. Either way works for me.

## Validation I did run

- `./scripts/upstream.sh init -f` applies all 27 patches cleanly
- `go build ./internal/service/bedrockagentcore/...` passes
- `go vet ./internal/service/bedrockagentcore/...` passes
- `make schema` regenerates `aws:bedrock/...GatewayIamRole` with both `service` and `region` properties present in `provider/cmd/pulumi-resource-aws/schema.json`

## Links

- Upstream bug report: [hashicorp/terraform-provider-aws#47628](https://github.com/hashicorp/terraform-provider-aws/issues/47628)
- Upstream fix (open): [hashicorp/terraform-provider-aws#47626](https://github.com/hashicorp/terraform-provider-aws/pull/47626)
- AWS docs: [AWS::BedrockAgentCore::GatewayTarget IamCredentialProvider](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrockagentcore-gatewaytarget-iamcredentialprovider.html)
