### PR TITLE
Patch Cognito IdP provider details diff

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -51,6 +51,7 @@ jobs:
           - ec2
           - docdb
           - redshiftserverless
+          - cognitoidp
         include:
           - service: sqs
             tests: TestAccSQSQueue
@@ -60,6 +61,8 @@ jobs:
             tests: TestAccDocDBCluster_basic
           - service: redshiftserverless
             tests: TestAccRedshiftServerlessNamespace_basic
+          - service: cognitoidp
+            tests: 'TestAccCognitoIDPIdentityProvider_(defaultProviderDetails|samlDefaultProviderDetails)'
           # TODO[pulumi/pulumi-aws#5388] route53resolver tests flaky
           # - service: route53resolver
           #   tests: TestAccRoute53Resolver

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -112,15 +112,28 @@ func TestCognitoIdentityProviderProviderDetailsUpgrade(t *testing.T) {
 			skipDefaultPreviewTest: true,
 		},
 	)
+	test.ClearGrpcLog(t)
 	result := test.Preview(t, optpreview.Diff())
 	assertpreview.HasNoReplacements(t, result)
-	assert.Equal(t, 1, result.ChangeSummary[apitype.OpUpdate])
 	for op, count := range result.ChangeSummary {
 		switch op {
 		case apitype.OpSame, apitype.OpUpdate:
 			continue
 		default:
 			assert.Zerof(t, count, "unexpected %s during provider upgrade preview", op)
+		}
+	}
+
+	diffs, err := test.GrpcLog(t).Diffs()
+	require.NoError(t, err)
+	for _, diff := range diffs {
+		if !strings.Contains(diff.Request.GetUrn(), "aws:cognito/identityProvider:IdentityProvider") {
+			continue
+		}
+
+		assert.NotContains(t, diff.Response.GetDiffs(), "providerDetails")
+		for key := range diff.Response.GetDetailedDiff() {
+			assert.NotContains(t, key, "providerDetails")
 		}
 	}
 }

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -361,6 +361,166 @@ resources:
 	}
 }
 
+func TestCognitoIdentityProviderProviderDetailsDiff(t *testing.T) {
+	t.Parallel()
+	skipIfShort(t)
+
+	type yamlProgram string
+
+	const google yamlProgram = `
+name: project
+runtime: yaml
+config:
+  randSuffix:
+    type: string
+  clientId:
+    type: string
+resources:
+  userPool:
+    type: aws:cognito:UserPool
+    properties:
+      name: pulumi-aws-5401-${randSuffix}
+      schemas:
+        - name: email
+          required: true
+          attributeDataType: String
+      passwordPolicy:
+        minimumLength: 8
+        requireUppercase: true
+        requireLowercase: true
+        requireNumbers: true
+        requireSymbols: true
+  identityProvider:
+    type: aws:cognito:IdentityProvider
+    properties:
+      userPoolId: ${userPool.id}
+      providerType: Google
+      providerName: Google
+      providerDetails:
+        client_id: ${clientId}
+        client_secret: client_secret
+        authorize_scopes: email profile openid
+      attributeMapping:
+        email: email
+        username: sub
+`
+
+	const saml yamlProgram = `
+name: project
+runtime: yaml
+config:
+  randSuffix:
+    type: string
+resources:
+  userPool:
+    type: aws:cognito:UserPool
+    properties:
+      name: pulumi-aws-5401-${randSuffix}
+      schemas:
+        - name: email
+          required: true
+          attributeDataType: String
+  identityProvider:
+    type: aws:cognito:IdentityProvider
+    properties:
+      userPoolId: ${userPool.id}
+      providerType: SAML
+      providerName: saml-${randSuffix}
+      providerDetails:
+        MetadataFile:
+          fn::secret: |
+            <?xml version="1.0"?>
+            <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://terraform-dev-ed.my.salesforce.com" validUntil="2070-08-31T14:30:09Z">
+              <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                <md:KeyDescriptor use="signing">
+                  <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                    <ds:X509Data>
+                      <ds:X509Certificate>MIICfjCCAeegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBbMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExEjAQBgNVBAoMCVRlcnJhZm9ybTErMCkGA1UEAwwidGVycmFmb3JtLWRldi1lZC5teS5zYWxlc2ZvcmNlLmNvbTAgFw0yMDA4MjkxNDQ4MzlaGA8yMDcwMDgxNzE0NDgzOVowWzELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAkNBMRIwEAYDVQQKDAlUZXJyYWZvcm0xKzApBgNVBAMMInRlcnJhZm9ybS1kZXYtZWQubXkuc2FsZXNmb3JjZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOxUTzEKdivVjfZ/BERGpX/ZWQsBKHut17dQTKW/3jox1N9EJ3ULj9qEDen6zQ74Ce8hSEkrG7MP9mcP1oEhQZSca5tTAop1GejJG+bfF4v6cXM9pqHlllrYrmXMfESiahqhBhE8VvoGJkvp393TcB1lX+WxO8Q74demTrQn5tgvAgMBAAGjUDBOMB0GA1UdDgQWBBREKZt4Av70WKQE4aLD2tvbSLnBlzAfBgNVHSMEGDAWgBREKZt4Av70WKQE4aLD2tvbSLnBlzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACxeC29WMGqeOlQF4JWwsYwIC82SUaZvMDqjAm9ieIrAZRH6J6Cu40c/rvsUGUjQ9logKX15RAyI7Rn0jBUgopRkNL71HyyM7ug4qN5An05VmKQWIbVfxkNVB2Ipb/ICMc5UE38G4y4VbANZFvbFbkVq6OAP2GGNl22o/XSnhFY8</ds:X509Certificate>
+                    </ds:X509Data>
+                  </ds:KeyInfo>
+                </md:KeyDescriptor>
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost"/>
+                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"/>
+              </md:IDPSSODescriptor>
+            </md:EntityDescriptor>
+`
+
+	testCases := []struct {
+		name         string
+		program      yamlProgram
+		firstConfig  map[string]string
+		secondConfig map[string]string
+		expectUpdate bool
+	}{
+		{
+			name:    "google defaults from read do not cause a diff",
+			program: google,
+			firstConfig: map[string]string{
+				"clientId": "test-url.apps.googleusercontent.com",
+			},
+			secondConfig: map[string]string{
+				"clientId": "test-url.apps.googleusercontent.com",
+			},
+		},
+		{
+			name:    "google configured value changes still cause a diff",
+			program: google,
+			firstConfig: map[string]string{
+				"clientId": "test-url.apps.googleusercontent.com",
+			},
+			secondConfig: map[string]string{
+				"clientId": "new-client-id-url.apps.googleusercontent.com",
+			},
+			expectUpdate: true,
+		},
+		{
+			name:    "saml secret metadata read-only details do not cause a diff",
+			program: saml,
+		},
+	}
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			workdir := t.TempDir()
+			err := os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"), []byte(tc.program), 0o600)
+			require.NoError(t, err)
+
+			pt := pulumitest.NewPulumiTest(t, workdir,
+				opttest.SkipInstall(),
+				opttest.TestInPlace(),
+				opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
+			)
+			pt.SetConfig(t, "randSuffix", fmt.Sprintf("%d", rand.Intn(1024*1024)))
+			for key, value := range tc.firstConfig {
+				pt.SetConfig(t, key, value)
+			}
+
+			pt.Up(t)
+			assertpreview.HasNoChanges(t, pt.Preview(t, optpreview.Refresh(), optpreview.Diff()))
+
+			for key, value := range tc.secondConfig {
+				pt.SetConfig(t, key, value)
+			}
+
+			if tc.expectUpdate {
+				pr := pt.Preview(t, optpreview.Diff())
+				assert.Equal(t, 1, pr.ChangeSummary[apitype.OpUpdate])
+				return
+			}
+
+			assertpreview.HasNoChanges(t, pt.Preview(t, optpreview.Refresh(), optpreview.Diff()))
+		})
+	}
+}
+
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func randSeq(n int) string {

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -110,7 +110,6 @@ func TestCognitoIdentityProviderProviderDetailsUpgrade(t *testing.T) {
 	test, _ := testProviderUpgrade(t, filepath.Join("test-programs", "cognito-identity-provider-provider-details"),
 		&testProviderUpgradeOptions{
 			skipDefaultPreviewTest: true,
-			skipCache:              true,
 		},
 	)
 	test.ClearGrpcLog(t)

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -110,6 +110,7 @@ func TestCognitoIdentityProviderProviderDetailsUpgrade(t *testing.T) {
 	test, _ := testProviderUpgrade(t, filepath.Join("test-programs", "cognito-identity-provider-provider-details"),
 		&testProviderUpgradeOptions{
 			skipDefaultPreviewTest: true,
+			skipCache:              true,
 		},
 	)
 	test.ClearGrpcLog(t)

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -106,6 +106,25 @@ func TestIamOpenIDConnectProviderUpgrade(t *testing.T) {
 	testProviderUpgrade(t, filepath.Join("test-programs", "iam-openidconnectprovider"), nil)
 }
 
+func TestCognitoIdentityProviderProviderDetailsUpgrade(t *testing.T) {
+	test, _ := testProviderUpgrade(t, filepath.Join("test-programs", "cognito-identity-provider-provider-details"),
+		&testProviderUpgradeOptions{
+			skipDefaultPreviewTest: true,
+		},
+	)
+	result := test.Preview(t, optpreview.Diff())
+	assertpreview.HasNoReplacements(t, result)
+	assert.Equal(t, 1, result.ChangeSummary[apitype.OpUpdate])
+	for op, count := range result.ChangeSummary {
+		switch op {
+		case apitype.OpSame, apitype.OpUpdate:
+			continue
+		default:
+			assert.Zerof(t, count, "unexpected %s during provider upgrade preview", op)
+		}
+	}
+}
+
 func TestKmsKeyUpgrade(t *testing.T) {
 	testProviderUpgrade(t, filepath.Join("test-programs", "kms-key"), nil)
 }

--- a/examples/test-programs/cognito-identity-provider-provider-details/Pulumi.yaml
+++ b/examples/test-programs/cognito-identity-provider-provider-details/Pulumi.yaml
@@ -35,20 +35,19 @@ resources:
       providerType: SAML
       providerName: pulumi-aws-5401-upgrade
       providerDetails:
-        MetadataFile:
-          fn::secret: |
-            <?xml version="1.0"?>
-            <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://terraform-dev-ed.my.salesforce.com" validUntil="2070-08-31T14:30:09Z">
-              <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-                <md:KeyDescriptor use="signing">
-                  <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                    <ds:X509Data>
-                      <ds:X509Certificate>MIICfjCCAeegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBbMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExEjAQBgNVBAoMCVRlcnJhZm9ybTErMCkGA1UEAwwidGVycmFmb3JtLWRldi1lZC5teS5zYWxlc2ZvcmNlLmNvbTAgFw0yMDA4MjkxNDQ4MzlaGA8yMDcwMDgxNzE0NDgzOVowWzELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAkNBMRIwEAYDVQQKDAlUZXJyYWZvcm0xKzApBgNVBAMMInRlcnJhZm9ybS1kZXYtZWQubXkuc2FsZXNmb3JjZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOxUTzEKdivVjfZ/BERGpX/ZWQsBKHut17dQTKW/3jox1N9EJ3ULj9qEDen6zQ74Ce8hSEkrG7MP9mcP1oEhQZSca5tTAop1GejJG+bfF4v6cXM9pqHlllrYrmXMfESiahqhBhE8VvoGJkvp393TcB1lX+WxO8Q74demTrQn5tgvAgMBAAGjUDBOMB0GA1UdDgQWBBREKZt4Av70WKQE4aLD2tvbSLnBlzAfBgNVHSMEGDAWgBREKZt4Av70WKQE4aLD2tvbSLnBlzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACxeC29WMGqeOlQF4JWwsYwIC82SUaZvMDqjAm9ieIrAZRH6J6Cu40c/rvsUGUjQ9logKX15RAyI7Rn0jBUgopRkNL71HyyM7ug4qN5An05VmKQWIbVfxkNVB2Ipb/ICMc5UE38G4y4VbANZFvbFbkVq6OAP2GGNl22o/XSnhFY8</ds:X509Certificate>
-                    </ds:X509Data>
-                  </ds:KeyInfo>
-                </md:KeyDescriptor>
-                <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost"/>
-                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"/>
-              </md:IDPSSODescriptor>
-            </md:EntityDescriptor>
+        MetadataFile: |
+          <?xml version="1.0"?>
+          <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://terraform-dev-ed.my.salesforce.com" validUntil="2070-08-31T14:30:09Z">
+            <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+              <md:KeyDescriptor use="signing">
+                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                  <ds:X509Data>
+                    <ds:X509Certificate>MIICfjCCAeegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBbMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExEjAQBgNVBAoMCVRlcnJhZm9ybTErMCkGA1UEAwwidGVycmFmb3JtLWRldi1lZC5teS5zYWxlc2ZvcmNlLmNvbTAgFw0yMDA4MjkxNDQ4MzlaGA8yMDcwMDgxNzE0NDgzOVowWzELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAkNBMRIwEAYDVQQKDAlUZXJyYWZvcm0xKzApBgNVBAMMInRlcnJhZm9ybS1kZXYtZWQubXkuc2FsZXNmb3JjZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOxUTzEKdivVjfZ/BERGpX/ZWQsBKHut17dQTKW/3jox1N9EJ3ULj9qEDen6zQ74Ce8hSEkrG7MP9mcP1oEhQZSca5tTAop1GejJG+bfF4v6cXM9pqHlllrYrmXMfESiahqhBhE8VvoGJkvp393TcB1lX+WxO8Q74demTrQn5tgvAgMBAAGjUDBOMB0GA1UdDgQWBBREKZt4Av70WKQE4aLD2tvbSLnBlzAfBgNVHSMEGDAWgBREKZt4Av70WKQE4aLD2tvbSLnBlzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACxeC29WMGqeOlQF4JWwsYwIC82SUaZvMDqjAm9ieIrAZRH6J6Cu40c/rvsUGUjQ9logKX15RAyI7Rn0jBUgopRkNL71HyyM7ug4qN5An05VmKQWIbVfxkNVB2Ipb/ICMc5UE38G4y4VbANZFvbFbkVq6OAP2GGNl22o/XSnhFY8</ds:X509Certificate>
+                  </ds:X509Data>
+                </ds:KeyInfo>
+              </md:KeyDescriptor>
+              <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+              <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost"/>
+              <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"/>
+            </md:IDPSSODescriptor>
+          </md:EntityDescriptor>

--- a/examples/test-programs/cognito-identity-provider-provider-details/Pulumi.yaml
+++ b/examples/test-programs/cognito-identity-provider-provider-details/Pulumi.yaml
@@ -1,0 +1,54 @@
+name: aws-cognito-identity-provider-provider-details
+runtime: yaml
+resources:
+  userPool:
+    type: aws:cognito:UserPool
+    properties:
+      name: pulumi-aws-5401-upgrade
+      schemas:
+        - name: email
+          required: true
+          attributeDataType: String
+      passwordPolicy:
+        minimumLength: 8
+        requireUppercase: true
+        requireLowercase: true
+        requireNumbers: true
+        requireSymbols: true
+  google:
+    type: aws:cognito:IdentityProvider
+    properties:
+      userPoolId: ${userPool.id}
+      providerType: Google
+      providerName: Google
+      providerDetails:
+        client_id: test-url.apps.googleusercontent.com
+        client_secret: client_secret
+        authorize_scopes: email profile openid
+      attributeMapping:
+        email: email
+        username: sub
+  saml:
+    type: aws:cognito:IdentityProvider
+    properties:
+      userPoolId: ${userPool.id}
+      providerType: SAML
+      providerName: pulumi-aws-5401-upgrade
+      providerDetails:
+        MetadataFile:
+          fn::secret: |
+            <?xml version="1.0"?>
+            <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://terraform-dev-ed.my.salesforce.com" validUntil="2070-08-31T14:30:09Z">
+              <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                <md:KeyDescriptor use="signing">
+                  <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                    <ds:X509Data>
+                      <ds:X509Certificate>MIICfjCCAeegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBbMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExEjAQBgNVBAoMCVRlcnJhZm9ybTErMCkGA1UEAwwidGVycmFmb3JtLWRldi1lZC5teS5zYWxlc2ZvcmNlLmNvbTAgFw0yMDA4MjkxNDQ4MzlaGA8yMDcwMDgxNzE0NDgzOVowWzELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAkNBMRIwEAYDVQQKDAlUZXJyYWZvcm0xKzApBgNVBAMMInRlcnJhZm9ybS1kZXYtZWQubXkuc2FsZXNmb3JjZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOxUTzEKdivVjfZ/BERGpX/ZWQsBKHut17dQTKW/3jox1N9EJ3ULj9qEDen6zQ74Ce8hSEkrG7MP9mcP1oEhQZSca5tTAop1GejJG+bfF4v6cXM9pqHlllrYrmXMfESiahqhBhE8VvoGJkvp393TcB1lX+WxO8Q74demTrQn5tgvAgMBAAGjUDBOMB0GA1UdDgQWBBREKZt4Av70WKQE4aLD2tvbSLnBlzAfBgNVHSMEGDAWgBREKZt4Av70WKQE4aLD2tvbSLnBlzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACxeC29WMGqeOlQF4JWwsYwIC82SUaZvMDqjAm9ieIrAZRH6J6Cu40c/rvsUGUjQ9logKX15RAyI7Rn0jBUgopRkNL71HyyM7ug4qN5An05VmKQWIbVfxkNVB2Ipb/ICMc5UE38G4y4VbANZFvbFbkVq6OAP2GGNl22o/XSnhFY8</ds:X509Certificate>
+                    </ds:X509Data>
+                  </ds:KeyInfo>
+                </md:KeyDescriptor>
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost"/>
+                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"/>
+              </md:IDPSSODescriptor>
+            </md:EntityDescriptor>

--- a/examples/testdata/recorded/TestProviderUpgrade/cognito-identity-provider-provider-details/6.78.0/stack.json
+++ b/examples/testdata/recorded/TestProviderUpgrade/cognito-identity-provider-provider-details/6.78.0/stack.json
@@ -1,0 +1,494 @@
+{
+  "version": 3,
+  "deployment": {
+    "manifest": {
+      "time": "2026-05-29T09:15:40.351601-04:00",
+      "magic": "4ae265b5e36f43e09c7ff61ff9e23e82843496e0c1ad370c8f62bd2c5f0f4369",
+      "version": "v3.242.0"
+    },
+    "secrets_providers": {
+      "type": "passphrase",
+      "state": {
+        "salt": "v1:/84UMFQ5v/k=:v1:XqjMPpL3Bocg1i0z:W3O8mutwwQQ8Zgjp2t18q3oqUimnJw=="
+      }
+    },
+    "resources": [
+      {
+        "urn": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:pulumi:Stack::aws-cognito-identity-provider-provider-details-test",
+        "custom": false,
+        "type": "pulumi:pulumi:Stack",
+        "created": "2026-05-29T13:15:35.173803Z",
+        "modified": "2026-05-29T13:15:35.173803Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#326",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#326"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#588"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#301"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go#57"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#228"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1234"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#590"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1430"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1856"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1065"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.25.9/x64/src/runtime/asm_arm64.s#1268"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:providers:aws::default",
+        "custom": true,
+        "id": "712d84b7-8562-4d44-8576-4c3ee9bfb2ac",
+        "type": "pulumi:providers:aws",
+        "inputs": {
+          "region": "us-east-2",
+          "skipCredentialsValidation": "false",
+          "skipRegionValidation": "true"
+        },
+        "outputs": {
+          "region": "us-east-2",
+          "skipCredentialsValidation": "false",
+          "skipRegionValidation": "true"
+        },
+        "created": "2026-05-29T13:15:38.140956Z",
+        "modified": "2026-05-29T13:15:38.140956Z"
+      },
+      {
+        "urn": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/userPool:UserPool::userPool",
+        "custom": true,
+        "id": "us-east-2_tUKTjMET0",
+        "type": "aws:cognito/userPool:UserPool",
+        "inputs": {
+          "__defaults": [
+            "deletionProtection",
+            "mfaConfiguration"
+          ],
+          "deletionProtection": "INACTIVE",
+          "mfaConfiguration": "OFF",
+          "name": "pulumi-aws-5401-upgrade",
+          "passwordPolicy": {
+            "__defaults": [],
+            "minimumLength": 8,
+            "requireLowercase": true,
+            "requireNumbers": true,
+            "requireSymbols": true,
+            "requireUppercase": true
+          },
+          "schemas": [
+            {
+              "__defaults": [],
+              "attributeDataType": "String",
+              "name": "email",
+              "required": true
+            }
+          ]
+        },
+        "outputs": {
+          "accountRecoverySetting": {
+            "recoveryMechanisms": [
+              {
+                "name": "verified_email",
+                "priority": 1
+              },
+              {
+                "name": "verified_phone_number",
+                "priority": 2
+              }
+            ]
+          },
+          "adminCreateUserConfig": {
+            "allowAdminCreateUserOnly": false,
+            "inviteMessageTemplate": null
+          },
+          "aliasAttributes": null,
+          "arn": "arn:aws:cognito-idp:us-east-2:616138583583:userpool/us-east-2_tUKTjMET0",
+          "autoVerifiedAttributes": null,
+          "creationDate": "2026-05-29T13:15:39Z",
+          "customDomain": "",
+          "deletionProtection": "INACTIVE",
+          "deviceConfiguration": null,
+          "domain": "",
+          "emailConfiguration": {
+            "configurationSet": "",
+            "emailSendingAccount": "COGNITO_DEFAULT",
+            "fromEmailAddress": "",
+            "replyToEmailAddress": "",
+            "sourceArn": ""
+          },
+          "emailMfaConfiguration": null,
+          "emailVerificationMessage": "",
+          "emailVerificationSubject": "",
+          "endpoint": "cognito-idp.us-east-2.amazonaws.com/us-east-2_tUKTjMET0",
+          "estimatedNumberOfUsers": 0,
+          "id": "us-east-2_tUKTjMET0",
+          "lambdaConfig": null,
+          "lastModifiedDate": "2026-05-29T13:15:39Z",
+          "mfaConfiguration": "OFF",
+          "name": "pulumi-aws-5401-upgrade",
+          "passwordPolicy": {
+            "minimumLength": 8,
+            "passwordHistorySize": 0,
+            "requireLowercase": true,
+            "requireNumbers": true,
+            "requireSymbols": true,
+            "requireUppercase": true,
+            "temporaryPasswordValidityDays": 7
+          },
+          "schemas": [
+            {
+              "attributeDataType": "String",
+              "developerOnlyAttribute": null,
+              "mutable": null,
+              "name": "email",
+              "numberAttributeConstraints": null,
+              "required": true,
+              "stringAttributeConstraints": null
+            }
+          ],
+          "signInPolicy": {
+            "allowedFirstAuthFactors": [
+              "PASSWORD"
+            ]
+          },
+          "smsAuthenticationMessage": "",
+          "smsConfiguration": null,
+          "smsVerificationMessage": "",
+          "softwareTokenMfaConfiguration": null,
+          "userAttributeUpdateSettings": null,
+          "userPoolAddOns": null,
+          "userPoolTier": "ESSENTIALS",
+          "usernameAttributes": null,
+          "usernameConfiguration": null,
+          "verificationMessageTemplate": {
+            "defaultEmailOption": "CONFIRM_WITH_CODE",
+            "emailMessage": "",
+            "emailMessageByLink": "",
+            "emailSubject": "",
+            "emailSubjectByLink": "",
+            "smsMessage": ""
+          },
+          "webAuthnConfiguration": null
+        },
+        "parent": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:pulumi:Stack::aws-cognito-identity-provider-provider-details-test",
+        "provider": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:providers:aws::default::712d84b7-8562-4d44-8576-4c3ee9bfb2ac",
+        "propertyDependencies": {
+          "name": [],
+          "passwordPolicy": [],
+          "schemas": []
+        },
+        "created": "2026-05-29T13:15:39.675001Z",
+        "modified": "2026-05-29T13:15:39.675001Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1020",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1020"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1246"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1099"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#525"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#328"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/pulumi/run.go#144"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#326"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#588"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#301"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go#57"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#228"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1234"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#590"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1430"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1856"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1065"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.25.9/x64/src/runtime/asm_arm64.s#1268"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/identityProvider:IdentityProvider::google",
+        "custom": true,
+        "id": "us-east-2_tUKTjMET0:Google",
+        "type": "aws:cognito/identityProvider:IdentityProvider",
+        "inputs": {
+          "__defaults": [],
+          "attributeMapping": {
+            "email": "email",
+            "username": "sub"
+          },
+          "providerDetails": {
+            "authorize_scopes": "email profile openid",
+            "client_id": "test-url.apps.googleusercontent.com",
+            "client_secret": "client_secret"
+          },
+          "providerName": "Google",
+          "providerType": "Google",
+          "userPoolId": "us-east-2_tUKTjMET0"
+        },
+        "outputs": {
+          "attributeMapping": {
+            "email": "email",
+            "username": "sub"
+          },
+          "id": "us-east-2_tUKTjMET0:Google",
+          "idpIdentifiers": null,
+          "providerDetails": {
+            "attributes_url": "https://people.googleapis.com/v1/people/me?personFields=",
+            "attributes_url_add_attributes": "true",
+            "authorize_scopes": "email profile openid",
+            "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+            "client_id": "test-url.apps.googleusercontent.com",
+            "client_secret": "client_secret",
+            "oidc_issuer": "https://accounts.google.com",
+            "token_request_method": "POST",
+            "token_url": "https://www.googleapis.com/oauth2/v4/token"
+          },
+          "providerName": "Google",
+          "providerType": "Google",
+          "userPoolId": "us-east-2_tUKTjMET0"
+        },
+        "parent": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:pulumi:Stack::aws-cognito-identity-provider-provider-details-test",
+        "dependencies": [
+          "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/userPool:UserPool::userPool"
+        ],
+        "provider": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:providers:aws::default::712d84b7-8562-4d44-8576-4c3ee9bfb2ac",
+        "propertyDependencies": {
+          "attributeMapping": [],
+          "providerDetails": [],
+          "providerName": [],
+          "providerType": [],
+          "userPoolId": [
+            "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/userPool:UserPool::userPool"
+          ]
+        },
+        "created": "2026-05-29T13:15:40.14168Z",
+        "modified": "2026-05-29T13:15:40.14168Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1020",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1020"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1246"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1099"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#525"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#328"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/pulumi/run.go#144"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#326"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#588"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#301"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go#57"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#228"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1234"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#590"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1430"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1856"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1065"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.25.9/x64/src/runtime/asm_arm64.s#1268"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/identityProvider:IdentityProvider::saml",
+        "custom": true,
+        "id": "us-east-2_tUKTjMET0:pulumi-aws-5401-upgrade",
+        "type": "aws:cognito/identityProvider:IdentityProvider",
+        "inputs": {
+          "__defaults": [],
+          "providerDetails": {
+            "MetadataFile": "\u003c?xml version=\"1.0\"?\u003e\n\u003cmd:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://terraform-dev-ed.my.salesforce.com\" validUntil=\"2070-08-31T14:30:09Z\"\u003e\n  \u003cmd:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"\u003e\n    \u003cmd:KeyDescriptor use=\"signing\"\u003e\n      \u003cds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"\u003e\n        \u003cds:X509Data\u003e\n          \u003cds:X509Certificate\u003eMIICfjCCAeegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBbMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExEjAQBgNVBAoMCVRlcnJhZm9ybTErMCkGA1UEAwwidGVycmFmb3JtLWRldi1lZC5teS5zYWxlc2ZvcmNlLmNvbTAgFw0yMDA4MjkxNDQ4MzlaGA8yMDcwMDgxNzE0NDgzOVowWzELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAkNBMRIwEAYDVQQKDAlUZXJyYWZvcm0xKzApBgNVBAMMInRlcnJhZm9ybS1kZXYtZWQubXkuc2FsZXNmb3JjZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOxUTzEKdivVjfZ/BERGpX/ZWQsBKHut17dQTKW/3jox1N9EJ3ULj9qEDen6zQ74Ce8hSEkrG7MP9mcP1oEhQZSca5tTAop1GejJG+bfF4v6cXM9pqHlllrYrmXMfESiahqhBhE8VvoGJkvp393TcB1lX+WxO8Q74demTrQn5tgvAgMBAAGjUDBOMB0GA1UdDgQWBBREKZt4Av70WKQE4aLD2tvbSLnBlzAfBgNVHSMEGDAWgBREKZt4Av70WKQE4aLD2tvbSLnBlzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACxeC29WMGqeOlQF4JWwsYwIC82SUaZvMDqjAm9ieIrAZRH6J6Cu40c/rvsUGUjQ9logKX15RAyI7Rn0jBUgopRkNL71HyyM7ug4qN5An05VmKQWIbVfxkNVB2Ipb/ICMc5UE38G4y4VbANZFvbFbkVq6OAP2GGNl22o/XSnhFY8\u003c/ds:X509Certificate\u003e\n        \u003c/ds:X509Data\u003e\n      \u003c/ds:KeyInfo\u003e\n    \u003c/md:KeyDescriptor\u003e\n    \u003cmd:NameIDFormat\u003eurn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\u003c/md:NameIDFormat\u003e\n    \u003cmd:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost\"/\u003e\n    \u003cmd:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect\"/\u003e\n  \u003c/md:IDPSSODescriptor\u003e\n\u003c/md:EntityDescriptor\u003e\n"
+          },
+          "providerName": "pulumi-aws-5401-upgrade",
+          "providerType": "SAML",
+          "userPoolId": "us-east-2_tUKTjMET0"
+        },
+        "outputs": {
+          "attributeMapping": {},
+          "id": "us-east-2_tUKTjMET0:pulumi-aws-5401-upgrade",
+          "idpIdentifiers": null,
+          "providerDetails": {
+            "ActiveEncryptionCertificate": "MIICvTCCAaWgAwIBAgIJAJkSWSuZAV9aMA0GCSqGSIb3DQEBCwUAMB4xHDAaBgNVBAMME3VzLWVhc3QtMl90VUtUak1FVDAwHhcNMjYwNTI5MTMxNTQwWhcNMzYwNTI4MjMyNzQwWjAeMRwwGgYDVQQDDBN1cy1lYXN0LTJfdFVLVGpNRVQwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA478QdpV5lBmz6DQUPNCpD/EO1Hgu97SC/Da6+Ud/ZCpi9Nx9SdQSKl12EOR75B8RCXVCd05DveUSwcspb/KFVEjP8VH6gTEtjYM2cCd3UCXr05iPwmYihzVk9kpIZTa4hCyremkbmEe7gt2N27EQBSEx95/Yj6Bs14ffM2HHdcqeo2LacaTtVlWgCMQhpHsjKUnGUnLBru/5uR8BlFqULJ1Svt5RBt+hKbKxDh+FYSU93bBKAplAityhuSeClAWhGDCZLmBh46d+dA1f1zXy0bIQ6HUKZ867+Zr33fUxyjQrHhiIHudVhYAyx2mrIlXW3TadTkghErtHfvzK4L2mcQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCFMpZFjKbL/n/nIqXn93H+9u0Ga2Ki+KPSsvZNTDwIXtIPJYf30UsOwtrD6SqpOqHdCPswizIrVZHeGJI9FBGzoGmkVJGwXOiU2FZUHRww9vKppo4Ou5+sp265dFODSJu1//n3fwWl0JCtJik7FvubZHiRPL3mBTUMv2t04ahx1fp04IDta3aHctl4cBL9YGZCUnp7D7ylJoDei8ljc9LCopUXyrRBS2rVyU3FbZfg6yim5QR1ZpfzfM0ZtIWzgXciJYZUeLq+lLSmy4Sg9xLCouNiVLnsE8m4+DEjMH2xr2G+DiHJi8vojT/kXIEFzpSFeuz2VkZtQ/jdQdt2RdNh",
+            "MetadataFile": "\u003c?xml version=\"1.0\"?\u003e\n\u003cmd:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://terraform-dev-ed.my.salesforce.com\" validUntil=\"2070-08-31T14:30:09Z\"\u003e\n  \u003cmd:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"\u003e\n    \u003cmd:KeyDescriptor use=\"signing\"\u003e\n      \u003cds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"\u003e\n        \u003cds:X509Data\u003e\n          \u003cds:X509Certificate\u003eMIICfjCCAeegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBbMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExEjAQBgNVBAoMCVRlcnJhZm9ybTErMCkGA1UEAwwidGVycmFmb3JtLWRldi1lZC5teS5zYWxlc2ZvcmNlLmNvbTAgFw0yMDA4MjkxNDQ4MzlaGA8yMDcwMDgxNzE0NDgzOVowWzELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAkNBMRIwEAYDVQQKDAlUZXJyYWZvcm0xKzApBgNVBAMMInRlcnJhZm9ybS1kZXYtZWQubXkuc2FsZXNmb3JjZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOxUTzEKdivVjfZ/BERGpX/ZWQsBKHut17dQTKW/3jox1N9EJ3ULj9qEDen6zQ74Ce8hSEkrG7MP9mcP1oEhQZSca5tTAop1GejJG+bfF4v6cXM9pqHlllrYrmXMfESiahqhBhE8VvoGJkvp393TcB1lX+WxO8Q74demTrQn5tgvAgMBAAGjUDBOMB0GA1UdDgQWBBREKZt4Av70WKQE4aLD2tvbSLnBlzAfBgNVHSMEGDAWgBREKZt4Av70WKQE4aLD2tvbSLnBlzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACxeC29WMGqeOlQF4JWwsYwIC82SUaZvMDqjAm9ieIrAZRH6J6Cu40c/rvsUGUjQ9logKX15RAyI7Rn0jBUgopRkNL71HyyM7ug4qN5An05VmKQWIbVfxkNVB2Ipb/ICMc5UE38G4y4VbANZFvbFbkVq6OAP2GGNl22o/XSnhFY8\u003c/ds:X509Certificate\u003e\n        \u003c/ds:X509Data\u003e\n      \u003c/ds:KeyInfo\u003e\n    \u003c/md:KeyDescriptor\u003e\n    \u003cmd:NameIDFormat\u003eurn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\u003c/md:NameIDFormat\u003e\n    \u003cmd:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost\"/\u003e\n    \u003cmd:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect\"/\u003e\n  \u003c/md:IDPSSODescriptor\u003e\n\u003c/md:EntityDescriptor\u003e\n",
+            "SSORedirectBindingURI": "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"
+          },
+          "providerName": "pulumi-aws-5401-upgrade",
+          "providerType": "SAML",
+          "userPoolId": "us-east-2_tUKTjMET0"
+        },
+        "parent": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:pulumi:Stack::aws-cognito-identity-provider-provider-details-test",
+        "dependencies": [
+          "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/userPool:UserPool::userPool"
+        ],
+        "provider": "urn:pulumi:test::aws-cognito-identity-provider-provider-details::pulumi:providers:aws::default::712d84b7-8562-4d44-8576-4c3ee9bfb2ac",
+        "propertyDependencies": {
+          "providerDetails": [],
+          "providerName": [],
+          "providerType": [],
+          "userPoolId": [
+            "urn:pulumi:test::aws-cognito-identity-provider-provider-details::aws:cognito/userPool:UserPool::userPool"
+          ]
+        },
+        "created": "2026-05-29T13:15:40.322964Z",
+        "modified": "2026-05-29T13:15:40.322964Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1020",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1020"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1246"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1099"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#525"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#328"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/pulumi/run.go#144"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#326"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#588"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#301"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go#57"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1243"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/go/common/util/rpcutil/interceptor.go#228"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1234"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.237.0/proto/go/language_grpc.pb.go#590"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1430"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1856"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.81.0/server.go#1065"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.25.9/x64/src/runtime/asm_arm64.s#1268"
+          }
+        ]
+      }
+    ],
+    "metadata": {}
+  }
+}

--- a/patches/0027-Suppress-Cognito-IdP-provider-details-default-diffs.patch
+++ b/patches/0027-Suppress-Cognito-IdP-provider-details-default-diffs.patch
@@ -1,0 +1,470 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: corymhall <43035978+corymhall@users.noreply.github.com>
+Date: Thu, 28 May 2026 14:49:48 -0400
+Subject: [PATCH] Suppress Cognito IdP provider details default diffs
+
+
+diff --git a/internal/service/cognitoidp/identity_provider.go b/internal/service/cognitoidp/identity_provider.go
+index 168cee841f1..d5a67765337 100644
+--- a/internal/service/cognitoidp/identity_provider.go
++++ b/internal/service/cognitoidp/identity_provider.go
+@@ -9,6 +9,7 @@ import (
+ 	"context"
+ 	"fmt"
+ 	"log"
++	"maps"
+ 	"strings"
+ 
+ 	"github.com/YakDriver/regexache"
+@@ -62,9 +63,10 @@ func resourceIdentityProvider() *schema.Resource {
+ 				},
+ 			},
+ 			"provider_details": {
+-				Type:     schema.TypeMap,
+-				Required: true,
+-				Elem:     &schema.Schema{Type: schema.TypeString},
++				Type:             schema.TypeMap,
++				Required:         true,
++				Elem:             &schema.Schema{Type: schema.TypeString},
++				DiffSuppressFunc: suppressIdentityProviderProviderDetailsDiff,
+ 			},
+ 			names.AttrProviderName: {
+ 				Type:         schema.TypeString,
+@@ -87,6 +89,99 @@ func resourceIdentityProvider() *schema.Resource {
+ 	}
+ }
+ 
++var defaultIdentityProviderDetails = map[string]map[string]string{
++	"Google": {
++		"attributes_url":                "https://people.googleapis.com/v1/people/me?personFields=",
++		"attributes_url_add_attributes": "true",
++		"authorize_url":                 "https://accounts.google.com/o/oauth2/v2/auth",
++		"oidc_issuer":                   "https://accounts.google.com",
++		"token_request_method":          "POST",
++		"token_url":                     "https://www.googleapis.com/oauth2/v4/token",
++	},
++}
++
++func suppressIdentityProviderProviderDetailsDiff(k, old, new string, d *schema.ResourceData) bool {
++	oldRaw, newRaw := d.GetChange("provider_details")
++	oldDetails := stringMap(oldRaw)
++	newDetails := stringMap(newRaw)
++	providerType := d.Get("provider_type").(string)
++
++	if k == "provider_details.%" {
++		return suppressIdentityProviderProviderDetailsCountDiff(providerType, oldDetails, newDetails)
++	}
++
++	detailKey, ok := strings.CutPrefix(k, "provider_details.")
++	if !ok {
++		return false
++	}
++
++	if _, configured := newDetails[detailKey]; configured {
++		return false
++	}
++
++	return isReadOnlyOrDefaultIdentityProviderDetail(providerType, detailKey, old, newDetails) && new == ""
++}
++
++func suppressIdentityProviderProviderDetailsCountDiff(providerType string, oldDetails, newDetails map[string]string) bool {
++	if len(oldDetails) <= len(newDetails) {
++		return false
++	}
++
++	removed := false
++	for key, oldValue := range oldDetails {
++		newValue, configured := newDetails[key]
++		switch {
++		case !configured:
++			if !isReadOnlyOrDefaultIdentityProviderDetail(providerType, key, oldValue, newDetails) {
++				return false
++			}
++			removed = true
++		case oldValue != newValue:
++			return false
++		}
++	}
++
++	return removed
++}
++
++func isReadOnlyOrDefaultIdentityProviderDetail(providerType, key, oldValue string, configuredDetails map[string]string) bool {
++	if defaults, ok := defaultIdentityProviderDetails[providerType]; ok {
++		if defaultValue, ok := defaults[key]; ok {
++			return oldValue == defaultValue
++		}
++	}
++
++	switch providerType {
++	case "SAML":
++		switch key {
++		case "ActiveEncryptionCertificate":
++			return true
++		case "SSORedirectBindingURI":
++			_, hasMetadataFile := configuredDetails["MetadataFile"]
++			return hasMetadataFile
++		}
++	}
++
++	return false
++}
++
++func stringMap(v any) map[string]string {
++	switch v := v.(type) {
++	case map[string]string:
++		return maps.Clone(v)
++	case map[string]any:
++		m := make(map[string]string, len(v))
++		for k, v := range v {
++			m[k] = fmt.Sprint(v)
++		}
++		return m
++	case nil:
++		return nil
++	default:
++		return nil
++	}
++}
++
+ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+ 	var diags diag.Diagnostics
+ 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
+diff --git a/internal/service/cognitoidp/identity_provider_internal_test.go b/internal/service/cognitoidp/identity_provider_internal_test.go
+new file mode 100644
+index 00000000000..ff216a7eba0
+--- /dev/null
++++ b/internal/service/cognitoidp/identity_provider_internal_test.go
+@@ -0,0 +1,171 @@
++// Copyright IBM Corp. 2014, 2026
++// SPDX-License-Identifier: MPL-2.0
++
++package cognitoidp
++
++import "testing"
++
++func TestSuppressIdentityProviderProviderDetailsCountDiff(t *testing.T) {
++	t.Parallel()
++
++	testCases := map[string]struct {
++		providerType string
++		oldDetails   map[string]string
++		newDetails   map[string]string
++		want         bool
++	}{
++		"google defaults removed": {
++			providerType: "Google",
++			oldDetails: map[string]string{
++				"attributes_url":                "https://people.googleapis.com/v1/people/me?personFields=",
++				"attributes_url_add_attributes": "true",
++				"authorize_scopes":              "email profile openid",
++				"authorize_url":                 "https://accounts.google.com/o/oauth2/v2/auth",
++				"client_id":                     "test-url.apps.googleusercontent.com",
++				"client_secret":                 "client_secret",
++				"oidc_issuer":                   "https://accounts.google.com",
++				"token_request_method":          "POST",
++				"token_url":                     "https://www.googleapis.com/oauth2/v4/token",
++			},
++			newDetails: map[string]string{
++				"authorize_scopes": "email profile openid",
++				"client_id":        "test-url.apps.googleusercontent.com",
++				"client_secret":    "client_secret",
++			},
++			want: true,
++		},
++		"configured value changes": {
++			providerType: "Google",
++			oldDetails: map[string]string{
++				"attributes_url":   "https://people.googleapis.com/v1/people/me?personFields=",
++				"authorize_scopes": "email profile openid",
++				"client_id":        "test-url.apps.googleusercontent.com",
++				"client_secret":    "client_secret",
++			},
++			newDetails: map[string]string{
++				"authorize_scopes": "email profile openid",
++				"client_id":        "new-client-id-url.apps.googleusercontent.com",
++				"client_secret":    "client_secret",
++			},
++			want: false,
++		},
++		"custom google detail removed": {
++			providerType: "Google",
++			oldDetails: map[string]string{
++				"attributes_url": "https://example.com/attributes",
++				"client_id":      "test-url.apps.googleusercontent.com",
++				"client_secret":  "client_secret",
++			},
++			newDetails: map[string]string{
++				"client_id":     "test-url.apps.googleusercontent.com",
++				"client_secret": "client_secret",
++			},
++			want: false,
++		},
++		"saml returned details removed with metadata file configured": {
++			providerType: "SAML",
++			oldDetails: map[string]string{
++				"ActiveEncryptionCertificate": "certificate",
++				"MetadataFile":                "<xml>",
++				"SSORedirectBindingURI":       "https://example.com/sso",
++			},
++			newDetails: map[string]string{
++				"MetadataFile": "<xml>",
++			},
++			want: true,
++		},
++		"saml redirect removed without metadata file configured": {
++			providerType: "SAML",
++			oldDetails: map[string]string{
++				"ActiveEncryptionCertificate": "certificate",
++				"SSORedirectBindingURI":       "https://example.com/sso",
++			},
++			newDetails: map[string]string{},
++			want:       false,
++		},
++		"saml metadata file removed": {
++			providerType: "SAML",
++			oldDetails: map[string]string{
++				"ActiveEncryptionCertificate": "certificate",
++				"MetadataFile":                "<xml>",
++				"SSORedirectBindingURI":       "https://example.com/sso",
++			},
++			newDetails: map[string]string{},
++			want:       false,
++		},
++	}
++
++	for name, tc := range testCases {
++		t.Run(name, func(t *testing.T) {
++			t.Parallel()
++
++			got := suppressIdentityProviderProviderDetailsCountDiff(tc.providerType, tc.oldDetails, tc.newDetails)
++
++			if got != tc.want {
++				t.Errorf("got %t, want %t", got, tc.want)
++			}
++		})
++	}
++}
++
++func TestIsReadOnlyOrDefaultIdentityProviderDetail(t *testing.T) {
++	t.Parallel()
++
++	testCases := map[string]struct {
++		providerType      string
++		key               string
++		oldValue          string
++		configuredDetails map[string]string
++		want              bool
++	}{
++		"default google detail": {
++			providerType:      "Google",
++			key:               "authorize_url",
++			oldValue:          "https://accounts.google.com/o/oauth2/v2/auth",
++			configuredDetails: map[string]string{},
++			want:              true,
++		},
++		"custom google detail": {
++			providerType:      "Google",
++			key:               "authorize_url",
++			oldValue:          "https://example.com/auth",
++			configuredDetails: map[string]string{},
++			want:              false,
++		},
++		"saml active encryption certificate": {
++			providerType:      "SAML",
++			key:               "ActiveEncryptionCertificate",
++			oldValue:          "certificate",
++			configuredDetails: map[string]string{},
++			want:              true,
++		},
++		"saml redirect with metadata file": {
++			providerType: "SAML",
++			key:          "SSORedirectBindingURI",
++			oldValue:     "https://example.com/sso",
++			configuredDetails: map[string]string{
++				"MetadataFile": "<xml>",
++			},
++			want: true,
++		},
++		"saml redirect without metadata file": {
++			providerType:      "SAML",
++			key:               "SSORedirectBindingURI",
++			oldValue:          "https://example.com/sso",
++			configuredDetails: map[string]string{},
++			want:              false,
++		},
++	}
++
++	for name, tc := range testCases {
++		t.Run(name, func(t *testing.T) {
++			t.Parallel()
++
++			got := isReadOnlyOrDefaultIdentityProviderDetail(tc.providerType, tc.key, tc.oldValue, tc.configuredDetails)
++
++			if got != tc.want {
++				t.Errorf("got %t, want %t", got, tc.want)
++			}
++		})
++	}
++}
+diff --git a/internal/service/cognitoidp/identity_provider_test.go b/internal/service/cognitoidp/identity_provider_test.go
+index 658c9e8680f..7fbba244bad 100644
+--- a/internal/service/cognitoidp/identity_provider_test.go
++++ b/internal/service/cognitoidp/identity_provider_test.go
+@@ -81,6 +81,48 @@ func TestAccCognitoIDPIdentityProvider_basic(t *testing.T) {
+ 	})
+ }
+ 
++func TestAccCognitoIDPIdentityProvider_defaultProviderDetails(t *testing.T) {
++	ctx := acctest.Context(t)
++	var identityProvider awstypes.IdentityProviderType
++	resourceName := "aws_cognito_identity_provider.test"
++	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
++
++	acctest.ParallelTest(ctx, t, resource.TestCase{
++		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
++		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckIdentityProviderDestroy(ctx, t),
++		Steps: []resource.TestStep{
++			{
++				Config: testAccIdentityProviderConfig_defaults(rName),
++				Check: resource.ComposeAggregateTestCheckFunc(
++					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.%", "9"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_scopes", names.AttrEmail),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_url", "https://accounts.google.com/o/oauth2/v2/auth"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.client_id", "test-url.apps.googleusercontent.com"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.client_secret", names.AttrClientSecret),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.attributes_url", "https://people.googleapis.com/v1/people/me?personFields="),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.attributes_url_add_attributes", acctest.CtTrue),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.token_request_method", "POST"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.token_url", "https://www.googleapis.com/oauth2/v4/token"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.oidc_issuer", "https://accounts.google.com"),
++				),
++			},
++			{
++				Config: testAccIdentityProviderConfig_defaultsUpdated(rName),
++				Check: resource.ComposeAggregateTestCheckFunc(
++					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.%", "9"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_scopes", names.AttrEmail),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.client_id", "new-client-id-url.apps.googleusercontent.com"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.client_secret", "updated_client_secret"),
++				),
++			},
++		},
++	})
++}
++
+ func TestAccCognitoIDPIdentityProvider_idpIdentifiers(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var identityProvider awstypes.IdentityProviderType
+@@ -188,6 +230,32 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
+ 	})
+ }
+ 
++func TestAccCognitoIDPIdentityProvider_samlDefaultProviderDetails(t *testing.T) {
++	ctx := acctest.Context(t)
++	var identityProvider awstypes.IdentityProviderType
++	resourceName := "aws_cognito_identity_provider.test"
++	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
++
++	acctest.ParallelTest(ctx, t, resource.TestCase{
++		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
++		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckIdentityProviderDestroy(ctx, t),
++		Steps: []resource.TestStep{
++			{
++				Config: testAccIdentityProviderConfig_samlDefaults(rName),
++				Check: resource.ComposeAggregateTestCheckFunc(
++					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.%", "3"),
++					resource.TestCheckResourceAttrSet(resourceName, "provider_details.ActiveEncryptionCertificate"),
++					resource.TestCheckResourceAttrSet(resourceName, "provider_details.MetadataFile"),
++					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"),
++				),
++			},
++		},
++	})
++}
++
+ func TestAccCognitoIDPIdentityProvider_disappears(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	var identityProvider awstypes.IdentityProviderType
+@@ -299,6 +367,48 @@ func testAccCheckIdentityProviderExists(ctx context.Context, t *testing.T, n str
+ 	}
+ }
+ 
++func testAccIdentityProviderConfig_defaults(rName string) string {
++	return fmt.Sprintf(`
++resource "aws_cognito_user_pool" "test" {
++  name                     = %[1]q
++  auto_verified_attributes = ["email"]
++}
++
++resource "aws_cognito_identity_provider" "test" {
++  user_pool_id  = aws_cognito_user_pool.test.id
++  provider_name = "Google"
++  provider_type = "Google"
++
++  provider_details = {
++    authorize_scopes = "email"
++    client_id        = "test-url.apps.googleusercontent.com"
++    client_secret    = "client_secret"
++  }
++}
++`, rName)
++}
++
++func testAccIdentityProviderConfig_defaultsUpdated(rName string) string {
++	return fmt.Sprintf(`
++resource "aws_cognito_user_pool" "test" {
++  name                     = %[1]q
++  auto_verified_attributes = ["email"]
++}
++
++resource "aws_cognito_identity_provider" "test" {
++  user_pool_id  = aws_cognito_user_pool.test.id
++  provider_name = "Google"
++  provider_type = "Google"
++
++  provider_details = {
++    authorize_scopes = "email"
++    client_id        = "new-client-id-url.apps.googleusercontent.com"
++    client_secret    = "updated_client_secret"
++  }
++}
++`, rName)
++}
++
+ func testAccIdentityProviderConfig_basic(rName string) string {
+ 	return fmt.Sprintf(`
+ resource "aws_cognito_user_pool" "test" {
+@@ -387,6 +497,25 @@ resource "aws_cognito_identity_provider" "test" {
+ `, rName, attribute)
+ }
+ 
++func testAccIdentityProviderConfig_samlDefaults(rName string) string {
++	return fmt.Sprintf(`
++resource "aws_cognito_user_pool" "test" {
++  name                     = %[1]q
++  auto_verified_attributes = ["email"]
++}
++
++resource "aws_cognito_identity_provider" "test" {
++  user_pool_id  = aws_cognito_user_pool.test.id
++  provider_name = %[1]q
++  provider_type = "SAML"
++
++  provider_details = {
++    MetadataFile = file("./test-fixtures/saml-metadata.xml")
++  }
++}
++`, rName)
++}
++
+ func testAccIdentityProviderConfig_saml(rName, userPoolName, encryptedResponses string) string {
+ 	return fmt.Sprintf(`
+ resource "aws_cognito_user_pool" "test" {

--- a/patches/0027-Suppress-Cognito-IdP-provider-details-default-diffs.patch
+++ b/patches/0027-Suppress-Cognito-IdP-provider-details-default-diffs.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Suppress Cognito IdP provider details default diffs
 
 
 diff --git a/internal/service/cognitoidp/identity_provider.go b/internal/service/cognitoidp/identity_provider.go
-index 168cee841f1..d5a67765337 100644
+index 168cee841f1..e8f4323e442 100644
 --- a/internal/service/cognitoidp/identity_provider.go
 +++ b/internal/service/cognitoidp/identity_provider.go
 @@ -9,6 +9,7 @@ import (
@@ -30,7 +30,7 @@ index 168cee841f1..d5a67765337 100644
  			},
  			names.AttrProviderName: {
  				Type:         schema.TypeString,
-@@ -87,6 +89,99 @@ func resourceIdentityProvider() *schema.Resource {
+@@ -87,6 +89,114 @@ func resourceIdentityProvider() *schema.Resource {
  	}
  }
  
@@ -45,6 +45,11 @@ index 168cee841f1..d5a67765337 100644
 +	},
 +}
 +
++// suppressIdentityProviderProviderDetailsDiff handles provider detail values that
++// Cognito returns from DescribeIdentityProvider even when they were not present
++// in configuration. The provider keeps those values in state so they remain
++// visible, but suppresses plans that would only remove known AWS-returned
++// defaults or read-only values from state.
 +func suppressIdentityProviderProviderDetailsDiff(k, old, new string, d *schema.ResourceData) bool {
 +	oldRaw, newRaw := d.GetChange("provider_details")
 +	oldDetails := stringMap(oldRaw)
@@ -60,6 +65,8 @@ index 168cee841f1..d5a67765337 100644
 +		return false
 +	}
 +
++	// Never suppress a diff for a configured key. If the configuration changes a
++	// provider detail value, Terraform must still plan an update for it.
 +	if _, configured := newDetails[detailKey]; configured {
 +		return false
 +	}
@@ -67,6 +74,10 @@ index 168cee841f1..d5a67765337 100644
 +	return isReadOnlyOrDefaultIdentityProviderDetail(providerType, detailKey, old, newDetails) && new == ""
 +}
 +
++// suppressIdentityProviderProviderDetailsCountDiff covers the TypeMap count
++// entry, which changes when Cognito adds extra provider detail keys during read.
++// The count diff is safe to suppress only when every missing key is one of the
++// known AWS-returned values and all still-configured keys are unchanged.
 +func suppressIdentityProviderProviderDetailsCountDiff(providerType string, oldDetails, newDetails map[string]string) bool {
 +	if len(oldDetails) <= len(newDetails) {
 +		return false
@@ -89,6 +100,10 @@ index 168cee841f1..d5a67765337 100644
 +	return removed
 +}
 +
++// isReadOnlyOrDefaultIdentityProviderDetail is intentionally allowlist-based.
++// Cognito provider_details is a free-form map, so suppressing arbitrary removed
++// keys could hide real user changes. Google returns documented endpoint defaults
++// when omitted, while SAML returns derived/read-only metadata fields.
 +func isReadOnlyOrDefaultIdentityProviderDetail(providerType, key, oldValue string, configuredDetails map[string]string) bool {
 +	if defaults, ok := defaultIdentityProviderDetails[providerType]; ok {
 +		if defaultValue, ok := defaults[key]; ok {


### PR DESCRIPTION
## Motivation

Fixes #5401 by patching the upstream Terraform AWS `aws_cognito_identity_provider` behavior that causes a permanent `providerDetails` diff when AWS returns provider-detail defaults/read-only values that were not present in user configuration.

The matching upstream Terraform change is https://github.com/hashicorp/terraform-provider-aws/pull/48121

## Summary

- Adds a new upstream patch that installs a narrow `DiffSuppressFunc` for Cognito IdP `provider_details`.
- Suppresses only absent AWS-returned defaults/read-only values for Google and SAML provider details.
- Keeps configured-key changes visible, including updates to `client_id`, `client_secret`, `authorize_scopes`, and `MetadataFile`.
- Adds Pulumi YAML integration coverage for Google default readback, SAML secret metadata readback, and a configured Google value update.
- Adds Pulumi provider-upgrade coverage that creates Google and SAML Cognito IdPs with a pre-fix published provider, records that baseline, then previews with the patched provider and asserts the identity-provider diffs do not include `providerDetails`.

## Testing

- `go test ./internal/service/cognitoidp` in the Terraform AWS fork worktree
- `make test_provider`
- `GITHUB_ACTIONS=1 make test TESTTAGS=java GOTESTARGS='-run TestCognitoIdentityProviderProviderDetailsDiff -count=0'`
- `GITHUB_ACTIONS=1 make test TESTTAGS=java GOTESTARGS='-run ^TestCognitoIdentityProviderProviderDetailsUpgrade$ -count=0'`
- `GITHUB_ACTIONS=1 make test TESTTAGS=java GOTESTARGS='-list ^TestCognitoIdentityProviderProviderDetailsUpgrade$'`
- `make test TESTTAGS=java GOTESTARGS='-run ^TestCognitoIdentityProviderProviderDetailsUpgrade$ -count=1'`
- `git diff --check`