### PR TITLE
Patch REST API body policy updates

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -51,6 +51,7 @@ jobs:
           - ec2
           - docdb
           - redshiftserverless
+          - apigateway
         include:
           - service: sqs
             tests: TestAccSQSQueue
@@ -60,6 +61,8 @@ jobs:
             tests: TestAccDocDBCluster_basic
           - service: redshiftserverless
             tests: TestAccRedshiftServerlessNamespace_basic
+          - service: apigateway
+            tests: TestAccAPIGatewayRestAPI_(Policy_|body)
           # TODO[pulumi/pulumi-aws#5388] route53resolver tests flaky
           # - service: route53resolver
           #   tests: TestAccRoute53Resolver

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -78,6 +78,32 @@ func TestApiGatewayResourceResponseUpgrade(t *testing.T) {
 	testProviderUpgrade(t, filepath.Join("test-programs", "apigateway-resource-response"), nil)
 }
 
+func TestApiGatewayRestApiBodyPolicyUpdate(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+
+	cwd := getCwd(t)
+	workdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"),
+		[]byte(testApiGatewayRestApiBodyPolicyProgram("Allow")), 0o600))
+
+	pt := pulumitest.NewPulumiTest(t, workdir,
+		opttest.SkipInstall(),
+		opttest.TestInPlace(),
+		opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
+	)
+	pt.SetConfig(t, "aws:region", "us-east-1")
+	pt.Up(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"),
+		[]byte(testApiGatewayRestApiBodyPolicyProgram("Deny")), 0o600))
+
+	result := pt.Up(t)
+	policy, ok := result.Outputs["policy"].Value.(string)
+	require.True(t, ok)
+	require.Contains(t, policy, `"Effect":"Deny"`)
+}
+
 func TestCloudwatchEventRuleUpgrade(t *testing.T) {
 	testProviderUpgrade(t, filepath.Join("test-programs", "cloudwatch-eventrule"), nil)
 }
@@ -878,6 +904,53 @@ outputs:
 			}
 		}
 	}
+}
+
+func testApiGatewayRestApiBodyPolicyProgram(effect string) string {
+	return fmt.Sprintf(`name: apigateway-restapi-body-policy
+runtime: yaml
+resources:
+  api:
+    type: aws:apigateway:RestApi
+    properties:
+      name: apigateway-restapi-body-policy-${pulumi.stack}
+      endpointConfiguration:
+        types: REGIONAL
+      body:
+        fn::toJSON:
+          swagger: "2.0"
+          info:
+            title: test
+            version: "2017-04-20T04:08:08Z"
+          schemes:
+            - https
+          paths:
+            /test:
+              get:
+                responses:
+                  "200":
+                    description: OK
+                x-amazon-apigateway-integration:
+                  httpMethod: GET
+                  type: HTTP
+                  responses:
+                    default:
+                      statusCode: 200
+                  uri: https://api.example.com/
+          x-amazon-apigateway-policy:
+            Version: "2012-10-17"
+            Statement:
+              - Action: execute-api:Invoke
+                Condition:
+                  IpAddress:
+                    aws:SourceIp: 123.123.123.123/32
+                Effect: %s
+                Principal:
+                  AWS: "*"
+                Resource: "*"
+outputs:
+  policy: ${api.policy}
+`, effect)
 }
 
 func TestSecurityGroupPreviewWarning(t *testing.T) {

--- a/patches/0027-Fix-REST-API-body-policy-updates.patch
+++ b/patches/0027-Fix-REST-API-body-policy-updates.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: corymhall <43035978+corymhall@users.noreply.github.com>
+Date: Thu, 28 May 2026 15:19:16 -0400
+Subject: [PATCH] Fix REST API body policy updates
+
+
+diff --git a/internal/service/apigateway/rest_api.go b/internal/service/apigateway/rest_api.go
+index 54c59696ecd..a8f75496570 100644
+--- a/internal/service/apigateway/rest_api.go
++++ b/internal/service/apigateway/rest_api.go
+@@ -747,7 +747,10 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
+ 		})
+ 	}
+ 
+-	if v, ok := d.GetOk(names.AttrPolicy); ok {
++	// Only re-apply policy after OpenAPI import when policy was configured
++	// explicitly. For Optional+Computed policy, GetOk can be true for a
++	// value that was read from the prior API state.
++	if v, ok := d.GetOk(names.AttrPolicy); ok && resourceRestAPIPolicyConfigured(d) {
+ 		if equivalent, err := awspolicy.PoliciesAreEquivalent(v.(string), aws.ToString(output.Policy)); err != nil || !equivalent {
+ 			policy, _ := structure.NormalizeJsonString(v.(string)) // validation covers error
+ 
+@@ -762,6 +765,15 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
+ 	return operations
+ }
+ 
++func resourceRestAPIPolicyConfigured(d *schema.ResourceData) bool {
++	rawConfig := d.GetRawConfig()
++	if rawConfig.IsNull() || !rawConfig.Type().IsObjectType() || !rawConfig.Type().HasAttribute(names.AttrPolicy) {
++		return false
++	}
++
++	return !rawConfig.GetAttr(names.AttrPolicy).IsNull()
++}
++
+ // escapeJSONPointer escapes string per RFC 6901
+ // so it can be used as path in JSON patch operations
+ func escapeJSONPointer(path string) string {
+diff --git a/internal/service/apigateway/rest_api_test.go b/internal/service/apigateway/rest_api_test.go
+index c9b5817fa95..98218a1066d 100644
+--- a/internal/service/apigateway/rest_api_test.go
++++ b/internal/service/apigateway/rest_api_test.go
+@@ -1482,6 +1482,13 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
+ 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Allow"`)),
+ 				),
+ 			},
++			{
++				Config: testAccRestAPIConfig_policySetByBody(rName, "Deny"),
++				Check: resource.ComposeAggregateTestCheckFunc(
++					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
++					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Deny"`)),
++				),
++			},
+ 			{
+ 				ResourceName:            resourceName,
+ 				ImportState:             true,


### PR DESCRIPTION
## Summary
- Add an upstream Terraform AWS Provider patch for API Gateway REST API OpenAPI body policy updates.
- Only re-apply top-level `policy` after `PutRestApi` when `policy` is present in raw user config.
- Extend the upstream `TestAccAPIGatewayRestAPI_Policy_setByBody` acceptance test and add a Pulumi YAML integration test for body-owned policy updates.
- Run the focused API Gateway upstream acceptance tests in `.github/workflows/aws-upstream-tests.yml`.

## Upstream
- Based on upstream PR hashicorp/terraform-provider-aws#48118.


## Testing
- In `/Users/chall/personal/terraform-provider-aws/.worktrees/fix-apigateway-restapi-body-policy`: `make test-compile TEST=./internal/service/apigateway`
- In `/Users/chall/personal/terraform-provider-aws/.worktrees/fix-apigateway-restapi-body-policy`: `make test PKG=apigateway TEST=./internal/service/apigateway TESTARGS='-run TestAccAPIGatewayRestAPI_Policy_setByBody'`
- Upstream acceptance: `make testacc PKG=apigateway TESTS='TestAccAPIGatewayRestAPI_(Policy_|body)'`
- In this repo: `GITHUB_ACTIONS=1 make GOTESTARGS='-run ^TestApiGatewayRestApiBodyPolicyUpdate$ -short -count=1' test`
- YAML syntax: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-upstream-tests.yml"); puts "yaml ok"'`

fixes #2321