### PR TITLE
fix: remove extra colon from addResourceNote markdown format

### DIFF
--- a/provider/doc_edits.go
+++ b/provider/doc_edits.go
@@ -88,7 +88,7 @@ func addResourceNote(resourceFile string, markdownNote string) tfbridge.DocsEdit
 			re := regexp.MustCompile(`[#] Resource: [\w-]+`)
 			return re.ReplaceAllFunc(content, func(matching []byte) []byte {
 				return append(append([]byte{}, matching...), []byte(
-					fmt.Sprintf("\n\n> **NOTE:**: %s", markdownNote),
+					fmt.Sprintf("\n\n> **NOTE:** %s", markdownNote),
 				)...)
 			}), nil
 		},

--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -42,7 +42,21 @@ func TestReplacementDoesNotIncludeTodos(t *testing.T) {
 	}
 }
 
+func TestAddResourceNote_UsesCorrectNoteFormat(t *testing.T) {
+	t.Parallel()
+
+	edit := addResourceNote("some_resource.html.markdown", "This is a note.")
+	content := []byte("# Resource: aws_some_resource\n\nSome content.")
+	out, err := edit.Edit("some_resource.html.markdown", content)
+	require.NoError(t, err)
+
+	// The note must use a single colon ("**NOTE:** text"), not a double colon ("**NOTE:**: text").
+	require.Contains(t, string(out), "> **NOTE:** This is a note.")
+	require.NotContains(t, string(out), "**NOTE:**: ")
+}
+
 func TestFixUpBucketReplicationConfig_InsertsNotesFromRuleSection(t *testing.T) {
+	t.Parallel()
 	content := strings.Join([]string{
 		"# Resource: aws_s3_bucket_replication_configuration",
 		"",
@@ -82,6 +96,7 @@ func TestFixUpBucketReplicationConfig_InsertsNotesFromRuleSection(t *testing.T) 
 }
 
 func TestFixUpBucketReplicationConfig_DoesNotDuplicateInsertedNotes(t *testing.T) {
+	t.Parallel()
 	noteBlock := strings.Join([]string{
 		"~> **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rule` object.",
 		"",


### PR DESCRIPTION
## Summary

- Problem: `addResourceNote` in `doc_edits.go` formats notes as `**NOTE:**: text` - extra colon after the closing `**`. Renders as "NOTE::" in published docs. Already visible in committed `schema.json` for `aws:iam/rolePoliciesExclusive` and `aws:iam/rolePolicyAttachmentsExclusive`.
- Change: drop the stray `:` (`**NOTE:**: ` -> `**NOTE:** `). Adds a regression test, and `t.Parallel()` to two nearby tests.
- Related issue/PR: n/a

## Change Type

- [x] Provider logic only (`provider/`)

## Validation Evidence

Reproduce right now:

```
grep "NOTE::" provider/cmd/pulumi-resource-aws/schema.json
```

- [ ] `make lint`
- [ ] `make test_provider`
- [ ] If schema-affecting: `make schema`
- [ ] If schema-affecting: `make build_sdks`

### Command output snippets

```text
# before:
> **NOTE:**: To reliably detect drift...

# after:
> **NOTE:** To reliably detect drift...
```

## Risk

- Blast radius: two resource doc strings, no runtime behavior changed.

## Rollback

- `git revert` + schema regen.