### PR TITLE
fix(rds): support autonaming for instance identifiers

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -54,6 +54,133 @@ func TestRdsInstanceUpgrade(t *testing.T) {
 	testProviderUpgrade(t, filepath.Join("test-programs", "rds-instance"), nil)
 }
 
+func TestRdsInstanceAutonaming(t *testing.T) {
+	t.Parallel()
+
+	test := rdsInstanceAutonamingPreviewTest(t, rdsInstanceAutonamingPreviewYAML)
+	test.Preview(t, optpreview.Diff())
+
+	checks, err := test.GrpcLog(t).Checks()
+	require.NoError(t, err)
+	var found bool
+	for _, check := range checks {
+		if !strings.Contains(check.Request.GetUrn(), "aws:rds/instance:Instance::tested-resource") {
+			continue
+		}
+
+		found = true
+		_, hasIdentifierInput := check.Request.GetNews().GetFields()["identifier"]
+		assert.False(t, hasIdentifierInput, "program should not explicitly set identifier")
+		require.Empty(t, check.Response.GetFailures())
+		assert.Equal(t, "test-tested-resource",
+			check.Response.GetInputs().GetFields()["identifier"].GetStringValue())
+	}
+	require.True(t, found, "expected RDS instance Check call")
+}
+
+func TestRdsInstanceIdentifierPrefixSuppressesAutonaming(t *testing.T) {
+	t.Parallel()
+
+	test := rdsInstanceAutonamingPreviewTest(t, rdsInstanceIdentifierPrefixPreviewYAML)
+	test.Preview(t, optpreview.Diff())
+
+	checks, err := test.GrpcLog(t).Checks()
+	require.NoError(t, err)
+	var found bool
+	for _, check := range checks {
+		if !strings.Contains(check.Request.GetUrn(), "aws:rds/instance:Instance::tested-resource") {
+			continue
+		}
+
+		found = true
+		_, hasIdentifierInput := check.Request.GetNews().GetFields()["identifier"]
+		assert.False(t, hasIdentifierInput, "program should not explicitly set identifier")
+		assert.Equal(t, "prefix-",
+			check.Request.GetNews().GetFields()["identifierPrefix"].GetStringValue())
+		require.Empty(t, check.Response.GetFailures())
+		assert.Nil(t, check.Response.GetInputs().GetFields()["identifier"])
+		assert.Equal(t, "prefix-",
+			check.Response.GetInputs().GetFields()["identifierPrefix"].GetStringValue())
+	}
+	require.True(t, found, "expected RDS instance Check call")
+}
+
+func rdsInstanceAutonamingPreviewTest(t *testing.T, program string) *pulumitest.PulumiTest {
+	t.Helper()
+
+	workdir := t.TempDir()
+	err := os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"), []byte(program), 0o600)
+	require.NoError(t, err)
+
+	test := pulumitest.NewPulumiTest(t, workdir,
+		opttest.SkipInstall(),
+		opttest.LocalProviderPath("aws", filepath.Join(getCwd(t), "..", "bin")),
+	)
+	test.SetConfig(t, "aws:accessKey", "test")
+	test.SetConfig(t, "aws:secretKey", "test")
+	test.SetConfig(t, "aws:region", "us-west-2")
+	test.SetConfig(t, "aws:skipCredentialsValidation", "true")
+	test.SetConfig(t, "aws:skipRegionValidation", "true")
+	test.SetConfig(t, "aws:skipRequestingAccountId", "true")
+	return test
+}
+
+func TestRdsInstanceAutonamingUpgrade(t *testing.T) {
+	test, _ := testProviderUpgrade(t, filepath.Join("test-programs", "rds-instance-autonaming"),
+		&testProviderUpgradeOptions{
+			skipDefaultPreviewTest: true,
+		},
+	)
+
+	diffs := runPreviewWithPlanDiff(t, test)
+	assert.NotContains(t, diffs, "tested-resource")
+}
+
+const rdsInstanceAutonamingPreviewYAML = `
+name: test
+runtime:
+  name: yaml
+
+config:
+  pulumi:autonaming:
+    value:
+      pattern: ${stack}-${name}
+
+resources:
+  tested-resource:
+    type: aws:rds/instance:Instance
+    properties:
+      engine: postgres
+      instanceClass: db.t4g.micro
+      allocatedStorage: 20
+      username: mydbuser
+      password: mypassword
+      skipFinalSnapshot: true
+`
+
+const rdsInstanceIdentifierPrefixPreviewYAML = `
+name: test
+runtime:
+  name: yaml
+
+config:
+  pulumi:autonaming:
+    value:
+      pattern: ${stack}-${name}
+
+resources:
+  tested-resource:
+    type: aws:rds/instance:Instance
+    properties:
+      identifierPrefix: prefix-
+      engine: postgres
+      instanceClass: db.t4g.micro
+      allocatedStorage: 20
+      username: mydbuser
+      password: mypassword
+      skipFinalSnapshot: true
+`
+
 func TestRoute53ResolverEndpointUpgrade(t *testing.T) {
 	testProviderUpgrade(t, filepath.Join("test-programs", "route53-resolver-endpoint"), nil)
 }

--- a/examples/test-programs/rds-instance-autonaming/Pulumi.yaml
+++ b/examples/test-programs/rds-instance-autonaming/Pulumi.yaml
@@ -1,0 +1,70 @@
+name: test
+runtime:
+  name: yaml
+
+config:
+  pulumi:autonaming:
+    value:
+      pattern: ${stack}-${name}
+
+resources:
+  vpc:
+    type: aws:ec2:Vpc
+    properties:
+      cidrBlock: 10.0.0.0/16
+
+  subneta:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${vpc.id}
+      cidrBlock: 10.0.1.0/24
+      availabilityZone: ${azs.names[0]}
+
+  subnetb:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${vpc.id}
+      cidrBlock: 10.0.2.0/24
+      availabilityZone: ${azs.names[1]}
+
+  subnetgroup:
+    type: aws:rds:SubnetGroup
+    properties:
+      subnetIds:
+        - ${subneta.id}
+        - ${subnetb.id}
+
+  securitygroup:
+    type: aws:ec2:SecurityGroup
+    properties:
+      vpcId: ${vpc.id}
+      ingress: []
+      egress: []
+
+  tested-resource:
+    type: aws:rds/instance:Instance
+    properties:
+      engine: postgres
+      instanceClass: db.t4g.micro
+      allocatedStorage: 20
+      storageType: gp3
+      dbName: mydbname
+      username: mydbuser
+      password: mypassword
+      dbSubnetGroupName: ${subnetgroup.name}
+      vpcSecurityGroupIds:
+        - ${securitygroup.id}
+      skipFinalSnapshot: true
+    options:
+      ignoreChanges:
+        - password
+
+outputs:
+  identifier: ${tested-resource.identifier}
+
+variables:
+  azs:
+    fn::invoke:
+      function: aws:getAvailabilityZones
+      arguments:
+        state: available

--- a/examples/testdata/recorded/TestProviderUpgrade/rds-instance-autonaming/6.78.0/stack.json
+++ b/examples/testdata/recorded/TestProviderUpgrade/rds-instance-autonaming/6.78.0/stack.json
@@ -1,0 +1,744 @@
+{
+  "version": 3,
+  "deployment": {
+    "manifest": {
+      "time": "2026-06-15T11:52:46.216925-04:00",
+      "magic": "dc383bdf9ea4c699d9c5133da3d55c6806482041e2bc63c49ba6ea42b49dc40a",
+      "version": "v3.223.0"
+    },
+    "secrets_providers": {
+      "type": "passphrase",
+      "state": {
+        "salt": "v1:VFVWXtzvLP0=:v1:1mUOdOzEHfI6RDhY:1IznVcbX+MsZdkeyU9MZccPcju+Rng=="
+      }
+    },
+    "resources": [
+      {
+        "urn": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "custom": false,
+        "type": "pulumi:pulumi:Stack",
+        "outputs": {
+          "identifier": "tested-resource3962577"
+        },
+        "created": "2026-06-15T15:47:58.326795Z",
+        "modified": "2026-06-15T15:47:58.326795Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::test::pulumi:providers:aws::default",
+        "custom": true,
+        "id": "27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "type": "pulumi:providers:aws",
+        "inputs": {
+          "region": "us-west-2",
+          "skipCredentialsValidation": "false",
+          "skipRegionValidation": "true"
+        },
+        "outputs": {
+          "region": "us-west-2",
+          "skipCredentialsValidation": "false",
+          "skipRegionValidation": "true"
+        },
+        "created": "2026-06-15T15:48:05.889761Z",
+        "modified": "2026-06-15T15:48:05.889761Z"
+      },
+      {
+        "urn": "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc",
+        "custom": true,
+        "id": "vpc-0c3e9264060a0e177",
+        "type": "aws:ec2/vpc:Vpc",
+        "inputs": {
+          "__defaults": [
+            "enableDnsSupport"
+          ],
+          "cidrBlock": "10.0.0.0/16",
+          "enableDnsSupport": true
+        },
+        "outputs": {
+          "__meta": "{\"schema_version\":\"1\"}",
+          "arn": "arn:aws:ec2:us-west-2:616138583583:vpc/vpc-0c3e9264060a0e177",
+          "assignGeneratedIpv6CidrBlock": false,
+          "cidrBlock": "10.0.0.0/16",
+          "defaultNetworkAclId": "acl-013a01575e2cfd002",
+          "defaultRouteTableId": "rtb-0cce8c9bb26bea464",
+          "defaultSecurityGroupId": "sg-0a1d9596fed0464bd",
+          "dhcpOptionsId": "dopt-1649d26e",
+          "enableDnsHostnames": false,
+          "enableDnsSupport": true,
+          "enableNetworkAddressUsageMetrics": false,
+          "id": "vpc-0c3e9264060a0e177",
+          "instanceTenancy": "default",
+          "ipv4IpamPoolId": null,
+          "ipv4NetmaskLength": null,
+          "ipv6AssociationId": "",
+          "ipv6CidrBlock": "",
+          "ipv6CidrBlockNetworkBorderGroup": "",
+          "ipv6IpamPoolId": "",
+          "ipv6NetmaskLength": 0,
+          "mainRouteTableId": "rtb-0cce8c9bb26bea464",
+          "ownerId": "616138583583"
+        },
+        "parent": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "provider": "urn:pulumi:test::test::pulumi:providers:aws::default::27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "propertyDependencies": {
+          "cidrBlock": []
+        },
+        "created": "2026-06-15T15:48:08.255484Z",
+        "modified": "2026-06-15T15:48:08.255484Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#996"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1220"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1075"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#505"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#319"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/go/pulumi/run.go#140"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::test::aws:ec2/subnet:Subnet::subnetb",
+        "custom": true,
+        "id": "subnet-0f9770171c9ef8b97",
+        "type": "aws:ec2/subnet:Subnet",
+        "inputs": {
+          "__defaults": [
+            "assignIpv6AddressOnCreation",
+            "enableDns64",
+            "enableResourceNameDnsARecordOnLaunch",
+            "enableResourceNameDnsAaaaRecordOnLaunch",
+            "ipv6Native",
+            "mapPublicIpOnLaunch"
+          ],
+          "assignIpv6AddressOnCreation": false,
+          "availabilityZone": "us-west-2b",
+          "cidrBlock": "10.0.2.0/24",
+          "enableDns64": false,
+          "enableResourceNameDnsARecordOnLaunch": false,
+          "enableResourceNameDnsAaaaRecordOnLaunch": false,
+          "ipv6Native": false,
+          "mapPublicIpOnLaunch": false,
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "outputs": {
+          "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":600000000000,\"delete\":1200000000000},\"schema_version\":\"1\"}",
+          "arn": "arn:aws:ec2:us-west-2:616138583583:subnet/subnet-0f9770171c9ef8b97",
+          "assignIpv6AddressOnCreation": false,
+          "availabilityZone": "us-west-2b",
+          "availabilityZoneId": "usw2-az1",
+          "cidrBlock": "10.0.2.0/24",
+          "customerOwnedIpv4Pool": "",
+          "enableDns64": false,
+          "enableLniAtDeviceIndex": 0,
+          "enableResourceNameDnsARecordOnLaunch": false,
+          "enableResourceNameDnsAaaaRecordOnLaunch": false,
+          "id": "subnet-0f9770171c9ef8b97",
+          "ipv6CidrBlock": "",
+          "ipv6CidrBlockAssociationId": "",
+          "ipv6Native": false,
+          "mapCustomerOwnedIpOnLaunch": false,
+          "mapPublicIpOnLaunch": false,
+          "outpostArn": "",
+          "ownerId": "616138583583",
+          "privateDnsHostnameTypeOnLaunch": "ip-name",
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "parent": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "dependencies": [
+          "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc"
+        ],
+        "provider": "urn:pulumi:test::test::pulumi:providers:aws::default::27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "propertyDependencies": {
+          "availabilityZone": [],
+          "cidrBlock": [],
+          "vpcId": [
+            "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc"
+          ]
+        },
+        "created": "2026-06-15T15:48:09.186943Z",
+        "modified": "2026-06-15T15:48:09.186943Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#996"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1220"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1075"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#505"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#319"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/go/pulumi/run.go#140"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::test::aws:ec2/subnet:Subnet::subneta",
+        "custom": true,
+        "id": "subnet-04b4d0569ca28b59f",
+        "type": "aws:ec2/subnet:Subnet",
+        "inputs": {
+          "__defaults": [
+            "assignIpv6AddressOnCreation",
+            "enableDns64",
+            "enableResourceNameDnsARecordOnLaunch",
+            "enableResourceNameDnsAaaaRecordOnLaunch",
+            "ipv6Native",
+            "mapPublicIpOnLaunch"
+          ],
+          "assignIpv6AddressOnCreation": false,
+          "availabilityZone": "us-west-2a",
+          "cidrBlock": "10.0.1.0/24",
+          "enableDns64": false,
+          "enableResourceNameDnsARecordOnLaunch": false,
+          "enableResourceNameDnsAaaaRecordOnLaunch": false,
+          "ipv6Native": false,
+          "mapPublicIpOnLaunch": false,
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "outputs": {
+          "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":600000000000,\"delete\":1200000000000},\"schema_version\":\"1\"}",
+          "arn": "arn:aws:ec2:us-west-2:616138583583:subnet/subnet-04b4d0569ca28b59f",
+          "assignIpv6AddressOnCreation": false,
+          "availabilityZone": "us-west-2a",
+          "availabilityZoneId": "usw2-az2",
+          "cidrBlock": "10.0.1.0/24",
+          "customerOwnedIpv4Pool": "",
+          "enableDns64": false,
+          "enableLniAtDeviceIndex": 0,
+          "enableResourceNameDnsARecordOnLaunch": false,
+          "enableResourceNameDnsAaaaRecordOnLaunch": false,
+          "id": "subnet-04b4d0569ca28b59f",
+          "ipv6CidrBlock": "",
+          "ipv6CidrBlockAssociationId": "",
+          "ipv6Native": false,
+          "mapCustomerOwnedIpOnLaunch": false,
+          "mapPublicIpOnLaunch": false,
+          "outpostArn": "",
+          "ownerId": "616138583583",
+          "privateDnsHostnameTypeOnLaunch": "ip-name",
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "parent": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "dependencies": [
+          "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc"
+        ],
+        "provider": "urn:pulumi:test::test::pulumi:providers:aws::default::27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "propertyDependencies": {
+          "availabilityZone": [],
+          "cidrBlock": [],
+          "vpcId": [
+            "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc"
+          ]
+        },
+        "created": "2026-06-15T15:48:09.243349Z",
+        "modified": "2026-06-15T15:48:09.243349Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#996"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1220"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1075"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#505"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#319"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/go/pulumi/run.go#140"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::test::aws:ec2/securityGroup:SecurityGroup::securitygroup",
+        "custom": true,
+        "id": "sg-070e7cf967d5c1c52",
+        "type": "aws:ec2/securityGroup:SecurityGroup",
+        "inputs": {
+          "__defaults": [
+            "description",
+            "name",
+            "revokeRulesOnDelete"
+          ],
+          "description": "Managed by Pulumi",
+          "egress": [],
+          "ingress": [],
+          "name": "test-securitygroup",
+          "revokeRulesOnDelete": false,
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "outputs": {
+          "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":600000000000,\"delete\":900000000000},\"schema_version\":\"1\"}",
+          "arn": "arn:aws:ec2:us-west-2:616138583583:security-group/sg-070e7cf967d5c1c52",
+          "description": "Managed by Pulumi",
+          "egress": [],
+          "id": "sg-070e7cf967d5c1c52",
+          "ingress": [],
+          "name": "test-securitygroup",
+          "namePrefix": "",
+          "ownerId": "616138583583",
+          "revokeRulesOnDelete": false,
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "parent": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "dependencies": [
+          "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc"
+        ],
+        "provider": "urn:pulumi:test::test::pulumi:providers:aws::default::27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "propertyDependencies": {
+          "egress": [],
+          "ingress": [],
+          "vpcId": [
+            "urn:pulumi:test::test::aws:ec2/vpc:Vpc::vpc"
+          ]
+        },
+        "created": "2026-06-15T15:48:10.545646Z",
+        "modified": "2026-06-15T15:48:10.545646Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#996"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1220"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1075"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#505"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#319"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/go/pulumi/run.go#140"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::test::aws:rds/subnetGroup:SubnetGroup::subnetgroup",
+        "custom": true,
+        "id": "test-subnetgroup",
+        "type": "aws:rds/subnetGroup:SubnetGroup",
+        "inputs": {
+          "__defaults": [
+            "description",
+            "name"
+          ],
+          "description": "Managed by Pulumi",
+          "name": "test-subnetgroup",
+          "subnetIds": [
+            "subnet-04b4d0569ca28b59f",
+            "subnet-0f9770171c9ef8b97"
+          ]
+        },
+        "outputs": {
+          "arn": "arn:aws:rds:us-west-2:616138583583:subgrp:test-subnetgroup",
+          "description": "Managed by Pulumi",
+          "id": "test-subnetgroup",
+          "name": "test-subnetgroup",
+          "namePrefix": "",
+          "subnetIds": [
+            "subnet-04b4d0569ca28b59f",
+            "subnet-0f9770171c9ef8b97"
+          ],
+          "supportedNetworkTypes": [
+            "IPV4"
+          ],
+          "vpcId": "vpc-0c3e9264060a0e177"
+        },
+        "parent": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "dependencies": [
+          "urn:pulumi:test::test::aws:ec2/subnet:Subnet::subneta",
+          "urn:pulumi:test::test::aws:ec2/subnet:Subnet::subnetb"
+        ],
+        "provider": "urn:pulumi:test::test::pulumi:providers:aws::default::27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "propertyDependencies": {
+          "subnetIds": [
+            "urn:pulumi:test::test::aws:ec2/subnet:Subnet::subneta",
+            "urn:pulumi:test::test::aws:ec2/subnet:Subnet::subnetb"
+          ]
+        },
+        "created": "2026-06-15T15:48:10.560261Z",
+        "modified": "2026-06-15T15:48:10.560261Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#996"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1220"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1075"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#505"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#319"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/go/pulumi/run.go#140"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      },
+      {
+        "urn": "urn:pulumi:test::test::aws:rds/instance:Instance::tested-resource",
+        "custom": true,
+        "id": "db-DCEFIJQM75A2HSFR63SC7JSV6A",
+        "type": "aws:rds/instance:Instance",
+        "inputs": {
+          "__defaults": [
+            "applyImmediately",
+            "autoMinorVersionUpgrade",
+            "copyTagsToSnapshot",
+            "dedicatedLogVolume",
+            "deleteAutomatedBackups",
+            "identifier",
+            "monitoringInterval",
+            "performanceInsightsEnabled",
+            "publiclyAccessible"
+          ],
+          "allocatedStorage": 20,
+          "applyImmediately": false,
+          "autoMinorVersionUpgrade": true,
+          "copyTagsToSnapshot": false,
+          "dbName": "mydbname",
+          "dbSubnetGroupName": "test-subnetgroup",
+          "dedicatedLogVolume": false,
+          "deleteAutomatedBackups": true,
+          "engine": "postgres",
+          "identifier": "tested-resource3962577",
+          "instanceClass": "db.t4g.micro",
+          "monitoringInterval": 0,
+          "password": {
+            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+            "plaintext": "\"REDACTED BY PROVIDERTEST\""
+          },
+          "performanceInsightsEnabled": false,
+          "publiclyAccessible": false,
+          "skipFinalSnapshot": true,
+          "storageType": "gp3",
+          "username": "mydbuser",
+          "vpcSecurityGroupIds": [
+            "sg-070e7cf967d5c1c52"
+          ]
+        },
+        "outputs": {
+          "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":3000000000000,\"delete\":3600000000000,\"update\":4800000000000},\"schema_version\":\"2\"}",
+          "address": "tested-resource3962577.chuqccm8uxqx.us-west-2.rds.amazonaws.com",
+          "allocatedStorage": 20,
+          "allowMajorVersionUpgrade": null,
+          "applyImmediately": false,
+          "arn": "arn:aws:rds:us-west-2:616138583583:db:tested-resource3962577",
+          "autoMinorVersionUpgrade": true,
+          "availabilityZone": "us-west-2b",
+          "backupRetentionPeriod": 0,
+          "backupTarget": "region",
+          "backupWindow": "11:32-12:02",
+          "blueGreenUpdate": null,
+          "caCertIdentifier": "rds-ca-rsa2048-g1",
+          "characterSetName": "",
+          "copyTagsToSnapshot": false,
+          "customIamInstanceProfile": "",
+          "customerOwnedIpEnabled": false,
+          "databaseInsightsMode": "standard",
+          "dbName": "mydbname",
+          "dbSubnetGroupName": "test-subnetgroup",
+          "dedicatedLogVolume": false,
+          "deleteAutomatedBackups": true,
+          "deletionProtection": false,
+          "domain": "",
+          "domainAuthSecretArn": "",
+          "domainDnsIps": null,
+          "domainFqdn": "",
+          "domainIamRoleName": "",
+          "domainOu": "",
+          "enabledCloudwatchLogsExports": null,
+          "endpoint": "tested-resource3962577.chuqccm8uxqx.us-west-2.rds.amazonaws.com:5432",
+          "engine": "postgres",
+          "engineLifecycleSupport": "open-source-rds-extended-support",
+          "engineVersion": "18.3",
+          "engineVersionActual": "18.3",
+          "finalSnapshotIdentifier": null,
+          "hostedZoneId": "Z1PVIF0B656C1W",
+          "iamDatabaseAuthenticationEnabled": false,
+          "id": "db-DCEFIJQM75A2HSFR63SC7JSV6A",
+          "identifier": "tested-resource3962577",
+          "identifierPrefix": "",
+          "instanceClass": "db.t4g.micro",
+          "iops": 3000,
+          "kmsKeyId": "",
+          "latestRestorableTime": "",
+          "licenseModel": "postgresql-license",
+          "listenerEndpoints": [],
+          "maintenanceWindow": "wed:12:11-wed:12:41",
+          "manageMasterUserPassword": null,
+          "masterUserSecretKmsKeyId": null,
+          "masterUserSecrets": [],
+          "maxAllocatedStorage": 0,
+          "monitoringInterval": 0,
+          "monitoringRoleArn": "",
+          "multiAz": false,
+          "ncharCharacterSetName": "",
+          "networkType": "IPV4",
+          "optionGroupName": "default:postgres-18",
+          "parameterGroupName": "default.postgres18",
+          "password": {
+            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+            "plaintext": "\"REDACTED BY PROVIDERTEST\""
+          },
+          "passwordWo": {
+            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+            "plaintext": "null"
+          },
+          "passwordWoVersion": null,
+          "performanceInsightsEnabled": false,
+          "performanceInsightsKmsKeyId": "",
+          "performanceInsightsRetentionPeriod": 0,
+          "port": 5432,
+          "publiclyAccessible": false,
+          "replicaMode": "",
+          "replicas": [],
+          "replicateSourceDb": "",
+          "resourceId": "db-DCEFIJQM75A2HSFR63SC7JSV6A",
+          "restoreToPointInTime": null,
+          "s3Import": null,
+          "skipFinalSnapshot": true,
+          "snapshotIdentifier": null,
+          "status": "available",
+          "storageEncrypted": false,
+          "storageThroughput": 125,
+          "storageType": "gp3",
+          "timezone": "",
+          "upgradeStorageConfig": null,
+          "username": "mydbuser",
+          "vpcSecurityGroupIds": [
+            "sg-070e7cf967d5c1c52"
+          ]
+        },
+        "parent": "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+        "dependencies": [
+          "urn:pulumi:test::test::aws:ec2/securityGroup:SecurityGroup::securitygroup",
+          "urn:pulumi:test::test::aws:rds/subnetGroup:SubnetGroup::subnetgroup"
+        ],
+        "provider": "urn:pulumi:test::test::pulumi:providers:aws::default::27d00354-bd3d-4301-81d4-6546608b3ec0",
+        "propertyDependencies": {
+          "allocatedStorage": [],
+          "dbName": [],
+          "dbSubnetGroupName": [
+            "urn:pulumi:test::test::aws:rds/subnetGroup:SubnetGroup::subnetgroup"
+          ],
+          "engine": [],
+          "instanceClass": [],
+          "password": [],
+          "skipFinalSnapshot": [],
+          "storageType": [],
+          "username": [],
+          "vpcSecurityGroupIds": [
+            "urn:pulumi:test::test::aws:ec2/securityGroup:SecurityGroup::securitygroup"
+          ]
+        },
+        "additionalSecretOutputs": [
+          "password"
+        ],
+        "created": "2026-06-15T15:52:46.180308Z",
+        "modified": "2026-06-15T15:52:46.180308Z",
+        "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440",
+        "stackTrace": [
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1440"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#996"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1220"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#1075"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/run.go#505"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#319"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/go/pulumi/run.go#140"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/work/pulumi-yaml/pulumi-yaml/pkg/server/server.go#317"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.219.0/proto/go/language_grpc.pb.go#579"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1405"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1815"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../home/runner/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go#1035"
+          },
+          {
+            "sourcePosition": "project:///../../../../../../../../../opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_arm64.s#1223"
+          }
+        ]
+      }
+    ],
+    "metadata": {}
+  }
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -3233,15 +3233,19 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo { 
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"identifier": {
 						Default: &tfbridge.DefaultInfo{
-							From: func(res *tfbridge.PulumiResource) (interface{}, error) {
-								name, rand, maxlen := res.URN.Name(), 7, 255
-								if engine, ok := res.Properties["engine"]; ok && engine.IsString() {
+							AutoNamed: true,
+							ComputeDefault: func(ctx context.Context, opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
+								rand, maxlen := 7, 255
+								if engine, ok := opts.Properties["engine"]; ok && engine.IsString() {
 									if strings.Contains(strings.ToLower(engine.StringValue()), "sqlserver") {
 										// SQL Server identifiers are capped at 15 characters.
 										rand, maxlen = 3, 15
 									}
 								}
-								return resource.NewUniqueHex(name, rand, maxlen)
+								return tfbridge.ComputeAutoNameDefault(ctx, tfbridge.AutoNameOptions{
+									Randlen: rand,
+									Maxlen:  maxlen,
+								}, opts)
 							},
 						},
 					},
@@ -4060,7 +4064,7 @@ func ProviderFromMeta(metaInfo *tfbridge.MetadataInfo) *tfbridge.ProviderInfo { 
 					"cluster_name": tfbridge.AutoName("clusterName", 255, "-"),
 				},
 			},
-			"aws_msk_configuration":            {Tok: awsResource(mskMod, "Configuration")},
+			"aws_msk_configuration": {Tok: awsResource(mskMod, "Configuration")},
 			"aws_msk_replicator": {
 				Tok: awsResource(mskMod, "Replicator"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -2,11 +2,14 @@ package provider
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -178,6 +181,120 @@ func TestCustomAutoNameTransforms(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRdsInstanceIdentifierAutonaming(t *testing.T) {
+	t.Parallel()
+
+	field := Provider().Resources["aws_db_instance"].Fields["identifier"]
+	require.NotNil(t, field.Default)
+	assert.True(t, field.Default.AutoNamed)
+	require.NotNil(t, field.Default.ComputeDefault)
+
+	tests := []struct {
+		name        string
+		opts        tfbridge.ComputeDefaultOptions
+		want        string
+		wantPattern *regexp.Regexp
+		wantErr     string
+	}{
+		{
+			name: "default keeps legacy name shape",
+			opts: rdsIdentifierDefaultOptions("rds", resource.PropertyMap{}),
+			wantPattern: regexp.MustCompile(
+				`^rds[0-9a-f]{7}$`),
+		},
+		{
+			name: "propose uses configured name",
+			opts: withRdsIdentifierAutonaming(
+				rdsIdentifierDefaultOptions("rds", resource.PropertyMap{}),
+				"dev-rds", info.ComputeDefaultAutonamingModePropose),
+			want: "dev-rds",
+		},
+		{
+			name: "enforce uses exact configured name",
+			opts: withRdsIdentifierAutonaming(
+				rdsIdentifierDefaultOptions("rds", resource.PropertyMap{}),
+				"Dev_RDS", info.ComputeDefaultAutonamingModeEnforce),
+			want: "Dev_RDS",
+		},
+		{
+			name: "disable errors when identifier is absent",
+			opts: withRdsIdentifierAutonaming(
+				rdsIdentifierDefaultOptions("rds", resource.PropertyMap{}),
+				"dev-rds", info.ComputeDefaultAutonamingModeDisable),
+			wantErr: "automatic naming is disabled",
+		},
+		{
+			name: "sqlserver default preserves shorter legacy suffix",
+			opts: rdsIdentifierDefaultOptions("sqlserver-db", resource.PropertyMap{
+				"engine": resource.NewStringProperty("sqlserver-ex"),
+			}),
+			wantPattern: regexp.MustCompile(
+				`^sqlserver-db[0-9a-f]{3}$`),
+		},
+		{
+			name: "prior state reuses existing identifier",
+			opts: withRdsIdentifierAutonaming(
+				withRdsIdentifierPriorValue(
+					rdsIdentifierDefaultOptions("rds", resource.PropertyMap{}), "existing-rds"),
+				"dev-rds", info.ComputeDefaultAutonamingModePropose),
+			want: "existing-rds",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := field.Default.ComputeDefault(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			name, ok := actual.(string)
+			require.Truef(t, ok, "expected string result, got %T", actual)
+			if tt.want != "" {
+				assert.Equal(t, tt.want, name)
+			}
+			if tt.wantPattern != nil {
+				assert.Regexp(t, tt.wantPattern, name)
+			}
+		})
+	}
+}
+
+func rdsIdentifierDefaultOptions(
+	urnName string, properties resource.PropertyMap,
+) tfbridge.ComputeDefaultOptions {
+	return tfbridge.ComputeDefaultOptions{
+		URN:        resource.NewURN("stack", "project", "", "aws:index/resource:Resource", urnName),
+		Properties: properties,
+		Seed:       []byte("test-seed"),
+	}
+}
+
+func withRdsIdentifierAutonaming(
+	opts tfbridge.ComputeDefaultOptions,
+	proposedName string, mode info.ComputeDefaultAutonamingOptionsMode,
+) tfbridge.ComputeDefaultOptions {
+	opts.Autonaming = &info.ComputeDefaultAutonamingOptions{
+		ProposedName: proposedName,
+		Mode:         mode,
+	}
+	return opts
+}
+
+func withRdsIdentifierPriorValue(
+	opts tfbridge.ComputeDefaultOptions, value string,
+) tfbridge.ComputeDefaultOptions {
+	opts.PriorState = resource.PropertyMap{
+		"identifier": resource.NewStringProperty(value),
+	}
+	opts.PriorValue = resource.NewStringProperty(value)
+	return opts
 }
 
 func TestExtractTags(t *testing.T) {


### PR DESCRIPTION
## Summary

This updates `aws:rds/instance:Instance` so the generated `identifier` default participates in Pulumi autonaming configuration.

The RDS identifier default now uses `ComputeDefault` with `AutoNamed: true` and delegates to `tfbridge.ComputeAutoNameDefault`. This preserves the previous fallback naming shape, including the shorter SQL Server suffix, while allowing `pulumi:autonaming` patterns and modes to apply.

## Compatibility

Existing resources should keep their prior identifier during provider upgrades because `ComputeAutoNameDefault` reuses the prior value when prior state is available. The upgrade fixture covers a baseline stack created by `v6.78.0` and previews it with the new provider.

`identifierPrefix` remains a separate explicit naming mechanism. There is no provider-specific prefix guard here: the bridge's generic Terraform `ConflictsWith` handling suppresses the `identifier` default when `identifierPrefix` is present. The PR includes a preview/gRPC assertion for that path.

## Tests

- `make provider`
- `make test_provider test_provider_cmd="cd provider && go test -p=1 -vet=off -v -short -run TestRdsInstanceIdentifierAutonaming -count=1 ."`
- `make test TESTTAGS=java TESTPARALLELISM=1 GOTESTARGS="-run \"^TestRdsInstance(Autonaming|IdentifierPrefixSuppressesAutonaming)$\" -count=1"`
- `make test TESTTAGS=java TESTPARALLELISM=1 GOTESTARGS="-run ^TestRdsInstanceAutonamingUpgrade$ -count=1"`
- `git diff --check`

Notes:

- `TestRdsInstanceAutonaming` is preview-only and asserts the provider `Check` response via gRPC log instead of creating a live RDS instance.
- `TestRdsInstanceIdentifierPrefixSuppressesAutonaming` proves `identifierPrefix` suppresses the `identifier` default through the bridge conflict path.
- `TestRdsInstanceAutonamingUpgrade` uses the recorded baseline stack to validate old-state compatibility.

fixes #6434
