### PR TITLE
ci: skip TestAccSQSQueue_managedEncryption upstream test

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -108,6 +108,7 @@ jobs:
       - if: ${{ matrix.tests }}
         name: Test ${{ matrix.service }}
         # TODO[pulumi/pulumi-aws#6115]: reenable TestAccSQSQueue_List_basic
+        # TODO[pulumi/pulumi-aws#6517]: reenable TestAccSQSQueue_managedEncryption
         run: |
           cd upstream
-          TF_ACC=1 make testacc GO_VER=go PKG=${{ matrix.service }} ACCTEST_PARALLELISM=6 TESTS="${{ matrix.tests }}" TESTARGS="-skip 'tags|TestAccSQSQueue_List_basic|.*/.*/Tags'"
+          TF_ACC=1 make testacc GO_VER=go PKG=${{ matrix.service }} ACCTEST_PARALLELISM=6 TESTS="${{ matrix.tests }}" TESTARGS="-skip 'tags|TestAccSQSQueue_List_basic|TestAccSQSQueue_managedEncryption|.*/.*/Tags'"


### PR DESCRIPTION
Skips the upstream acceptance test `TestAccSQSQueue_managedEncryption` in `run-upstream-tests`. Its step 3 deletes the queue via an inline `CheckSDKResourceDisappears` without `ExpectNonEmptyPlan: true`, so the post-apply refresh plan is non-empty (`+ create`) and the step fails, unlike the sibling `_disappears`/`_recentlyDeleted` tests which set it.

Tracked upstream at hashicorp/terraform-provider-aws#48831 and on our side by #6517. Re-enable once fixed upstream.

Part of #6517
