### PR TITLE
Bump the runner size on upgrade-provider workflow

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -35,3 +35,4 @@ releaseVerification:
 autoMergeProviderUpgrades: false
 runner:
     prerequisites: pulumi-ubuntu-8core
+    upgradeProvider: pulumi-ubuntu-8core

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   upgrade_provider:
     name: upgrade-provider
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
       # Run as first step so we don't delete things that have just been installed
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
Recently the upgrade-provider workflow has been failing due to resource constraints.

Failing workflow: https://github.com/pulumi/pulumi-aws/actions/runs/29470316917/job/87532035402
Tested with this branch: https://github.com/pulumi/pulumi-aws/actions/runs/29509129254/job/87657692538