### PR TITLE
fix: Fix aws_route timeouts-only update fix from upstream PR #47413

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -56,7 +56,7 @@ jobs:
           - service: sqs
             tests: TestAccSQSQueue
           - service: ec2
-            tests: TestAccEC2KeyPair_publicKey
+            tests: 'TestAccEC2KeyPair_publicKey|TestAccVPCRoute_timeoutsOnlyChange'
           - service: docdb
             tests: TestAccDocDBCluster_basic
           - service: redshiftserverless

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -694,19 +694,12 @@ func TestRegress5219(t *testing.T) {
 // Regress aws_route update failing with "route target attribute not
 // specified" when only customTimeouts changes, see pulumi/pulumi-aws#6549
 func TestRegress6549(t *testing.T) {
-	skipIfShort(t)
-	t.Parallel()
+	opts := nodeProviderUpgradeOpts()
+	opts.skipDefaultPreviewTest = true
 	dir := filepath.Join("test-programs", "regress-6549")
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	options := []opttest.Option{
-		opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
-		opttest.YarnLink("@pulumi/aws"),
-	}
-	test := pulumitest.NewPulumiTest(t, dir, options...)
-	test.Up(t)
+	test, _ := testProviderUpgrade(t, dir, opts,
+		optproviderupgrade.NewSourcePath(filepath.Join(dir, "step1")))
 
-	test.UpdateSource(t, filepath.Join(dir, "step1"))
 	res := test.Up(t, optup.Diff())
 
 	assert.Equal(t, map[string]int{

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pulumi/providertest/optproviderupgrade"
 	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/assertup"
 	"github.com/pulumi/providertest/pulumitest/optnewstack"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
@@ -703,10 +704,12 @@ func TestRegress6549(t *testing.T) {
 
 	res := test.Up(t, optup.Diff())
 
-	assert.Equal(t, map[string]int{
-		"update": 1,
-		"same":   3, // vpc, internet gateway, route table
-	}, *res.Summary.ResourceChanges)
+	// The v6->v7 provider upgrade itself introduces incidental diffs on
+	// unrelated resources (e.g. new computed attributes), so assert only on
+	// what this regression test cares about: the update succeeds and the
+	// Route is not replaced.
+	assertup.HasNoReplacements(t, res)
+	assert.NotZero(t, (*res.Summary.ResourceChanges)["update"])
 }
 
 type expectFailure struct {

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -691,6 +691,30 @@ func TestRegress5219(t *testing.T) {
 	assert.Truef(t, t2.Sub(t1) < 10*time.Minute, "Expected pulumi up to fail within 10 minutes")
 }
 
+// Regress aws_route update failing with "route target attribute not
+// specified" when only customTimeouts changes, see pulumi/pulumi-aws#6549
+func TestRegress6549(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+	dir := filepath.Join("test-programs", "regress-6549")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	options := []opttest.Option{
+		opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
+		opttest.YarnLink("@pulumi/aws"),
+	}
+	test := pulumitest.NewPulumiTest(t, dir, options...)
+	test.Up(t)
+
+	test.UpdateSource(t, filepath.Join(dir, "step1"))
+	res := test.Up(t, optup.Diff())
+
+	assert.Equal(t, map[string]int{
+		"update": 1,
+		"same":   3, // vpc, internet gateway, route table
+	}, *res.Summary.ResourceChanges)
+}
+
 type expectFailure struct {
 	*testing.T
 	failed bool

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -696,6 +696,7 @@ func TestRegress5219(t *testing.T) {
 func TestRegress6549(t *testing.T) {
 	opts := nodeProviderUpgradeOpts()
 	opts.skipDefaultPreviewTest = true
+	opts.setEnvRegion = false
 	dir := filepath.Join("test-programs", "regress-6549")
 	test, _ := testProviderUpgrade(t, dir, opts,
 		optproviderupgrade.NewSourcePath(filepath.Join(dir, "step1")))

--- a/examples/test-programs/regress-6549/Pulumi.yaml
+++ b/examples/test-programs/regress-6549/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: regress-6549
+runtime: nodejs
+description: Regress aws_route update failing when only customTimeouts changes
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/examples/test-programs/regress-6549/index.ts
+++ b/examples/test-programs/regress-6549/index.ts
@@ -1,0 +1,12 @@
+import * as aws from "@pulumi/aws";
+
+const vpc = new aws.ec2.Vpc("test", { cidrBlock: "10.1.0.0/16" });
+const igw = new aws.ec2.InternetGateway("test", { vpcId: vpc.id });
+const routeTable = new aws.ec2.RouteTable("test", { vpcId: vpc.id });
+const route = new aws.ec2.Route("test", {
+    routeTableId: routeTable.id,
+    destinationCidrBlock: "10.3.0.0/16",
+    gatewayId: igw.id,
+});
+
+export const routeId = route.id;

--- a/examples/test-programs/regress-6549/package.json
+++ b/examples/test-programs/regress-6549/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "regress-6549",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^6.0.0"
+    }
+}

--- a/examples/test-programs/regress-6549/step1/index.ts
+++ b/examples/test-programs/regress-6549/step1/index.ts
@@ -11,7 +11,7 @@ const route = new aws.ec2.Route("test", {
     customTimeouts: {
         create: "5m",
         delete: "5m",
-    },
+    }
 });
 
 export const routeId = route.id;

--- a/examples/test-programs/regress-6549/step1/index.ts
+++ b/examples/test-programs/regress-6549/step1/index.ts
@@ -1,0 +1,17 @@
+import * as aws from "@pulumi/aws";
+
+const vpc = new aws.ec2.Vpc("test", { cidrBlock: "10.1.0.0/16" });
+const igw = new aws.ec2.InternetGateway("test", { vpcId: vpc.id });
+const routeTable = new aws.ec2.RouteTable("test", { vpcId: vpc.id });
+const route = new aws.ec2.Route("test", {
+    routeTableId: routeTable.id,
+    destinationCidrBlock: "10.3.0.0/16",
+    gatewayId: igw.id,
+}, {
+    customTimeouts: {
+        create: "5m",
+        delete: "5m",
+    },
+});
+
+export const routeId = route.id;

--- a/examples/test-programs/regress-6549/tsconfig.json
+++ b/examples/test-programs/regress-6549/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/patches/0028-Backport-fix-aws_route-update-failure-when-only-time.patch
+++ b/patches/0028-Backport-fix-aws_route-update-failure-when-only-time.patch
@@ -1,0 +1,112 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piers Karsenbarg <piers@pulumi.com>
+Date: Fri, 17 Jul 2026 13:11:59 +0100
+Subject: [PATCH] Backport fix aws_route update failure when only timeouts
+ change from hashicorp/terraform-provider-aws#47413
+
+
+diff --git a/internal/service/ec2/vpc_route.go b/internal/service/ec2/vpc_route.go
+index 286fb0568e5..cdc01f2f7c4 100644
+--- a/internal/service/ec2/vpc_route.go
++++ b/internal/service/ec2/vpc_route.go
+@@ -379,6 +379,12 @@ func resourceRouteFlatten(d *schema.ResourceData, route *awstypes.Route) diag.Di
+ 
+ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+ 	var diags diag.Diagnostics
++
++	// If no route target attributes changed, there is nothing to update via the API.
++	if !d.HasChanges(routeValidTargets...) {
++		return diags
++	}
++
+ 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+ 
+ 	destinationAttributeKey, destination, err := routeDestinationAttribute(d)
+diff --git a/internal/service/ec2/vpc_route_test.go b/internal/service/ec2/vpc_route_test.go
+index 618e778c7f0..59f8a689eb3 100644
+--- a/internal/service/ec2/vpc_route_test.go
++++ b/internal/service/ec2/vpc_route_test.go
+@@ -1531,6 +1531,37 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
+ 	})
+ }
+ 
++func TestAccVPCRoute_timeoutsOnlyChange(t *testing.T) {
++	ctx := acctest.Context(t)
++	var route awstypes.Route
++	resourceName := "aws_route.test"
++	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
++	destinationCidr := "10.3.0.0/16"
++
++	acctest.ParallelTest(ctx, t, resource.TestCase{
++		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
++		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
++		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
++		CheckDestroy:             testAccCheckRouteDestroy(ctx, t),
++		Steps: []resource.TestStep{
++			{
++				Config: testAccVPCRouteConfig_ipv4InternetGateway(rName, destinationCidr),
++				Check:  testAccCheckRouteExists(ctx, t, resourceName, &route),
++			},
++			{
++				Config: testAccVPCRouteConfig_ipv4InternetGatewayWithTimeouts(rName, destinationCidr),
++				Check:  testAccCheckRouteExists(ctx, t, resourceName, &route),
++			},
++			{
++				ResourceName:      resourceName,
++				ImportState:       true,
++				ImportStateIdFunc: testAccRouteImportStateIdFunc(resourceName),
++				ImportStateVerify: true,
++			},
++		},
++	})
++}
++
+ func TestAccVPCRoute_ipv4ToVPCEndpoint(t *testing.T) {
+ 	ctx := acctest.Context(t)
+ 	if testing.Short() {
+@@ -2727,6 +2758,45 @@ resource "aws_route" "test" {
+ `, rName, destinationCidr)
+ }
+ 
++func testAccVPCRouteConfig_ipv4InternetGatewayWithTimeouts(rName, destinationCidr string) string {
++	return fmt.Sprintf(`
++resource "aws_vpc" "test" {
++  cidr_block = "10.1.0.0/16"
++
++  tags = {
++    Name = %[1]q
++  }
++}
++
++resource "aws_internet_gateway" "test" {
++  vpc_id = aws_vpc.test.id
++
++  tags = {
++    Name = %[1]q
++  }
++}
++
++resource "aws_route_table" "test" {
++  vpc_id = aws_vpc.test.id
++
++  tags = {
++    Name = %[1]q
++  }
++}
++
++resource "aws_route" "test" {
++  route_table_id         = aws_route_table.test.id
++  destination_cidr_block = %[2]q
++  gateway_id             = aws_internet_gateway.test.id
++
++  timeouts {
++    create = "5m"
++    delete = "5m"
++  }
++}
++`, rName, destinationCidr)
++}
++
+ func testAccVPCRouteConfig_ipv4InternetGatewayDuplicate(rName, destinationCidr string) string {
+ 	return fmt.Sprintf(`
+ resource "aws_vpc" "test" {


### PR DESCRIPTION
## Summary
- Adds patch 0028 backporting hashicorp/terraform-provider-aws#47413, fixing `aws_route` update failures with "route target attribute not specified" when only the `timeouts` block changes (or when a provider upgrade produces a timeouts-only diff).
- Adds an early return in `resourceRouteUpdate` when no route target attributes have changed, avoiding an unnecessary/erroring API call.
- Includes the upstream acceptance test `TestAccVPCRoute_timeoutsOnlyChange` and its supporting config helper.

## Test plan
- [ ] Run `./scripts/upstream.sh init -f` and confirm the patch applies cleanly
- [ ] Run acceptance tests for `TestAccVPCRoute_timeoutsOnlyChange` / `TestAccVPCRoute_basic` in `internal/service/ec2`

Fixed: #6549