### PR TITLE
Document provider ownership, testing, and patch workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/upstream-patch.yaml
+++ b/.github/ISSUE_TEMPLATE/upstream-patch.yaml
@@ -1,0 +1,102 @@
+name: Upstream Patch Tracking
+description: Track why Pulumi AWS carries a patch and when it can be removed
+labels: ["area/patch"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue to record the design, compatibility, testing, and removal
+        conditions for a patch carried by Pulumi AWS. Read
+        [`docs/upstream-patches.md`](https://github.com/pulumi/pulumi-aws/blob/master/docs/upstream-patches.md) before completing it.
+
+  - type: dropdown
+    id: owner-label
+    attributes:
+      label: Owning repository
+      description: Select the matching existing label and apply it to the issue after creation.
+      options:
+        - awaiting-upstream
+        - awaiting/bridge
+        - awaiting/core
+        - awaiting/codegen
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-work
+    attributes:
+      label: Related issues and pull requests
+      description: Link the user-facing issue, owning-project issue, upstream pull request, and Pulumi patch pull request when available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: need
+    attributes:
+      label: Why the patch is needed
+      description: Explain why Pulumi AWS should carry the change instead of waiting for the owner or solving it without a patch.
+      placeholder: Include the affected behavior, urgency, alternatives considered, and why those alternatives are insufficient.
+    validations:
+      required: true
+
+  - type: textarea
+    id: upstream-assessment
+    attributes:
+      label: Owning-project change
+      description: Assess the proposed owner-side solution and explain whether the patch matches it.
+      placeholder: |
+        If an external contributor opened the upstream change, assess whether it is complete enough to carry.
+        If Pulumi needs a different change, explain why and whether a separate upstream pull request is required.
+        For Pulumi-specific behavior, explain why the change would be incorrect or irrelevant upstream.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and maintenance risks
+      description: Describe how the patch may affect existing programs, state, future upgrades, and eventual removal. Address relevant public API or schema changes, state migrations, identifiers, import behavior, cross-cutting resource effects, the risk that upstream adopts an incompatible design, known unknowns, and untested behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Regression coverage
+      description: Name the tests that prove the behavior and where CI selects them. Mark unavailable or inapplicable coverage explicitly.
+      placeholder: |
+        - Upstream acceptance test:
+        - aws-upstream-tests.yml selection:
+        - Pulumi examples regression test:
+        - Provider-upgrade test, if required:
+        - Other validation or blocked evidence:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lifetime
+    attributes:
+      label: Expected lifetime
+      options:
+        - Temporary until the owning project releases a compatible solution
+        - Intentionally permanent Pulumi-specific divergence
+        - Unknown pending owner or compatibility investigation
+    validations:
+      required: true
+
+  - type: textarea
+    id: removal
+    attributes:
+      label: Removal conditions and validation
+      description: State the observable conditions for removing the patch and the tests required to prove removal is safe. “Fixed upstream” alone is insufficient.
+      placeholder: For a permanent patch, explain why removal is not expected and what future change would require reassessment.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Patch policy
+      options:
+        - label: I have read `docs/upstream-patches.md` and will report exact test outcomes in the patch pull request.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,20 @@
 - [ ] Upstream or patch pipeline change (`upstream/`, `patches/`, `scripts/upstream.sh`)
 - [ ] CI workflow source change (`.ci-mgmt.yaml`)
 
+## Carried Upstream Patch
+Complete this section only when adding or changing a patch under `patches/`. See [`docs/upstream-patches.md`](https://github.com/pulumi/pulumi-aws/blob/master/docs/upstream-patches.md).
+
+- [ ] Patch tracking issue created:
+- [ ] Owning-project issue or pull request linked:
+- [ ] Differences from the owning-project change explained:
+- [ ] Compatibility and removal risks documented:
+- [ ] Required upstream acceptance test added:
+- [ ] Test selected in `.github/workflows/aws-upstream-tests.yml`:
+- [ ] Pulumi regression test added:
+- [ ] Provider-upgrade coverage added, if required:
+
 ## Validation Evidence
-Paste exact commands and outcomes.
+Paste exact commands and outcomes. Include outcomes for the patch tests above, and identify tests that were skipped, not selected, or blocked by credentials.
 
 - [ ] `make lint`
 - [ ] `make test_provider`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@ This is a Go-based Pulumi resource provider that bridges the Terraform provider 
 - `make build` - Build provider and all SDKs
 - `make provider` - Build provider binary
 - `make schema` - Generate provider schema
-- `make tfgen` - Generate SDKs from schema
 - `make upstream` - Initialize upstream submodule
 
 ### SDK Targets
@@ -22,8 +21,8 @@ This is a Go-based Pulumi resource provider that bridges the Terraform provider 
 - `make build_java` - Build Java SDK
 
 ### Development Targets
-- `make lint_provider` - Lint provider Go code
-- `make test_provider` - Run provider unit tests
+- `make lint` - Lint provider Go code
+- `make test_provider` - Run root provider package tests
 
 ## Repository Structure
 
@@ -31,31 +30,39 @@ This is a Go-based Pulumi resource provider that bridges the Terraform provider 
 provider/             -- Go provider implementation
 sdk/                  -- Generated SDKs (never edit directly)
 upstream/             -- Terraform provider submodule
+patches/              -- Carried upstream patches
 scripts/              -- Build utilities
-examples/             -- Example Pulumi programs
-.ci-mgmt.yaml         -- CI management configuration
-Makefile              -- Build orchestration
+examples/             -- Pulumi tests and programs
+.ci-mgmt.yaml         -- Source for generated CI and Makefile
+Makefile              -- Generated build orchestration
 ```
 
 ### Key Files
 - `provider/resources.go` - Resource definitions
-- `provider/resources_test.go` - Unit tests
+- `provider/resources_test.go` - Provider tests
 
 ## Development Workflow
 
 1. Initialize repository: `make upstream`
-2. Make changes in `provider/`
-3. Lint: `make lint_provider`
+2. Make changes in `provider/` or, for a carried upstream patch, `upstream/`
+3. Lint: `make lint`
 4. Test: `make test_provider`
 5. Build provider: `make provider`
-6. Build SDKs: `make build_sdks`
+6. Build SDKs when schema changes: `make build_sdks`
+
+## Investigation and Testing
+
+- Start provider issue investigation with `triage-provider-issue`; invoke a narrower helper directly only when that route is already established.
+- Before adding or changing tests, read `TESTING.md` and use the lowest-cost test that directly proves the behavior.
+- Before deciding, creating, or materially changing a carried patch, read `docs/upstream-patches.md` for the shared policy and Pulumi AWS-specific requirements, then use `upstream-patches` for patch mechanics.
+- Use `pulumi-upgrade-provider` for provider upgrades.
 
 ## Rules
 
-- Before deciding, creating, or materially changing a carried patch, use `upstream-patches` for the shared policy and patch mechanics, then read `docs/upstream-patches.md` for Pulumi AWS-specific requirements.
 - **Never work directly in `sdk/` folders** - All SDK generation is automated through `make`
+- **Never edit the generated `Makefile` or ci-mgmt-marked workflows directly** - Change `.ci-mgmt.yaml` and run `make ci-mgmt`
 - **Never cancel running builds** - Builds may take several minutes
-- **Do not run tests in `examples/`** - They require cloud credentials and run in CI
+- **Do not run unfiltered `make test` by default** - The `examples/` package mixes local, recorded, and live AWS tests; inspect and run the focused test described in `TESTING.md`
 - **Set timeouts to 300+ seconds** for build operations
 
 ## CI Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Makefile              -- Generated build orchestration
 ## Investigation and Testing
 
 - Start provider issue investigation with `triage-provider-issue`; invoke a narrower helper directly only when that route is already established.
+- Use `docs/provider-runtime.md` to distinguish engine, bridge, upstream provider, and Pulumi AWS-owned behavior before choosing an editing point.
 - Before adding or changing tests, read `TESTING.md` and use the lowest-cost test that directly proves the behavior.
 - Before deciding, creating, or materially changing a carried patch, read `docs/upstream-patches.md` for the shared policy and Pulumi AWS-specific requirements, then use `upstream-patches` for patch mechanics.
 - Use `pulumi-upgrade-provider` for provider upgrades.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Makefile              -- Generated build orchestration
 - Start provider issue investigation with `triage-provider-issue`; invoke a narrower helper directly only when that route is already established.
 - Use `docs/provider-runtime.md` to distinguish engine, bridge, upstream provider, and Pulumi AWS-owned behavior before choosing an editing point.
 - Before adding or changing tests, read `TESTING.md` and use the lowest-cost test that directly proves the behavior.
-- Before deciding, creating, or materially changing a carried patch, read `docs/upstream-patches.md` for the shared policy and Pulumi AWS-specific requirements, then use `upstream-patches` for patch mechanics.
+- Before deciding, creating, or materially changing a carried patch, read `docs/upstream-patches.md` for the policy and Pulumi AWS-specific requirements, then use `upstream-patches` for patch mechanics.
 - Use `pulumi-upgrade-provider` for provider upgrades.
 
 ## Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Makefile              -- Build orchestration
 
 ## Rules
 
+- Before deciding, creating, or materially changing a carried patch, use `upstream-patches` for the shared policy and patch mechanics, then read `docs/upstream-patches.md` for Pulumi AWS-specific requirements.
 - **Never work directly in `sdk/` folders** - All SDK generation is automated through `make`
 - **Never cancel running builds** - Builds may take several minutes
 - **Do not run tests in `examples/`** - They require cloud credentials and run in CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,10 +49,10 @@ If you are using an AI coding assistant:
 ## Carrying Upstream Patches
 
 Upstream patches add recurring upgrade cost and can create behavior that Pulumi
-must maintain indefinitely. When contributing a patch, use the
-`upstream-patches` skill for shared patch policy and mechanics, then follow
-[`docs/upstream-patches.md`](./docs/upstream-patches.md) for Pulumi AWS-specific
-tracking, test, CI, and AWS safety requirements.
+must maintain indefinitely. Before contributing one, follow
+[`docs/upstream-patches.md`](./docs/upstream-patches.md) for patch policy and
+Pulumi AWS-specific tracking, test, CI, and AWS safety requirements. Use the
+`upstream-patches` skill for patch mechanics.
 
 Do not treat a patch applying cleanly as sufficient validation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,16 @@ If you are using an AI coding assistant:
 1. Do not manually edit generated files under `sdk/`.
 1. Include exact validation commands and outcomes in the pull request description.
 
+## Carrying Upstream Patches
+
+Upstream patches add recurring upgrade cost and can create behavior that Pulumi
+must maintain indefinitely. When contributing a patch, use the
+`upstream-patches` skill for shared patch policy and mechanics, then follow
+[`docs/upstream-patches.md`](./docs/upstream-patches.md) for Pulumi AWS-specific
+tracking, test, CI, and AWS safety requirements.
+
+Do not treat a patch applying cleanly as sufficient validation.
+
 ## Running Integration Tests
 
 The examples and integration tests in this repository will create and destroy real AWS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,19 +56,11 @@ tracking, test, CI, and AWS safety requirements.
 
 Do not treat a patch applying cleanly as sufficient validation.
 
-## Running Integration Tests
+## Testing
 
-The examples and integration tests in this repository will create and destroy real AWS
-cloud resources while running. Before running these tests, make sure that you have
-[configured Pulumi with AWS](https://pulumi.io/install/aws.html) successfully once before.
+See [`TESTING.md`](./TESTING.md) to choose the lowest-cost test that proves the behavior, use the repository's test helpers, and run focused tests.
 
-The only additional step you need to take to run tests in this repo is to set the
-`AWS_REGION` environment variable to the region you'd like to create test resources in.
-The integration tests do try to clean up after themselves by deleting everything that was
-created, but in the event of bugs or test failures you may need to go into the AWS Console
-and delete resources yourself.
-
-Once you have set `AWS_REGION` and configured your AWS credentials, `make test` will run your integration tests.
+The `examples/` package mixes live AWS tests, recorded provider-upgrade tests, and local checks. Do not run unfiltered `make test` unless you intend to run the full acceptance suite. For a live test, configure Pulumi with AWS, set `AWS_REGION`, inspect the fixture and cleanup path, and run only the named test. Failed cleanup may require manual removal of AWS resources.
 
 ## Generating IAM Policies
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,315 @@
+# Testing `pulumi-aws`
+
+Test the owning behavior at the cheapest layer that can prove it. The language and AWS resource used in a bug report do not determine the test: a Node.js program that exposes an AWS provider `Diff` bug may become a credential-free provider RPC replay if neither Node.js nor AWS is part of the invariant.
+
+For the shared test APIs, see the [`pulumitest` documentation](https://github.com/pulumi/providertest/blob/main/pulumitest/README.md). This guide explains which test belongs in this repository and gives the repository-specific setup for each test type.
+
+## Quick reference
+
+| Behavior to prove | Test to write | Location | AWS credentials |
+| --- | --- | --- | --- |
+| Pure helper, mapping, transform, or metadata rule | Provider unit test | `provider/*_test.go` | No |
+| Small `CheckConfig`, `Configure`, or other RPC with hand-built inputs | Direct provider server test | `provider/*_test.go` | No; use `httptest` for AWS requests |
+| Exact `Check`, `Diff`, or configuration RPC regression | Raw provider RPC replay | `provider/replay_regressions_test.go` or `provider/configure_test.go` | No |
+| Pulumi schema or generated API shape | Schema/codegen test and generated SDK build | `provider/`, `provider/cmd/`, and generated artifacts | No |
+| State written by an older provider | Provider-upgrade test | `examples/*_test.go` and `examples/testdata/recorded/` | Baseline recording: yes; replay may still need config credentials |
+| Real AWS CRUD, refresh, import, auth, or runtime behavior | YAML acceptance test | `examples/examples_yaml_test.go` and `examples/test-programs/` | Yes |
+| Generated package or language-runtime behavior | Language SDK test | Corresponding `examples/examples_<language>_test.go` | Only if the assertion also needs AWS |
+
+## Decide where the test belongs
+
+This guide covers tests for behavior owned or carried by `pulumi-aws`. Before writing one, state the failed invariant in one sentence and choose the lowest repository test layer that can observe it:
+
+1. If the behavior comes from `provider/`, a mapping, or an overlay, prefer a provider unit or RPC-level test.
+2. If the invariant begins with state written by an older Pulumi AWS provider, use a provider-upgrade test.
+3. If the Pulumi lifecycle or an AWS response is part of the invariant, use a focused program test under `examples/`.
+4. If the assertion concerns a generated class, function signature, package, or language runtime, use an SDK test.
+5. Use live AWS only when an AWS response, persisted remote state, authentication flow, or deployed runtime is part of the assertion.
+
+For a carried patch, follow [`docs/upstream-patches.md`](./docs/upstream-patches.md) in addition to this guide. If ownership has not been established, investigate it before adding a broad Pulumi test as a proxy for behavior owned elsewhere.
+
+A test that only proves that a common resource deployed is broad smoke. Add broad smoke only when it covers a missing packaging, runtime, authentication, or release boundary.
+
+## Provider unit tests
+
+Use a provider unit test when the relevant input can be constructed directly in Go. This is the preferred test for parsing, metadata, callbacks, and deterministic transforms because a failure points at provider-owned code without involving the engine or AWS.
+
+```go
+func TestParseAssumeRolesRejectsLegacyKey(t *testing.T) {
+    vars := resource.PropertyMap{
+        "assumeRole": resource.NewObjectProperty(resource.PropertyMap{
+            "roleArn": resource.NewStringProperty(
+                "arn:aws:iam::123456789012:role/example"),
+        }),
+    }
+
+    _, err := parseAssumeRoles(vars)
+    require.ErrorContains(t, err,
+        "invalid config key 'aws:assumeRole', should be 'aws:assumeRoles'")
+}
+```
+
+Put tests for the root provider package beside the code they exercise. Use an invariant test over all resources when the rule is provider-wide; `provider/resources_test.go` contains examples that compare generated resource metadata with the upstream schema.
+
+`make test_provider` currently runs `go test .` from `provider/`, so it does not execute tests under `provider/pkg/...` or `provider/cmd/...`. Those package-local tests exist, but do not treat them as CI coverage until the target is changed to include subpackages.
+
+Run root provider tests with:
+
+```sh
+make test_provider
+```
+
+Run one provider test with:
+
+```sh
+make test_provider GO_TEST_EXEC="go test -run '^TestName\\z' -count=1"
+```
+
+## Direct provider server tests
+
+Call the provider server directly when the RPC request is small and does not need to come from a real Pulumi program. This is useful for provider configuration and for behavior that makes a bounded AWS request which can be served by `httptest`.
+
+```go
+func TestCheckConfigRejectsLegacyAssumeRole(t *testing.T) {
+    unsetAWSEnv()
+    t.Setenv("AWS_ACCESS_KEY_ID", "test")
+    t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+    t.Setenv("AWS_REGION", "us-west-2")
+    t.Setenv("AWS_SKIP_CREDENTIALS_VALIDATION", "true")
+
+    provider, err := testProviderServer()
+    require.NoError(t, err)
+
+    _, err = provider.CheckConfig(context.Background(), &pulumirpc.CheckRequest{
+        Urn:  "urn:pulumi:test::project::pulumi:providers:aws::default",
+        Olds: mustStruct(t, map[string]any{}),
+        News: mustStruct(t, map[string]any{
+            "accessKey": "test",
+            "assumeRole": map[string]any{
+                "roleArn": "arn:aws:iam::123456789012:role/example",
+            },
+            "region":    "us-west-2",
+            "secretKey": "test",
+        }),
+    })
+
+    require.ErrorContains(t, err, "invalid config key 'aws:assumeRole'")
+}
+```
+
+If the exact engine-shaped request or old state is the regression input, use the existing raw RPC replay helper instead.
+
+## Raw provider RPC replay tests
+
+`replaySequence` sends complete recorded RPC requests to the current in-process provider and compares its responses with the embedded expectations. It is useful for a narrow `Check`, `Diff`, `CheckConfig`, `DiffConfig`, or `Configure` regression that would otherwise require a live Pulumi program.
+
+```go
+func TestCheckConfigWithUnknownKeys(t *testing.T) {
+    t.Parallel()
+
+    replaySequence(t, `[
+      {
+        "method": "/pulumirpc.ResourceProvider/CheckConfig",
+        "request": {
+          "urn": "urn:pulumi:test::project::pulumi:providers:aws::default",
+          "olds": {},
+          "news": {
+            "unknownKey": "injected",
+            "accessKey": "test",
+            "region": "us-east-1",
+            "secretKey": "test",
+            "skipCredentialsValidation": "true",
+            "skipRequestingAccountId": "true"
+          }
+        },
+        "response": {
+          "inputs": "*",
+          "failures": [{"reason": "*"}]
+        }
+      }
+    ]`)
+}
+```
+
+Use `setReplayAWSEnv` when the provider needs configuration but the RPC should not contact AWS. `replaySequence` constructs the real muxed provider server with an empty schema, which avoids the cost of loading the generated schema for methods that do not need it.
+
+The replay JSON is both input and assertion: `request` defines the regression scenario and `response` is the expected current behavior. Keep only the RPCs needed by the invariant. Large multi-method transcripts make failures harder to attribute and couple the test to unrelated provider output.
+
+To derive a replay from a real lifecycle:
+
+1. Reproduce the behavior with a focused `pulumitest` test; gRPC logging is enabled by default.
+2. Take the completed provider entry from `grpc.json`, not the `request_started` entry.
+3. Reduce it to the request fields needed to reproduce and the response fields that express the invariant.
+4. Replace account-specific identifiers with inert values and inspect the result for credentials or resource data.
+5. Put the test in `provider/replay_regressions_test.go`, or in `provider/configure_test.go` for configuration RPCs.
+
+There is no repository helper today that records, filters, or updates raw replay fixtures. The JSON is maintained in the Go test. If reducing the recording would require inventing old state or weakening the expected response with broad wildcards, keep a focused `pulumitest` test instead.
+
+Run a replay as a provider test:
+
+```sh
+make test_provider GO_TEST_EXEC="go test -run '^TestCheckConfigWithUnknownKeys\\z' -count=1"
+```
+
+## Schema and code-generation tests
+
+A provider mapping change can be wrong even when its Go implementation compiles. If a change affects resource tokens, fields, types, aliases, defaults, overlays, or generated documentation:
+
+1. Add a focused Go test for nontrivial transformation logic.
+2. Regenerate the schema.
+3. Inspect the schema diff for the intended public API change.
+4. Build generated SDKs to prove each language accepts the new schema.
+
+```sh
+make schema
+make build_sdks
+```
+
+Inspect the generated diff before committing; CI regenerates each SDK and fails if committed output is stale. Do not manually edit files under `sdk/`.
+
+Use a language smoke test only when schema inspection and SDK compilation cannot prove the assertion—for example, an overlay must package a Node.js callback or generated Python import code must execute.
+
+## Provider-upgrade tests
+
+Use an upgrade test when the invariant begins with state produced by an older provider. Ordinary acceptance tests create state with the local provider and cannot prove upgrade compatibility.
+
+```go
+func TestQueueUpgrade(t *testing.T) {
+    testProviderUpgrade(t,
+        filepath.Join("test-programs", "queue-upgrade"), nil)
+}
+```
+
+The helper restores recorded baseline state, switches to the local provider, and previews the existing stack. By default it asserts that the upgrade does not replace resources.
+
+Add explicit assertions when the intended migration allows some changes:
+
+```go
+test, _ := testProviderUpgrade(t, program, opts,
+    optproviderupgrade.NewSourcePath(filepath.Join(program, "step1")))
+
+result := test.Up(t, optup.Diff())
+assertup.HasNoReplacements(t, result)
+require.NotNil(t, result.Summary.ResourceChanges)
+require.NotZero(t, (*result.Summary.ResourceChanges)["update"])
+```
+
+Keep baseline fixtures stable. Refreshing them changes the historical state being tested and can hide the incompatibility the test was created to detect. Record a new baseline only when the baseline version or scenario intentionally changes, and review both `stack.json` and `grpc.json`.
+
+Run one upgrade test with:
+
+```sh
+make GOTESTARGS="-run '^TestQueueUpgrade$' -count=1" test
+```
+
+## Live AWS acceptance tests
+
+Use a live acceptance test when the assertion requires AWS itself. Examples include remote defaults observed during refresh, IAM role chaining, IMDS, Lambda callback execution, ECR image publishing, and CRUD behavior changed by a carried upstream patch.
+
+Provider behavior should use YAML unless a generated SDK or language runtime is part of the assertion. Put new regression programs under `examples/test-programs/<name>`.
+
+```go
+func TestAccExample(t *testing.T) {
+    cwd := getCwd(t)
+    test := pulumitest.NewPulumiTest(t,
+        filepath.Join(cwd, "test-programs", "example"),
+        opttest.SkipInstall(),
+        opttest.LocalProviderPath("aws", filepath.Join(cwd, "..", "bin")),
+    )
+    test.SetConfig(t, "aws:region", getEnvRegion(t))
+
+    runExampleLifecycle(t, test, exampleLifecycleOptions{})
+}
+```
+
+`runExampleLifecycle` performs the standard contract:
+
+1. Preview and update.
+2. Export and re-import state.
+3. Preview and update again, expecting no changes.
+4. Run optional output or AWS API validation.
+5. Refresh, expecting no changes.
+
+Use lifecycle options only when the test names the reason:
+
+- `skipRefresh` when refresh is known not to converge.
+- `allowEmptyPreviewChanges` or `allowEmptyUpdateChanges` when a no-op operation legitimately reports changes.
+- `validate` when outputs or the backing AWS API are the assertion.
+
+Expected-failure tests must match the intended diagnostic. An assertion that accepts any update failure can pass because of an account quota or transient AWS error:
+
+```go
+_, err := test.UpErr(t)
+require.ErrorContains(t, err, "the diagnostic this regression protects")
+```
+
+For import, source edits, multiple stacks, or another materially different lifecycle, call `pulumitest` operations directly rather than adding switches to `runExampleLifecycle`.
+
+Configure AWS credentials and run one test at a time:
+
+```sh
+AWS_REGION=us-west-2 \
+make GOTESTARGS="-run '^TestAccExample$' -count=1" test
+```
+
+Do not run unfiltered `make test` unless you intend to create resources for the full acceptance suite.
+
+## Generated SDK and runtime tests
+
+Keep a language test only when the language boundary contributes to the behavior. Use the repository's local SDK setup rather than a published package:
+
+| Language | Local SDK setup | Reference |
+| --- | --- | --- |
+| Node.js | `opttest.YarnLink("@pulumi/aws")` | `newJSExampleTest` |
+| Python | Install `sdk/python/bin` into the program's declared virtualenv | `newPythonExampleTest` |
+| Go | `opttest.GoModReplacement`, followed by `go mod tidy` | `TestReleaseVerificationGo` |
+| .NET | `opttest.DotNetReference` | `TestReleaseVerificationCs` |
+
+The extra Go tidy is required because `GoModReplacement` edits `go.mod` but does not resolve transitive dependencies from the local SDK. Python uses explicit setup because `opttest.PythonLink` installs into the ambient interpreter, not necessarily the virtualenv declared in `Pulumi.yaml`.
+
+Build and install the required SDK before running its test. For example:
+
+```sh
+make build_nodejs install_nodejs_sdk
+AWS_REGION=us-west-2 \
+make GOTESTARGS="-run '^TestNodeSDKBehavior$' -count=1" test
+```
+
+Do not copy a provider-behavior test into several languages. SDK compilation plus one smoke test per language covers package integration; duplicated cloud lifecycles increase cost without testing a new boundary.
+
+## What to test for common changes
+
+| Change | Required evidence |
+| --- | --- |
+| Pure helper or config parser | Provider unit test covering success and failure inputs |
+| Provider `Check` transform | Unit test when inputs are simple; raw RPC replay when the engine-shaped request matters |
+| Diff suppression | Raw RPC replay with a suppressed-diff case and a negative control that still updates |
+| Resource mapping, alias, field, or type | Focused provider/codegen test, regenerated schema, and SDK builds |
+| Upstream provider version bump | Provider-upgrade suite plus tests tied to patches affected by the rebase |
+| Carried upstream patch | Follow `docs/upstream-patches.md`; add the required focused Pulumi regression under `examples/` |
+| Real refresh, import, auth, or runtime behavior | Focused YAML acceptance test |
+| Overlay or generated SDK API | Relevant language test; add live AWS only when runtime or cloud behavior is asserted |
+| Published package or plugin acquisition | Release-verification workflow, not an ordinary provider regression test |
+
+## Confirm execution evidence
+
+A test is useful evidence only when its execution path is known:
+
+1. **Defined:** the test and a direct assertion exist.
+2. **Selected:** the documented command or CI workflow discovers that test.
+3. **Executed:** the test ran rather than skipping because of short mode, missing configuration, credentials, or another guard.
+4. **Asserted:** execution reached and passed the intended invariant.
+
+`make test_provider` selects only the root `provider` package. A test under `provider/pkg/**` or `provider/cmd/**` requires separate selection until that target changes.
+
+The `examples/` package mixes live AWS tests, provider-upgrade tests, local checks, and tests with skip conditions. After a focused local or CI run, inspect the named test result rather than inferring execution from a passing package or workflow. Report exact commands and outcomes, including skipped, unselected, or credential-blocked tests.
+
+## Compile without running cloud tests
+
+Compile the examples test package without executing tests:
+
+```sh
+GITHUB_ACTIONS=1 make TESTTAGS= GOTESTARGS="-run '^$'" test
+```
+
+This catches fixture-driver and SDK-linking compile failures but does not validate provider behavior. Record the exact focused tests and generation commands run in the pull request description.

--- a/docs/provider-runtime.md
+++ b/docs/provider-runtime.md
@@ -1,0 +1,102 @@
+# Pulumi AWS Provider Runtime
+
+Pulumi AWS is a bridged provider. For most resources, this repository does not
+implement the resource lifecycle: the Pulumi engine selects operations, the
+Terraform bridge translates provider RPCs, and the Terraform AWS provider
+implements resource behavior. This document identifies the narrower behavior
+owned by `pulumi-aws` and where to change it.
+
+## Upstream contracts
+
+Use the Pulumi developer documentation for behavior owned by the engine:
+
+- [Resource providers](https://pulumi-developer-docs.readthedocs.io/latest/docs/architecture/providers/README.html)
+- [ResourceProvider gRPC protocol](https://pulumi-developer-docs.readthedocs.io/latest/docs/_generated/proto/provider.html)
+- [Resource registration and diffing](https://pulumi-developer-docs.readthedocs.io/latest/docs/architecture/deployment-execution/resource-registration.html)
+- [Deployment steps, including refresh and import](https://pulumi-developer-docs.readthedocs.io/latest/docs/architecture/deployment-execution/steps.html)
+
+Use the Terraform Bridge developer documentation for Terraform-to-Pulumi
+translation:
+
+- [Bridge developer documentation](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/README.html)
+- [Resource IDs](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/resource-ids.html)
+- [Provider metadata](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/metadata.html)
+- [Automatic aliasing](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/auto-aliasing.html)
+- [Automatic token mapping](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/automatic-token-mapping.html)
+- [Muxing providers](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/muxwith.html)
+- [Schema overlays](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/overlays.html)
+- [Generated documentation edits](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/docs-edits.html)
+- [Testing bridged providers](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/testing.html)
+
+The Terraform AWS provider under [`upstream/`](../upstream/) owns its resource
+schemas, CRUD and import implementations, state upgrades, retries, waiters, and
+AWS API calls. AWS service APIs own remote behavior. A local patch changes the
+upstream provider seen by Pulumi; follow
+[`docs/upstream-patches.md`](./upstream-patches.md) before creating one.
+
+## System boundary
+
+```text
+Pulumi program
+    |
+    v
+Pulumi engine                     operation planning and state management
+    |
+    | ResourceProvider gRPC
+    v
+Pulumi Terraform Bridge           Terraform/Pulumi value and lifecycle translation
+    |
+    | ProviderInfo customizations from this repository
+    v
+Muxed Terraform AWS provider      SDKv2 and Plugin Framework resources
+    |
+    v
+AWS service APIs
+```
+
+The same provider construction also feeds schema generation:
+
+```text
+Terraform AWS schemas + ProviderInfo + overlays
+    |
+    v
+Pulumi package schema and bridge metadata
+    |
+    v
+Generated SDKs and runtime provider
+```
+
+A `ProviderInfo` change may therefore affect schema generation, runtime
+translation, or both. Determine which consumer reads the field before choosing
+a test or regeneration command.
+
+## Repository-owned control surfaces
+
+| Control surface | Entry point | What changes here |
+| --- | --- | --- |
+| Upstream provider assembly | [`provider/upstream_provider.go`](../provider/upstream_provider.go), [`provider/pkg/iam/`](../provider/pkg/iam/), and [`provider/pkg/rds/`](../provider/pkg/rds/) | Adjustments applied to the SDKv2 or Plugin Framework provider before the bridge consumes it. This constructor runs during schema generation and runtime startup. |
+| Bridge configuration | [`provider/resources.go`](../provider/resources.go) | Provider configuration, Terraform-to-Pulumi tokens, field overrides, autonaming, aliases, ID overrides, and input/output or state transforms. |
+| Pulumi-side input handling | [`provider/region.go`](../provider/region.go), [`provider/tags.go`](../provider/tags.go), and the pre-configure callback in `provider/resources.go` | Behavior that must run before upstream Terraform logic, such as provider credential diagnostics or Pulumi-specific `Check` inputs. |
+| Schema additions and post-processing | [`provider/overlays.go`](../provider/overlays.go), [`provider/types.go`](../provider/types.go), and [`provider/enums.go`](../provider/enums.go) | Pulumi-only resources and types, generated API shape, and schema transformations not supplied by upstream. |
+| Generated documentation edits | [`provider/doc_edits.go`](../provider/doc_edits.go) and [`provider/replacements.json`](../provider/replacements.json) | Targeted changes to converted upstream documentation. |
+| Runtime assembly and metadata | [`provider/cmd/pulumi-resource-aws/`](../provider/cmd/pulumi-resource-aws/), [`provider/cmd/pulumi-tfgen-aws/`](../provider/cmd/pulumi-tfgen-aws/), and [`provider/pkg/minimalschema/`](../provider/pkg/minimalschema/) | SDKv2/Plugin Framework mux startup, embedded schema, and generated bridge/runtime metadata. Generated JSON files are outputs, not editing points. |
+| Carried upstream behavior | [`patches/`](../patches/) | Temporary or intentional divergence from the released Terraform AWS provider. Develop the source change in `upstream/`, then generate the patch. |
+
+## Route a change
+
+- When the engine chooses an unexpected operation or orders operations
+  unexpectedly, start with the engine deployment and provider-protocol docs.
+- When Terraform and Pulumi differ without a `pulumi-aws` override, investigate
+  the bridge translation before adding local behavior.
+- When CRUD, import, state upgrade, retry, waiter, or AWS API behavior comes from
+  a Terraform resource, the owning implementation is under `upstream/`.
+- When the behavior comes from a token, field override, alias, transform,
+  provider callback, overlay, or documentation edit, change the corresponding
+  local control surface above.
+- When generated schema, metadata, or SDKs are wrong, trace them back to
+  `ProviderInfo`, an overlay, or upstream schema rather than editing generated
+  output.
+
+Use [`TESTING.md`](../TESTING.md) to select the lowest repository test layer
+that proves a local change. Use the issue-triage skills referenced by
+[`AGENTS.md`](../AGENTS.md) when the owning layer is not yet established.

--- a/docs/upstream-patches.md
+++ b/docs/upstream-patches.md
@@ -1,10 +1,125 @@
-# Carrying Upstream Patches in Pulumi AWS
+# Carrying Upstream Patches
 
-Use the `upstream-patches` skill before deciding, creating, or materially changing a carried patch. Its carried-patch policy defines the shared ownership, compatibility, state, evidence, tracking, and removal requirements for bridged providers. The skill also owns `./scripts/upstream.sh` patch mechanics.
+Use this policy before creating a new patch or materially changing the behavior or public commitment of an existing patch. Repository guidance supplies local commands, test paths, workflows, labels, and templates.
 
-This document adds Pulumi AWS-specific repository and test requirements.
+## Avoid patches by default
 
-## Track the patch
+A carried patch adds recurring cost and risk to every upstream upgrade:
+
+- changes to the same upstream files can require a manual rebase;
+- a bad conflict resolution can introduce behavior that neither Pulumi nor upstream tested;
+- a patched property, resource, or behavior can become a public contract that Pulumi must maintain indefinitely;
+- upstream may later solve the same problem with an incompatible API or state representation;
+- cross-cutting patches can be difficult to test completely and difficult to remove safely.
+
+Prefer waiting for an acceptable upstream release, using bridge or provider configuration, or offering a documented workaround when those choices meet the user need. Severity may justify carrying a patch proactively, but urgency does not remove the compatibility and evidence requirements below.
+
+## Identify the owner
+
+Classify the behavior before designing the patch.
+
+### Upstream-owned behavior
+
+When the change fixes behavior in the upstream Terraform provider:
+
+- develop the correct solution in the upstream source, not directly in a generated patch file;
+- submit the change upstream in parallel with the Pulumi patch;
+- assess an existing upstream pull request rather than assuming it is safe to carry;
+- create a higher-quality upstream change when the existing proposal is incomplete;
+- carry the same change submitted upstream and explain any necessary differences.
+
+Do not weaken the upstream solution merely to make the Pulumi patch easier to remove.
+
+Every upstream-owned patch that changes resource behavior requires:
+
+1. An upstream acceptance test in the patch that reproduces the affected lifecycle or API behavior. Unit tests may supplement this test but do not replace it.
+2. Selection of that acceptance test in the Pulumi provider repository's targeted upstream-test CI.
+3. A Pulumi regression test that fails without the patch and passes with it.
+
+Assert the affected behavior directly. A successful deployment alone may not prove the regression.
+
+### Pulumi-specific behavior
+
+Some patches work around behavior owned by the bridge, a Pulumi provider, code generation, or the Pulumi engine. For these patches:
+
+- link the issue in the repository that owns the underlying problem;
+- explain why the change must be made in upstream provider code rather than bridge configuration or local provider code;
+- limit the patch to the incompatibility between Terraform and Pulumi behavior;
+- add a Pulumi regression test that fails without the patch;
+- add provider-upgrade coverage when the patch changes schema, diff, or state behavior consumed by existing Pulumi state;
+- state whether the divergence is temporary or intentionally permanent.
+
+Do not submit an upstream pull request for behavior that would be incorrect or irrelevant in Terraform.
+
+### Repository integration
+
+Some patches support Pulumi-specific integration such as a shim, provider identity, documentation generation, or repository build tooling.
+
+Prefer local provider configuration, documentation changes, or build orchestration when those can express the change. If upstream code is the only practical extension point, explain why in the tracking issue.
+
+Use validation specific to the integration. Do not add upstream acceptance or Pulumi lifecycle tests that cannot exercise the change.
+
+## Assess compatibility and maintenance risk
+
+Record known risks and unknowns in the tracking issue and patch pull request.
+
+### Public API changes
+
+If users adopt a property or resource added by a patch, Pulumi may have to support it even if upstream later chooses another name or design. Compare an upstream-owned patched API with the upstream submission. For Pulumi-specific behavior, state whether the divergence is an intentional permanent contract.
+
+Prefer patches that can be removed without changing Pulumi programs or state. Treat a patch that creates permanent surface area as an exceptional compatibility commitment, not a temporary backport.
+
+### State migrations
+
+Terraform records a schema version with resource state and selects state upgraders using that version. The bridge also records the Terraform schema version in Pulumi state.
+
+A migration that appears correct in Terraform may not be persisted by Pulumi. During a no-refresh `pulumi up`, the bridge can run the upgrader while computing the diff. If there is no diff, Pulumi does not call `Update`, so the upgraded state may not be written. A later deletion can therefore receive the old state. This behavior is tracked in [pulumi-terraform-bridge#3008](https://github.com/pulumi/pulumi-terraform-bridge/issues/3008).
+
+A downstream migration can also collide with upstream. If a patch adds a `0 → 1` migration, patched state may be marked version `1`. If upstream later releases a different `0 → 1` migration, that upgrader is not called for state already marked version `1`.
+
+Before carrying a state migration:
+
+- confirm that migration is required instead of making provider operations compatible with state written by released versions;
+- compare the schema version and migration with the upstream pull request when the behavior is upstream-owned;
+- explain how each expected replacement for the patch will consume state written by it;
+- add a Pulumi provider-upgrade test that creates state with a released provider and covers no-refresh update, refresh, and direct deletion;
+- preserve identifiers needed by later operations unless live lifecycle evidence proves a migration is necessary.
+
+### Cross-cutting changes
+
+If a patch changes shared code or multiple resources, name the affected resources and their test coverage. List behavior that remains untested. Do not infer broad safety from one representative resource without explaining why that resource exercises the shared behavior.
+
+## Track the patch lifecycle
+
+Every patch requires a provider-repository tracking issue containing:
+
+- why the patch is needed and which repository owns the underlying behavior;
+- links to the user-facing issue and owning upstream, bridge, codegen, or Pulumi issue;
+- the upstream pull request when the behavior is upstream-owned;
+- compatibility risks and unknowns;
+- exact regression test names and CI selection;
+- whether the patch is temporary or intentionally permanent;
+- observable removal conditions and the tests required to prove removal is safe.
+
+“Remove when fixed upstream” is not a sufficient removal condition. The issue must explain how to establish that the upstream replacement is compatible with Pulumi programs and state written while the patch was present.
+
+The patch pull request must link the tracking issue and relevant owner-side change, explain differences, and report exact test outcomes. Keep defined, selected, executed, asserted, skipped, and credential-blocked evidence distinct.
+
+## Stop conditions
+
+Stop and ask for maintainer judgment rather than silently proceeding when:
+
+- the patch introduces or renames public schema without a clear long-term compatibility decision;
+- the proposed patch differs materially from an unreviewed or incomplete upstream pull request;
+- a cross-cutting change lacks credible regression coverage;
+- required live infrastructure cannot be exercised safely;
+- ownership or safe removal conditions remain unclear.
+
+## Pulumi AWS repository requirements
+
+The shared policy above applies together with these Pulumi AWS-specific repository and test requirements.
+
+### Track the patch
 
 Create the tracking issue with [the upstream patch issue form](../.github/ISSUE_TEMPLATE/upstream-patch.yaml). Apply:
 
@@ -13,7 +128,7 @@ Create the tracking issue with [the upstream patch issue form](../.github/ISSUE_
 
 Use the carried-patch section of [the pull request template](../.github/pull_request_template.md) to link the tracking issue and owning-project change, record compatibility and removal decisions, and name the required tests.
 
-## Add regression coverage
+### Add regression coverage
 
 Every upstream-owned patch that changes resource behavior requires all of the following in Pulumi AWS:
 
@@ -21,11 +136,11 @@ Every upstream-owned patch that changes resource behavior requires all of the fo
 2. Select that exact test in `.github/workflows/aws-upstream-tests.yml`. A passing service job does not prove a new test ran unless its test expression includes the test.
 3. Add a Pulumi regression test under `examples/` that fails without the patch and passes with it.
 
-Put Pulumi regression tests required for Pulumi-specific patches under `examples/` as well. Add a provider-upgrade test when the shared policy requires coverage of schema, diff, identifier, or state compatibility.
+Put Pulumi regression tests required for Pulumi-specific patches under `examples/` as well. Use [`TESTING.md`](../TESTING.md) to design the focused Pulumi regression and decide whether provider-upgrade or language-specific coverage is also needed. Add a provider-upgrade test when the shared policy requires coverage of schema, diff, identifier, or state compatibility.
 
 Assert the affected field or lifecycle transition directly. A successful deployment alone may not prove the regression.
 
-## Handle live AWS tests safely
+### Handle live AWS tests safely
 
 Upstream acceptance and Pulumi examples tests may create real AWS resources. Before running one:
 
@@ -35,7 +150,7 @@ Upstream acceptance and Pulumi examples tests may create real AWS resources. Bef
 - follow `upstream/AGENTS.md` for upstream acceptance tests;
 - report tests blocked by credentials or unsafe fixtures rather than implying they executed.
 
-## Develop and report the patch
+### Develop and report the patch
 
 Develop upstream-owned changes in `upstream/` and use the `upstream-patches` skill to generate or amend the patch; do not edit `patches/*.patch` directly for ordinary development.
 

--- a/docs/upstream-patches.md
+++ b/docs/upstream-patches.md
@@ -1,0 +1,42 @@
+# Carrying Upstream Patches in Pulumi AWS
+
+Use the `upstream-patches` skill before deciding, creating, or materially changing a carried patch. Its carried-patch policy defines the shared ownership, compatibility, state, evidence, tracking, and removal requirements for bridged providers. The skill also owns `./scripts/upstream.sh` patch mechanics.
+
+This document adds Pulumi AWS-specific repository and test requirements.
+
+## Track the patch
+
+Create the tracking issue with [the upstream patch issue form](../.github/ISSUE_TEMPLATE/upstream-patch.yaml). Apply:
+
+- `area/patch`; and
+- the applicable owner label: `awaiting-upstream`, `awaiting/bridge`, `awaiting/core`, or `awaiting/codegen`.
+
+Use the carried-patch section of [the pull request template](../.github/pull_request_template.md) to link the tracking issue and owning-project change, record compatibility and removal decisions, and name the required tests.
+
+## Add regression coverage
+
+Every upstream-owned patch that changes resource behavior requires all of the following in Pulumi AWS:
+
+1. Include an upstream acceptance test in the patch that reproduces the affected lifecycle or AWS API behavior.
+2. Select that exact test in `.github/workflows/aws-upstream-tests.yml`. A passing service job does not prove a new test ran unless its test expression includes the test.
+3. Add a Pulumi regression test under `examples/` that fails without the patch and passes with it.
+
+Put Pulumi regression tests required for Pulumi-specific patches under `examples/` as well. Add a provider-upgrade test when the shared policy requires coverage of schema, diff, identifier, or state compatibility.
+
+Assert the affected field or lifecycle transition directly. A successful deployment alone may not prove the regression.
+
+## Handle live AWS tests safely
+
+Upstream acceptance and Pulumi examples tests may create real AWS resources. Before running one:
+
+- inspect the fixture and cleanup path;
+- assess cost, concurrency, permissions, and blast radius;
+- account for asynchronous cleanup and recovery after interruption;
+- follow `upstream/AGENTS.md` for upstream acceptance tests;
+- report tests blocked by credentials or unsafe fixtures rather than implying they executed.
+
+## Develop and report the patch
+
+Develop upstream-owned changes in `upstream/` and use the `upstream-patches` skill to generate or amend the patch; do not edit `patches/*.patch` directly for ordinary development.
+
+Submit the owner-side change in parallel when the behavior belongs upstream. In the Pulumi AWS pull request, report exact test commands and outcomes, including tests that were defined but not selected, skipped, or blocked by credentials.

--- a/docs/upstream-patches.md
+++ b/docs/upstream-patches.md
@@ -117,7 +117,7 @@ Stop and ask for maintainer judgment rather than silently proceeding when:
 
 ## Pulumi AWS repository requirements
 
-The shared policy above applies together with these Pulumi AWS-specific repository and test requirements.
+The policy above applies together with these Pulumi AWS-specific repository and test requirements.
 
 ### Track the patch
 
@@ -136,7 +136,7 @@ Every upstream-owned patch that changes resource behavior requires all of the fo
 2. Select that exact test in `.github/workflows/aws-upstream-tests.yml`. A passing service job does not prove a new test ran unless its test expression includes the test.
 3. Add a Pulumi regression test under `examples/` that fails without the patch and passes with it.
 
-Put Pulumi regression tests required for Pulumi-specific patches under `examples/` as well. Use [`TESTING.md`](../TESTING.md) to design the focused Pulumi regression and decide whether provider-upgrade or language-specific coverage is also needed. Add a provider-upgrade test when the shared policy requires coverage of schema, diff, identifier, or state compatibility.
+Put Pulumi regression tests required for Pulumi-specific patches under `examples/` as well. Use [`TESTING.md`](../TESTING.md) to design the focused Pulumi regression and decide whether provider-upgrade or language-specific coverage is also needed. Add a provider-upgrade test when the policy requires coverage of schema, diff, identifier, or state compatibility.
 
 Assert the affected field or lifecycle transition directly. A successful deployment alone may not prove the regression.
 


### PR DESCRIPTION
## Summary

Pulumi AWS delegates most resource lifecycle behavior to the Pulumi engine,
Terraform Bridge, and Terraform AWS provider, but the repository guidance did
not clearly distinguish those owners from the behavior configured locally. It
also treated all `examples/` tests as live AWS tests and described carried
patches mainly through their mechanics.

This PR establishes one repository-owned development path:

- `docs/provider-runtime.md` links to the canonical engine and bridge contracts
  and maps Pulumi AWS-owned controls such as `ProviderInfo` mappings,
  callbacks, overlays, mux metadata, and documentation edits.
- `TESTING.md` routes changes to provider unit tests, direct provider tests,
  raw RPC replay, schema/codegen tests, recorded provider upgrades, focused
  live AWS tests, or SDK tests. It distinguishes tests that are defined,
  selected, executed, and asserted.
- `docs/upstream-patches.md` explains why patches are exceptional, how to
  evaluate ownership and compatibility, and what tracking, regression, and
  removal evidence Pulumi AWS requires.
- `AGENTS.md`, `CONTRIBUTING.md`, the patch issue form, and the pull request
  template route contributors and coding agents through those guides.

The carried-patch policy intentionally lives in this repository so maintainers,
contributors, and coding agents use the same requirements. The shared
`upstream-patches` skill remains responsible for patch mechanics.

The testing guide documents helpers introduced by
[pulumi-aws#6564](https://github.com/pulumi/pulumi-aws/pull/6564), so that PR
should merge before this one.

## Change Type

- [ ] Provider logic only (`provider/`)
- [ ] Schema or mapping change (may require SDK regeneration)
- [ ] Upstream or patch pipeline change (`upstream/`, `patches/`, `scripts/upstream.sh`)
- [ ] CI workflow source change (`.ci-mgmt.yaml`)
- [x] Repository documentation and contribution templates

## Validation Evidence

- [ ] `make lint` — not run; no provider code changed
- [ ] `make test_provider` — not run; no provider code changed
- [ ] If schema-affecting: `make schema` — not applicable
- [ ] If schema-affecting: `make build_sdks` — not applicable
- [ ] If CI source changed: `make ci-mgmt` — not applicable

### Command output snippets

```text
git diff --check
```

## Risk

- Blast radius: contributor and agent guidance only; provider behavior, schema,
  SDKs, and existing patches are unchanged.
- Merge ordering: merge pulumi-aws#6564 first so the documented `pulumitest`
  helpers exist on the base branch.

## Rollback

- Revert plan: revert the documentation and template commits.
- Follow-up cleanup: none.
