### PR TITLE
Fix undefined variable references in SQS dead-letter queue example

### DIFF
--- a/provider/replacements.json
+++ b/provider/replacements.json
@@ -2562,7 +2562,11 @@
   "sqs_queue.html.markdown": [
     {
       "old": "    sourceQueueArns   = [aws_sqs_queue.terraform_queue.arn]",
-      "new": "    sourceQueueArns   = [aws_sqs_queue.example_queue.arn]"
+      "new": "    sourceQueueArns   = [aws_sqs_queue.queue.arn]"
+    },
+    {
+      "old": "  name = \"pulumi-example-queue\"\n\n  redrive_policy = jsonencode({\n    deadLetterTargetArn = aws_sqs_queue.queue_deadletter.arn",
+      "new": "  name = \"pulumi-example-queue\"\n\n  redrive_policy = jsonencode({\n    deadLetterTargetArn = aws_sqs_queue.example_queue_deadletter.arn"
     },
     {
       "old": "* `sqs_managed_sse_enabled` - (Optional) Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys. See [Encryption at rest](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html). Terraform will only perform drift detection of its value when present in a configuration.",

--- a/sdk/dotnet/Sqs/Queue.cs
+++ b/sdk/dotnet/Sqs/Queue.cs
@@ -98,32 +98,32 @@ namespace Pulumi.Aws.Sqs
     /// 
     /// return await Deployment.RunAsync(() =&gt; 
     /// {
-    ///     var queue = new Aws.Sqs.Queue("queue", new()
-    ///     {
-    ///         Name = "pulumi-example-queue",
-    ///         RedrivePolicy = JsonSerializer.Serialize(new Dictionary&lt;string, object?&gt;
-    ///         {
-    ///             ["deadLetterTargetArn"] = queueDeadletter.Arn,
-    ///             ["maxReceiveCount"] = 4,
-    ///         }),
-    ///     });
-    /// 
     ///     var exampleQueueDeadletter = new Aws.Sqs.Queue("example_queue_deadletter", new()
     ///     {
     ///         Name = "pulumi-example-deadletter-queue",
     ///     });
     /// 
+    ///     var queue = new Aws.Sqs.Queue("queue", new()
+    ///     {
+    ///         Name = "pulumi-example-queue",
+    ///         RedrivePolicy = Output.JsonSerialize(Output.Create(new Dictionary&lt;string, object?&gt;
+    ///         {
+    ///             ["deadLetterTargetArn"] = exampleQueueDeadletter.Arn,
+    ///             ["maxReceiveCount"] = 4,
+    ///         })),
+    ///     });
+    /// 
     ///     var exampleQueueRedriveAllowPolicy = new Aws.Sqs.RedriveAllowPolicy("example_queue_redrive_allow_policy", new()
     ///     {
     ///         QueueUrl = exampleQueueDeadletter.Id,
-    ///         RedriveAllowPolicyName = JsonSerializer.Serialize(new Dictionary&lt;string, object?&gt;
+    ///         RedriveAllowPolicyName = Output.JsonSerialize(Output.Create(new Dictionary&lt;string, object?&gt;
     ///         {
     ///             ["redrivePermission"] = "byQueue",
     ///             ["sourceQueueArns"] = new[]
     ///             {
-    ///                 exampleQueue.Arn,
+    ///                 queue.Arn,
     ///             },
-    ///         }),
+    ///         })),
     ///     });
     /// 
     /// });

--- a/sdk/go/aws/sqs/queue.go
+++ b/sdk/go/aws/sqs/queue.go
@@ -132,40 +132,46 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			tmpJSON0, err := json.Marshal(map[string]interface{}{
-//				"deadLetterTargetArn": queueDeadletter.Arn,
-//				"maxReceiveCount":     4,
-//			})
-//			if err != nil {
-//				return err
-//			}
-//			json0 := string(tmpJSON0)
-//			_, err = sqs.NewQueue(ctx, "queue", &sqs.QueueArgs{
-//				Name:          pulumi.String("pulumi-example-queue"),
-//				RedrivePolicy: pulumi.String(json0),
-//			})
-//			if err != nil {
-//				return err
-//			}
 //			exampleQueueDeadletter, err := sqs.NewQueue(ctx, "example_queue_deadletter", &sqs.QueueArgs{
 //				Name: pulumi.String("pulumi-example-deadletter-queue"),
 //			})
 //			if err != nil {
 //				return err
 //			}
-//			tmpJSON1, err := json.Marshal(map[string]interface{}{
-//				"redrivePermission": "byQueue",
-//				"sourceQueueArns": []interface{}{
-//					exampleQueue.Arn,
-//				},
+//			queue, err := sqs.NewQueue(ctx, "queue", &sqs.QueueArgs{
+//				Name: pulumi.String("pulumi-example-queue"),
+//				RedrivePolicy: exampleQueueDeadletter.Arn.ApplyT(func(arn string) (pulumi.String, error) {
+//					var _zero pulumi.String
+//					tmpJSON0, err := json.Marshal(map[string]interface{}{
+//						"deadLetterTargetArn": arn,
+//						"maxReceiveCount":     4,
+//					})
+//					if err != nil {
+//						return _zero, err
+//					}
+//					json0 := string(tmpJSON0)
+//					return pulumi.String(json0), nil
+//				}).(pulumi.StringOutput),
 //			})
 //			if err != nil {
 //				return err
 //			}
-//			json1 := string(tmpJSON1)
 //			_, err = sqs.NewRedriveAllowPolicy(ctx, "example_queue_redrive_allow_policy", &sqs.RedriveAllowPolicyArgs{
-//				QueueUrl:           exampleQueueDeadletter.ID(),
-//				RedriveAllowPolicy: pulumi.String(json1),
+//				QueueUrl: exampleQueueDeadletter.ID(),
+//				RedriveAllowPolicy: queue.Arn.ApplyT(func(arn string) (pulumi.String, error) {
+//					var _zero pulumi.String
+//					tmpJSON1, err := json.Marshal(map[string]interface{}{
+//						"redrivePermission": "byQueue",
+//						"sourceQueueArns": []string{
+//							arn,
+//						},
+//					})
+//					if err != nil {
+//						return _zero, err
+//					}
+//					json1 := string(tmpJSON1)
+//					return pulumi.String(json1), nil
+//				}).(pulumi.StringOutput),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/java/src/main/java/com/pulumi/aws/sqs/Queue.java
+++ b/sdk/java/src/main/java/com/pulumi/aws/sqs/Queue.java
@@ -164,26 +164,26 @@ import javax.annotation.Nullable;
  *     }
  * 
  *     public static void stack(Context ctx) {
- *         var queue = new Queue("queue", QueueArgs.builder()
- *             .name("pulumi-example-queue")
- *             .redrivePolicy(serializeJson(
- *                 jsonObject(
- *                     jsonProperty("deadLetterTargetArn", queueDeadletter.arn()),
- *                     jsonProperty("maxReceiveCount", 4)
- *                 )))
- *             .build());
- * 
  *         var exampleQueueDeadletter = new Queue("exampleQueueDeadletter", QueueArgs.builder()
  *             .name("pulumi-example-deadletter-queue")
  *             .build());
  * 
+ *         var queue = new Queue("queue", QueueArgs.builder()
+ *             .name("pulumi-example-queue")
+ *             .redrivePolicy(exampleQueueDeadletter.arn().applyValue(_arn -> serializeJson(
+ *                 jsonObject(
+ *                     jsonProperty("deadLetterTargetArn", _arn),
+ *                     jsonProperty("maxReceiveCount", 4)
+ *                 ))))
+ *             .build());
+ * 
  *         var exampleQueueRedriveAllowPolicy = new RedriveAllowPolicy("exampleQueueRedriveAllowPolicy", RedriveAllowPolicyArgs.builder()
  *             .queueUrl(exampleQueueDeadletter.id())
- *             .redriveAllowPolicy(serializeJson(
+ *             .redriveAllowPolicy(queue.arn().applyValue(_arn -> serializeJson(
  *                 jsonObject(
  *                     jsonProperty("redrivePermission", "byQueue"),
- *                     jsonProperty("sourceQueueArns", jsonArray(exampleQueue.arn()))
- *                 )))
+ *                     jsonProperty("sourceQueueArns", jsonArray(_arn))
+ *                 ))))
  *             .build());
  * 
  *     }

--- a/sdk/nodejs/sqs/queue.ts
+++ b/sdk/nodejs/sqs/queue.ts
@@ -64,19 +64,19 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as aws from "@pulumi/aws";
  *
+ * const exampleQueueDeadletter = new aws.sqs.Queue("example_queue_deadletter", {name: "pulumi-example-deadletter-queue"});
  * const queue = new aws.sqs.Queue("queue", {
  *     name: "pulumi-example-queue",
- *     redrivePolicy: JSON.stringify({
- *         deadLetterTargetArn: queueDeadletter.arn,
+ *     redrivePolicy: pulumi.jsonStringify({
+ *         deadLetterTargetArn: exampleQueueDeadletter.arn,
  *         maxReceiveCount: 4,
  *     }),
  * });
- * const exampleQueueDeadletter = new aws.sqs.Queue("example_queue_deadletter", {name: "pulumi-example-deadletter-queue"});
  * const exampleQueueRedriveAllowPolicy = new aws.sqs.RedriveAllowPolicy("example_queue_redrive_allow_policy", {
  *     queueUrl: exampleQueueDeadletter.id,
- *     redriveAllowPolicy: JSON.stringify({
+ *     redriveAllowPolicy: pulumi.jsonStringify({
  *         redrivePermission: "byQueue",
- *         sourceQueueArns: [exampleQueue.arn],
+ *         sourceQueueArns: [queue.arn],
  *     }),
  * });
  * ```

--- a/sdk/python/pulumi_aws/sqs/queue.py
+++ b/sdk/python/pulumi_aws/sqs/queue.py
@@ -775,18 +775,18 @@ class Queue(pulumi.CustomResource):
         import json
         import pulumi_aws as aws
 
+        example_queue_deadletter = aws.sqs.Queue("example_queue_deadletter", name="pulumi-example-deadletter-queue")
         queue = aws.sqs.Queue("queue",
             name="pulumi-example-queue",
-            redrive_policy=json.dumps({
-                "deadLetterTargetArn": queue_deadletter["arn"],
+            redrive_policy=pulumi.Output.json_dumps({
+                "deadLetterTargetArn": example_queue_deadletter.arn,
                 "maxReceiveCount": 4,
             }))
-        example_queue_deadletter = aws.sqs.Queue("example_queue_deadletter", name="pulumi-example-deadletter-queue")
         example_queue_redrive_allow_policy = aws.sqs.RedriveAllowPolicy("example_queue_redrive_allow_policy",
             queue_url=example_queue_deadletter.id,
-            redrive_allow_policy=json.dumps({
+            redrive_allow_policy=pulumi.Output.json_dumps({
                 "redrivePermission": "byQueue",
-                "sourceQueueArns": [example_queue["arn"]],
+                "sourceQueueArns": [queue.arn],
             }))
         ```
 
@@ -917,18 +917,18 @@ class Queue(pulumi.CustomResource):
         import json
         import pulumi_aws as aws
 
+        example_queue_deadletter = aws.sqs.Queue("example_queue_deadletter", name="pulumi-example-deadletter-queue")
         queue = aws.sqs.Queue("queue",
             name="pulumi-example-queue",
-            redrive_policy=json.dumps({
-                "deadLetterTargetArn": queue_deadletter["arn"],
+            redrive_policy=pulumi.Output.json_dumps({
+                "deadLetterTargetArn": example_queue_deadletter.arn,
                 "maxReceiveCount": 4,
             }))
-        example_queue_deadletter = aws.sqs.Queue("example_queue_deadletter", name="pulumi-example-deadletter-queue")
         example_queue_redrive_allow_policy = aws.sqs.RedriveAllowPolicy("example_queue_redrive_allow_policy",
             queue_url=example_queue_deadletter.id,
-            redrive_allow_policy=json.dumps({
+            redrive_allow_policy=pulumi.Output.json_dumps({
                 "redrivePermission": "byQueue",
-                "sourceQueueArns": [example_queue["arn"]],
+                "sourceQueueArns": [queue.arn],
             }))
         ```
 


### PR DESCRIPTION
## Description

Fixes https://github.com/pulumi/registry/issues/11827.

The "Dead-Letter Queue" example generated for `aws.sqs.Queue` referenced variables that are never defined, in every generated language (Python, TypeScript, Go, C#, Java). For example, in Python:

```python
queue = aws.sqs.Queue("queue",
    name="pulumi-example-queue",
    redrive_policy=json.dumps({
        "deadLetterTargetArn": queue_deadletter["arn"],   # <- `queue_deadletter` is undefined
        "maxReceiveCount": 4,
    })
)
example_queue_deadletter = aws.sqs.Queue("example_queue_deadletter", name="pulumi-example-deadletter-queue")
example_queue_redrive_allow_policy = aws.sqs.RedriveAllowPolicy("example_queue_redrive_allow_policy",
    queue_url=example_queue_deadletter.id,
    redrive_allow_policy=json.dumps({
        "redrivePermission": "byQueue",
        "sourceQueueArns": [example_queue["arn"]],   # <- `example_queue` is undefined
    })
)
```

**Root cause:** the primary queue resource in this example is already named `queue` upstream, and the dead-letter queue / redrive-allow-policy resources are already renamed to the `example_` naming scheme by `provider/replacements.json`. But two references were left inconsistent:

- The `sourceQueueArns` replacement pointed its renamed reference at `example_queue.arn` — a resource that doesn't exist under that name (the primary resource is just `queue`).
- `deadLetterTargetArn` was never updated to reference the renamed `example_queue_deadletter` resource.

This PR fixes both entries in `provider/replacements.json`.

## Verification

- Confirmed against the actual pinned `upstream` submodule content (not just the `terraform-provider-aws` `main` branch, which differs) that the current replacements reproduce the exact live bug via `pulumi convert --from terraform --language python`.
- With both entries corrected, ran the full local verification loop per `CONTRIBUTING.md`:
  - `make schema` — regenerated `schema.json`; confirmed the SQS dead-letter-queue example is fully self-consistent across all 5 languages, with proper `.arn`/`.id` attribute access (no more dict-subscript fallback on undefined names) and correct declaration order.
  - `make build_sdks` — regenerated SDK docstrings for `sdk/{nodejs,python,dotnet,go,java}`; verified the generated Python and Go source directly.
- Confirmed the fix is properly scoped: the replacement patterns only touch the "Dead-letter queue" section and leave the doc's other five example sections (Example Usage, FIFO queue, High-throughput FIFO queue, and two SSE examples) untouched.

## Test plan

- [x] `make schema`
- [x] `make build_sdks`
- [x] CI