### PR TITLE
Fix undefined variable references in SQS dead-letter queue example (#6566)

### DIFF
--- a/patches/0030-Fix-panic-in-route53recoverycontrolconfig-safety_rul.patch
+++ b/patches/0030-Fix-panic-in-route53recoverycontrolconfig-safety_rul.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sky Moore <i@msky.me>
+Date: Tue, 28 Jul 2026 19:20:00 -0500
+Subject: [PATCH] Fix panic in route53recoverycontrolconfig safety_rule Create
+
+resourceSafetyRuleCreate, via createAssertionRule and createGatingRule,
+dereferenced output.AssertionRule and output.GatingRule before checking
+the error returned by CreateSafetyRule. When the API returns an error,
+for example ServiceQuotaExceededException when a control panel already
+holds the maximum number of safety rules, output is nil and the
+dereference panics with a nil pointer. Through the bridge this crashes
+the provider process and cascades connection refused errors to every
+other in-flight resource served by the same plugin.
+
+Move the result assignment below the error check and the nil-response
+check so the underlying AWS error surfaces as a diagnostic instead of a
+panic.
+
+Tracking issue: https://github.com/pulumi/pulumi-aws/issues/6577
+Upstream issue: https://github.com/hashicorp/terraform-provider-aws/issues/49154
+Upstream pull request: https://github.com/hashicorp/terraform-provider-aws/pull/49155
+
+diff --git a/internal/service/route53recoverycontrolconfig/safety_rule.go b/internal/service/route53recoverycontrolconfig/safety_rule.go
+index e9f2637ec9c..7f4a6b55712 100644
+--- a/internal/service/route53recoverycontrolconfig/safety_rule.go
++++ b/internal/service/route53recoverycontrolconfig/safety_rule.go
+@@ -263,16 +263,17 @@ func createAssertionRule(ctx context.Context, d *schema.ResourceData, meta any)
+ 	}
+ 
+ 	output, err := conn.CreateSafetyRule(ctx, input)
+-	result := output.AssertionRule
+ 
+ 	if err != nil {
+ 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Assertion Rule: %s", err)
+ 	}
+ 
+-	if result == nil {
++	if output == nil || output.AssertionRule == nil {
+ 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Assertion Rule empty response")
+ 	}
+ 
++	result := output.AssertionRule
++
+ 	d.SetId(aws.ToString(result.SafetyRuleArn))
+ 
+ 	if _, err := waitSafetyRuleCreated(ctx, conn, d.Id()); err != nil {
+@@ -305,16 +306,17 @@ func createGatingRule(ctx context.Context, d *schema.ResourceData, meta any) dia
+ 	}
+ 
+ 	output, err := conn.CreateSafetyRule(ctx, input)
+-	result := output.GatingRule
+ 
+ 	if err != nil {
+ 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Gating Rule: %s", err)
+ 	}
+ 
+-	if result == nil {
++	if output == nil || output.GatingRule == nil {
+ 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Gating Rule empty response")
+ 	}
+ 
++	result := output.GatingRule
++
+ 	d.SetId(aws.ToString(result.SafetyRuleArn))
+ 
+ 	if _, err := waitSafetyRuleCreated(ctx, conn, d.Id()); err != nil {
+--
+2.39.0
+


### PR DESCRIPTION
## Description

Fixes https://github.com/pulumi/registry/issues/11827.

The "Dead-Letter Queue" example generated for `aws.sqs.Queue` referenced
variables that are never defined, in every generated language (Python,
TypeScript, Go, C#, Java). For example, in Python:

```python
queue = aws.sqs.Queue("queue",
    name="pulumi-example-queue",
    redrive_policy=json.dumps({
        "deadLetterTargetArn": queue_deadletter["arn"],   # <- `queue_deadletter` is undefined
        "maxReceiveCount": 4,
    })
)
example_queue_deadletter = aws.sqs.Queue("example_queue_deadletter", name="pulumi-example-deadletter-queue")
example_queue_redrive_allow_policy = aws.sqs.RedriveAllowPolicy("example_queue_redrive_allow_policy",
    queue_url=example_queue_deadletter.id,
    redrive_allow_policy=json.dumps({
        "redrivePermission": "byQueue",
        "sourceQueueArns": [example_queue["arn"]],   # <- `example_queue` is undefined
    })
)
```

**Root cause:** the primary queue resource in this example is already
named `queue` upstream, and the dead-letter queue / redrive-allow-policy
resources are already renamed to the `example_` naming scheme by
`provider/replacements.json`. But two references were left inconsistent:

- The `sourceQueueArns` replacement pointed its renamed reference at
`example_queue.arn` — a resource that doesn't exist under that name (the
primary resource is just `queue`).
- `deadLetterTargetArn` was never updated to reference the renamed
`example_queue_deadletter` resource.

This PR fixes both entries in `provider/replacements.json`.

## Verification

- Confirmed against the actual pinned `upstream` submodule content (not
just the `terraform-provider-aws` `main` branch, which differs) that the
current replacements reproduce the exact live bug via `pulumi convert
--from terraform --language python`.
- With both entries corrected, ran the full local verification loop per
`CONTRIBUTING.md`:
- `make schema` — regenerated `schema.json`; confirmed the SQS
dead-letter-queue example is fully self-consistent across all 5
languages, with proper `.arn`/`.id` attribute access (no more
dict-subscript fallback on undefined names) and correct declaration
order.
- `make build_sdks` — regenerated SDK docstrings for
`sdk/{nodejs,python,dotnet,go,java}`; verified the generated Python and
Go source directly.
- Confirmed the fix is properly scoped: the replacement patterns only
touch the "Dead-letter queue" section and leave the doc's other five
example sections (Example Usage, FIFO queue, High-throughput FIFO queue,
and two SSE examples) untouched.

## Test plan

- [x] `make schema`
- [x] `make build_sdks`
- [ ] CI