### PR TITLE
Remove old upstream tests

### DIFF
--- a/.github/workflows/aws-upstream-tests.yml
+++ b/.github/workflows/aws-upstream-tests.yml
@@ -47,21 +47,12 @@ jobs:
       fail-fast: false
       matrix:
         service:
-          - sqs
           - ec2
-          - docdb
-          - redshiftserverless
           - cognitoidp
           - rds
         include:
-          - service: sqs
-            tests: TestAccSQSQueue
           - service: ec2
             tests: 'TestAccEC2KeyPair_publicKey|TestAccVPCRoute_timeoutsOnlyChange'
-          - service: docdb
-            tests: TestAccDocDBCluster_basic
-          - service: redshiftserverless
-            tests: TestAccRedshiftServerlessNamespace_basic
           - service: rds
             tests: TestAccRDSCluster_storageTypeUpdateNonAurora
           - service: cognitoidp


### PR DESCRIPTION
The purpose of these upstream tests is to test resources that we have patched. The tests that we are removing in this PR relate to old patches that do not exist anymore

