### PR TITLE
[ci-mgmt verification] Cache all Go module dependencies

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -26,6 +26,7 @@ XrunUpstreamTools: true
 pulumiConvert: 1
 allowMissingDocs: false
 goBuildParallelism: 2
+fullGoCache: true
 aws: true
 releaseVerification:
     nodejs: examples/release-verification

--- a/.github/actions/setup-go-cache/action.yml
+++ b/.github/actions/setup-go-cache/action.yml
@@ -1,0 +1,102 @@
+name: Setup Go cache
+description: Restore Go module and build caches for generated provider workflows
+
+inputs:
+  cache-key:
+    description: Identifies the workload that writes the build cache
+    required: true
+  target-os:
+    description: GOOS compiled by this workload; defaults to the host GOOS
+    required: false
+    default: ""
+  target-arch:
+    description: GOARCH compiled by this workload; defaults to the host GOARCH
+    required: false
+    default: ""
+  prime-modules:
+    description: Download dependencies for the checked-out Go modules before saving the module cache
+    required: false
+    default: "false"
+  save:
+    description: Save caches when the job succeeds
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Get Go cache configuration
+      id: cache-config
+      shell: bash
+      env:
+        TARGET_OS: ${{ inputs.target-os }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: |
+        set -euo pipefail
+        echo "build-cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "module-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+        echo "target-os=${TARGET_OS:-$(go env GOOS)}" >> "$GITHUB_OUTPUT"
+        echo "target-arch=${TARGET_ARCH:-$(go env GOARCH)}" >> "$GITHUB_OUTPUT"
+
+    - name: Prepare Go module cache restore
+      shell: bash
+      env:
+        MODULE_CACHE: ${{ steps.cache-config.outputs.module-cache }}
+      run: |
+        set -euo pipefail
+        if [[ -z "$MODULE_CACHE" || "$MODULE_CACHE" == "/" ]]; then
+          echo "Refusing to remove unsafe Go module cache path: '$MODULE_CACHE'" >&2
+          exit 1
+        fi
+        rm -rf -- "$MODULE_CACHE"
+
+    - name: Restore and save Go module cache
+      if: inputs.save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.module-cache }}
+        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Restore Go module cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.module-cache }}
+        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Prime Go module cache
+      if: inputs.prime-modules == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        while IFS= read -r -d '' dependency_file; do
+          module_dir=$(dirname "$dependency_file")
+          if [[ -f "$module_dir/go.mod" ]]; then
+            (cd "$module_dir" && go mod download)
+          fi
+        done < <(find . -type f -name go.sum -not -path './.git/*' -print0 | sort -z)
+
+    - name: Restore and save Go build cache
+      if: inputs.save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.build-cache }}
+        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-
+
+    - name: Restore Go build cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.build-cache }}
+        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-

--- a/.github/workflows/build_provider.yml
+++ b/.github/workflows/build_provider.yml
@@ -80,26 +80,12 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
           # only saving the cache in the prerequisites job
           cache_save: false
-      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
-      - name: Get GOCACHE
-        id: gocache
-        shell: bash
-        run: |
-          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
-      - name: Get GOMODCACHE
-        id: gomodcache
-        shell: bash
-        run: |
-          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
-      - name: Go Cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
         with:
-          path: |
-            ${{ steps.gocache.outputs.path }}
-            ${{ steps.gomodcache.outputs.path }}
-          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
-          restore-keys: |
-            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
+          cache-key: provider
+          target-os: ${{ matrix.platform.os }}
+          target-arch: ${{ matrix.platform.arch }}
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
         env:

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -80,16 +80,11 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
           # only saving the cache in the prerequisites job
           cache_save: false
-      - name: Setup Go Cache
+      - name: Setup Go cache
         if: matrix.language == 'go' || contains(matrix.language, 'go')
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        uses: ./.github/actions/setup-go-cache
         with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-            sdk/go/*.sum
-            sdk/*.sum
-            *.sum
+          cache-key: sdk-go
       - name: Prepare local workspace
         run: make prepare_local_workspace
         env:
@@ -129,9 +124,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/.github/workflows/main-post-build.yml
+++ b/.github/workflows/main-post-build.yml
@@ -67,15 +67,10 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
           # only saving the cache in the prerequisites job
           cache_save: false
-      - name: Setup Go Cache
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
         with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-            sdk/go/*.sum
-            sdk/*.sum
-            *.sum
+          cache-key: coverage
       - name: Echo Coverage Output Dir
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -90,24 +90,11 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
-    - name: Setup Go Cache
-      if: inputs.acceptance_fanout
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
-    - name: Setup Go Cache
-      if: inputs.acceptance_fanout == false
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-      with:
-        cache-dependency-path: |
-          provider/*.sum
-          upstream/*.sum
-          sdk/go/*.sum
-          sdk/*.sum
-          *.sum
+        cache-key: prerequisites
+        prime-modules: true
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -102,13 +102,10 @@ jobs:
         version: 2026.3.7
         github_token: ${{ steps.app-auth.outputs.token }}
         cache_save: false
-    - name: Restore Go Cache
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+        cache-key: test-provider
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:
@@ -176,13 +173,10 @@ jobs:
         version: 2026.3.7
         github_token: ${{ steps.app-auth.outputs.token }}
         cache_save: false
-    - name: Restore Go Cache
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+        cache-key: schema
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,6 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - name: Checkout p/examples
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        repository: pulumi/examples
-        path: p-examples
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -75,6 +70,16 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # also save this cache since we are using a different mise env.
         cache_save: true
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
+      with:
+        cache-key: integration-tests
+        save: ${{ matrix.current-shard == 0 }}
+    - name: Checkout p/examples
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: pulumi/examples
+        path: p-examples
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -76,15 +76,10 @@ jobs:
           version: 2026.3.7
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-      - name: Setup Go Cache
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
         with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-            sdk/go/*.sum
-            sdk/*.sum
-            *.sum
+          cache-key: verify-release
       - name: Generate Pulumi Access Token
         id: generate_pulumi_token
         uses: pulumi/auth-actions@141415910c3beb54e03b48e9057c204c97b956f2 # v2.1.0


### PR DESCRIPTION
## Summary
- Problem: ci-mgmt test-provider fixtures validate generated YAML but do not execute the generated workflows.
- Change: opt this branch into the candidate `fullGoCache` configuration and regenerate the Pulumi AWS workflows from ci-mgmt commit `2b380511c`.
- Related issue/PR: follow-up to #6620 that verifies comprehensive Go module-cache priming; this PR is not intended to merge.

## Change Type
- [ ] Provider logic only (`provider/`)
- [ ] Schema or mapping change (may require SDK regeneration)
- [ ] Upstream or patch pipeline change (`upstream/`, `patches/`, `scripts/upstream.sh`)
- [x] CI workflow source change (`.ci-mgmt.yaml`)

## Carried Upstream Patch
Not applicable.

## Validation Evidence

- [ ] `make lint` — not applicable; provider code is unchanged
- [ ] `make test_provider` — not run locally; this PR exists to exercise provider CI
- [ ] If schema-affecting: `make schema` — not applicable
- [ ] If schema-affecting: `make build_sdks` — not applicable
- [x] If CI source changed: generated with the candidate `provider-ci` binary from ci-mgmt commit `2b380511c`
- [x] ci-mgmt's pinned `actionlint` passed for all changed generated workflows

### Command output snippets
```text
candidate provider-ci generation: passed
actionlint on changed generated workflows: passed
composite action YAML parsing: passed
```

A whole-repository `actionlint` run is currently blocked by the unchanged top-level `description` key in `.github/workflows/aws-upstream-tests.yml`.

## Risk
- Blast radius: GitHub Actions cache restore and save behavior in generated provider, SDK, schema, test, coverage, and release-verification jobs.
- Edge cases: pull-request CI exercises the PR workflows but does not exercise push- or tag-only release paths.

## Rollback
- Revert plan: close this temporary PR after its checks, including `Sentinel`, finish.
- Follow-up cleanup: delete the verification branch after recording the check results in the ci-mgmt PR.




