### PR TITLE
Map Pricing Plan Manager resources to a dedicated module

### DIFF
--- a/provider/tokens.go
+++ b/provider/tokens.go
@@ -176,6 +176,7 @@ const (
 	pinpointMod                 = "Pinpoint"                 // Pinpoint
 	pipesMod                    = "Pipes"                    // Pipes
 	pricingMod                  = "Pricing"                  // Pricing
+	pricingPlanManagerMod       = "PricingPlanManager"       // Pricing Plan Manager
 	qldbMod                     = "Qldb"                     // QLDB
 	quicksightMod               = "Quicksight"               // Quicksight
 	ramMod                      = "Ram"                      // Resource Access Manager
@@ -421,6 +422,7 @@ var moduleMap = map[string]string{
 	"pipes":                           pipesMod,
 	"polly":                           "Polly",
 	"pricing":                         pricingMod,
+	"pricingplanmanager":              pricingPlanManagerMod,
 	"prometheus":                      ampMod,
 	"qbusiness":                       "Qbusiness",
 	"qldb":                            qldbMod,

--- a/provider/tokens_test.go
+++ b/provider/tokens_test.go
@@ -1,0 +1,22 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPricingPlanManagerSubscriptionToken(t *testing.T) {
+	t.Parallel()
+
+	strategy := tks.MappedModules("aws_", "", moduleMap, func(mod, name string) (string, error) {
+		return awsResource(mod, name).String(), nil
+	})
+	resource := info.Resource{}
+
+	require.NoError(t, strategy.Resource("aws_pricingplanmanager_subscription", &resource))
+	assert.Equal(t, "aws:pricingplanmanager/subscription:Subscription", resource.Tok.String())
+}


### PR DESCRIPTION
## Summary

Add a dedicated `pricingplanmanager` bridge module mapping so the future Terraform resource `aws_pricingplanmanager_subscription` resolves to the stable Pulumi token `aws:pricingplanmanager/subscription:Subscription`. Without this mapping, the bridge's prefix matcher classifies the resource under the existing `pricing` module and produces `aws:pricing/planmanagerSubscription:PlanmanagerSubscription`.

The change adds the module mapping and a focused token-contract test. hashicorp/terraform-provider-aws#49233 adds the upstream service client, and hashicorp/terraform-provider-aws#49235 adds the subscription resource.

## Change Type

- [x] Provider logic only (`provider/`)
- [x] Schema or mapping change (may require SDK regeneration)
- [ ] Upstream or patch pipeline change (`upstream/`, `patches/`, `scripts/upstream.sh`)
- [ ] CI workflow source change (`.ci-mgmt.yaml`)

## Carried Upstream Patch

Not applicable. This change does not add or modify a carried patch.

## Validation Evidence

- [ ] `make lint` ran against current `master` and reported 58 pre-existing findings: 3 `gci`, 1 `gosec`, 49 `lll`, and 5 `revive`. None are in the changed files. The repository-pinned golangci-lint 2.7.0 binary was initially built with Go 1.25 and could not analyze Go 1.26.6, so the same 2.7.0 version was rebuilt with Go 1.26.6 before collecting this result.
- [x] `make test_provider`
- [x] `make schema`
- [x] `make build_sdks`
- [ ] `make ci-mgmt` was not run because no CI source changed.

Relevant command output:

```text
# Test-first token contract before the mapping
expected: aws:pricingplanmanager/subscription:Subscription
actual:   aws:pricing/planmanagerSubscription:PlanmanagerSubscription

# Focused contract after the mapping, synchronized with current master
go test -run '^TestPricingPlanManagerSubscriptionToken$' .
ok  github.com/pulumi/pulumi-aws/provider/v7  5.225s

# Canonical provider suite
make test_provider
ok  github.com/pulumi/pulumi-aws/provider/v7  24.931s

# Canonical generation and SDK build
make schema
PASS (no intended schema change while the upstream resource is absent)

make build_sdks
PASS (Node.js, Python, .NET, Go, and Java; no tracked generated changes)

git diff --check origin/master...HEAD
PASS
```

`make schema` produced three unrelated, nondeterministic example-description changes; they were excluded. The SDK build exposed two disposable-runner constraints before passing: SourceLink rejected the partial clone's Git repository format 1, and the sandbox blocked tfgen's temporary localhost listener. Retrying with format-0 metadata in the disposable clone and the required loopback permission completed the canonical build without tracked generated changes.

## Risk

- Blast radius: token selection for Terraform names beginning with `aws_pricingplanmanager_`.
- Current released schemas are unchanged because the upstream resource has not landed.
- The mapping depends on the upstream service prefix remaining `pricingplanmanager`.

## Rollback

- Revert this change to restore the prefix fallback behavior.
- No follow-up cleanup is required because this change creates no AWS resources or provider state.
