### PR TITLE
Opt into the pulumi new credentials preflight

### DIFF
--- a/provider/overlays.go
+++ b/provider/overlays.go
@@ -197,6 +197,9 @@ func postProcessCallbackFunction(spec *schema.PackageSpec) {
 // It applies post processing steps to overlays. e.g. copying input properties from another resource
 func postProcessOverlays(spec *schema.PackageSpec) {
 	postProcessCallbackFunction(spec)
+	// Opt into the `pulumi new` credentials preflight and point users at the configuration docs.
+	spec.ValidateCredentialsOnNew = true
+	spec.ConfigurationDocsURL = "https://www.pulumi.com/registry/packages/aws/installation-configuration/"
 }
 
 func init() {


### PR DESCRIPTION
Set the new `validateCredentialsOnNew` and `configurationDocsUrl` package schema fields so interactive `pulumi new` validates AWS credentials after creating a project and links to the configuration docs on failure.

```
  Created project 'preflight-test'
  Created stack 'dev'
  Saved config

  Your new project is ready to go! ✨

  warning: The AWS provider reported problems with this stack's configuration:
      Invalid credentials configured.
      Please see https://www.pulumi.com/registry/packages/aws/installation-configuration/ for more information about providing credentials.
      NEW: You can use Pulumi ESC to set up dynamic credentials with AWS OIDC to ensure the correct and valid credentials are used.
      Learn more: https://www.pulumi.com/registry/packages/aws/installation-configuration/#dynamically-generate-credentials-via-pulumi-esc
  `pulumi up` may fail until this is resolved.
  For help configuring the AWS provider, see https://www.pulumi.com/registry/packages/aws/installation-configuration/

  To perform an initial deployment, run 'cd proj', then, run `pulumi up`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)