### PR TITLE
Use upstream AWS names for token modules

### DIFF
--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -62,6 +62,18 @@ func TestExplicitTokenMappingsAreNecessary(t *testing.T) {
 	}
 }
 
+func TestUpstreamModuleMap(t *testing.T) {
+	t.Parallel()
+
+	modules, err := upstreamModuleMap()
+	require.NoError(t, err)
+
+	assert.Equal(t, "AccountAccess", modules["accountaccess"])
+	assert.Equal(t, "LambdaMicroVMs", modules["lambdamicrovms"])
+	assert.Equal(t, ampMod, modules["prometheus"], "Pulumi compatibility overrides take precedence")
+	assert.NotContains(t, modules, "bedrockagent", "more-specific upstream prefixes can be excluded")
+}
+
 func TestAutomaticTokenMappings(t *testing.T) {
 	t.Parallel()
 

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	awsnames "github.com/hashicorp/terraform-provider-aws/names/data"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +72,29 @@ func TestUpstreamModuleMap(t *testing.T) {
 	assert.Equal(t, "AccountAccess", modules["accountaccess"])
 	assert.Equal(t, "LambdaMicroVMs", modules["lambdamicrovms"])
 	assert.Equal(t, ampMod, modules["prometheus"], "Pulumi compatibility overrides take precedence")
-	assert.NotContains(t, modules, "bedrockagent", "more-specific upstream prefixes can be excluded")
+	assert.Equal(t, "SSO", modules["sso"], "not-implemented endpoint-only services are included")
+
+	services, err := awsnames.ReadAllServiceData()
+	require.NoError(t, err)
+	upstreamPrefixes := map[string]struct{}{}
+	for _, service := range services {
+		prefix := upstreamResourcePrefix(service)
+		if prefix != "" {
+			upstreamPrefixes[prefix] = struct{}{}
+		}
+	}
+	for prefix := range upstreamModuleExclusions {
+		assert.Contains(t, upstreamPrefixes, prefix, "exclusion must match an upstream service prefix")
+		assert.NotContains(t, modules, prefix, "excluded upstream prefix")
+	}
+
+	for _, service := range services {
+		if service.ProviderPackage() == "ec2" {
+			assert.Equal(t, "ec2", upstreamResourcePrefix(service), "regex prefix uses its canonical form")
+			return
+		}
+	}
+	t.Fatal("EC2 service metadata not found")
 }
 
 func TestAutomaticTokenMappings(t *testing.T) {

--- a/provider/tokens.go
+++ b/provider/tokens.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"unicode"
@@ -563,6 +564,14 @@ var upstreamModuleExclusions = map[string]struct{}{
 	"ssmquicksetup":             {},
 }
 
+func upstreamResourcePrefix(service awsnames.ServiceRecord) string {
+	prefix := service.ResourcePrefixActual()
+	if prefix == "" || regexp.QuoteMeta(prefix) != prefix {
+		prefix = service.ResourcePrefixCorrect()
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(prefix, "aws_"), "_")
+}
+
 func upstreamModuleMap() (map[string]string, error) {
 	services, err := awsnames.ReadAllServiceData()
 	if err != nil {
@@ -575,7 +584,7 @@ func upstreamModuleMap() (map[string]string, error) {
 			continue
 		}
 
-		prefix := strings.TrimSuffix(strings.TrimPrefix(service.ResourcePrefix(), "aws_"), "_")
+		prefix := upstreamResourcePrefix(service)
 		if prefix == "" || service.ProviderNameUpper() == "" {
 			continue
 		}

--- a/provider/tokens.go
+++ b/provider/tokens.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"unicode"
 
+	awsnames "github.com/hashicorp/terraform-provider-aws/names/data"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens/fallbackstrat"
@@ -22,7 +23,6 @@ const (
 	acmMod                      = "Acm"                      // AWS Certificate Manager
 	acmpcaMod                   = "Acmpca"                   // AWS Private Certificate Authority
 	accountMod                  = "Account"                  // Account
-	accountAccessMod            = "AccountAccess"            // Account Access
 	accessAnalyzerMod           = "AccessAnalyzer"           // Access Analyzer
 	ampMod                      = "Amp"                      // Amp
 	amplifyMod                  = "Amplify"                  // Amplify
@@ -142,7 +142,6 @@ const (
 	kmsMod                      = "Kms"                      // Key Management Service (KMS)
 	lakeFormationMod            = "LakeFormation"            // LakeFormation
 	lambdaMod                   = "Lambda"                   // Lambda
-	lambdaMicrovmsMod           = "LambdaMicroVMs"           // Lambda MicroVMs
 	lexMod                      = "Lex"                      // Lex
 	licensemanagerMod           = "LicenseManager"           // License Manager
 	lightsailMod                = "LightSail"                // LightSail
@@ -248,7 +247,9 @@ const (
 	legacyElbv2Mod = "ElasticLoadBalancingV2"
 )
 
-var moduleMap = map[string]string{
+// moduleOverrides contains published Pulumi module names that intentionally differ
+// from the canonical service names in the upstream AWS provider metadata.
+var moduleOverrides = map[string]string{
 	// Ignored: ec2Mod. The ec2Mod includes tokens from:
 	// - "aws_eip"
 	// - "aws_flow_log"
@@ -260,7 +261,6 @@ var moduleMap = map[string]string{
 
 	"accessanalyzer":                  accessAnalyzerMod,
 	"account":                         accountMod,
-	"accountaccess":                   accountAccessMod,
 	"acm":                             acmMod,
 	"acmpca":                          acmpcaMod,
 	"alb":                             albMod,
@@ -385,7 +385,6 @@ var moduleMap = map[string]string{
 	"kms":                             kmsMod,
 	"lakeformation":                   lakeFormationMod,
 	"lambda":                          lambdaMod,
-	"lambdamicrovms":                  lambdaMicrovmsMod,
 	"lb":                              lbMod,
 	"lex":                             lexMod,
 	"licensemanager":                  licensemanagerMod,
@@ -535,6 +534,61 @@ func awsResource(mod string, res string) tokens.Type {
 	return awsTypeDefaultFile(mod, res)
 }
 
+// upstreamModuleExclusions contains upstream service prefixes that would change
+// published Pulumi module or member names. The older, shorter moduleOverrides
+// prefix remains available after these more-specific prefixes are removed.
+var upstreamModuleExclusions = map[string]struct{}{
+	"bedrockagent":              {},
+	"bedrockagentcore":          {},
+	"caller_identity":           {},
+	"chimesdkvoice":             {},
+	"cloudfrontkeyvaluestore":   {},
+	"cloudwatch_event":          {},
+	"docdbelastic":              {},
+	"kinesis_analytics":         {},
+	"kinesis_firehose":          {},
+	"kinesis_stream":            {},
+	"lambdacore":                {},
+	"lexv2models":               {},
+	"notificationscontacts":     {},
+	"opensearchserverless":      {},
+	"pinpointsmsvoicev2":        {},
+	"resiliencehubv2":           {},
+	"route53_resolver":          {},
+	"route53profiles":           {},
+	"s3files":                   {},
+	"s3vectors":                 {},
+	"servicecatalogappregistry": {},
+	"ssmcontacts":               {},
+	"ssmquicksetup":             {},
+}
+
+func upstreamModuleMap() (map[string]string, error) {
+	services, err := awsnames.ReadAllServiceData()
+	if err != nil {
+		return nil, fmt.Errorf("read upstream AWS service names: %w", err)
+	}
+
+	modules := make(map[string]string, len(services)+len(moduleOverrides))
+	for _, service := range services {
+		if service.Exclude() || service.NotImplemented() && !service.EndpointOnly() {
+			continue
+		}
+
+		prefix := strings.TrimSuffix(strings.TrimPrefix(service.ResourcePrefix(), "aws_"), "_")
+		if prefix == "" || service.ProviderNameUpper() == "" {
+			continue
+		}
+		if _, excluded := upstreamModuleExclusions[prefix]; !excluded {
+			modules[prefix] = service.ProviderNameUpper()
+		}
+	}
+	for prefix, module := range moduleOverrides {
+		modules[prefix] = module
+	}
+	return modules, nil
+}
+
 func awsTokenStrategy(prov *tfbridge.ProviderInfo) tks.Strategy {
 	finalize := func(mod, name string) (string, error) {
 		if name == "" {
@@ -542,6 +596,9 @@ func awsTokenStrategy(prov *tfbridge.ProviderInfo) tks.Strategy {
 		}
 		return awsResource(mod, name).String(), nil
 	}
+
+	moduleMap, err := upstreamModuleMap()
+	contract.AssertNoErrorf(err, "failed to load upstream AWS service names")
 
 	strategy, err := fallbackstrat.MappedModulesWithInferredFallback(
 		prov, "aws_", "", moduleMap, finalize)


### PR DESCRIPTION
Derive new token module names from the canonical service prefix and
casing metadata while excluding prefixes that would change published APIs.
